### PR TITLE
Add internal fields for card

### DIFF
--- a/card.go
+++ b/card.go
@@ -46,6 +46,9 @@ type Card struct {
 	Year          uint16            `json:"exp_year"`
 	Fingerprint   string            `json:"fingerprint"`
 	Funding       CardFunding       `json:"funding"`
+	IIN           string            `json:"iin"`
+	Issuer        string            `json:"issuer"`
+	Description   string            `json:"description"`
 	LastFour      string            `json:"last4"`
 	Brand         CardBrand         `json:"brand"`
 	Default       bool              `json:"default_for_currency"`

--- a/card.go
+++ b/card.go
@@ -46,9 +46,6 @@ type Card struct {
 	Year          uint16            `json:"exp_year"`
 	Fingerprint   string            `json:"fingerprint"`
 	Funding       CardFunding       `json:"funding"`
-	IIN           string            `json:"iin"`
-	Issuer        string            `json:"issuer"`
-	Description   string            `json:"description"`
 	LastFour      string            `json:"last4"`
 	Brand         CardBrand         `json:"brand"`
 	Default       bool              `json:"default_for_currency"`
@@ -68,6 +65,24 @@ type Card struct {
 	Recipient     *Recipient        `json:"recipient"`
 	DynLastFour   string            `json:"dynamic_last4"`
 	Deleted       bool              `json:"deleted"`
+
+	// Description is a succinct summary of the card's information.
+	//
+	// Please note that this field is for internal use only and is not returned
+	// as part of standard API requests.
+	Description string `json:"description"`
+
+	// IIN is the card's "Issuer Identification Number".
+	//
+	// Please note that this field is for internal use only and is not returned
+	// as part of standard API requests.
+	IIN string `json:"iin"`
+
+	// Issuer is a bank or financial institution that provides the card.
+	//
+	// Please note that this field is for internal use only and is not returned
+	// as part of standard API requests.
+	Issuer string `json:"issuer"`
 }
 
 // CardList is a list object for cards.


### PR DESCRIPTION
Adds a set of fields for specialized use that may be available depending on
gating, but which usually are not.

Replaces #220.