### PR TITLE
Add missing field on subscription params

### DIFF
--- a/sub.go
+++ b/sub.go
@@ -15,6 +15,7 @@ type SubParams struct {
 	TrialEnd                                        int64
 	Card                                            *CardParams
 	Quantity                                        uint64
+	ProrationDate                                   int64
 	FeePercent, TaxPercent                          float64
 	NoProrate, EndCancel, QuantityZero, TrialEndNow bool
 }

--- a/sub/client.go
+++ b/sub/client.go
@@ -65,6 +65,10 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 		body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
 	}
 
+	if params.ProrationDate > 0 {
+		body.Add("proration_date", strconv.FormatInt(params.ProrationDate, 10))
+	}
+
 	params.AppendTo(body)
 
 	sub := &stripe.Sub{}


### PR DESCRIPTION
Per the documentation, there's a 'proration_date' field that lets the caller
override the default proration date:
https://stripe.com/docs/api#update_subscription

I wasn't sure what the best way to test this was. If you have any suggestions, I'm happy to update the PR.