### PR TITLE
Add `go vet` and `gofmt` check to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
-all: checkin
+all: checkin vet check-gofmt
+
+check-gofmt:
+	scripts/check_gofmt.sh
 
 checkin:
 	go test -run "TestCheckin*" ./client
+
 test:
 	go test ./... -p=1
+
 build:
 	go build ./...
+
+vet:
+	go vet ./...

--- a/scripts/check_gofmt.sh
+++ b/scripts/check_gofmt.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+find_files() {
+  find . -not \( \
+      \( \
+        -name 'vendor' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+bad_files=$(find_files | xargs gofmt -s -l)
+if [[ -n "${bad_files}" ]]; then
+    echo "!!! gofmt needs to be run on the following files: "
+    echo "${bad_files}"
+    exit 1
+fi

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -67,7 +67,7 @@ func TestSubscriptionNew(t *testing.T) {
 	}
 
 	if target.PeriodEnd != subParams.BillingCycleAnchor {
-		t.Errorf("PeriodEnd %f does not match expected BillingCycleAnchor %f\n", target.PeriodEnd, subParams.BillingCycleAnchor)
+		t.Errorf("PeriodEnd %v does not match expected BillingCycleAnchor %v\n", target.PeriodEnd, subParams.BillingCycleAnchor)
 	}
 
 	customer.Del(cust.ID)
@@ -202,7 +202,7 @@ func TestSubscriptionCancel(t *testing.T) {
 	}
 
 	if s.Canceled == 0 {
-		t.Errorf("Subscription.Canceled %i expected to be non 0\n", s.Canceled)
+		t.Errorf("Subscription.Canceled %v expected to be non 0\n", s.Canceled)
 	}
 
 	customer.Del(cust.ID)


### PR DESCRIPTION
This changes the CI run so that `go vet` and a `gofmt` check are run.
This will make the process of finding formatting problems on
contributions automatic.