### PR TITLE
Bump to 6.4.2 and append to CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+6.4.2 2015-06-23
+	Add BusinessUrl, BusinessUrl, BusinessPrimaryColor, SupportEmail, and
+	SupportUrl to Account.
+
 6.4.1 2015-06-16
 	Change card.dynamic_last_four to card.dynamic_last4
 

--- a/stripe.go
+++ b/stripe.go
@@ -23,7 +23,7 @@ const (
 const apiversion = "2015-04-07"
 
 // clientversion is the binding version
-const clientversion = "6.4.1"
+const clientversion = "6.4.2"
 
 // defaultHTTPTimeout is the default timeout on the http.Client used by the library.
 // This is chosen to be consistent with the other Stripe language libraries and


### PR DESCRIPTION
Follow up from https://github.com/stripe/stripe-go/pull/111, I realized we need to bump the `clientversion`, added pertinent bits to the `CHANGELOG` as well.

r? @cosn 