### PR TITLE
Add a default timeout of 80 seconds for API requests.

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -65,7 +65,7 @@ func SetDebug(value bool) {
 // GetBackend returns the currently used backend in the binding.
 func GetBackend() Backend {
 	if backend == nil {
-		backend = NewInternalBackend(&http.Client{Timeout: 80}, "")
+		backend = NewInternalBackend(&http.Client{Timeout: 80 * time.Second}, "")
 	}
 
 	return backend

--- a/stripe.go
+++ b/stripe.go
@@ -23,6 +23,11 @@ const apiversion = "2014-11-20"
 // clientversion is the binding version
 const clientversion = "2.0.0"
 
+// Default timeout on the http.Client used by the bindings.
+// This is chosen to be consistent with the other Stripe language bindings and
+// to coordinate with other timeouts configured in the Stripe infrastructure.
+const defaultHTTPTimeout = 80 * time.Second
+
 // Backend is an interface for making calls against a Stripe service.
 // This interface exists to enable mocking for during testing if needed.
 type Backend interface {
@@ -65,7 +70,7 @@ func SetDebug(value bool) {
 // GetBackend returns the currently used backend in the binding.
 func GetBackend() Backend {
 	if backend == nil {
-		backend = NewInternalBackend(&http.Client{Timeout: 80 * time.Second}, "")
+		backend = NewInternalBackend(&http.Client{Timeout: defaultHTTPTimeout}, "")
 	}
 
 	return backend

--- a/stripe.go
+++ b/stripe.go
@@ -65,7 +65,7 @@ func SetDebug(value bool) {
 // GetBackend returns the currently used backend in the binding.
 func GetBackend() Backend {
 	if backend == nil {
-		backend = NewInternalBackend(http.DefaultClient, "")
+		backend = NewInternalBackend(&http.Client{Timeout: 80}, "")
 	}
 
 	return backend


### PR DESCRIPTION
The `http.DefaultClient` has no timeout on requests. In our other bindings, we set an 80 second timeout. AFAIK this particular value is tied to a considered funnel of timeouts that works back through our systems.

r? @cosn 
