### PR TITLE
Deprecate `Zip` in favor of `PostalCode`

### DIFF
--- a/account.go
+++ b/account.go
@@ -129,12 +129,15 @@ type LegalEntity struct {
 
 // Address is the structure for an account address.
 type Address struct {
-	Line1   string `json:"line1"`
-	Line2   string `json:"line2"`
-	City    string `json:"city"`
-	State   string `json:"state"`
-	Zip     string `json:"postal_code"`
-	Country string `json:"country"`
+	Line1      string `json:"line1"`
+	Line2      string `json:"line2"`
+	City       string `json:"city"`
+	State      string `json:"state"`
+	PostalCode string `json:"postal_code"`
+	Country    string `json:"country"`
+
+	// Deprecated. Please use PostalCode instead.
+	Zip string `json:"postal_code"`
 }
 
 // DOB is a structure for an account owner's date of birth.
@@ -234,8 +237,13 @@ func (l *LegalEntity) AppendDetails(values *url.Values) {
 		values.Add("legal_entity[address][state]", l.Address.State)
 	}
 
+	// Deprecated. Ordered before PostalCode check so that it takes precedence.
 	if len(l.Address.Zip) > 0 {
 		values.Add("legal_entity[address][postal_code]", l.Address.Zip)
+	}
+
+	if len(l.Address.PostalCode) > 0 {
+		values.Add("legal_entity[address][postal_code]", l.Address.PostalCode)
 	}
 
 	if len(l.Address.Country) > 0 {
@@ -260,6 +268,11 @@ func (l *LegalEntity) AppendDetails(values *url.Values) {
 
 	if len(l.PersonalAddress.Zip) > 0 {
 		values.Add("legal_entity[personal_address][postal_code]", l.PersonalAddress.Zip)
+	}
+
+	// Deprecated. Ordered before PostalCode check so that it takes precedence.
+	if len(l.PersonalAddress.PostalCode) > 0 {
+		values.Add("legal_entity[personal_address][postal_code]", l.PersonalAddress.PostalCode)
 	}
 
 	if len(l.PersonalAddress.Country) > 0 {
@@ -295,8 +308,13 @@ func (l *LegalEntity) AppendDetails(values *url.Values) {
 			values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][address][state]", i), owner.Address.State)
 		}
 
+		// Deprecated. Ordered before PostalCode check so that it takes precedence.
 		if len(owner.Address.Zip) > 0 {
 			values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][address][postal_code]", i), owner.Address.Zip)
+		}
+
+		if len(owner.Address.PostalCode) > 0 {
+			values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][address][postal_code]", i), owner.Address.PostalCode)
 		}
 
 		if len(owner.Address.Country) > 0 {

--- a/charge.go
+++ b/charge.go
@@ -115,8 +115,13 @@ func (s *ShippingDetails) AppendDetails(values *url.Values) {
 		values.Add("shipping[address][state]", s.Address.State)
 	}
 
+	// Deprecated. Ordered before PostalCode check so that it takes precedence.
 	if len(s.Address.Zip) > 0 {
 		values.Add("shipping[address][postal_code]", s.Address.Zip)
+	}
+
+	if len(s.Address.PostalCode) > 0 {
+		values.Add("shipping[address][postal_code]", s.Address.PostalCode)
 	}
 
 	if len(s.Phone) > 0 {

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -30,7 +30,7 @@ func TestChargeNew(t *testing.T) {
 				Line2: "Apt 1",
 				City:  "Somewhere",
 				State: "SW",
-				Zip:   "10044",
+				PostalCode: "10044",
 			},
 		},
 	}
@@ -79,8 +79,8 @@ func TestChargeNew(t *testing.T) {
 	if target.Shipping.Address.State != chargeParams.Shipping.Address.State {
 		t.Errorf("Shipping address state %q does not match expected address state %v\n", target.Shipping.Address.State, chargeParams.Shipping.Address.State)
 	}
-	if target.Shipping.Address.Zip != chargeParams.Shipping.Address.Zip {
-		t.Errorf("Shipping address zip %q does not match expected address zip %v\n", target.Shipping.Address.Zip, chargeParams.Shipping.Address.Zip)
+	if target.Shipping.Address.PostalCode != chargeParams.Shipping.Address.PostalCode {
+		t.Errorf("Shipping address zip %q does not match expected address zip %v\n", target.Shipping.Address.PostalCode, chargeParams.Shipping.Address.PostalCode)
 	}
 }
 

--- a/customer.go
+++ b/customer.go
@@ -78,8 +78,13 @@ func (s *CustomerShippingDetails) AppendDetails(values *url.Values) {
 		values.Add("shipping[address][state]", s.Address.State)
 	}
 
+	// Deprecated. Ordered before PostalCode check so that it takes precedence.
 	if len(s.Address.Zip) > 0 {
 		values.Add("shipping[address][postal_code]", s.Address.Zip)
+	}
+
+	if len(s.Address.PostalCode) > 0 {
+		values.Add("shipping[address][postal_code]", s.Address.PostalCode)
 	}
 
 	if len(s.Phone) > 0 {

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -97,11 +97,11 @@ func TestCustomerUpdateWithShipping(t *testing.T) {
 		Shipping: &stripe.CustomerShippingDetails{
 			Name: "Shipping Name",
 			Address: stripe.Address{
-				Line1: "One Street",
-				Line2: "Apt 1",
-				City:  "Somewhere",
-				State: "SW",
-				Zip:   "10044",
+				Line1:      "One Street",
+				Line2:      "Apt 1",
+				City:       "Somewhere",
+				State:      "SW",
+				PostalCode: "10044",
 			},
 		},
 	}
@@ -133,8 +133,8 @@ func TestCustomerUpdateWithShipping(t *testing.T) {
 	if target.Shipping.Address.State != customerParams.Shipping.Address.State {
 		t.Errorf("Shipping address state %q does not match expected address state %v\n", target.Shipping.Address.State, customerParams.Shipping.Address.State)
 	}
-	if target.Shipping.Address.Zip != customerParams.Shipping.Address.Zip {
-		t.Errorf("Shipping address zip %q does not match expected address zip %v\n", target.Shipping.Address.Zip, customerParams.Shipping.Address.Zip)
+	if target.Shipping.Address.PostalCode != customerParams.Shipping.Address.PostalCode {
+		t.Errorf("Shipping address zip %q does not match expected address zip %v\n", target.Shipping.Address.PostalCode, customerParams.Shipping.Address.PostalCode)
 	}
 
 	Del(target.ID)


### PR DESCRIPTION
Deprecates an address' the `Zip` property in favor of `PostalCode`, but
for now maintains `Zip` for backward compatibility.

The impetus for this is that the bindings are already inconsistent with
the API in that this property is serialized under a different name, but
as described in #155 are also self-inconsistent in that the property is
just called `PostalCode` elsewhere.

Any thoughts on this one appreciated! Thanks!