### PR TITLE
Add metadata field to Card resource

### DIFF
--- a/card.go
+++ b/card.go
@@ -41,29 +41,30 @@ type CardListParams struct {
 // Card is the resource representing a Stripe credit/debit card.
 // For more details see https://stripe.com/docs/api#cards.
 type Card struct {
-	ID            string       `json:"id"`
-	Month         uint8        `json:"exp_month"`
-	Year          uint16       `json:"exp_year"`
-	Fingerprint   string       `json:"fingerprint"`
-	Funding       CardFunding  `json:"funding"`
-	LastFour      string       `json:"last4"`
-	Brand         CardBrand    `json:"brand"`
-	Default       bool         `json:"default_for_currency"`
-	City          string       `json:"address_city"`
-	Country       string       `json:"address_country"`
-	Address1      string       `json:"address_line1"`
-	Address1Check Verification `json:"address_line1_check"`
-	Address2      string       `json:"address_line2"`
-	State         string       `json:"address_state"`
-	Zip           string       `json:"address_zip"`
-	ZipCheck      Verification `json:"address_zip_check"`
-	CardCountry   string       `json:"country"`
-	Customer      *Customer    `json:"customer"`
-	CVCCheck      Verification `json:"cvc_check"`
-	Name          string       `json:"name"`
-	Recipient     *Recipient   `json:"recipient"`
-	DynLastFour   string       `json:"dynamic_last4"`
-	Deleted       bool         `json:"deleted"`
+	ID            string            `json:"id"`
+	Month         uint8             `json:"exp_month"`
+	Year          uint16            `json:"exp_year"`
+	Fingerprint   string            `json:"fingerprint"`
+	Funding       CardFunding       `json:"funding"`
+	LastFour      string            `json:"last4"`
+	Brand         CardBrand         `json:"brand"`
+	Default       bool              `json:"default_for_currency"`
+	City          string            `json:"address_city"`
+	Country       string            `json:"address_country"`
+	Address1      string            `json:"address_line1"`
+	Address1Check Verification      `json:"address_line1_check"`
+	Address2      string            `json:"address_line2"`
+	State         string            `json:"address_state"`
+	Zip           string            `json:"address_zip"`
+	ZipCheck      Verification      `json:"address_zip_check"`
+	CardCountry   string            `json:"country"`
+	Customer      *Customer         `json:"customer"`
+	CVCCheck      Verification      `json:"cvc_check"`
+	Meta          map[string]string `json:"metadata"`
+	Name          string            `json:"name"`
+	Recipient     *Recipient        `json:"recipient"`
+	DynLastFour   string            `json:"dynamic_last4"`
+	Deleted       bool              `json:"deleted"`
 }
 
 // CardList is a list object for cards.

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -42,6 +42,10 @@ func TestCardNew(t *testing.T) {
 		t.Errorf("Unexpected last four %q for card number %v\n", target.LastFour, cardParams.Number)
 	}
 
+	if target.Meta == nil || len(target.Meta) > 0 {
+		t.Errorf("Unexpected nil or non-empty metadata in card\n")
+	}
+
 	if target.Month != 10 {
 		t.Errorf("Unexpected expiration month %d for card where we set %q\n", target.Month, cardParams.Month)
 	}


### PR DESCRIPTION
Adds a missing metadata field (Meta) to the Card resource.

Fixes #214.