### PR TITLE
Rename deprecated customer param value

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -13,7 +13,7 @@ type CustomerParams struct {
 	Plan          string
 	Quantity      uint64
 	TrialEnd      int64
-	DefaultCard   string
+	DefaultSource string
 }
 
 // SetSource adds valid sources to a CustomerParams object,

--- a/customer/client.go
+++ b/customer/client.go
@@ -124,8 +124,8 @@ func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Custom
 			body.Add("email", params.Email)
 		}
 
-		if len(params.DefaultCard) > 0 {
-			body.Add("default_card", params.DefaultCard)
+		if len(params.DefaultSource) > 0 {
+			body.Add("default_source", params.DefaultSource)
 		}
 		params.AppendTo(body)
 	}


### PR DESCRIPTION
The API was updated on [2015-02-18](https://stripe.com/docs/upgrades#2015-02-18) to remove the old Card and DefaultCard
parameters, in favour of Source and DefaultSource.

The codebase was updated in https://github.com/stripe/stripe-go/commit/43e56d28015faea5136409a86cad1664fb321c23 to reflect the new
changes to the API, but the customer params did not get updated at that
time.

This relates to #101.