### PR TITLE
Add custom MarshalJSON method to PaymentSource, so it accurately represents the JSON rep. of its type

### DIFF
--- a/payment_source.go
+++ b/payment_source.go
@@ -137,3 +137,33 @@ func (s *PaymentSource) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// MarshalJSON handles serialization of a PaymentSource.
+// This custom marshaling is needed because the specific type
+// of payment instrument it represents is specified by the PaymentSourceType
+func (s *PaymentSource) MarshalJSON() ([]byte, error) {
+	var target interface{}
+
+	switch s.Type {
+	case PaymentSourceBitcoinReceiver:
+		target = struct {
+			Type PaymentSourceType `json:"object"`
+			*BitcoinReceiver
+		}{
+			Type:            s.Type,
+			BitcoinReceiver: s.BitcoinReceiver,
+		}
+	case PaymentSourceCard:
+		target = struct {
+			Type     PaymentSourceType `json:"object"`
+			Customer string            `json:"customer"`
+			*Card
+		}{
+			Type:     s.Type,
+			Customer: s.Card.Customer.ID,
+			Card:     s.Card,
+		}
+	}
+
+	return json.Marshal(target)
+}

--- a/payment_source.go
+++ b/payment_source.go
@@ -142,6 +142,7 @@ func (s *PaymentSource) UnmarshalJSON(data []byte) error {
 // This custom marshaling is needed because the specific type
 // of payment instrument it represents is specified by the PaymentSourceType
 func (s *PaymentSource) MarshalJSON() ([]byte, error) {
+	type source PaymentSource
 	var target interface{}
 
 	switch s.Type {
@@ -163,6 +164,8 @@ func (s *PaymentSource) MarshalJSON() ([]byte, error) {
 			Customer: s.Card.Customer.ID,
 			Card:     s.Card,
 		}
+	default:
+		target = source(*s)
 	}
 
 	return json.Marshal(target)

--- a/payment_source.go
+++ b/payment_source.go
@@ -142,7 +142,6 @@ func (s *PaymentSource) UnmarshalJSON(data []byte) error {
 // This custom marshaling is needed because the specific type
 // of payment instrument it represents is specified by the PaymentSourceType
 func (s *PaymentSource) MarshalJSON() ([]byte, error) {
-	type source PaymentSource
 	var target interface{}
 
 	switch s.Type {
@@ -164,8 +163,8 @@ func (s *PaymentSource) MarshalJSON() ([]byte, error) {
 			Customer: s.Card.Customer.ID,
 			Card:     s.Card,
 		}
-	default:
-		target = source(*s)
+	case "":
+		target = s.ID
 	}
 
 	return json.Marshal(target)

--- a/payment_source.go
+++ b/payment_source.go
@@ -2,16 +2,16 @@ package stripe
 
 import (
 	"encoding/json"
-	"net/url"
 	"errors"
 	"fmt"
+	"net/url"
 )
 
 // SourceParams is a union struct used to describe an
 // arbitrary payment source.
 type SourceParams struct {
-	Token	string
-	Card	*CardParams
+	Token string
+	Card  *CardParams
 }
 
 // AppendDetails adds the source's details to the query string values.
@@ -31,12 +31,12 @@ func (sp *SourceParams) AppendDetails(values *url.Values, creating bool) {
 type CustomerSourceParams struct {
 	Params
 	Customer string
-	Source *SourceParams
+	Source   *SourceParams
 }
 
 // SetSource adds valid sources to a CustomerSourceParams object,
 // returning an error for unsupported sources.
-func (cp *CustomerSourceParams) SetSource(sp interface{}) (error) {
+func (cp *CustomerSourceParams) SetSource(sp interface{}) error {
 	source, err := SourceParamsFor(sp)
 	cp.Source = source
 	return err
@@ -52,16 +52,16 @@ func SourceParamsFor(obj interface{}) (*SourceParams, error) {
 	var sp *SourceParams
 	var err error
 	switch p := obj.(type) {
-		case *CardParams:
-			sp = &SourceParams{
-				Card: p,
-			}
-		case string:
-			sp = &SourceParams{
-				Token: p,
-			}
-		default:
-			err = errors.New(fmt.Sprintf("Unsupported source type %s", p))
+	case *CardParams:
+		sp = &SourceParams{
+			Card: p,
+		}
+	case string:
+		sp = &SourceParams{
+			Token: p,
+		}
+	default:
+		err = errors.New(fmt.Sprintf("Unsupported source type %s", p))
 	}
 	return sp, err
 }


### PR DESCRIPTION
This PR adds a custom `MarshalJSON` method to `PaymentSource`. Now when the `PaymentSource` object is marshaled, it will represent the same JSON object that it was presented with.

Code:
```
//...
var customer Customer
//...
return json.Marshal(customer)
```

Before Output:
```json
"customer": {
  "id": "djndfjkngknjgnkjfnkg",
  "sources": {
    "data": [
      {
        "object": "card",
        "id": "card_5wey6SaMFjuRx6"
      }
    ]
  }
}
```

After Output:
```json
"customer": {
  "id": "djndfjkngknjgnkjfnkg",
  "sources": {
    "data": [
      {
        "object": "card",
        "customer": "djndfjkngknjgnkjfnkg",
        "id": "dfjvkjfnknf",
        "exp_month": 10,
        "exp_year": 2016,
        "more_keys": "more_values"
      }
    ]
  }
}
```

This fixes #88 

**Edit:** I did some work handling the third case of the switch statement, where the type isn't a `PaymentSourceBitcoinReceiver` or `PaymentSourceCard`. I thought it was alright if we just fell back to the default, but that didn't really produce a clean output either. However, looking at the way `UnmarshalJSON` works, it seems pretty confident it's type is either `PaymentSourceBitcoinReceiver`, `PaymentSourceCard` or an id string. Based on this, I felt that just marshaling the raw string is the best option. Internally, you guys might have other ideas.