### PR TITLE
Add missing invoice parameters for use with `GetNext`

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -14,6 +14,12 @@ type InvoiceParams struct {
 	Desc, Statement, Sub string
 	Fee                  uint64
 	Closed, Forgive      bool
+	SubPlan              string
+	SubProrate           bool
+	SubProrationDate     int64
+	SubProrationDateNow  bool
+	SubQuantity          uint64
+	SubTrialEnd          int64
 	TaxPercent           float64
 }
 

--- a/invoice.go
+++ b/invoice.go
@@ -15,7 +15,7 @@ type InvoiceParams struct {
 	Fee                  uint64
 	Closed, Forgive      bool
 	SubPlan              string
-	SubProrate           bool
+	SubNoProrate         bool
 	SubProrationDate     int64
 	SubProrationDateNow  bool
 	SubQuantity          uint64

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -171,6 +171,26 @@ func (c Client) GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 		body.Add("subscription", params.Sub)
 	}
 
+	if len(params.SubPlan) > 0 {
+		body.Add("subscription_plan", params.SubPlan)
+	}
+
+	if params.SubProrate {
+		body.Add("subscription_prorate", strconv.FormatBool(true))
+	}
+
+	if params.SubProrationDate > 0 {
+		body.Add("subscription_proration_date", strconv.FormatInt(params.SubProrationDate, 10))
+	}
+
+	if params.SubQuantity > 0 {
+		body.Add("subscription_quantity", strconv.FormatUint(params.SubQuantity, 10))
+	}
+
+	if params.SubTrialEnd > 0 {
+		body.Add("subscription_trial_end", strconv.FormatInt(params.SubTrialEnd, 10))
+	}
+
 	params.AppendTo(body)
 
 	invoice := &stripe.Invoice{}

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -175,8 +175,8 @@ func (c Client) GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 		body.Add("subscription_plan", params.SubPlan)
 	}
 
-	if params.SubProrate {
-		body.Add("subscription_prorate", strconv.FormatBool(true))
+	if params.SubNoProrate {
+		body.Add("subscription_prorate", strconv.FormatBool(false))
 	}
 
 	if params.SubProrationDate > 0 {

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -2,11 +2,14 @@ package invoice
 
 import (
 	"testing"
+	"time"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/currency"
 	"github.com/stripe/stripe-go/customer"
 	"github.com/stripe/stripe-go/invoiceitem"
+	"github.com/stripe/stripe-go/plan"
+	"github.com/stripe/stripe-go/sub"
 	. "github.com/stripe/stripe-go/utils"
 )
 
@@ -262,6 +265,59 @@ func TestAllInvoicesScenarios(t *testing.T) {
 
 	_, err = Get(targetInvoice.ID, nil)
 
+	if err != nil {
+		t.Error(err)
+	}
+
+	planParams := &stripe.PlanParams{
+		ID:       "test",
+		Name:     "Test Plan",
+		Amount:   99,
+		Currency: currency.USD,
+		Interval: plan.Month,
+	}
+
+	_, err = plan.New(planParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	subParams := &stripe.SubParams{
+		Customer:    cust.ID,
+		Plan:        planParams.ID,
+		Quantity:    10,
+		TrialEndNow: true,
+	}
+
+	subscription, err := sub.New(subParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	nextParams := &stripe.InvoiceParams{
+		Customer:         cust.ID,
+		Sub:              subscription.ID,
+		SubPlan:          planParams.ID,
+		SubProrate:       true,
+		SubProrationDate: time.Now().AddDate(0, 0, 12).Unix(),
+		SubQuantity:      1,
+		SubTrialEnd:      time.Now().AddDate(0, 0, 12).Unix(),
+	}
+
+	nextInvoice, err := GetNext(nextParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if nextInvoice.Customer.ID != cust.ID {
+		t.Errorf("Invoice customer %v does not match expected customer%v\n", nextInvoice.Customer.ID, cust.ID)
+	}
+
+	if nextInvoice.Sub != subscription.ID {
+		t.Errorf("Invoice subscription %v does not match expected subscription%v\n", nextInvoice.Sub, subscription.ID)
+	}
+
+	_, err = plan.Del(planParams.ID)
 	if err != nil {
 		t.Error(err)
 	}

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -298,7 +298,7 @@ func TestAllInvoicesScenarios(t *testing.T) {
 		Customer:         cust.ID,
 		Sub:              subscription.ID,
 		SubPlan:          planParams.ID,
-		SubProrate:       true,
+		SubNoProrate:     false,
 		SubProrationDate: time.Now().AddDate(0, 0, 12).Unix(),
 		SubQuantity:      1,
 		SubTrialEnd:      time.Now().AddDate(0, 0, 12).Unix(),


### PR DESCRIPTION
Adds a large set of missing parameters to `InvoiceParams` that are
designed to be used to [retrieve an upcoming invoice][docs]. Fixes #198.

A few design justifications here:

* I've continued using the prefix of `Sub` for "subscription" because
  this seems consistent with elsewhere in the library.
* The new parameter serializations should really be tested as a unit
  somewhere, but because we don't have a pattern for this, I've re-used
  the same approach as elsewhere in the suite by just hitting the API.
* I've made the single huge test in the invoices suite even more huge
  because as stated in its comments, there's a huge amount of
  bootstrapping that's needed in order to properly test any of this.
* I've only made minimal effort to test the invoice which the API
  responds with. This is because testing other fields according to other
  input parameters is non-trivial. It's not great, but it's better than
  what we have today.

And lastly: mandatory comment about how we need to fix this test suite.

/cc @remistr Would you mind reviewing this one? Thanks!

[docs]: https://stripe.com/docs/api/go#upcoming_invoice