### PR TITLE
Added support for new fields in LegalEntity

### DIFF
--- a/account.go
+++ b/account.go
@@ -113,19 +113,22 @@ type Account struct {
 
 // LegalEntity is the structure for properties related to an account's legal state.
 type LegalEntity struct {
-	Type             LegalEntityType      `json:"type"`
-	BusinessName     string               `json:"business_name"`
-	Address          Address              `json:"address"`
-	First            string               `json:"first_name"`
-	Last             string               `json:"last_name"`
-	PersonalAddress  Address              `json:"personal_address"`
-	DOB              DOB                  `json:"dob"`
-	AdditionalOwners []Owner              `json:"additional_owners"`
-	Verification     IdentityVerification `json:"verification"`
-	SSN              string               `json:"ssn_last_4"`
-	PersonalID       string               `json:"personal_id_number"`
-	BusinessTaxID    string               `json:"business_tax_id"`
-	BusinessVatID    string               `json:"business_vat_id"`
+	Type                  LegalEntityType      `json:"type"`
+	BusinessName          string               `json:"business_name"`
+	Address               Address              `json:"address"`
+	First                 string               `json:"first_name"`
+	Last                  string               `json:"last_name"`
+	PersonalAddress       Address              `json:"personal_address"`
+	DOB                   DOB                  `json:"dob"`
+	AdditionalOwners      []Owner              `json:"additional_owners"`
+	Verification          IdentityVerification `json:"verification"`
+	SSN                   string               `json:"ssn_last_4"`
+	SSNProvided           bool                 `json:"ssn_last_4_provided"`
+	PersonalID            string               `json:"personal_id_number"`
+	PersonalIDProvided    bool                 `json:"personal_id_number_provided"`
+	BusinessTaxID         string               `json:"business_tax_id"`
+	BusinessTaxIDProvided bool                 `json:"business_tax_id_provided"`
+	BusinessVatID         string               `json:"business_vat_id"`
 }
 
 // Address is the structure for an account address.

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -38,9 +38,52 @@ func TestAccountNew(t *testing.T) {
 		},
 	}
 
-	_, err := New(params)
+	target, err := New(params)
 	if err != nil {
 		t.Error(err)
+	}
+
+	if !target.LegalEntity.BusinessTaxIDProvided {
+		t.Errorf("Account is missing BusinessTaxIDProvided even though we submitted the value.\n")
+	}
+
+	if !target.LegalEntity.SSNProvided {
+		t.Errorf("Account is missing BusinessTaxIDProvided even though we submitted the value.\n")
+	}
+}
+
+func TestAccountLegalEntity(t *testing.T) {
+	params := &stripe.AccountParams{
+		Managed: true,
+		Country: "US",
+		LegalEntity: &stripe.LegalEntity{
+			Type:          stripe.Company,
+			BusinessTaxID: "111111",
+			SSN:           "1111",
+			PersonalID:    "111111111",
+			DOB: stripe.DOB{
+				Day:   1,
+				Month: 2,
+				Year:  1990,
+			},
+		},
+	}
+
+	target, err := New(params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !target.LegalEntity.BusinessTaxIDProvided {
+		t.Errorf("Account is missing BusinessTaxIDProvided even though we submitted the value.\n")
+	}
+
+	if !target.LegalEntity.SSNProvided {
+		t.Errorf("Account is missing SSNProvided even though we submitted the value.\n")
+	}
+
+	if !target.LegalEntity.PersonalIDProvided {
+		t.Errorf("Account is missing PersonalIDProvided even though we submitted the value.\n")
 	}
 }
 


### PR DESCRIPTION
The bindings now surface SSNProvided, PersonalIDProvided and BusinessTaxIDProvided

r? @brandur 

Extra fields for Kana and such will be added in a separate PR later