### PR TITLE
Return the resource when canceling a subscription

### DIFF
--- a/sub/client.go
+++ b/sub/client.go
@@ -151,11 +151,11 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 // Cancel removes a subscription.
 // For more details see https://stripe.com/docs/api#cancel_subscription.
-func Cancel(id string, params *stripe.SubParams) error {
+func Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 	return getC().Cancel(id, params)
 }
 
-func (c Client) Cancel(id string, params *stripe.SubParams) error {
+func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 	body := &url.Values{}
 
 	if params.EndCancel {
@@ -164,7 +164,11 @@ func (c Client) Cancel(id string, params *stripe.SubParams) error {
 
 	params.AppendTo(body)
 
-	return c.B.Call("DELETE", fmt.Sprintf("/customers/%v/subscriptions/%v", params.Customer, id), c.Key, body, &params.Params, nil)
+
+	sub := &stripe.Sub{}
+	err := c.B.Call("DELETE", fmt.Sprintf("/customers/%v/subscriptions/%v", params.Customer, id), c.Key, body, &params.Params, sub)
+
+	return sub, err
 }
 
 // List returns a list of subscriptions.

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -189,10 +189,14 @@ func TestSubscriptionCancel(t *testing.T) {
 	}
 
 	subscription, _ := New(subParams)
-	err := Cancel(subscription.ID, &stripe.SubParams{Customer: cust.ID})
+	s, err := Cancel(subscription.ID, &stripe.SubParams{Customer: cust.ID})
 
 	if err != nil {
 		t.Error(err)
+	}
+
+	if s.Canceled == 0 {
+		t.Errorf("Subscription.Canceled %i expected to be non 0\n", s.Canceled)
 	}
 
 	customer.Del(cust.ID)


### PR DESCRIPTION
When you cancel a subscription it now returns the subscription object
instead of just an error.

r? @brandur 

Fixes #150. Supersedes #151.