### PR TITLE
Add Token support to BankAccountParams

### DIFF
--- a/recipient.go
+++ b/recipient.go
@@ -34,7 +34,7 @@ type RecipientListParams struct {
 
 // BankAccountParams is the set of parameters that can be used when creating or updating a bank account.
 type BankAccountParams struct {
-	Country, Routing, Account string
+	Token, Country, Routing, Account string
 }
 
 // Recipient is the resource representing a Stripe recipient.

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -36,7 +36,9 @@ func (c Client) New(params *stripe.RecipientParams) (*stripe.Recipient, error) {
 		"type": {string(params.Type)},
 	}
 
-	if params.Bank != nil {
+	if params.Bank != nil && len(params.Bank.Token) > 0 {
+		body.Add("bank_account", params.Bank.Token)
+	} else if params.Bank != nil {
 		params.Bank.AppendDetails(body)
 	}
 


### PR DESCRIPTION
This commit adds `Token` support to BankAccountParams.

Fix #62 