### PR TITLE
Allow `Account` to be specified for `ListParams`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ stripe := &client.API{}
 stripe.Init("access_token", nil)
 ```
 
+In order to make a request on behalf of a managed account, use the
+`StripeAccount` field on a `ListParams` or `Params` class. For example:
+
+```go
+// For a list request
+listParams := &stripe.ChargeListParams{StripeAccount: merchantID}
+```
+
+```go
+// For any other kind of request
+params := &stripe.CustomerParams{StripeAccount: merchantID}
+```
+
 ### Google AppEngine
 
 If you're running the client in a Google AppEngine environment, you'll need to

--- a/README.md
+++ b/README.md
@@ -97,10 +97,27 @@ for i.Next() {
 Alternatively, you can use the `even.Data.Raw` property to unmarshal to the
 appropriate struct.
 
-### Connect Flows
+### Authentication with Connect
 
-If you're using an access token you will need to use a client. Simply pass the
-access token value as the `tok` when initializing the client.
+There are two ways of authenticating requests when performing actions on behalf
+of a connected account, one that uses the `Stripe-Account` header containing an
+account's ID, and one that uses the account's keys. Usually the former is the
+recommended approach. [See the documentation for more information][connect].
+
+To use the `Stripe-Account` approach, pass the `StripeAccount` field to a
+`ListParams` or `Params` class. For example:
+
+```go
+// For a list request
+listParams := &stripe.ChargeListParams{StripeAccount: merchantID}
+```
+
+```go
+// For any other kind of request
+params := &stripe.CustomerParams{StripeAccount: merchantID}
+```
+
+To use a key, pass it to `API`'s `Init` function:
 
 ```go
 
@@ -111,19 +128,6 @@ import (
 
 stripe := &client.API{}
 stripe.Init("access_token", nil)
-```
-
-In order to make a request on behalf of a managed account, use the
-`StripeAccount` field on a `ListParams` or `Params` class. For example:
-
-```go
-// For a list request
-listParams := &stripe.ChargeListParams{StripeAccount: merchantID}
-```
-
-```go
-// For any other kind of request
-params := &stripe.CustomerParams{StripeAccount: merchantID}
 ```
 
 ### Google AppEngine
@@ -263,6 +267,7 @@ pull request][pulls].
 
 [api-docs]: https://stripe.com/docs/api/go
 [api-changelog]: https://stripe.com/docs/upgrades
+[connect]: https://stripe.com/docs/connect/authentication
 [godoc]: http://godoc.org/github.com/stripe/stripe-go
 [issues]: https://github.com/stripe/stripe-go/issues/new
 [package-management]: https://code.google.com/p/go-wiki/wiki/PackageManagementTools

--- a/account/client.go
+++ b/account/client.go
@@ -211,7 +211,7 @@ func (c Client) List(params *stripe.AccountListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &accountList{}
-		err := c.B.Call("GET", "/accounts", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/accounts", c.Key, &b, lp.ToParams(), list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/account/client.go
+++ b/account/client.go
@@ -201,17 +201,19 @@ func (c Client) List(params *stripe.AccountListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &accountList{}
-		err := c.B.Call("GET", "/accounts", c.Key, &b, lp.ToParams(), list)
+		err := c.B.Call("GET", "/accounts", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/balance/client.go
+++ b/balance/client.go
@@ -81,6 +81,7 @@ func List(params *stripe.TxListParams) *Iter {
 func (c Client) List(params *stripe.TxListParams) *Iter {
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -111,6 +112,7 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
@@ -120,7 +122,7 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 		}
 
 		list := &transactionList{}
-		err := c.B.Call("GET", "/balance/history", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/balance/history", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -129,13 +129,15 @@ func List(params *stripe.BankAccountListParams) *Iter {
 func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 	body := &url.Values{}
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	params.AppendTo(body)
 	lp = &params.ListParams
+	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BankAccountList{}
-		err := c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, &b, nil, list)
+		err := c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -107,6 +107,7 @@ func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -117,11 +118,12 @@ func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &receiverList{}
-		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -28,6 +28,7 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -38,11 +39,12 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &receiverList{}
-		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, &b, nil, list)
+		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/card/client.go
+++ b/card/client.go
@@ -156,20 +156,22 @@ func List(params *stripe.CardListParams) *Iter {
 func (c Client) List(params *stripe.CardListParams) *Iter {
 	body := &url.Values{}
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	params.AppendTo(body)
 	lp = &params.ListParams
+	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CardList{}
 		var err error
 
 		if len(params.Account) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, &b, nil, list)
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, &b, p, list)
 		} else if len(params.Customer) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards", params.Customer), c.Key, &b, nil, list)
+			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards", params.Customer), c.Key, &b, p, list)
 		} else if len(params.Recipient) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", params.Recipient), c.Key, &b, nil, list)
+			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", params.Recipient), c.Key, &b, p, list)
 		} else {
 			err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 		}

--- a/charge/client.go
+++ b/charge/client.go
@@ -185,6 +185,7 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -199,11 +200,12 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &chargeList{}
-		err := c.B.Call("GET", "/charges", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/charges", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -39,17 +39,19 @@ func (c Client) List(params *stripe.CountrySpecListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &countrySpecList{}
-		err := c.B.Call("GET", "/country_specs", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/country_specs", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -136,17 +136,19 @@ func (c Client) List(params *stripe.CouponListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &couponList{}
-		err := c.B.Call("GET", "/coupons", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/coupons", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/customer/client.go
+++ b/customer/client.go
@@ -172,6 +172,7 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -182,11 +183,12 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &customerList{}
-		err := c.B.Call("GET", "/customers", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/customers", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -70,17 +70,19 @@ func (c Client) List(params *stripe.DisputeListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &disputeList{}
-		err := c.B.Call("GET", "/disputes", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/disputes", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/event/client.go
+++ b/event/client.go
@@ -41,6 +41,7 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -55,11 +56,12 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &eventList{}
-		err := c.B.Call("GET", "/events", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/events", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/fee/client.go
+++ b/fee/client.go
@@ -51,6 +51,7 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -65,11 +66,12 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &feeList{}
-		err := c.B.Call("GET", "/application_fees", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/application_fees", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -81,13 +81,15 @@ func List(params *stripe.FeeRefundListParams) *Iter {
 func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 	body := &url.Values{}
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	params.AppendTo(body)
 	lp = &params.ListParams
+	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeRefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.Fee), c.Key, &b, nil, list)
+		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.Fee), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -81,6 +81,7 @@ func (c Client) List(params *stripe.FileUploadListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -91,11 +92,12 @@ func (c Client) List(params *stripe.FileUploadListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &fileUploadList{}
-		err := c.B.Call("GET", "/files", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/files", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -193,6 +193,7 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -207,11 +208,12 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &invoiceList{}
-		err := c.B.Call("GET", "/invoices", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/invoices", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {
@@ -231,6 +233,7 @@ func ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 	body := &url.Values{}
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if len(params.Customer) > 0 {
 		body.Add("customer", params.Customer)
@@ -242,10 +245,11 @@ func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 
 	params.AppendTo(body)
 	lp = &params.ListParams
+		p = params.ToParams()
 
 	return &LineIter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceLineList{}
-		err := c.B.Call("GET", fmt.Sprintf("/invoices/%v/lines", params.ID), c.Key, &b, nil, list)
+		err := c.B.Call("GET", fmt.Sprintf("/invoices/%v/lines", params.ID), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -135,6 +135,7 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -149,11 +150,12 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &invoiceItemList{}
-		err := c.B.Call("GET", "/invoiceitems", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/invoiceitems", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/order/client.go
+++ b/order/client.go
@@ -246,6 +246,7 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -260,11 +261,12 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &orderList{}
-		err := c.B.Call("GET", "/orders", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/orders", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/params.go
+++ b/params.go
@@ -33,7 +33,13 @@ type ListParams struct {
 	// By default, listing through an iterator will automatically grab
 	// additional pages as the query progresses. To change this behavior
 	// and just load a single page, set this to true.
-	Single bool
+	Single  bool
+
+	// Account may contain the ID of a connected account. By including this
+	// field, the request is made as if it originated from the connected
+	// account instead of under the account of the owner of the configured
+	// Stripe key.
+	Account string
 }
 
 // ListMeta is the structure that contains the common properties
@@ -142,8 +148,19 @@ func (p *ListParams) AppendTo(body *url.Values) {
 
 		body.Add("limit", strconv.Itoa(p.Limit))
 	}
+
 	for _, v := range p.Exp {
 		body.Add("expand[]", v)
+	}
+}
+
+// Converts a ListParams to a Params by moving over any fields that have valid
+// targets in the new type. This is useful because fields in `Params` can be
+// injected directly into an `http.Request` while generally `ListParams` is
+// only used to build a set of parameters.
+func (p *ListParams) ToParams() *Params {
+	return &Params{
+		Account: p.Account,
 	}
 }
 

--- a/params.go
+++ b/params.go
@@ -17,10 +17,20 @@ const (
 // Params is the structure that contains the common properties
 // of any *Params structure.
 type Params struct {
-	Exp                     []string
-	Meta                    map[string]string
-	Extra                   url.Values
-	IdempotencyKey, Account string
+	Exp            []string
+	Meta           map[string]string
+	Extra          url.Values
+	IdempotencyKey string
+
+	// StripeAccount may contain the ID of a connected account. By including
+	// this field, the request is made as if it originated from the connected
+	// account instead of under the account of the owner of the configured
+	// Stripe key.
+	StripeAccount string
+
+	// Account is deprecated form of StripeAccount that will do the same thing.
+	// Please use StripeAccount instead.
+	Account string
 }
 
 // ListParams is the structure that contains the common properties
@@ -33,13 +43,13 @@ type ListParams struct {
 	// By default, listing through an iterator will automatically grab
 	// additional pages as the query progresses. To change this behavior
 	// and just load a single page, set this to true.
-	Single  bool
+	Single bool
 
-	// Account may contain the ID of a connected account. By including this
-	// field, the request is made as if it originated from the connected
+	// StripeAccount may contain the ID of a connected account. By including
+	// this field, the request is made as if it originated from the connected
 	// account instead of under the account of the owner of the configured
 	// Stripe key.
-	Account string
+	StripeAccount string
 }
 
 // ListMeta is the structure that contains the common properties
@@ -74,6 +84,12 @@ func NewIdempotencyKey() string {
 // SetAccount sets a value for the Stripe-Account header.
 func (p *Params) SetAccount(val string) {
 	p.Account = val
+	p.StripeAccount = val
+}
+
+// SetAccount sets a value for the Stripe-Account header.
+func (p *Params) SetStripeAccount(val string) {
+	p.StripeAccount = val
 }
 
 // Expand appends a new field to expand.
@@ -160,7 +176,7 @@ func (p *ListParams) AppendTo(body *url.Values) {
 // only used to build a set of parameters.
 func (p *ListParams) ToParams() *Params {
 	return &Params{
-		Account: p.Account,
+		StripeAccount: p.StripeAccount,
 	}
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	stripe "github.com/stripe/stripe-go"
+	. "github.com/stripe/stripe-go/testing"
 )
 
 func TestParamsWithExtras(t *testing.T) {
@@ -73,5 +74,42 @@ func TestListParamsExpansion(t *testing.T) {
 		if !reflect.DeepEqual(body, testCase.ExpectedBody) {
 			t.Fatalf("Expected body of %v but got %v.", testCase.ExpectedBody, body)
 		}
+	}
+}
+
+func TestCheckinListParamsToParams(t *testing.T) {
+	listParams := &stripe.ListParams{StripeAccount: TestMerchantID}
+	params := listParams.ToParams()
+
+	if params.StripeAccount != TestMerchantID {
+		t.Fatalf("Expected StripeAccount of %v but got %v.",
+			TestMerchantID, params.StripeAccount)
+	}
+}
+
+func TestCheckinParamsSetAccount(t *testing.T) {
+	p := &stripe.Params{}
+	p.SetAccount(TestMerchantID)
+
+	if p.Account != TestMerchantID {
+		t.Fatalf("Expected Account of %v but got %v.", TestMerchantID, p.Account)
+	}
+
+	if p.StripeAccount != TestMerchantID {
+		t.Fatalf("Expected StripeAccount of %v but got %v.", TestMerchantID, p.StripeAccount)
+	}
+}
+
+func TestCheckinParamsSetStripeAccount(t *testing.T) {
+	p := &stripe.Params{}
+	p.SetStripeAccount(TestMerchantID)
+
+	if p.StripeAccount != TestMerchantID {
+		t.Fatalf("Expected Account of %v but got %v.", TestMerchantID, p.StripeAccount)
+	}
+
+	// Check that we don't set the deprecated parameter.
+	if p.Account != "" {
+		t.Fatalf("Expected empty Account but got %v.", TestMerchantID)
 	}
 }

--- a/params_test.go
+++ b/params_test.go
@@ -55,7 +55,7 @@ func TestListParamsExpansion(t *testing.T) {
 			ExpectedBody: url.Values{"foo": {"bar"}},
 		},
 		{
-			InitialBody:  url.Values{"foo": {"bar"}},
+			InitialBody:  url.Values{"foo": {"bar", "baz"}},
 			Expand:       []string{"data", "data.foo"},
 			ExpectedBody: url.Values{"foo": {"bar", "baz"}, "expand[]": {"data", "data.foo"}},
 		},

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -118,16 +118,18 @@ func List(params *stripe.SourceListParams) *Iter {
 func (s Client) List(params *stripe.SourceListParams) *Iter {
 	body := &url.Values{}
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	params.AppendTo(body)
 	lp = &params.ListParams
+	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SourceList{}
 		var err error
 
 		if len(params.Customer) > 0 {
-			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", params.Customer), s.Key, &b, nil, list)
+			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", params.Customer), s.Key, &b, p, list)
 		} else {
 			err = errors.New("Invalid source params: customer needs to be set")
 		}

--- a/plan/client.go
+++ b/plan/client.go
@@ -135,17 +135,19 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &planList{}
-		err := c.B.Call("GET", "/plans", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/plans", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/product/client.go
+++ b/product/client.go
@@ -162,6 +162,7 @@ func (c Client) List(params *stripe.ProductListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -186,11 +187,12 @@ func (c Client) List(params *stripe.ProductListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &productList{}
-		err := c.B.Call("GET", "/products", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/products", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -170,6 +170,7 @@ func (c Client) List(params *stripe.RecipientListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -180,11 +181,12 @@ func (c Client) List(params *stripe.RecipientListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &recipientList{}
-		err := c.B.Call("GET", "/recipients", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/recipients", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/refund/client.go
+++ b/refund/client.go
@@ -100,13 +100,15 @@ func List(params *stripe.RefundListParams) *Iter {
 func (c Client) List(params *stripe.RefundListParams) *Iter {
 	body := &url.Values{}
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	params.AppendTo(body)
 	lp = &params.ListParams
+	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/refunds"), c.Key, &b, nil, list)
+		err := c.B.Call("GET", fmt.Sprintf("/refunds"), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -82,13 +82,15 @@ func List(params *stripe.ReversalListParams) *Iter {
 func (c Client) List(params *stripe.ReversalListParams) *Iter {
 	body := &url.Values{}
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	params.AppendTo(body)
 	lp = &params.ListParams
+	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ReversalList{}
-		err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals", params.Transfer), c.Key, &b, nil, list)
+		err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals", params.Transfer), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/sku/client.go
+++ b/sku/client.go
@@ -193,6 +193,7 @@ func (c Client) List(params *stripe.SKUListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -222,11 +223,12 @@ func (c Client) List(params *stripe.SKUListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &skuList{}
-		err := c.B.Call("GET", "/skus", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/skus", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/stripe.go
+++ b/stripe.go
@@ -54,7 +54,9 @@ type SupportedBackend string
 
 const (
 	APIBackend     SupportedBackend = "api"
+	APIURL string = "https://api.stripe.com/v1"
 	UploadsBackend SupportedBackend = "uploads"
+	UploadsURL string = "https://uploads.stripe.com/v1"
 )
 
 // Backends are the currently supported endpoints.
@@ -97,9 +99,9 @@ func SetHTTPClient(client *http.Client) {
 func NewBackends(httpClient *http.Client) *Backends {
 	return &Backends{
 		API: BackendConfiguration{
-			APIBackend, "https://api.stripe.com/v1", httpClient},
+			APIBackend, APIURL, httpClient},
 		Uploads: BackendConfiguration{
-			UploadsBackend, "https://uploads.stripe.com/v1", httpClient},
+			UploadsBackend, UploadsURL, httpClient},
 	}
 }
 
@@ -201,8 +203,14 @@ func (s *BackendConfiguration) NewRequest(method, path, key, contentType string,
 			req.Header.Add("Idempotency-Key", idempotency)
 		}
 
+		// Support the value of the old Account field for now.
 		if account := strings.TrimSpace(params.Account); account != "" {
 			req.Header.Add("Stripe-Account", account)
+		}
+
+		// But prefer StripeAccount.
+		if stripeAccount := strings.TrimSpace(params.StripeAccount); stripeAccount != "" {
+			req.Header.Add("Stripe-Account", stripeAccount)
 		}
 	}
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -1,0 +1,37 @@
+package stripe_test
+
+import (
+	"testing"
+
+	stripe "github.com/stripe/stripe-go"
+	. "github.com/stripe/stripe-go/testing"
+)
+
+func TestCheckinBackendConfigurationNewRequestWithStripeAccount(t *testing.T) {
+	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	p := &stripe.Params{StripeAccount: TestMerchantID}
+
+	req, err := c.NewRequest("", "", "", "", nil, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if req.Header.Get("Stripe-Account") != TestMerchantID {
+		t.Fatalf("Expected Stripe-Account %v but got %v.",
+			TestMerchantID, req.Header.Get("Stripe-Account"))
+	}
+
+	// Also test the deprecated Account field for now as well. This should be
+	// identical to the exercise above.
+	p = &stripe.Params{Account: TestMerchantID}
+
+	req, err = c.NewRequest("", "", "", "", nil, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if req.Header.Get("Stripe-Account") != TestMerchantID {
+		t.Fatalf("Expected Stripe-Account %v but got %v.",
+			TestMerchantID, req.Header.Get("Stripe-Account"))
+	}
+}

--- a/sub/client.go
+++ b/sub/client.go
@@ -191,13 +191,15 @@ func List(params *stripe.SubListParams) *Iter {
 func (c Client) List(params *stripe.SubListParams) *Iter {
 	body := &url.Values{}
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	params.AppendTo(body)
 	lp = &params.ListParams
+	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubList{}
-		err := c.B.Call("GET", fmt.Sprintf("/customers/%v/subscriptions", params.Customer), c.Key, &b, nil, list)
+		err := c.B.Call("GET", fmt.Sprintf("/customers/%v/subscriptions", params.Customer), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,0 +1,13 @@
+package testing
+
+// This file should contain any testing helpers that should be commonly
+// available across all tests in the Stripe package.
+//
+// There's not much in here because it' a relatively recent addition to the
+// package, but should be used as appropriate for any new changes.
+
+const (
+	// TestMerchantID is a token that can be used to represent a merchant ID in
+	// simple tests.
+	TestMerchantID = "acct_xxxx"
+)

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -173,6 +173,7 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 
 	var body *url.Values
 	var lp *stripe.ListParams
+	var p *stripe.Params
 
 	if params != nil {
 		body = &url.Values{}
@@ -195,11 +196,12 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 
 		params.AppendTo(body)
 		lp = &params.ListParams
+		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &transferList{}
-		err := c.B.Call("GET", "/transfers", c.Key, &b, nil, list)
+		err := c.B.Call("GET", "/transfers", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {


### PR DESCRIPTION
As discussed in #196, we cannot currently send an account header when
using list endpoints. I believe that this was a known limitation of the
original implementation that was never addressed because of subtle
differences in the way `Params` and `ListParams` are used (the former is
serialized around an `http.Request` object while the latter is just used
to build a set of parameter values).

This patch adds an `Account` field to `ListParams` and suggests that
it's injected in list callbacks using a new `ToParams` function on
`ListParams`. This implementation is not complete, and just demonstrates
its use on a single endpoint. The new field will have to be added to all
list callbacks to be fully workable.

@remistr Thoughts on this implementation? Obviously not currently complete and
missing tests, but what do you think about the overall approach?

Fixes #196.