### PR TITLE
Support adding arbitrary key-value params to Stripe requests.

### DIFF
--- a/params.go
+++ b/params.go
@@ -18,6 +18,7 @@ const (
 type Params struct {
 	Exp            []string
 	Meta           map[string]string
+	Extra          url.Values
 	IdempotencyKey string
 }
 
@@ -74,6 +75,15 @@ func (p *Params) AddMeta(key, value string) {
 	p.Meta[key] = value
 }
 
+// AddExtra adds a new arbitrary key-value pair to the request data
+func (p *Params) AddExtra(key, value string) {
+	if p.Extra == nil {
+		p.Extra = make(url.Values)
+	}
+
+	p.Extra.Add(key, value)
+}
+
 // AddFilter adds a new filter with a given key, op and value.
 func (f *Filters) AddFilter(key, op, value string) {
 	filter := &filter{Key: key, Op: op, Val: value}
@@ -88,6 +98,12 @@ func (p *Params) AppendTo(body *url.Values) {
 
 	for _, v := range p.Exp {
 		body.Add("expand[]", v)
+	}
+
+	for k, vs := range p.Extra {
+		for _, v := range vs {
+			body.Add(k, v)
+		}
 	}
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,43 @@
+package stripe_test
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	stripe "github.com/stripe/stripe-go"
+)
+
+func TestParamsWithExtras(t *testing.T) {
+	testCases := []struct {
+		InitialBody  url.Values
+		Extras       [][2]string
+		ExpectedBody url.Values
+	}{
+		{
+			InitialBody:  url.Values{"foo": {"bar"}},
+			Extras:       [][2]string{},
+			ExpectedBody: url.Values{"foo": {"bar"}},
+		},
+		{
+			InitialBody:  url.Values{"foo": {"bar"}},
+			Extras:       [][2]string{{"foo", "baz"}, {"other", "thing"}},
+			ExpectedBody: url.Values{"foo": {"bar", "baz"}, "other": {"thing"}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		p := stripe.Params{}
+
+		for _, extra := range testCase.Extras {
+			p.AddExtra(extra[0], extra[1])
+		}
+
+		body := testCase.InitialBody
+		p.AppendTo(&body)
+
+		if !reflect.DeepEqual(body, testCase.ExpectedBody) {
+			t.Fatalf("Expected body of %v but got %v.", testCase.ExpectedBody, body)
+		}
+	}
+}


### PR DESCRIPTION
This adds the ability to include arbitrary key-value parameters in requests using the new `AddExtra` method on the `Params` type. This allows for cases where we're beta testing new parameters in the API but haven't documented them for public release.

A couple explicit decisions that are worth calling out:
* I have no idea if `Extra` is the right name here -- totally open to suggestions.
* We had discussed using a `map[string]interface{}` type for this at one point but I actually don't think this works well. There is no sense of type in URL parameters so short of writing our own serialization (ala https://github.com/google/go-querystring) we can't accept arbitrary types.
* There are no functional tests of this capability since that would either (a) depend on a transient beta feature in the API or (b) confusingly duplicate a parameter like `amount` that's already available as a static type.

r? @cosn 