### PR TITLE
Send "country" when creating or updating an account.

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -26,6 +26,11 @@ func writeAccountParams(
 		body.Add("email", params.Email)
 	}
 
+	// Country.
+	if len(params.Country) > 0 {
+		body.Add("country", params.Country)
+	}
+
 	if len(params.DefaultCurrency) > 0 {
 		body.Add("default_currency", params.DefaultCurrency)
 	}


### PR DESCRIPTION
Pass `country` argument, if provided. This is an optional argument to **POST** `https://api.stripe.com/v1/accounts`.

Please see https://stripe.com/docs/api#create_account.