### PR TITLE
Do not use AccessToken parameter to specify key for connect

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -173,8 +173,8 @@ type ChargeListParams struct {
 // For more details see https://stripe.com/docs/api#charge_capture.
 type CaptureParams struct {
 	Params
-	Amount, Fee        uint64
-	Email, AccessToken string
+	Amount, Fee uint64
+	Email       string
 }
 
 // Charge is the resource representing a Stripe charge.

--- a/charge/client.go
+++ b/charge/client.go
@@ -59,13 +59,7 @@ func (c Client) Create(params *ChargeParams) (*Charge, error) {
 
 	token := c.Tok
 	if params.Fee > 0 {
-		if len(params.AccessToken) == 0 {
-			err := errors.New("Invalid charge params: an access token is required for application fees")
-			return nil, err
-		}
-
 		body.Add("application_fee", strconv.FormatUint(params.Fee, 10))
-		token = params.AccessToken
 	}
 
 	params.AppendTo(body)
@@ -168,13 +162,7 @@ func (c Client) Capture(id string, params *CaptureParams) (*Charge, error) {
 		}
 
 		if params.Fee > 0 {
-			if len(params.AccessToken) == 0 {
-				err := errors.New("Invalid charge params: an access token is required for application fees")
-				return nil, err
-			}
-
 			body.Add("application_fee", strconv.FormatUint(params.Fee, 10))
-			token = params.AccessToken
 		}
 
 		params.AppendTo(body)

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -2,7 +2,6 @@
 package invoice
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -43,13 +42,7 @@ func (c Client) Create(params *InvoiceParams) (*Invoice, error) {
 
 	token := c.Tok
 	if params.Fee > 0 {
-		if len(params.AccessToken) == 0 {
-			err := errors.New("Invalid invoice params: an access token is required for application fees")
-			return nil, err
-		}
-
 		body.Add("application_fee", strconv.FormatUint(params.Fee, 10))
-		token = params.AccessToken
 	}
 
 	invoice := &Invoice{}
@@ -132,13 +125,7 @@ func (c Client) Update(id string, params *InvoiceParams) (*Invoice, error) {
 		}
 
 		if params.Fee > 0 {
-			if len(params.AccessToken) == 0 {
-				err := errors.New("Invalid invoice params: an access token is required for application fees")
-				return nil, err
-			}
-
 			body.Add("application_fee", strconv.FormatUint(params.Fee, 10))
-			token = params.AccessToken
 		}
 
 		params.AppendTo(body)

--- a/params.go
+++ b/params.go
@@ -9,9 +9,8 @@ import (
 // Params is the structure that contains the common properties
 // of any *Params structure.
 type Params struct {
-	Exp         []string
-	Meta        map[string]string
-	AccessToken string
+	Exp  []string
+	Meta map[string]string
 }
 
 // ListParams is the structure that contains the common properties

--- a/sub/client.go
+++ b/sub/client.go
@@ -2,7 +2,6 @@
 package sub
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -47,13 +46,7 @@ func (c Client) Create(params *SubParams) (*Subscription, error) {
 
 	token := c.Tok
 	if params.FeePercent > 0 {
-		if len(params.AccessToken) == 0 {
-			err := errors.New("Invalid sub params: an access token is required for application fees")
-			return nil, err
-		}
-
 		body.Add("application_fee_percent", strconv.FormatFloat(params.FeePercent, 'f', 2, 64))
-		token = params.AccessToken
 	}
 
 	params.AppendTo(body)
@@ -122,13 +115,7 @@ func (c Client) Update(id string, params *SubParams) (*Subscription, error) {
 
 	token := c.Tok
 	if params.FeePercent > 0 {
-		if len(params.AccessToken) == 0 {
-			err := errors.New("Invalid sub params: an access token is required for application fees")
-			return nil, err
-		}
-
 		body.Add("application_fee_percent", strconv.FormatFloat(params.FeePercent, 'f', 2, 64))
-		token = params.AccessToken
 	}
 
 	params.AppendTo(body)

--- a/token/client.go
+++ b/token/client.go
@@ -25,13 +25,7 @@ func (c Client) Create(params *TokenParams) (*Token, error) {
 	token := c.Tok
 
 	if len(params.Customer) > 0 {
-		if len(params.AccessToken) == 0 {
-			err := errors.New("Invalid Token params: an access token is required for customer")
-			return nil, err
-		}
-
 		body.Add("customer", params.Customer)
-		token = params.AccessToken
 	}
 
 	if params.Card != nil {


### PR DESCRIPTION
`AccessToken` is currently accepted as a parameter for certain types of requests where we expect you to use a Connect token (e.g. creating a token from a shared customer, adding an application fee to something).  I think putting this in the bindings is confusing since it implies that the `AccessToken` parameter is like other parameters (i.e. passed in the POST body) rather than simply being another name for the API key.  The validation this provides is largely unnecessary -- the API itself is very capable of handling this logic and returning a sane error.  I believe Connect users should instead be creating a separate `client.Api` instance with the desired key.  

Note that this is in fact consistent with our other bindings.  The `ACCESS_TOKEN` positional argument we show [e.g. for shared customers](https://stripe.com/docs/connect/shared-customers#making-a-charge) in fact [corresponds to an `api_key` parameter](https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/api_operations/create.rb#L5), not something special for connect.  I think the inclusion of this parameter in our other bindings is a reflection of a bad design decision there to not allow creating separate client instances.

r? @cosn 
