### PR TITLE
bindings for PII tokenization

### DIFF
--- a/token.go
+++ b/token.go
@@ -1,5 +1,9 @@
 package stripe
 
+import (
+	"net/url"
+)
+
 // TokenType is the list of allowed values for a token's type.
 // Allowed values are "card", "bank_account".
 type TokenType string
@@ -10,6 +14,7 @@ type TokenParams struct {
 	Params
 	Card     *CardParams
 	Bank     *BankAccountParams
+	PII      *PIIParams
 	Customer string
 	// Email is an undocumented parameter used by Stripe Checkout
 	// It may be removed from the API without notice.
@@ -30,4 +35,15 @@ type Token struct {
 	// Email is an undocumented field but included for all tokens created
 	// with Stripe Checkout.
 	Email string `json:"email"`
+}
+
+// Personal identifiable information
+type PIIParams struct {
+	Params
+	PersonalIDNumber string
+}
+
+// AppendDetails adds the PII data's details to the query string values.
+func (p *PIIParams) AppendDetails(values *url.Values) {
+	values.Add("pii[personal_id_number]", p.PersonalIDNumber)
 }

--- a/token/client.go
+++ b/token/client.go
@@ -11,6 +11,7 @@ import (
 const (
 	Card stripe.TokenType = "card"
 	Bank stripe.TokenType = "bank_account"
+	PII	 stripe.TokenType = "pii"
 )
 
 // Client is used to invoke /tokens APIs.
@@ -37,8 +38,10 @@ func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
 		params.Card.AppendDetails(body, true)
 	} else if params.Bank != nil {
 		params.Bank.AppendDetails(body)
+	} else if params.PII != nil {
+		params.PII.AppendDetails(body)
 	} else if len(params.Customer) == 0 {
-		err := errors.New("Invalid Token params: either Card or Bank need to be set")
+		err := errors.New("Invalid Token params: either Card, Bank, or PII need to be set")
 		return nil, err
 	}
 

--- a/token/client.go
+++ b/token/client.go
@@ -11,7 +11,7 @@ import (
 const (
 	Card stripe.TokenType = "card"
 	Bank stripe.TokenType = "bank_account"
-	PII	 stripe.TokenType = "pii"
+	PII  stripe.TokenType = "pii"
 )
 
 // Client is used to invoke /tokens APIs.

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -73,3 +73,25 @@ func TestTokenGet(t *testing.T) {
 		t.Errorf("Bank account status %q does not match expected value\n", target.Bank.Status)
 	}
 }
+
+func TestPIITokenNew(t *testing.T) {
+	tokenParams := &stripe.TokenParams{
+		PII: &stripe.PIIParams{
+			PersonalIDNumber: "000000000",
+		},
+	}
+
+	target, err := New(tokenParams)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if target.Created == 0 {
+		t.Errorf("Created date is not set\n")
+	}
+
+	if target.Type != PII {
+		t.Errorf("Type %v does not match expected value\n", target.Type)
+	}
+}


### PR DESCRIPTION
r? @brandur 

`POST /v1/tokens` needs to be able to accept `pii[personal_id_number]` to create PII tokens

Made the simplest change possible. Open to suggestions.