### PR TITLE
TOSAcceptance are not updated when account is updated

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -71,6 +71,10 @@ func writeAccountParams(
 		params.TransferSchedule.AppendDetails(body)
 	}
 
+	if params.TOSAcceptance != nil {
+		params.TOSAcceptance.AppendDetails(body)
+	}
+
 	if params.BankAccount != nil {
 		params.BankAccount.AppendDetails(body)
 	}

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -30,6 +30,11 @@ func TestAccountNew(t *testing.T) {
 				Year:  1990,
 			},
 		},
+		TOSAcceptance: &stripe.TOSAcceptanceParams{
+			IP:        "127.0.0.1",
+			Date:      1437578361,
+			UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12",
+		},
 	}
 
 	_, err := New(params)


### PR DESCRIPTION
Account is correctly updated when I set AccountParams.
However, TOSAcceptance is not updated no matter what is set.

It happens because TOSAcceptance.AppendDetails is not called in the account update.
