### PR TITLE
Use top level refund endpoints.

### DIFF
--- a/refund.go
+++ b/refund.go
@@ -20,7 +20,6 @@ type RefundParams struct {
 // For more details see https://stripe.com/docs/api#list_refunds.
 type RefundListParams struct {
 	ListParams
-	Charge string
 }
 
 // Refund is the resource representing a Stripe refund.

--- a/refund/client.go
+++ b/refund/client.go
@@ -46,10 +46,14 @@ func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 		body.Add("reason", string(params.Reason))
 	}
 
+	if len(params.Charge) > 0 {
+		body.Add("charge", string(params.Charge))
+	}
+
 	params.AppendTo(body)
 
 	refund := &stripe.Refund{}
-	err := c.B.Call("POST", fmt.Sprintf("/charges/%v/refunds", params.Charge), c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", fmt.Sprintf("/refunds"), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -61,15 +65,11 @@ func Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
-	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Charge must be set")
-	}
-
 	body := &url.Values{}
 	params.AppendTo(body)
 
 	refund := &stripe.Refund{}
-	err := c.B.Call("GET", fmt.Sprintf("/charges/%v/refunds/%v", params.Charge, id), c.Key, body, &params.Params, refund)
+	err := c.B.Call("GET", fmt.Sprintf("/refunds/%v", id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -86,7 +86,7 @@ func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, 
 	params.AppendTo(body)
 
 	refund := &stripe.Refund{}
-	err := c.B.Call("POST", fmt.Sprintf("/charges/%v/refunds/%v", params.Charge, id), c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", fmt.Sprintf("/refunds/%v", id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -106,7 +106,7 @@ func (c Client) List(params *stripe.RefundListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/charges/%v/refunds", params.Charge), c.Key, &b, nil, list)
+		err := c.B.Call("GET", fmt.Sprintf("/refunds"), c.Key, &b, nil, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {


### PR DESCRIPTION
TODO: change `beta_refunds` endpoint before merging, once non-beta endpoints have shipped.

r? @cosn 
cc @kyleconroy 

Note: I added a bunch of error raising because we noticed during debugging that a lot of things wouldn't be caught. If this is too much, let me know and I'm happy to remove.

Also - I wouldn't mind having a test to make sure that the list method works without the charge filter, but this returns a large set of results and I'm not sure verifying the size is straightforward with the returned iterator. Open to suggestions! Or I can leave as is.