### PR TITLE
Adding Deleted field to Customer

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -47,6 +47,7 @@ type Customer struct {
 	Email         string            `json:"email"`
 	Meta          map[string]string `json:"metadata"`
 	Subs          *SubList          `json:"subscriptions"`
+	Deleted       bool              `json:"deleted"`
 }
 
 // UnmarshalJSON handles deserialization of a Customer.

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -16,8 +16,8 @@ func init() {
 func TestCustomerNew(t *testing.T) {
 	customerParams := &stripe.CustomerParams{
 		Balance: -123,
-		Desc:  "Test Customer",
-		Email: "a@b.com",
+		Desc:    "Test Customer",
+		Email:   "a@b.com",
 	}
 	customerParams.SetSource(&stripe.CardParams{
 		Name:   "Test Card",
@@ -88,13 +88,22 @@ func TestCustomerDel(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	target, err := Get(res.ID, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if target.Deleted != true {
+		t.Errorf("Customer id %q expected to be marked as deleted\n", target.ID)
+	}
 }
 
 func TestCustomerUpdate(t *testing.T) {
 	customerParams := &stripe.CustomerParams{
 		Balance: 7,
-		Desc:  "Original Desc",
-		Email: "first@b.com",
+		Desc:    "Original Desc",
+		Email:   "first@b.com",
 	}
 	customerParams.SetSource(&stripe.CardParams{
 		Number: "378282246310005",
@@ -106,13 +115,14 @@ func TestCustomerUpdate(t *testing.T) {
 
 	updated := &stripe.CustomerParams{
 		Balance: -10,
-		Desc:  "Updated Desc",
-		Email: "desc@b.com",
+		Desc:    "Updated Desc",
+		Email:   "desc@b.com",
 	}
 	updated.SetSource(&stripe.CardParams{
 		Number: "4242424242424242",
 		Month:  "10",
 		Year:   "20",
+		CVC:    "123",
 	})
 
 	target, err := Update(original.ID, updated)


### PR DESCRIPTION
When you retrieve a customer that has been deleted, the Stripe API returns a property 'deleted' along with a subset of the Customer details. That is missing from Customer struct so I am adding it here along with a test. 

I also fixed an existing test (TestCustomerUpdate) that was failing because no CVC was supplied with CardParams. 

Some formatting fixes too. 

This fixes the issue I raised - https://github.com/stripe/stripe-go/issues/95