### PR TITLE
Add charge ID to errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -40,6 +40,7 @@ type Error struct {
 	Param          string    `json:"param,omitempty"`
 	RequestID      string    `json:"request_id,omitempty"`
 	HTTPStatusCode int       `json:"status,omitempty"`
+	ChargeID       string    `json:"charge,omitempty"`
 }
 
 // Error serializes the Error object and prints the JSON string.

--- a/stripe.go
+++ b/stripe.go
@@ -266,6 +266,10 @@ func (s *BackendConfiguration) Do(req *http.Request, v interface{}) error {
 				err.Param = param.(string)
 			}
 
+			if charge, found := root["charge"]; found {
+				err.ChargeID = charge.(string)
+			}
+
 			if LogLevel > 0 {
 				Logger.Printf("Error encountered from Stripe: %v\n", err)
 			}


### PR DESCRIPTION
r? @cosn Fixes #139 

```go
package main

import (
    "log"
    "os"

    "github.com/stripe/stripe-go"
    "github.com/stripe/stripe-go/charge"
)

func main() {
    stripe.Key = "sk_live_token"

    chargeParams := &stripe.ChargeParams{
        Amount:   400,
        Currency: "usd",
        Desc:     "Charge for test@example.com",
    }
    chargeParams.SetSource(&stripe.CardParams{
        Number: "4000000000000002",
        Month:  "12",
        Year:   "2020",
        CVC:    "123",
    })
    _, err := charge.New(chargeParams)
    if serr, ok := err.(*stripe.Error); ok {
        log.Println(serr.ChargeID)
    }
}
```