### PR TITLE
reveal HTTP status code json

### DIFF
--- a/error.go
+++ b/error.go
@@ -39,7 +39,7 @@ type Error struct {
 	Code           ErrorCode `json:"code,omitempty"`
 	Param          string    `json:"param,omitempty"`
 	RequestID      string    `json:"request_id,omitempty"`
-	HTTPStatusCode int       `json:"-"`
+	HTTPStatusCode int       `json:"status,omitempty"`
 }
 
 // Error serializes the Error object and prints the JSON string.


### PR DESCRIPTION
r? @kyleconroy 

cc @cos we want to show the HTTP status code because we now have different ones such as 401, 404, 429, etc. - was there a reason we didn't show this in the first place?