### PR TITLE
Include country on account requests

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -22,6 +22,10 @@ func New(params *stripe.AccountParams) (*stripe.Account, error) {
 func writeAccountParams(
 	params *stripe.AccountParams, body *url.Values,
 ) {
+	if len(params.Country) > 0 {
+		body.Add("country", params.Country)
+	}
+
 	if len(params.Email) > 0 {
 		body.Add("email", params.Email)
 	}


### PR DESCRIPTION
Creating an account with a different country to the platform account causes an error

type: "invalid_request_error"
message: "Address for business must match account country"
param: "legal_entity[address][country]"

This is because the country parameter is not being populated in the API request.