### PR TITLE
Allow update of the country field in customer shipping details.

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -82,6 +82,10 @@ func (s *CustomerShippingDetails) AppendDetails(values *url.Values) {
 		values.Add("shipping[address][postal_code]", s.Address.Zip)
 	}
 
+	if len(s.Address.Country) > 0 {
+		values.Add("shipping[address][country]", s.Address.Country)
+	}
+
 	if len(s.Phone) > 0 {
 		values.Add("shipping[phone]", s.Phone)
 	}


### PR DESCRIPTION
Attempts to update the country of a customer's shipping address were previously setting the country to null.