### PR TITLE
Upgrade to API version 2016-03-07

### DIFF
--- a/account.go
+++ b/account.go
@@ -73,23 +73,24 @@ type Account struct {
 	ChargesEnabled bool   `json:"charges_enabled"`
 	Country        string `json:"country"`
 	// Currencies is the list of supported currencies.
-	Currencies           []string `json:"currencies_supported"`
-	DefaultCurrency      string   `json:"default_currency"`
-	DetailsSubmitted     bool     `json:"details_submitted"`
-	TransfersEnabled     bool     `json:"transfers_enabled"`
-	Name                 string   `json:"display_name"`
-	Email                string   `json:"email"`
-	Statement            string   `json:"statement_descriptor"`
-	Timezone             string   `json:"timezone"`
-	BusinessName         string   `json:"business_name"`
-	BusinessPrimaryColor string   `json:"business_primary_color"`
-	BusinessUrl          string   `json:"business_url"`
-	SupportPhone         string   `json:"support_phone"`
-	SupportEmail         string   `json:"support_email"`
-	SupportUrl           string   `json:"support_url"`
-	ProductDesc          string   `json:"product_description"`
-	Managed              bool     `json:"managed"`
-	DebitNegativeBal     bool     `json:"debit_negative_balances"`
+	Currencies           []string         `json:"currencies_supported"`
+	DefaultCurrency      string           `json:"default_currency"`
+	DetailsSubmitted     bool             `json:"details_submitted"`
+	TransfersEnabled     bool             `json:"transfers_enabled"`
+	Name                 string           `json:"display_name"`
+	Email                string           `json:"email"`
+	ExternalAccounts     ExternalAccounts `json:"external_accounts"`
+	Statement            string           `json:"statement_descriptor"`
+	Timezone             string           `json:"timezone"`
+	BusinessName         string           `json:"business_name"`
+	BusinessPrimaryColor string           `json:"business_primary_color"`
+	BusinessUrl          string           `json:"business_url"`
+	SupportPhone         string           `json:"support_phone"`
+	SupportEmail         string           `json:"support_email"`
+	SupportUrl           string           `json:"support_url"`
+	ProductDesc          string           `json:"product_description"`
+	Managed              bool             `json:"managed"`
+	DebitNegativeBal     bool             `json:"debit_negative_balances"`
 	Keys                 *struct {
 		Secret  string `json:"secret"`
 		Publish string `json:"publishable"`
@@ -109,6 +110,33 @@ type Account struct {
 	} `json:"tos_acceptance"`
 	SupportAddress *Address `json:"support_address"`
 	Deleted        bool     `json:"deleted"`
+}
+
+type ExternalAccounts struct {
+	Object     string            `json:"object"`
+	Data       []ExternalAccount `json:"data"`
+	HasMore    bool              `json:"has_more"`
+	TotalCount uint              `json:"total_count"`
+	Url        string            `json:"url"`
+}
+
+type ExternalAccount struct {
+	BankAccount *BankAccount
+	Card        *Card
+}
+
+func (ea *ExternalAccount) UnmarshalJSON(b []byte) (err error) {
+	bank, card := BankAccount{}, Card{}
+	if err = json.Unmarshal(b, &bank); err == nil {
+		ea.BankAccount = &bank
+		return
+	}
+	if err = json.Unmarshal(b, &card); err == nil {
+		ea.Card = &card
+		return
+	}
+
+	return
 }
 
 // LegalEntity is the structure for properties related to an account's legal state.

--- a/account.go
+++ b/account.go
@@ -69,28 +69,26 @@ type TransferScheduleParams struct {
 // Account is the resource representing your Stripe account.
 // For more details see https://stripe.com/docs/api/#account.
 type Account struct {
-	ID             string `json:"id"`
-	ChargesEnabled bool   `json:"charges_enabled"`
-	Country        string `json:"country"`
-	// Currencies is the list of supported currencies.
-	Currencies           []string         `json:"currencies_supported"`
-	DefaultCurrency      string           `json:"default_currency"`
-	DetailsSubmitted     bool             `json:"details_submitted"`
-	TransfersEnabled     bool             `json:"transfers_enabled"`
-	Name                 string           `json:"display_name"`
-	Email                string           `json:"email"`
+	ID                   string               `json:"id"`
+	ChargesEnabled       bool                 `json:"charges_enabled"`
+	Country              string               `json:"country"`
+	DefaultCurrency      string               `json:"default_currency"`
+	DetailsSubmitted     bool                 `json:"details_submitted"`
+	TransfersEnabled     bool                 `json:"transfers_enabled"`
+	Name                 string               `json:"display_name"`
+	Email                string               `json:"email"`
 	ExternalAccounts     *ExternalAccountList `json:"external_accounts"`
-	Statement            string           `json:"statement_descriptor"`
-	Timezone             string           `json:"timezone"`
-	BusinessName         string           `json:"business_name"`
-	BusinessPrimaryColor string           `json:"business_primary_color"`
-	BusinessUrl          string           `json:"business_url"`
-	SupportPhone         string           `json:"support_phone"`
-	SupportEmail         string           `json:"support_email"`
-	SupportUrl           string           `json:"support_url"`
-	ProductDesc          string           `json:"product_description"`
-	Managed              bool             `json:"managed"`
-	DebitNegativeBal     bool             `json:"debit_negative_balances"`
+	Statement            string               `json:"statement_descriptor"`
+	Timezone             string               `json:"timezone"`
+	BusinessName         string               `json:"business_name"`
+	BusinessPrimaryColor string               `json:"business_primary_color"`
+	BusinessUrl          string               `json:"business_url"`
+	SupportPhone         string               `json:"support_phone"`
+	SupportEmail         string               `json:"support_email"`
+	SupportUrl           string               `json:"support_url"`
+	ProductDesc          string               `json:"product_description"`
+	Managed              bool                 `json:"managed"`
+	DebitNegativeBal     bool                 `json:"debit_negative_balances"`
 	Keys                 *struct {
 		Secret  string `json:"secret"`
 		Publish string `json:"publishable"`

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -215,10 +215,6 @@ func TestAccountGet(t *testing.T) {
 		t.Errorf("Account is missing country\n")
 	}
 
-	if len(target.Currencies) == 0 {
-		t.Errorf("Account is missing currencies\n")
-	}
-
 	if len(target.DefaultCurrency) == 0 {
 		t.Errorf("Account is missing default currency\n")
 	}

--- a/account_test.go
+++ b/account_test.go
@@ -1,0 +1,63 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAccountUnmarshal(t *testing.T) {
+	accountData := map[string]interface{}{
+		"id": "acct_1234",
+		"external_accounts": map[string]interface{}{
+			"object": "list",
+			"has_more": true,
+			"data": []map[string]interface{}{
+				map[string]interface{}{
+					"object": "bank_account",
+					"id":     "ba_1234",
+				},
+				map[string]interface{}{
+					"object": "card",
+					"id":     "card_1234",
+				},
+			},
+		},
+	}
+
+	bytes, err := json.Marshal(&accountData)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var account Account
+	err = json.Unmarshal(bytes, &account)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if account.ID != "acct_1234" {
+		t.Errorf("Problem deserializing account, got ID %v", account.ID)
+	}
+
+	if !account.ExternalAccounts.More {
+		t.Errorf("Problem deserializing account, wrong value for list More")
+	}
+
+	if len(account.ExternalAccounts.BankAccountValues) != 1 {
+		t.Errorf("Problem deserializing account, got wrong number of bank accounts")
+	}
+
+	bankAccountID := account.ExternalAccounts.BankAccountValues[0].ID
+	if "ba_1234" != bankAccountID {
+		t.Errorf("Problem deserializing account, got bank account ID %v", bankAccountID)
+	}
+
+	if len(account.ExternalAccounts.CardValues) != 1 {
+		t.Errorf("Problem deserializing account, got wrong number of cards")
+	}
+
+	cardID := account.ExternalAccounts.CardValues[0].ID
+	if "card_1234" != cardID {
+		t.Errorf("Problem deserializing account, got card ID %v", cardID)
+	}
+}

--- a/account_test.go
+++ b/account_test.go
@@ -43,21 +43,24 @@ func TestAccountUnmarshal(t *testing.T) {
 		t.Errorf("Problem deserializing account, wrong value for list More")
 	}
 
-	if len(account.ExternalAccounts.BankAccountValues) != 1 {
-		t.Errorf("Problem deserializing account, got wrong number of bank accounts")
+	if len(account.ExternalAccounts.Values) != 2 {
+		t.Errorf("Problem deserializing account, got wrong number of external accounts")
 	}
 
-	bankAccountID := account.ExternalAccounts.BankAccountValues[0].ID
-	if "ba_1234" != bankAccountID {
-		t.Errorf("Problem deserializing account, got bank account ID %v", bankAccountID)
+	bankAccount := account.ExternalAccounts.Values[0]
+	if bankAccount == nil {
+		t.Errorf("Problem deserializing account, didn't get a bank account")
+	}
+	if "ba_1234" != bankAccount.ID {
+		t.Errorf("Problem deserializing account, got bank account ID %v", bankAccount.ID)
 	}
 
-	if len(account.ExternalAccounts.CardValues) != 1 {
-		t.Errorf("Problem deserializing account, got wrong number of cards")
+	card := account.ExternalAccounts.Values[1]
+	if card == nil {
+		t.Errorf("Problem deserializing account, didn't get a card")
 	}
 
-	cardID := account.ExternalAccounts.CardValues[0].ID
-	if "card_1234" != cardID {
-		t.Errorf("Problem deserializing account, got card ID %v", cardID)
+	if "card_1234" != card.ID {
+		t.Errorf("Problem deserializing account, got card ID %v", card.ID)
 	}
 }

--- a/stripe.go
+++ b/stripe.go
@@ -48,13 +48,6 @@ type BackendConfiguration struct {
 	HTTPClient *http.Client
 }
 
-// StripeObject is a very minimal type that we can deserialize from JSON to
-// check a type. This is useful when we're trying to determine types within a
-// polymorphic list.
-type StripeObject struct {
-	Object string `json:"object"`
-}
-
 // SupportedBackend is an enumeration of supported Stripe endpoints.
 // Currently supported values are "api" and "uploads".
 type SupportedBackend string

--- a/stripe.go
+++ b/stripe.go
@@ -21,7 +21,7 @@ const (
 )
 
 // apiversion is the currently supported API version
-const apiversion = "2015-07-13"
+const apiversion = "2016-03-07"
 
 // clientversion is the binding version
 const clientversion = "12.1.0"

--- a/stripe.go
+++ b/stripe.go
@@ -48,6 +48,13 @@ type BackendConfiguration struct {
 	HTTPClient *http.Client
 }
 
+// StripeObject is a very minimal type that we can deserialize from JSON to
+// check a type. This is useful when we're trying to determine types within a
+// polymorphic list.
+type StripeObject struct {
+	Object string `json:"object"`
+}
+
 // SupportedBackend is an enumeration of supported Stripe endpoints.
 // Currently supported values are "api" and "uploads".
 type SupportedBackend string


### PR DESCRIPTION
Follows the [changelog][changelog] through and makes necessary changes to support the latest Stripe API version.

Important changes:

* `BankAccounts` on `Account` replaced by `ExternalAccounts`.
* `Currencies` on `Account` removed in favor of new `CountrySpec` resource.

There were quite a few other changes in the API too, but they were either already integrated or didn't require any modifications to the bindings.

Fixes #205. Supersedes #169.

/cc @mmcgrana Sorry to be a pain, but would you mind taking a look at this one? Thanks! (And BTW the tests are still broken due to a _still_ in progress test data deletion :/)

[changelog]: https://stripe.com/docs/upgrades