### PR TITLE
Support special `now` value for trial end on subscription update

### DIFF
--- a/sub/client.go
+++ b/sub/client.go
@@ -130,7 +130,9 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 		body.Add("coupon", params.Coupon)
 	}
 
-	if params.TrialEnd > 0 {
+	if params.TrialEndNow {
+		body.Add("trial_end", "now")
+	} else if params.TrialEnd > 0 {
 		body.Add("trial_end", strconv.FormatInt(params.TrialEnd, 10))
 	}
 


### PR DESCRIPTION
This was previously accepted on subscription creations, but not updates.
The [docs][docs] on update indicate that it can be used in both places:

> Unix timestamp representing the end of the trial period the customer
> will get before being charged for the first time. If set, trial_end
> will override the default trial period of the plan the customer is
> being subscribed to. The special value now can be provided to end the
> customer's trial immediately.

Fixes #176.

[docs]: https://stripe.com/docs/api#update_subscription