### PR TITLE
Fix marshalling error of Transfer value, when creating a Charge with Stripe connect.

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -81,7 +81,7 @@ type Charge struct {
 	Shipping       *ShippingDetails  `json:"shipping"`
 	Dest           *Account          `json:"destination"`
 	Fee            *Fee              `json:"application_fee"`
-	Transfer       string            `json:"transfer"`
+	Transfer       *Transfer         `json:"transfer"`
 }
 
 // FraudDetails is the structure detailing fraud status.

--- a/charge.go
+++ b/charge.go
@@ -81,7 +81,7 @@ type Charge struct {
 	Shipping       *ShippingDetails  `json:"shipping"`
 	Dest           *Account          `json:"destination"`
 	Fee            *Fee              `json:"application_fee"`
-	Transfer       *Transfer         `json:"transfer"`
+	Transfer       string            `json:"transfer"`
 }
 
 // FraudDetails is the structure detailing fraud status.

--- a/transfer.go
+++ b/transfer.go
@@ -1,5 +1,7 @@
 package stripe
 
+import "encoding/json"
+
 // TransferStatus is the list of allowed values for the transfer's status.
 // Allowed values are "paid", "pending", "failed", "canceled".
 type TransferStatus string
@@ -54,4 +56,21 @@ type Transfer struct {
 	Recipient *Recipient        `json:"recipient"`
 	Statement string            `json:"statement_descriptor"`
 	Reversals *ReversalList     `json:"reversals"`
+}
+
+// UnmarshalJSON handles deserialization of a Transfer.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (t *Transfer) UnmarshalJSON(data []byte) error {
+	type transfer Transfer
+	var tb transfer
+	err := json.Unmarshal(data, &tb)
+	if err == nil {
+		*t = Transfer(tb)
+	} else {
+		// the id is surrounded by "\" characters, so strip them
+		t.ID = string(data[1 : len(data)-1])
+	}
+
+	return nil
 }


### PR DESCRIPTION
We have been getting unmarshalling failure on Charges with a Transfer attribute within them.

The "transfer" returned in the Charge response is an ID string, NOT a marshalled Transfer struct.

Example of response from API:

transfer: "tr_16OUxc2pKrqcgQOlXCWTvigk"

Example of unmarshalled stripe.Charge:

stripe.Charge{ID:"\n  \"id\": \"ch_16OUxc2pKrqcgQOlafUGNmP4\",\n  \"object\": \"charge\",\n  \"created\": 1436886284,\n  \"livemode\": false,\n  \"paid\": true,\n  \"status\": \"succeeded\",\n  \"amount\": 1234,\n  \"currency\": \"gbp\",\n  \"refunded\": false,\n  \"source\": {\n    \"id\": \"card_16MzBJ2pKrqcgQOltgAMyQj0\",\n    \"object\": \"card\",\n    \"last4\": \"4242\",\n    \"brand\": \"Visa\",\n    \"funding\": \"credit\",\n    \"exp_month\": 12,\n    \"exp_year\": 2016,\n    \"fingerprint\": \"tdQFuY4RvxQICnmm\",\n    \"country\": \"US\",\n    \"name\": null,\n    \"address_line1\": null,\n    \"address_line2\": null,\n    \"address_city\": null,\n    \"address_state\": null,\n    \"address_zip\": \"W1A\",\n    \"address_country\": null,\n    \"cvc_check\": null,\n    \"address_line1_check\": null,\n    \"address_zip_check\": \"pass\",\n    \"tokenization_method\": null,\n    \"dynamic_last4\": null,\n    \"metadata\": {},\n    \"customer\": \"cus_6a9UWnifVIiiwh\"\n  },\n  \"captured\": true,\n  \"balance_transaction\": \"txn_16OUxc2pKrqcgQOl6zuWOQhJ\",\n  \"failure_message\": null,\n  \"failure_code\": null,\n  \"amount_refunded\": 0,\n  \"customer\": \"cus_6a9UWnifVIiiwh\",\n  \"invoice\": null,\n  \"description\": null,\n  \"dispute\": null,\n  \"metadata\": {},\n  \"statement_descriptor\": null,\n  \"fraud_details\": {},\n  \"transfer\": \"tr_16OUxc2pKrqcgQOlXCWTvigk\",\n  \"receipt_email\": null,\n  \"receipt_number\": null,\n  \"shipping\": null,\n  \"destination\": \"acct_16O5izBI0TFTknl3\",\n  \"application_fee\": \"fee_6biOKJBWs4CEri\",\n  \"refunds\": {\n    \"object\": \"list\",\n    \"total_count\": 0,\n    \"has_more\": false,\n    \"url\": \"/v1/charges/ch_16OUxc2pKrqcgQOlafUGNmP4/refunds\",\n    \"data\": []\n  }\n", Live:false, Amount:0x0, Captured:false, Created:0, Currency:"", Paid:false, Refunded:false, Refunds:(*stripe.RefundList)(nil), AmountRefunded:0x0, Tx:(*stripe.Transaction)(nil), Customer:(*stripe.Customer)(nil), Desc:"", Dispute:(*stripe.Dispute)(nil), FailMsg:"", FailCode:"", Invoice:(*stripe.Invoice)(nil), Meta:map[string]string(nil), Email:"", Statement:"", FraudDetails:(*stripe.FraudDetails)(nil), Status:"", Source:(*stripe.PaymentSource)(nil), Shipping:(*stripe.ShippingDetails)(nil), Dest:(*stripe.Account)(nil), Fee:(*stripe.Fee)(nil), Transfer:(*stripe.Transfer)(nil)}

As you can see most of the JSON is appearing in the Charge.ID field.

Changing the type of Transfer in Charge from *Transfer to string resolves the issue.

Not sure if this is a bug with the normal API or that fact that we are trying out the Stripe connect beta.

We are only using this in the test environment at the moment.