### PR TITLE
Support overriding the default API URL

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// url is the public Stripe URL for APIs.
+// defaultUrl is the public Stripe URL for APIs.
 const defaultUrl = "https://api.stripe.com/v1"
 
 // apiversion is the currently supported API version
@@ -34,13 +34,13 @@ type InternalBackend struct {
 }
 
 func NewInternalBackend(httpClient *http.Client, url string) *InternalBackend {
-	if url == "" {
+	if len(url) == 0 {
 		url = defaultUrl
 	}
 
 	return &InternalBackend{
 		url:        url,
-		httpClient: GetHttpClient(),
+		httpClient: httpClient,
 	}
 }
 


### PR DESCRIPTION
In our other binding libraries, we support overriding the default API URL.  This is primarily useful for internal purposes and but also useful for folks who want to run an API mock server for testing.

r? @cosn 
