### PR TITLE
Protect getValue() for case where the key is missing.

### DIFF
--- a/event.go
+++ b/event.go
@@ -69,6 +69,8 @@ func getValue(m map[string]interface{}, keys []string) string {
 	for i := 1; i < len(keys); i++ {
 		node = node.(map[string]interface{})[keys[i]]
 	}
-
+	if node == nil {
+		return ""
+	}
 	return node.(string)
 }


### PR DESCRIPTION
Using GetObjValue() to try to fetch some values out of metadata, if those values don't exist for whatever reason, getValue() crashes.
