### PR TITLE
Add request ID to Stripe errors

### DIFF
--- a/client/error_test.go
+++ b/client/error_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/stripe/stripe-go"
@@ -20,6 +21,10 @@ func TestErrors(t *testing.T) {
 
 	if stripeErr.Type != InvalidRequest {
 		t.Errorf("Type %v does not match expected type\n", stripeErr.Type)
+	}
+
+	if !strings.HasPrefix("req_", stripeErr.RequestID) {
+		t.Errorf("Request ID %v does not start with 'req_'\n", stripeErr.RequestID)
 	}
 
 	if stripeErr.HTTPStatusCode != 401 {

--- a/error.go
+++ b/error.go
@@ -38,6 +38,7 @@ type Error struct {
 	Msg            string    `json:"message"`
 	Code           ErrorCode `json:"code,omitempty"`
 	Param          string    `json:"param,omitempty"`
+	RequestID      string    `json:"request_id,omitempty"`
 	HTTPStatusCode int       `json:"-"`
 }
 

--- a/stripe.go
+++ b/stripe.go
@@ -244,6 +244,7 @@ func (s *BackendConfiguration) Do(req *http.Request, v interface{}) error {
 				Type:           ErrorType(root["type"].(string)),
 				Msg:            root["message"].(string),
 				HTTPStatusCode: res.StatusCode,
+				RequestID:      res.Header.Get("Request-Id"),
 			}
 
 			if code, found := root["code"]; found {


### PR DESCRIPTION
While request IDs are never in the Stripe error JSON, I added the
`json:"request_id"` so that the ID will show up when the error is printed.