### PR TITLE
Include email field and parameter on Tokens

### DIFF
--- a/token.go
+++ b/token.go
@@ -33,5 +33,5 @@ type Token struct {
 	Card    *Card        `json:"card"`
 	// Email is an undocumented field but included for all tokens created
 	// with Stripe Checkout.
-	Email string `json:"email,omitempty"`
+	Email string `json:"email"`
 }


### PR DESCRIPTION
Checkout passes and returns an email field on tokens.  We need to access these in Go in checkout-api but want to mark the fact that they are undocumented.

r? @cosn 
