### PR TITLE
Add Event.EventData() function - returns interface{} that represents the correct type of the event data object.

### DIFF
--- a/event/client_test.go
+++ b/event/client_test.go
@@ -70,6 +70,20 @@ func TestEvent(t *testing.T) {
 			val = target.Data.Obj["source"].(map[string]interface{})["currency"].(string)
 		}
 
+		if charge, ok := e.EventData().(*stripe.Charge); ok {
+			if charge.Source.Type == stripe.PaymentSourceCard {
+				if charge.Source.Card.LastFour != val {
+					t.Errorf("Value %q does not match expected value %q\n", charge.Source.Card.LastFour, val)
+				}
+			} else if charge.Source.Type == stripe.PaymentSourceBitcoinReceiver {
+				if string(charge.Source.BitcoinReceiver.Currency) != val {
+					t.Errorf("Value %q does not match expected value %q\n", charge.Source.BitcoinReceiver.Currency, val)
+				}
+			}
+		} else {
+			t.Errorf("Source object was a charge, but failed to unmarshal into *stripe.Charge")
+		}
+
 		if targetVal != val {
 			t.Errorf("Value %q does not match expected value %q\n", targetVal, val)
 		}


### PR DESCRIPTION
Currently, when receiving events you have to either unmarshal the Raw data for yourself or use the `Event.GetObjValue(keys...)` function. For us it was just easier to have the library handle this for us.

Assumptions:

1.) If the `EventData.UnmarshalJSON` does not return an error, `Event.EventData()` will not return a JSON failure. (If it does there is a mismatch between the client library and the server which likely means the client library has to be upgraded - but I'm assuming if this isn't the case, you have some malformed data that  `EventData.UnmarshalJSON` would have caught). This assumption provides the motivation for not returning `error` in `Event.EventData()`.

2.) Events follow the format of `resource.action`, exceptions are `ping` (not sure how to handle this), and the `bitcoin.receiver` set of events (it seems these should be `bitcoin_receiver`, like `application_fee`). The `parseEventType` should be kept up to date, but if it isn't, it will return a `map[string]interface{}` much like the `EventData.Obj` (A user should assume that if the go type exists, it won't return `map[string]interface{}` I guess).

Usage:

```go
for i.Next() {
	e := i.Event()
	// You can only care about Charge events, ok will be false for other events.
	if charge, ok := e.EventData().(*stripe.Charge); ok {
		// do things with Charge Object.
	} else if card, ok := e.EventData().(*stripe.Card); ok {
		// do things with Card
	}
}
```

The changes should be backwards compatible - and tests are included under event that extend the current ones.