### PR TITLE
Add risk parameters for token creation.

### DIFF
--- a/token.go
+++ b/token.go
@@ -19,6 +19,12 @@ type TokenParams struct {
 	// Email is an undocumented parameter used by Stripe Checkout
 	// It may be removed from the API without notice.
 	Email string
+	// The following parameters are undocumented and may be removed
+	// from the API without notice.
+	PaymentUserAgent string
+	UserAgent        string
+	Referrer         string
+	Ip               string
 }
 
 // Token is the resource representing a Stripe token.

--- a/token/client.go
+++ b/token/client.go
@@ -43,6 +43,22 @@ func (c Client) Create(params *TokenParams) (*Token, error) {
 		return nil, err
 	}
 
+	if len(params.PaymentUserAgent) > 0 {
+		body.Add("payment_user_agent", params.PaymentUserAgent)
+	}
+
+	if len(params.UserAgent) > 0 {
+		body.Add("user_agent", params.UserAgent)
+	}
+
+	if len(params.Referrer) > 0 {
+		body.Add("referrer", params.Referrer)
+	}
+
+	if len(params.Ip) > 0 {
+		body.Add("ip", params.Ip)
+	}
+
 	params.AppendTo(body)
 
 	tok := &Token{}


### PR DESCRIPTION
For trusted sources (e.g. Shopify) we allow them to pass certain information (like the original client IP address) that is relevant to risk.  We intend to use this functionality in the new API for Checkout.  This adds the parameters we need for that project.

As compared to email, these parameters are somewhat weirder and less well documented.  Do we still want them in published bindings (they are exposed in the Checkout.js source)?  Should we simply provide an escape hatch for passing arbitrary params as an alternative?

r? @cosn 
