### PR TITLE
Added the ability to update a card's expiration date

### DIFF
--- a/card.go
+++ b/card.go
@@ -84,12 +84,26 @@ func (c *CardParams) AppendDetails(values *url.Values, creating bool) {
 		} else {
 			values.Add("card[object]", "card")
 			values.Add("card[number]", c.Number)
-			values.Add("card[exp_month]", c.Month)
-			values.Add("card[exp_year]", c.Year)
 
 			if len(c.CVC) > 0 {
 				values.Add("card[cvc]", c.CVC)
 			}
+		}
+	}
+
+	if len(c.Month) > 0 {
+		if creating {
+			values.Add("card[exp_month]", c.Month)
+		} else {
+			values.Add("exp_month", c.Month)
+		}
+	}
+
+	if len(c.Year) > 0 {
+		if creating {
+			values.Add("card[exp_year]", c.Year)
+		} else {
+			values.Add("exp_year", c.Year)
 		}
 	}
 


### PR DESCRIPTION
You can now update a card's expiration month or year. Added extra tests
to ensure this didn't break existing behaviour.

fixes #186 

r? @brandur 