### PR TITLE
Allow a recipient's bank account to be updated by token

### DIFF
--- a/recipient/client.go
+++ b/recipient/client.go
@@ -105,7 +105,11 @@ func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recip
 		}
 
 		if params.Bank != nil {
-			params.Bank.AppendDetails(body)
+			if len(params.Bank.Token) > 0 {
+				body.Add("bank_account", params.Bank.Token)
+			} else {
+				params.Bank.AppendDetails(body)
+			}
 		}
 
 		if len(params.Token) > 0 {

--- a/recipient/client_test.go
+++ b/recipient/client_test.go
@@ -234,6 +234,61 @@ func TestRecipientUpdate(t *testing.T) {
 	Del(target.ID)
 }
 
+func TestRecipientUpdateToken(t *testing.T) {
+	tokenParams := &stripe.TokenParams{
+		Bank: &stripe.BankAccountParams{
+			Country: "US",
+			Routing: "110000000",
+			Account: "000123456789",
+		},
+	}
+
+	tok, _ := token.New(tokenParams)
+
+	recipientParams := &stripe.RecipientParams{
+		Name:  "Original Name",
+		Type:  Individual,
+		Email: "original@b.com",
+		Desc:  "Original Desc",
+	}
+
+	original, _ := New(recipientParams)
+
+	updated := &stripe.RecipientParams{
+		Bank: &stripe.BankAccountParams{
+			Token: tok.ID,
+		},
+	}
+
+	target, err := Update(original.ID, updated)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if target.Bank == nil {
+		t.Errorf("Bank account is not set\n")
+	}
+
+	if target.Bank.Country != tokenParams.Bank.Country {
+		t.Errorf("Bank country %q does not match expected country %q\n", target.Bank.Country, tokenParams.Bank.Country)
+	}
+
+	if target.Bank.Currency != currency.USD {
+		t.Errorf("Bank currency %q does not match expected value\n", target.Bank.Currency)
+	}
+
+	if target.Bank.LastFour != "6789" {
+		t.Errorf("Bank last four %q does not match expected value\n", target.Bank.LastFour)
+	}
+
+	if len(target.Bank.Name) == 0 {
+		t.Errorf("Bank name is not set\n")
+	}
+
+	Del(target.ID)
+}
+
 func TestRecipientDel(t *testing.T) {
 	recipientParams := &stripe.RecipientParams{
 		Name: "Recipient Name",

--- a/recipient/client_test.go
+++ b/recipient/client_test.go
@@ -234,7 +234,7 @@ func TestRecipientUpdate(t *testing.T) {
 	Del(target.ID)
 }
 
-func TestRecipientUpdateToken(t *testing.T) {
+func TestRecipientUpdateBankAccount(t *testing.T) {
 	tokenParams := &stripe.TokenParams{
 		Bank: &stripe.BankAccountParams{
 			Country: "US",
@@ -254,13 +254,13 @@ func TestRecipientUpdateToken(t *testing.T) {
 
 	original, _ := New(recipientParams)
 
-	updated := &stripe.RecipientParams{
+	updateParamsToken := &stripe.RecipientParams{
 		Bank: &stripe.BankAccountParams{
 			Token: tok.ID,
 		},
 	}
 
-	target, err := Update(original.ID, updated)
+	target, err := Update(original.ID, updateParamsToken)
 
 	if err != nil {
 		t.Error(err)
@@ -286,7 +286,41 @@ func TestRecipientUpdateToken(t *testing.T) {
 		t.Errorf("Bank name is not set\n")
 	}
 
-	Del(target.ID)
+	updateParamsBankAccount := &stripe.RecipientParams{
+		Bank: &stripe.BankAccountParams{
+			Country: "US",
+			Routing: "110000000",
+			Account: "000333333335",
+		},
+	}
+
+	target2, err := Update(original.ID, updateParamsBankAccount)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if target2.Bank == nil {
+		t.Errorf("Bank account is not set\n")
+	}
+
+	if target2.Bank.Country != tokenParams.Bank.Country {
+		t.Errorf("Bank country %q does not match expected country %q\n", target2.Bank.Country, tokenParams.Bank.Country)
+	}
+
+	if target2.Bank.Currency != currency.USD {
+		t.Errorf("Bank currency %q does not match expected value\n", target2.Bank.Currency)
+	}
+
+	if target2.Bank.LastFour != "3335" {
+		t.Errorf("Bank last four %q does not match expected value\n", target2.Bank.LastFour)
+	}
+
+	if len(target2.Bank.Name) == 0 {
+		t.Errorf("Bank name is not set\n")
+	}
+
+	Del(target2.ID)
 }
 
 func TestRecipientDel(t *testing.T) {


### PR DESCRIPTION
As described in #184, we allow a bank account to be referenced by a
token when creating a new recipient, but we currently don't allow the
same when updating a recipient. This patch addresses that problem.

Fixes #184.

/cc @remistr Would you mind taking a review pass on this one? Thanks!