### PR TITLE
Include email token parameter in requests

### DIFF
--- a/token/client.go
+++ b/token/client.go
@@ -42,6 +42,10 @@ func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
 		return nil, err
 	}
 
+	if len(params.Email) > 0 {
+		body.Add("email", params.Email)
+	}
+
 	params.AppendTo(body)
 
 	tok := &stripe.Token{}


### PR DESCRIPTION
I included this as a valid param but apparently never wrote the code to include it in requests...

r? @cosn 
