### PR TITLE
account: Adds new support/business fields

### DIFF
--- a/account.go
+++ b/account.go
@@ -36,12 +36,13 @@ const (
 // AccountParams are the parameters allowed during account creation/updates.
 type AccountParams struct {
 	Params
-	Country, Email, DefaultCurrency, Statement, BusinessName, SupportPhone string
-	LegalEntity                                                            *LegalEntity
-	TransferSchedule                                                       *TransferScheduleParams
-	Managed                                                                bool
-	BankAccount                                                            *BankAccountParams
-	TOSAcceptance                                                          *TOSAcceptanceParams
+	Country, Email, DefaultCurrency, Statement, BusinessName, BusinessUrl,
+	BusinessPrimaryColor, SupportPhone, SupportEmail, SupportUrl string
+	LegalEntity      *LegalEntity
+	TransferSchedule *TransferScheduleParams
+	Managed          bool
+	BankAccount      *BankAccountParams
+	TOSAcceptance    *TOSAcceptanceParams
 }
 
 // AccountListParams are the parameters allowed during account listing.
@@ -57,27 +58,31 @@ type TransferScheduleParams struct {
 	MinimumDelay       bool
 }
 
-// Account is the resource representing youe Stripe account.
+// Account is the resource representing your Stripe account.
 // For more details see https://stripe.com/docs/api/#account.
 type Account struct {
 	ID             string `json:"id"`
 	ChargesEnabled bool   `json:"charges_enabled"`
 	Country        string `json:"country"`
 	// Currencies is the list of supported currencies.
-	Currencies       []string `json:"currencies_supported"`
-	DefaultCurrency  string   `json:"default_currency"`
-	DetailsSubmitted bool     `json:"details_submitted"`
-	TransfersEnabled bool     `json:"transfers_enabled"`
-	Name             string   `json:"display_name"`
-	Email            string   `json:"email"`
-	Statement        string   `json:"statement_descriptor"`
-	Timezone         string   `json:"timezone"`
-	BusinessName     string   `json:"business_name"`
-	SupportPhone     string   `json:"support_phone"`
-	ProductDesc      string   `json:"product_description"`
-	Managed          bool     `json:"managed"`
-	DebitNegativeBal bool     `json:"debit_negative_balances"`
-	Keys             *struct {
+	Currencies           []string `json:"currencies_supported"`
+	DefaultCurrency      string   `json:"default_currency"`
+	DetailsSubmitted     bool     `json:"details_submitted"`
+	TransfersEnabled     bool     `json:"transfers_enabled"`
+	Name                 string   `json:"display_name"`
+	Email                string   `json:"email"`
+	Statement            string   `json:"statement_descriptor"`
+	Timezone             string   `json:"timezone"`
+	BusinessName         string   `json:"business_name"`
+	BusinessPrimaryColor string   `json:"business_primary_color"`
+	BusinessUrl          string   `json:"business_url"`
+	SupportPhone         string   `json:"support_phone"`
+	SupportEmail         string   `json:"support_email"`
+	SupportUrl           string   `json:"support_url"`
+	ProductDesc          string   `json:"product_description"`
+	Managed              bool     `json:"managed"`
+	DebitNegativeBal     bool     `json:"debit_negative_balances"`
+	Keys                 *struct {
 		Secret  string `json:"secret"`
 		Publish string `json:"publishable"`
 	} `json:"keys"`

--- a/account/client.go
+++ b/account/client.go
@@ -19,15 +19,9 @@ func New(params *stripe.AccountParams) (*stripe.Account, error) {
 	return getC().New(params)
 }
 
-func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
-	body := &url.Values{
-		"managed": {strconv.FormatBool(params.Managed)},
-	}
-
-	if len(params.Country) > 0 {
-		body.Add("country", params.Country)
-	}
-
+func writeAccountParams(
+	params *stripe.AccountParams, body *url.Values,
+) {
 	if len(params.Email) > 0 {
 		body.Add("email", params.Email)
 	}
@@ -44,8 +38,24 @@ func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 		body.Add("business_name", params.BusinessName)
 	}
 
+	if len(params.BusinessPrimaryColor) > 0 {
+		body.Add("business_primary_color", params.BusinessPrimaryColor)
+	}
+
+	if len(params.BusinessUrl) > 0 {
+		body.Add("business_url", params.BusinessUrl)
+	}
+
 	if len(params.SupportPhone) > 0 {
 		body.Add("support_phone", params.SupportPhone)
+	}
+
+	if len(params.SupportEmail) > 0 {
+		body.Add("support_email", params.SupportEmail)
+	}
+
+	if len(params.SupportUrl) > 0 {
+		body.Add("support_url", params.SupportUrl)
 	}
 
 	if params.LegalEntity != nil {
@@ -59,6 +69,14 @@ func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 	if params.BankAccount != nil {
 		params.BankAccount.AppendDetails(body)
 	}
+}
+
+func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
+	body := &url.Values{
+		"managed": {strconv.FormatBool(params.Managed)},
+	}
+
+	writeAccountParams(params, body)
 
 	if params.TOSAcceptance != nil {
 		params.TOSAcceptance.AppendDetails(body)
@@ -118,37 +136,7 @@ func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account
 		commonParams = &params.Params
 		body = &url.Values{}
 
-		if len(params.Email) > 0 {
-			body.Add("email", params.Email)
-		}
-
-		if len(params.DefaultCurrency) > 0 {
-			body.Add("default_currency", params.DefaultCurrency)
-		}
-
-		if len(params.Statement) > 0 {
-			body.Add("statement_descriptor", params.Statement)
-		}
-
-		if len(params.BusinessName) > 0 {
-			body.Add("business_name", params.BusinessName)
-		}
-
-		if len(params.SupportPhone) > 0 {
-			body.Add("support_phone", params.SupportPhone)
-		}
-
-		if params.LegalEntity != nil {
-			params.LegalEntity.AppendDetails(body)
-		}
-
-		if params.TransferSchedule != nil {
-			params.TransferSchedule.AppendDetails(body)
-		}
-
-		if params.BankAccount != nil {
-			params.BankAccount.AppendDetails(body)
-		}
+		writeAccountParams(params, body)
 
 		params.AppendTo(body)
 	}

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -13,8 +13,14 @@ func init() {
 
 func TestAccountNew(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
-		Country: "CA",
+		Managed:              true,
+		Country:              "CA",
+		BusinessUrl:          "www.stripe.com",
+		BusinessName:         "Stripe",
+		BusinessPrimaryColor: "#ffffff",
+		SupportEmail:         "foo@bar.com",
+		SupportUrl:           "www.stripe.com",
+		SupportPhone:         "4151234567",
 		LegalEntity: &stripe.LegalEntity{
 			Type:         stripe.Individual,
 			BusinessName: "Stripe Go",
@@ -97,5 +103,29 @@ func TestAccountGet(t *testing.T) {
 
 	if len(target.Timezone) == 0 {
 		t.Errorf("Account is missing timezone\n")
+	}
+
+	if len(target.BusinessName) == 0 {
+		t.Errorf("Account is missing business name\n")
+	}
+
+	if len(target.BusinessPrimaryColor) == 0 {
+		t.Errorf("Account is missing business primary color\n")
+	}
+
+	if len(target.BusinessUrl) == 0 {
+		t.Errorf("Account is missing business URL\n")
+	}
+
+	if len(target.SupportPhone) == 0 {
+		t.Errorf("Account is missing support phone\n")
+	}
+
+	if len(target.SupportEmail) == 0 {
+		t.Errorf("Account is missing support email\n")
+	}
+
+	if len(target.SupportUrl) == 0 {
+		t.Errorf("Account is missing support URL\n")
 	}
 }


### PR DESCRIPTION
We recently documented a few support/business fields at `/v1/account` (see [here](https://stripe.com/docs/api#update_account)) and this adds a few new fields: `business_primary_color`, `business_url`, `support_email`, and `support_url`. Let me know if any changes need to be made.

r? @cosn 