### PR TITLE
added additional fields for card info

### DIFF
--- a/card.go
+++ b/card.go
@@ -46,6 +46,9 @@ type Card struct {
 	Year          uint16            `json:"exp_year"`
 	Fingerprint   string            `json:"fingerprint"`
 	Funding       CardFunding       `json:"funding"`
+	IIN           string            `json:"iin"`
+	Issuer        string            `json:"issuer"`
+	Description   string            `json:"description"`
 	LastFour      string            `json:"last4"`
 	Brand         CardBrand         `json:"brand"`
 	Default       bool              `json:"default_for_currency"`


### PR DESCRIPTION
Sync the card info. structure in sdk with API document.
The returned example from API is like following:

> {
> id: xxxxxxxxxx
> object: "card"
> address_city: null
> address_country: null
> address_line1: null
> address_line1_check: null
> address_line2: null
> address_state: null
> address_zip: null
> address_zip_check: null
> brand: "xxxx"
> country: "xx"
> customer: xxxxxxxxx
> cvc_check: "unchecked"
> **description: "Debit MasterCard"**
> dynamic_last4: null
> exp_month: 3
> exp_year: 2021
> fingerprint: "xxxxxxxxxxxxxxxxxxx"
> funding: "debit"
> **iin: "111111"**
> **issuer: "CIMB BANK BERHAD"**
> last4: "2222"
> metadata:
> name: null
> tokenization_method: null
> use: "debit"
> }