### PR TITLE
Return the resource when deleting it

### DIFF
--- a/customer/client.go
+++ b/customer/client.go
@@ -138,12 +138,16 @@ func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Custom
 
 // Del removes a customer.
 // For more details see https://stripe.com/docs/api#delete_customer.
-func Del(id string) error {
+func Del(id string) (*stripe.Customer, error) {
 	return getC().Del(id)
 }
 
-func (c Client) Del(id string) error {
-	return c.B.Call("DELETE", "/customers/"+id, c.Key, nil, nil, nil)
+func (c Client) Del(id string) (*stripe.Customer, error) {
+
+	cust := &stripe.Customer{}
+	err := c.B.Call("DELETE", "/customers/"+id, c.Key, nil, nil, cust)
+
+	return cust, err
 }
 
 // List returns a list of customers.

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -83,10 +83,14 @@ func TestCustomerGet(t *testing.T) {
 func TestCustomerDel(t *testing.T) {
 	res, _ := New(nil)
 
-	err := Del(res.ID)
+	c, err := Del(res.ID)
 
 	if err != nil {
 		t.Error(err)
+	}
+
+	if c.Deleted != true {
+		t.Errorf("Customer id %q expected to be marked as deleted on the returned resource\n", c.ID)
 	}
 
 	target, err := Get(res.ID, nil)

--- a/example_test.go
+++ b/example_test.go
@@ -70,10 +70,14 @@ func ExampleInvoice_update() {
 func ExampleCustomer_delete() {
 	stripe.Key = "sk_key"
 
-	err := customer.Del("acct_example_id")
+	c, err := customer.Del("acct_example_id")
 
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if !c.Deleted {
+		log.Fatal("Customer doesn't appear deleted while it should be")
 	}
 }
 

--- a/sub/client.go
+++ b/sub/client.go
@@ -151,11 +151,11 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 // Cancel removes a subscription.
 // For more details see https://stripe.com/docs/api#cancel_subscription.
-func Cancel(id string, params *stripe.SubParams) error {
+func Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 	return getC().Cancel(id, params)
 }
 
-func (c Client) Cancel(id string, params *stripe.SubParams) error {
+func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 	body := &url.Values{}
 
 	if params.EndCancel {
@@ -164,7 +164,11 @@ func (c Client) Cancel(id string, params *stripe.SubParams) error {
 
 	params.AppendTo(body)
 
-	return c.B.Call("DELETE", fmt.Sprintf("/customers/%v/subscriptions/%v", params.Customer, id), c.Key, body, &params.Params, nil)
+
+	sub := &stripe.Sub{}
+	err := c.B.Call("DELETE", fmt.Sprintf("/customers/%v/subscriptions/%v", params.Customer, id), c.Key, body, &params.Params, sub)
+
+	return sub, err
 }
 
 // List returns a list of subscriptions.

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -189,10 +189,14 @@ func TestSubscriptionCancel(t *testing.T) {
 	}
 
 	subscription, _ := New(subParams)
-	err := Cancel(subscription.ID, &stripe.SubParams{Customer: cust.ID})
+	s, err := Cancel(subscription.ID, &stripe.SubParams{Customer: cust.ID})
 
 	if err != nil {
 		t.Error(err)
+	}
+
+	if s.Canceled == 0 {
+		t.Errorf("Subscription.Canceled %i expected to be non 0\n", s.Canceled)
 	}
 
 	customer.Del(cust.ID)


### PR DESCRIPTION
When you cancel a subscription or delete a customer it now returns the
corresponding resource.

Fixes #150.