### PR TITLE
Provide some nominal documentation for `BankAccountParams`

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -18,7 +18,8 @@ type BankAccountParams struct {
 	// nested.
 	AccountID string
 
-	// Token referencing an existing external account.
+	// A token referencing an external account like one returned from
+	// Stripe.js.
 	Token string
 
 	// Information on an external account to reference. Only used if `Token`

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -13,9 +13,20 @@ type BankAccountStatus string
 // BankAccountParams is the set of parameters that can be used when creating or updating a bank account.
 type BankAccountParams struct {
 	Params
-	AccountID, Token, Country, Routing, Account, Currency string
-	Default                                               bool
-	Customer                                              string
+
+	// The identifier of the parent account under which bank accounts are
+	// nested.
+	AccountID string
+
+	// Token referencing an existing external account.
+	Token string
+
+	// Information on an external account to reference. Only used if `Token`
+	// is not provided.
+	Account, Country, Currency, Routing string
+
+	Default  bool
+	Customer string
 }
 
 // BankAccountListParams is the set of parameters that can be used when listing bank accounts.


### PR DESCRIPTION
As mentioned in #164, it's pretty confusing that these parameters
contain both an `Account` and an `AccountID` with neither being
documented. To make matters worse, `Account` was improperly named
and should actually be called `AccountNumber`. This patch adds a small
amount of documentation to help point out the distinction.

/cc @remistr Mind giving this one a quick review?