### PR TITLE
Update bank account creation API.

### DIFF
--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -28,15 +28,22 @@ func New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 }
 
 func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
-	body := &url.Values{
-		"country":        {params.Country},
-		"account_number": {params.Account},
-		"routing_number": {params.Routing},
-		"currency":       {params.Currency},
-	}
 
-	if params.Default {
-		body.Add("default_for_currency", strconv.FormatBool(params.Default))
+	body := &url.Values{}
+
+	// Use token (if exists) or a dictionary containing a user’s bank account details.
+	if len(params.Token) > 0 {
+		body.Add("external_account", params.Token)
+	} else {
+		body.Add("external_account[object]", "bank_account")
+		body.Add("external_account[country]", params.Country)
+		body.Add("external_account[account_number]", params.Account)
+		body.Add("external_account[routing_number]", params.Routing)
+		body.Add("external_account[currency]", params.Currency)
+
+		if params.Default {
+			body.Add("external_account[default_for_currency]", strconv.FormatBool(params.Default))
+		}
 	}
 	params.AppendTo(body)
 


### PR DESCRIPTION
Pass **token** or **dictionary** containing a user’s bank account details as
value for `external_account`.

Please see https://stripe.com/docs/api/go#create_bank_account for reference.