### PR TITLE
Add `external_account` parameter for account update requests

### DIFF
--- a/account.go
+++ b/account.go
@@ -38,6 +38,7 @@ type AccountParams struct {
 	Params
 	Country, Email, DefaultCurrency, Statement, BusinessName, BusinessUrl,
 	BusinessPrimaryColor, SupportPhone, SupportEmail, SupportUrl string
+	ExternalAccount  *BankAccountParams
 	LegalEntity      *LegalEntity
 	TransferSchedule *TransferScheduleParams
 	Managed          bool

--- a/account.go
+++ b/account.go
@@ -38,17 +38,24 @@ type AccountParams struct {
 	Params
 	Country, Email, DefaultCurrency, Statement, BusinessName, BusinessUrl,
 	BusinessPrimaryColor, SupportPhone, SupportEmail, SupportUrl string
-	ExternalAccount  *BankAccountParams
+	ExternalAccount  *AccountExternalAccountParams
 	LegalEntity      *LegalEntity
 	TransferSchedule *TransferScheduleParams
 	Managed          bool
-	BankAccount      *BankAccountParams
 	TOSAcceptance    *TOSAcceptanceParams
 }
 
 // AccountListParams are the parameters allowed during account listing.
 type AccountListParams struct {
 	ListParams
+}
+
+// AccountExternalAccountParams are the parameters allowed to reference an
+// external account when creating an account. It should either have Token set
+// or everything else.
+type AccountExternalAccountParams struct {
+	Params
+	Account, Country, Currency, Routing, Token string
 }
 
 // TransferScheduleParams are the parameters allowed for transfer schedules.

--- a/account/client.go
+++ b/account/client.go
@@ -35,6 +35,14 @@ func writeAccountParams(
 		body.Add("default_currency", params.DefaultCurrency)
 	}
 
+	if params.ExternalAccount != nil {
+		if len(params.ExternalAccount.Token) > 0 {
+			body.Add("external_account", params.ExternalAccount.Token)
+		} else if params.ExternalAccount != nil {
+			params.ExternalAccount.AppendDetails(body)
+		}
+	}
+
 	if len(params.Statement) > 0 {
 		body.Add("statement_descriptor", params.Statement)
 	}

--- a/account/client.go
+++ b/account/client.go
@@ -38,8 +38,15 @@ func writeAccountParams(
 	if params.ExternalAccount != nil {
 		if len(params.ExternalAccount.Token) > 0 {
 			body.Add("external_account", params.ExternalAccount.Token)
-		} else if params.ExternalAccount != nil {
-			params.ExternalAccount.AppendDetails(body)
+		} else {
+			body.Add("external_account[object]", "bank_account")
+			body.Add("external_account[account_number]", params.ExternalAccount.Account)
+			body.Add("external_account[country]", params.ExternalAccount.Country)
+			body.Add("external_account[currency]", params.ExternalAccount.Currency)
+
+			if len(params.ExternalAccount.Routing) > 0 {
+				body.Add("external_account[routing_number]", params.ExternalAccount.Routing)
+			}
 		}
 	}
 
@@ -81,10 +88,6 @@ func writeAccountParams(
 
 	if params.TOSAcceptance != nil {
 		params.TOSAcceptance.AppendDetails(body)
-	}
-
-	if params.BankAccount != nil {
-		params.BankAccount.AppendDetails(body)
 	}
 }
 

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -116,7 +116,7 @@ func TestAccountUpdateWithBankAccount(t *testing.T) {
 	acct, _ := New(params)
 
 	params = &stripe.AccountParams{
-		ExternalAccount: &stripe.BankAccountParams{
+		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Country: "US",
 			Routing: "110000000",
 			Account: "000123456789",
@@ -148,7 +148,7 @@ func TestAccountUpdateWithToken(t *testing.T) {
 	tok, _ := token.New(tokenParams)
 
 	params = &stripe.AccountParams{
-		ExternalAccount: &stripe.BankAccountParams{
+		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Token: tok.ID,
 		},
 	}

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/token"
 	. "github.com/stripe/stripe-go/utils"
 )
 
@@ -98,6 +99,58 @@ func TestAccountUpdate(t *testing.T) {
 
 	params = &stripe.AccountParams{
 		Statement: "Stripe Go",
+	}
+
+	_, err := Update(acct.ID, params)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAccountUpdateWithBankAccount(t *testing.T) {
+	params := &stripe.AccountParams{
+		Managed: true,
+		Country: "CA",
+	}
+
+	acct, _ := New(params)
+
+	params = &stripe.AccountParams{
+		ExternalAccount: &stripe.BankAccountParams{
+			Country: "US",
+			Routing: "110000000",
+			Account: "000123456789",
+		},
+	}
+
+	_, err := Update(acct.ID, params)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAccountUpdateWithToken(t *testing.T) {
+	params := &stripe.AccountParams{
+		Managed: true,
+		Country: "CA",
+	}
+
+	acct, _ := New(params)
+
+	tokenParams := &stripe.TokenParams{
+		Bank: &stripe.BankAccountParams{
+			Country: "US",
+			Routing: "110000000",
+			Account: "000123456789",
+		},
+	}
+
+	tok, _ := token.New(tokenParams)
+
+	params = &stripe.AccountParams{
+		ExternalAccount: &stripe.BankAccountParams{
+			Token: tok.ID,
+		},
 	}
 
 	_, err := Update(acct.ID, params)


### PR DESCRIPTION
Allows accounts to be updated with an `external_account` as defined in
the API.

I've tried to follow the pattern demonstrated in the "recipient"
resource here, but I'm not totally sure if it's fully correct.

Fixes #144.

/cc @kyleconroy Mind taking a look at this? Thanks!