### PR TITLE
Add ability to reverse transfers.

### DIFF
--- a/refund/client.go
+++ b/refund/client.go
@@ -39,7 +39,7 @@ func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	}
 
 	if params.Transfer {
-		body.Add("refund_transfer", strconv.FormatBool(params.Transfer))
+		body.Add("reverse_transfer", strconv.FormatBool(params.Transfer))
 	}
 
 	if len(params.Reason) > 0 {


### PR DESCRIPTION
The refund client was sending `refund_transfer` instead of
`reverse_transfer`. Fixes #133.