### PR TITLE
change and document iterators for consistency

### DIFF
--- a/balance/client.go
+++ b/balance/client.go
@@ -127,29 +127,17 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Transactions.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Transaction, error) {
-	t, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return t.(*stripe.Transaction), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Charge returns the most recent Transaction
+// visited by a call to Next.
+func (i *Iter) Transaction() *stripe.Transaction {
+	return i.Current().(*stripe.Transaction)
 }
 
 func getC() Client {

--- a/balance/client_test.go
+++ b/balance/client_test.go
@@ -120,19 +120,16 @@ func TestBalanceList(t *testing.T) {
 	params.Single = true
 
 	i := List(params)
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if target == nil {
+	for i.Next() {
+		if i.Transaction() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 }

--- a/card/client.go
+++ b/card/client.go
@@ -162,29 +162,17 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Cards.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Card, error) {
-	c, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.(*stripe.Card), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Card returns the most recent Card
+// visited by a call to Next.
+func (i *Iter) Card() *stripe.Card {
+	return i.Current().(*stripe.Card)
 }
 
 func getC() Client {

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -167,20 +167,17 @@ func TestCardList(t *testing.T) {
 	New(card)
 
 	i := List(&stripe.CardListParams{Customer: cust.ID})
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if target == nil {
+	for i.Next() {
+		if i.Card() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 
 	customer.Del(cust.ID)

--- a/charge/client.go
+++ b/charge/client.go
@@ -192,29 +192,17 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Charges.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Charge, error) {
-	c, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.(*stripe.Charge), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Charge returns the most recent Charge
+// visited by a call to Next.
+func (i *Iter) Charge() *stripe.Charge {
+	return i.Current().(*stripe.Charge)
 }
 
 func getC() Client {

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -173,19 +173,16 @@ func TestChargeList(t *testing.T) {
 	params.Single = true
 
 	i := List(params)
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if target == nil {
+	for i.Next() {
+		if i.Charge() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 }

--- a/client/checkin_test.go
+++ b/client/checkin_test.go
@@ -132,12 +132,8 @@ func TestCheckinList(t *testing.T) {
 	params.Single = true
 
 	i := c.Plans.List(params)
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
+	for i.Next() {
+		target := i.Plan()
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
@@ -146,6 +142,9 @@ func TestCheckinList(t *testing.T) {
 		if target.Amount != 100 {
 			t.Errorf("Amount %v does not match expected value\n", target.Amount)
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 
 	for i := 0; i < runs; i++ {

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -131,29 +131,17 @@ func (c Client) List(params *stripe.CouponListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Coupons.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Coupon, error) {
-	c, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.(*stripe.Coupon), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Coupon returns the most recent Coupon
+// visited by a call to Next.
+func (i *Iter) Coupon() *stripe.Coupon {
+	return i.Current().(*stripe.Coupon)
 }
 
 func getC() Client {

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -98,20 +98,17 @@ func TestCouponList(t *testing.T) {
 	}
 
 	i := List(nil)
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if target == nil {
+	for i.Next() {
+		if i.Coupon() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 
 	for i := 0; i < 5; i++ {

--- a/customer/client.go
+++ b/customer/client.go
@@ -188,29 +188,17 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Customers.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Customer, error) {
-	c, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.(*stripe.Customer), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Customer returns the most recent Customer
+// visited by a call to Next.
+func (i *Iter) Customer() *stripe.Customer {
+	return i.Current().(*stripe.Customer)
 }
 
 func getC() Client {

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -190,20 +190,17 @@ func TestCustomerList(t *testing.T) {
 	}
 
 	i := List(nil)
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if target == nil {
+	for i.Next() {
+		if i.Customer() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 
 	for _, v := range customers {

--- a/event/client.go
+++ b/event/client.go
@@ -70,29 +70,17 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Events.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Event, error) {
-	e, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return e.(*stripe.Event), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Event returns the most recent Event
+// visited by a call to Next.
+func (i *Iter) Event() *stripe.Event {
+	return i.Current().(*stripe.Event)
 }
 
 func getC() Client {

--- a/event/client_test.go
+++ b/event/client_test.go
@@ -18,12 +18,8 @@ func TestEvent(t *testing.T) {
 	params.Type = "charge.*"
 
 	i := List(params)
-	for !i.Stop() {
-		e, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
+	for i.Next() {
+		e := i.Event()
 
 		if e == nil {
 			t.Error("No nil values expected")
@@ -72,5 +68,8 @@ func TestEvent(t *testing.T) {
 
 		// no need to actually check the value, we're just validating this doesn't bomb
 		e.GetObjValue("does not exist")
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -84,13 +84,11 @@ func ExamplePlan_list() {
 	params.Filters.AddFilter("limit", "", "3")
 	params.Single = true
 
-	i := plan.List(params)
-	for !i.Stop() {
-		target, err := i.Next()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		log.Printf("%v ", target.Name)
+	it := plan.List(params)
+	for it.Next() {
+		log.Printf("%v ", it.Plan().Name)
+	}
+	if err := it.Err(); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/fee/client.go
+++ b/fee/client.go
@@ -78,29 +78,17 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Fees.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Fee, error) {
-	f, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return f.(*stripe.Fee), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Fee returns the most recent Fee
+// visited by a call to Next.
+func (i *Iter) Fee() *stripe.Fee {
+	return i.Current().(*stripe.Fee)
 }
 
 func getC() Client {

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -99,29 +99,17 @@ func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of FeeRefunds.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.FeeRefund, error) {
-	f, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return f.(*stripe.FeeRefund), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// FeeRefund returns the most recent FeeRefund
+// visited by a call to Next.
+func (i *Iter) FeeRefund() *stripe.FeeRefund {
+	return i.Current().(*stripe.FeeRefund)
 }
 
 func getC() Client {

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -242,54 +242,30 @@ func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Invoices.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Invoice, error) {
-	ii, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return ii.(*stripe.Invoice), err
+// Invoice returns the most recent Invoice
+// visited by a call to Next.
+func (i *Iter) Invoice() *stripe.Invoice {
+	return i.Current().(*stripe.Invoice)
 }
 
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
-}
-
-// LineIter is a iterator for list responses.
+// LineIter is an iterator for lists of InvoiceLines.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type LineIter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *LineIter) Next() (*stripe.InvoiceLine, error) {
-	ii, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return ii.(*stripe.InvoiceLine), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *LineIter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *LineIter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// InvoiceLine returns the most recent InvoiceLine
+// visited by a call to Next.
+func (i *LineIter) InvoiceLine() *stripe.InvoiceLine {
+	return i.Current().(*stripe.InvoiceLine)
 }
 
 func getC() Client {

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -193,14 +193,8 @@ func TestAllInvoicesScenarios(t *testing.T) {
 	}
 
 	ii := invoiceitem.List(&stripe.InvoiceItemListParams{Customer: cust.ID})
-	for !ii.Stop() {
-		targetInvoiceItemList, err := ii.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if targetInvoiceItemList == nil {
+	for ii.Next() {
+		if ii.InvoiceItem() == nil {
 			t.Error("No nil values expected")
 		}
 
@@ -208,16 +202,13 @@ func TestAllInvoicesScenarios(t *testing.T) {
 			t.Error("No metadata returned")
 		}
 	}
+	if err := ii.Err(); err != nil {
+		t.Error(err)
+	}
 
 	i := List(&stripe.InvoiceListParams{Customer: cust.ID})
-	for !i.Stop() {
-		targetInvoiceList, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if targetInvoiceList == nil {
+	for i.Next() {
+		if i.Invoice() == nil {
 			t.Error("No nil values expected")
 		}
 
@@ -225,22 +216,22 @@ func TestAllInvoicesScenarios(t *testing.T) {
 			t.Error("No metadata returned")
 		}
 	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
+	}
 
 	il := ListLines(&stripe.InvoiceLineListParams{ID: targetInvoice.ID, Customer: cust.ID})
-	for !il.Stop() {
-		targetLineList, err := il.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if targetLineList == nil {
+	for il.Next() {
+		if il.InvoiceLine() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if il.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := il.Err(); err != nil {
+		t.Error(err)
 	}
 
 	err = invoiceitem.Del(targetItem.ID)

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -149,29 +149,17 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of InvoiceItems.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.InvoiceItem, error) {
-	ii, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return ii.(*stripe.InvoiceItem), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// InvoiceItem returns the most recent InvoiceItem
+// visited by a call to Next.
+func (i *Iter) InvoiceItem() *stripe.InvoiceItem {
+	return i.Current().(*stripe.InvoiceItem)
 }
 
 func getC() Client {

--- a/iter_test.go
+++ b/iter_test.go
@@ -1,0 +1,217 @@
+package stripe
+
+import (
+	"errors"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestIterEmpty(t *testing.T) {
+	tq := testQuery{{nil, ListMeta{}, nil}}
+	g, gerr := collect(GetIter(nil, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if len(g) != 0 {
+		t.Fatalf("results = %v want empty", g)
+	}
+	if gerr != nil {
+		t.Fatalf("err = %v want nil", gerr)
+	}
+}
+
+func TestIterEmptyErr(t *testing.T) {
+	tq := testQuery{{nil, ListMeta{}, errTest}}
+	g, gerr := collect(GetIter(nil, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if len(g) != 0 {
+		t.Fatalf("results = %v want empty", g)
+	}
+	if gerr != errTest {
+		t.Fatalf("err = %v want %v", gerr, errTest)
+	}
+}
+
+func TestIterOne(t *testing.T) {
+	tq := testQuery{{[]interface{}{1}, ListMeta{}, nil}}
+	want := []interface{}{1}
+	g, gerr := collect(GetIter(nil, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if !reflect.DeepEqual(g, want) {
+		t.Fatalf("results = %v want %v", g, want)
+	}
+	if gerr != nil {
+		t.Fatalf("err = %v want %v", gerr, nil)
+	}
+}
+
+func TestIterOneErr(t *testing.T) {
+	tq := testQuery{{[]interface{}{1}, ListMeta{}, errTest}}
+	want := []interface{}{1}
+	g, gerr := collect(GetIter(nil, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if !reflect.DeepEqual(g, want) {
+		t.Fatalf("results = %v want %v", g, want)
+	}
+	if gerr != errTest {
+		t.Fatalf("err = %v want %v", gerr, errTest)
+	}
+}
+
+func TestIterPage2Empty(t *testing.T) {
+	tq := testQuery{
+		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
+		{nil, ListMeta{}, nil},
+	}
+	want := []interface{}{&item{"x"}}
+	g, gerr := collect(GetIter(nil, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if !reflect.DeepEqual(g, want) {
+		t.Fatalf("results = %v want %v", g, want)
+	}
+	if gerr != nil {
+		t.Fatalf("err = %v want %v", gerr, nil)
+	}
+}
+
+func TestIterPage2EmptyErr(t *testing.T) {
+	tq := testQuery{
+		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
+		{nil, ListMeta{}, errTest},
+	}
+	want := []interface{}{&item{"x"}}
+	g, gerr := collect(GetIter(nil, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if !reflect.DeepEqual(g, want) {
+		t.Fatalf("results = %v want %v", g, want)
+	}
+	if gerr != errTest {
+		t.Fatalf("err = %v want %v", gerr, errTest)
+	}
+}
+
+func TestIterTwoPages(t *testing.T) {
+	tq := testQuery{
+		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{2}, ListMeta{0, false, ""}, nil},
+	}
+	want := []interface{}{&item{"x"}, 2}
+	g, gerr := collect(GetIter(nil, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if !reflect.DeepEqual(g, want) {
+		t.Fatalf("results = %v want %v", g, want)
+	}
+	if gerr != nil {
+		t.Fatalf("err = %v want nil", gerr)
+	}
+}
+
+func TestIterTwoPagesErr(t *testing.T) {
+	tq := testQuery{
+		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{2}, ListMeta{0, false, ""}, errTest},
+	}
+	want := []interface{}{&item{"x"}, 2}
+	g, gerr := collect(GetIter(nil, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if !reflect.DeepEqual(g, want) {
+		t.Fatalf("results = %v want %v", g, want)
+	}
+	if gerr != errTest {
+		t.Fatalf("err = %v want %v", gerr, errTest)
+	}
+}
+
+func TestIterReversed(t *testing.T) {
+	tq := testQuery{{[]interface{}{1, 2}, ListMeta{}, nil}}
+	want := []interface{}{2, 1}
+	g, gerr := collect(GetIter(&ListParams{End: "x"}, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if !reflect.DeepEqual(g, want) {
+		t.Fatalf("results = %v want %v", g, want)
+	}
+	if gerr != nil {
+		t.Fatalf("err = %v want %v", gerr, nil)
+	}
+}
+
+func TestIterReversedTwoPages(t *testing.T) {
+	tq := testQuery{
+		{[]interface{}{&item{"3"}, 4}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{1, 2}, ListMeta{}, nil},
+	}
+	want := []interface{}{4, &item{"3"}, 2, 1}
+	g, gerr := collect(GetIter(&ListParams{End: "x"}, nil, tq.query))
+	if len(tq) != 0 {
+		t.Fatalf("expect all pages to be fetched")
+	}
+	if !reflect.DeepEqual(g, want) {
+		t.Fatalf("results = %v want %v", g, want)
+	}
+	if gerr != nil {
+		t.Fatalf("err = %v want %v", gerr, nil)
+	}
+}
+
+var errTest = errors.New("test error")
+
+type item struct {
+	ID string
+}
+
+type testQuery []struct {
+	v []interface{}
+	m ListMeta
+	e error
+}
+
+func (tq *testQuery) query(url.Values) ([]interface{}, ListMeta, error) {
+	x := (*tq)[0]
+	*tq = (*tq)[1:]
+	return x.v, x.m, x.e
+}
+
+func collect(it *Iter) ([]interface{}, error) {
+	var g []interface{}
+	for it.Next() {
+		g = append(g, it.Current())
+	}
+	return g, it.Err()
+}
+
+func TestReverse(t *testing.T) {
+	var cases = [][]interface{}{
+		{},
+		{1},
+		{1, 2},
+		{1, 2, 3},
+		{1, 2, 3, 4},
+	}
+	for _, a := range cases {
+		b := make([]interface{}, len(a))
+		copy(b, a)
+		reverse(b)
+		for i, g := range b {
+			if w := a[len(a)-1-i]; !reflect.DeepEqual(g, w) {
+				t.Errorf("reverse(%v)[%d] = %v want %v", a, i, g, w)
+			}
+		}
+	}
+}

--- a/plan/client.go
+++ b/plan/client.go
@@ -150,30 +150,19 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Plans.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Plan, error) {
-	p, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return p.(*stripe.Plan), err
+// Plan returns the most recent Plan
+// visited by a call to Next.
+func (i *Iter) Plan() *stripe.Plan {
+	return i.Current().(*stripe.Plan)
 }
 
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
-}
 func getC() Client {
 	return Client{stripe.GetBackend(), stripe.Key}
 }

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -143,12 +143,8 @@ func TestPlanList(t *testing.T) {
 	params.Filters.AddFilter("limit", "", "1")
 
 	i := List(params)
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
+	for i.Next() {
+		target := i.Plan()
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
@@ -157,6 +153,9 @@ func TestPlanList(t *testing.T) {
 		if target.Amount != 99 {
 			t.Errorf("Amount %v does not match expected value\n", target.Amount)
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 
 	for i := 0; i < runs; i++ {

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -186,29 +186,17 @@ func (c Client) List(params *stripe.RecipientListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Recipients.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Recipient, error) {
-	r, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return r.(*stripe.Recipient), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Recipient returns the most recent Recipient
+// visited by a call to Next.
+func (i *Iter) Recipient() *stripe.Recipient {
+	return i.Current().(*stripe.Recipient)
 }
 
 func getC() Client {

--- a/recipient/client_test.go
+++ b/recipient/client_test.go
@@ -161,19 +161,16 @@ func TestRecipientList(t *testing.T) {
 	}
 
 	i := List(nil)
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if target == nil {
+	for i.Next() {
+		if i.Recipient() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 }

--- a/refund/client.go
+++ b/refund/client.go
@@ -100,29 +100,17 @@ func (c Client) List(params *stripe.RefundListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Refunds.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Refund, error) {
-	r, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return r.(*stripe.Refund), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Refund returns the most recent Refund
+// visited by a call to Next.
+func (i *Iter) Refund() *stripe.Refund {
+	return i.Current().(*stripe.Refund)
 }
 
 func getC() Client {

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -126,12 +126,8 @@ func TestRefundList(t *testing.T) {
 	}
 
 	i := List(&stripe.RefundListParams{Charge: ch.ID})
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
+	for i.Next() {
+		target := i.Refund()
 
 		if target.Amount != 200 {
 			t.Errorf("Amount %v does not match expected value\n", target.Amount)
@@ -144,5 +140,8 @@ func TestRefundList(t *testing.T) {
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 }

--- a/sub/client.go
+++ b/sub/client.go
@@ -178,29 +178,17 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Subs.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Sub, error) {
-	s, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return s.(*stripe.Sub), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Sub returns the most recent Sub
+// visited by a call to Next.
+func (i *Iter) Sub() *stripe.Sub {
+	return i.Current().(*stripe.Sub)
 }
 
 func getC() Client {

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -287,20 +287,17 @@ func TestSubscriptionList(t *testing.T) {
 	}
 
 	i := List(&stripe.SubListParams{Customer: cust.ID})
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if target == nil {
+	for i.Next() {
+		if i.Sub() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 
 	customer.Del(cust.ID)

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -187,29 +187,17 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 	})}
 }
 
-// Iter is a iterator for list responses.
+// Iter is an iterator for lists of Transfers.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
 type Iter struct {
-	Iter *stripe.Iter
+	*stripe.Iter
 }
 
-// Next returns the next value in the list.
-func (i *Iter) Next() (*stripe.Transfer, error) {
-	t, err := i.Iter.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	return t.(*stripe.Transfer), err
-}
-
-// Stop returns true if there are no more iterations to be performed.
-func (i *Iter) Stop() bool {
-	return i.Iter.Stop()
-}
-
-// Meta returns the list metadata.
-func (i *Iter) Meta() *stripe.ListMeta {
-	return i.Iter.Meta()
+// Transfer returns the most recent Transfer
+// visited by a call to Next.
+func (i *Iter) Transfer() *stripe.Transfer {
+	return i.Current().(*stripe.Transfer)
 }
 
 func getC() Client {

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -186,20 +186,17 @@ func TestTransferList(t *testing.T) {
 	}
 
 	i := List(&stripe.TransferListParams{Recipient: rec.ID})
-	for !i.Stop() {
-		target, err := i.Next()
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if target == nil {
+	for i.Next() {
+		if i.Transfer() == nil {
 			t.Error("No nil values expected")
 		}
 
 		if i.Meta() == nil {
 			t.Error("No metadata returned")
 		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
 	}
 
 	recipient.Del(rec.ID)


### PR DESCRIPTION
This change alters the design and behavior to be more
consistent with the standard library. Method Step
(returning bool and used in the for loop test) does the
work of fetching new items. Method Current doesn't
advance the iterator; it just returns the current item.

Also add tests and documentation to explicitly describe
side effects.

fixes #29
