### PR TITLE
Add support for go sub functions not passing in customer

### DIFF
--- a/discount/client.go
+++ b/discount/client.go
@@ -28,13 +28,13 @@ func (c Client) Del(customerID string) (*stripe.Discount, error) {
 
 // DelSub removes a discount from a customer's subscription.
 // For more details see https://stripe.com/docs/api#delete_subscription_discount.
-func DelSub(customerID, subscriptionID string) (*stripe.Discount, error) {
-	return getC().DelSub(customerID, subscriptionID)
+func DelSub(subscriptionID string) (*stripe.Discount, error) {
+	return getC().DelSub(subscriptionID)
 }
 
-func (c Client) DelSub(customerID, subscriptionID string) (*stripe.Discount, error) {
+func (c Client) DelSub(subscriptionID string) (*stripe.Discount, error) {
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", fmt.Sprintf("/customers/%v/subscriptions/%v/discount", customerID, subscriptionID), c.Key, nil, nil, discount)
+	err := c.B.Call("DELETE", fmt.Sprintf("/subscriptions/%v/discount", subscriptionID), c.Key, nil, nil, discount)
 
 	return discount, err
 }

--- a/sub.go
+++ b/sub.go
@@ -28,6 +28,7 @@ type SubParams struct {
 type SubListParams struct {
 	ListParams
 	Customer string
+	Plan     string
 }
 
 // Sub is the resource representing a Stripe subscription.

--- a/sub.go
+++ b/sub.go
@@ -42,6 +42,7 @@ type Sub struct {
 	Status      SubStatus         `json:"status"`
 	FeePercent  float64           `json:"application_fee_percent"`
 	Canceled    int64             `json:"canceled_at"`
+	Created     int64             `json:"created"`
 	Start       int64             `json:"start"`
 	PeriodEnd   int64             `json:"current_period_end"`
 	PeriodStart int64             `json:"current_period_start"`

--- a/sub/client.go
+++ b/sub/client.go
@@ -222,14 +222,24 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 
 	if params != nil {
 		body = &url.Values{}
+
+		if len(params.Customer) > 0 {
+			body.Add("customer", params.Customer)
+		}
+
+		if len(params.Plan) > 0 {
+			body.Add("plan", params.Plan)
+		}
+
 		params.AppendTo(body)
+
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubList{}
-		err := c.B.Call("GET", fmt.Sprintf("/subscriptions"), c.Key, &b, p, list)
+		err := c.B.Call("GET", "/subscriptions", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/sub/client.go
+++ b/sub/client.go
@@ -30,53 +30,62 @@ func New(params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
-	body := &url.Values{
-		"plan": {params.Plan},
-	}
-
-	if len(params.Token) > 0 {
-		body.Add("card", params.Token)
-	} else if params.Card != nil {
-		params.Card.AppendDetails(body, true)
-	}
-
-	if len(params.Coupon) > 0 {
-		body.Add("coupon", params.Coupon)
-	}
-
-	if params.TrialEndNow {
-		body.Add("trial_end", "now")
-	} else if params.TrialEnd > 0 {
-		body.Add("trial_end", strconv.FormatInt(params.TrialEnd, 10))
-	}
-
-	if params.Quantity > 0 {
-		body.Add("quantity", strconv.FormatUint(params.Quantity, 10))
-	} else if params.QuantityZero {
-		body.Add("quantity", "0")
-	}
-
+	var body *url.Values
+	var commonParams *stripe.Params
 	token := c.Key
-	if params.FeePercent > 0 {
-		body.Add("application_fee_percent", strconv.FormatFloat(params.FeePercent, 'f', 2, 64))
-	}
 
-	if params.TaxPercent > 0 {
-		body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
-	} else if params.TaxPercentZero {
-		body.Add("tax_percent", "0")
-	}
+	if params != nil {
 
-	if params.BillingCycleAnchorNow {
-		body.Add("billing_cycle_anchor", "now")
-	} else if params.BillingCycleAnchor > 0 {
-		body.Add("billing_cycle_anchor", strconv.FormatInt(params.BillingCycleAnchor, 10))
-	}
+		body = &url.Values{
+			"plan":     {params.Plan},
+			"customer": {params.Customer},
+		}
 
-	params.AppendTo(body)
+		if len(params.Token) > 0 {
+			body.Add("card", params.Token)
+		} else if params.Card != nil {
+			params.Card.AppendDetails(body, true)
+		}
+
+		if len(params.Coupon) > 0 {
+			body.Add("coupon", params.Coupon)
+		}
+
+		if params.TrialEndNow {
+			body.Add("trial_end", "now")
+		} else if params.TrialEnd > 0 {
+			body.Add("trial_end", strconv.FormatInt(params.TrialEnd, 10))
+		}
+
+		if params.TaxPercent > 0 {
+			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+		} else if params.TaxPercentZero {
+			body.Add("tax_percent", "0")
+		}
+
+		if params.Quantity > 0 {
+			body.Add("quantity", strconv.FormatUint(params.Quantity, 10))
+		} else if params.QuantityZero {
+			body.Add("quantity", "0")
+		}
+
+		if params.FeePercent > 0 {
+			body.Add("application_fee_percent", strconv.FormatFloat(params.FeePercent, 'f', 2, 64))
+		}
+
+		if params.BillingCycleAnchorNow {
+			body.Add("billing_cycle_anchor", "now")
+		} else if params.BillingCycleAnchor > 0 {
+			body.Add("billing_cycle_anchor", strconv.FormatInt(params.BillingCycleAnchor, 10))
+		}
+
+		commonParams = &params.Params
+
+		params.AppendTo(body)
+	}
 
 	sub := &stripe.Sub{}
-	err := c.B.Call("POST", fmt.Sprintf("/customers/%v/subscriptions", params.Customer), token, body, &params.Params, sub)
+	err := c.B.Call("POST", "/subscriptions", token, body, commonParams, sub)
 
 	return sub, err
 }
@@ -88,15 +97,17 @@ func Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Customer must be set")
+	var body *url.Values
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &url.Values{}
+		params.AppendTo(body)
+		commonParams = &params.Params
 	}
 
-	body := &url.Values{}
-	params.AppendTo(body)
-
 	sub := &stripe.Sub{}
-	err := c.B.Call("GET", fmt.Sprintf("/customers/%v/subscriptions/%v", params.Customer, id), c.Key, body, &params.Params, sub)
+	err := c.B.Call("GET", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
 
 	return sub, err
 }
@@ -108,59 +119,65 @@ func Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	body := &url.Values{}
-
-	if len(params.Plan) > 0 {
-		body.Add("plan", params.Plan)
-	}
-
-	if params.NoProrate {
-		body.Add("prorate", strconv.FormatBool(false))
-	}
-
-	if len(params.Token) > 0 {
-		body.Add("card", params.Token)
-	} else if params.Card != nil {
-		if len(params.Card.Token) > 0 {
-			body.Add("card", params.Card.Token)
-		} else {
-			params.Card.AppendDetails(body, true)
-		}
-	}
-
-	if len(params.Coupon) > 0 {
-		body.Add("coupon", params.Coupon)
-	}
-
-	if params.TrialEndNow {
-		body.Add("trial_end", "now")
-	} else if params.TrialEnd > 0 {
-		body.Add("trial_end", strconv.FormatInt(params.TrialEnd, 10))
-	}
-
-	if params.Quantity > 0 {
-		body.Add("quantity", strconv.FormatUint(params.Quantity, 10))
-	}
-
+	var body *url.Values
+	var commonParams *stripe.Params
 	token := c.Key
-	if params.FeePercent > 0 {
-		body.Add("application_fee_percent", strconv.FormatFloat(params.FeePercent, 'f', 2, 64))
-	}
 
-	if params.TaxPercent > 0 {
-		body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
-	} else if params.TaxPercentZero {
-		body.Add("tax_percent", "0")
-	}
+	if params != nil {
+		body = &url.Values{}
 
-	if params.ProrationDate > 0 {
-		body.Add("proration_date", strconv.FormatInt(params.ProrationDate, 10))
-	}
+		if len(params.Plan) > 0 {
+			body.Add("plan", params.Plan)
+		}
 
-	params.AppendTo(body)
+		if params.NoProrate {
+			body.Add("prorate", strconv.FormatBool(false))
+		}
+
+		if len(params.Token) > 0 {
+			body.Add("card", params.Token)
+		} else if params.Card != nil {
+			if len(params.Card.Token) > 0 {
+				body.Add("card", params.Card.Token)
+			} else {
+				params.Card.AppendDetails(body, true)
+			}
+		}
+
+		if len(params.Coupon) > 0 {
+			body.Add("coupon", params.Coupon)
+		}
+
+		if params.TrialEndNow {
+			body.Add("trial_end", "now")
+		} else if params.TrialEnd > 0 {
+			body.Add("trial_end", strconv.FormatInt(params.TrialEnd, 10))
+		}
+
+		if params.Quantity > 0 {
+			body.Add("quantity", strconv.FormatUint(params.Quantity, 10))
+		}
+
+		if params.FeePercent > 0 {
+			body.Add("application_fee_percent", strconv.FormatFloat(params.FeePercent, 'f', 2, 64))
+		}
+
+		if params.TaxPercent > 0 {
+			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+		} else if params.TaxPercentZero {
+			body.Add("tax_percent", "0")
+		}
+
+		if params.ProrationDate > 0 {
+			body.Add("proration_date", strconv.FormatInt(params.ProrationDate, 10))
+		}
+
+		commonParams = &params.Params
+		params.AppendTo(body)
+	}
 
 	sub := &stripe.Sub{}
-	err := c.B.Call("POST", fmt.Sprintf("/customers/%v/subscriptions/%v", params.Customer, id), token, body, &params.Params, sub)
+	err := c.B.Call("POST", fmt.Sprintf("/subscriptions/%v", id), token, body, commonParams, sub)
 
 	return sub, err
 }
@@ -172,16 +189,22 @@ func Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	body := &url.Values{}
+	var body *url.Values
+	var commonParams *stripe.Params
 
-	if params.EndCancel {
-		body.Add("at_period_end", strconv.FormatBool(true))
+	if params != nil {
+		body = &url.Values{}
+
+		if params.EndCancel {
+			body.Add("at_period_end", strconv.FormatBool(true))
+		}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
 	}
 
-	params.AppendTo(body)
-
 	sub := &stripe.Sub{}
-	err := c.B.Call("DELETE", fmt.Sprintf("/customers/%v/subscriptions/%v", params.Customer, id), c.Key, body, &params.Params, sub)
+	err := c.B.Call("DELETE", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
 
 	return sub, err
 }
@@ -193,17 +216,20 @@ func List(params *stripe.SubListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.SubListParams) *Iter {
-	body := &url.Values{}
+	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
-	params.AppendTo(body)
-	lp = &params.ListParams
-	p = params.ToParams()
+	if params != nil {
+		body = &url.Values{}
+		params.AppendTo(body)
+		lp = &params.ListParams
+		p = params.ToParams()
+	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubList{}
-		err := c.B.Call("GET", fmt.Sprintf("/customers/%v/subscriptions", params.Customer), c.Key, &b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/subscriptions"), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -156,7 +156,7 @@ func TestSubscriptionGet(t *testing.T) {
 	}
 
 	subscription, _ := New(subParams)
-	target, err := Get(subscription.ID, &stripe.SubParams{Customer: cust.ID})
+	target, err := Get(subscription.ID, nil)
 
 	if err != nil {
 		t.Error(err)
@@ -200,7 +200,7 @@ func TestSubscriptionCancel(t *testing.T) {
 	}
 
 	subscription, _ := New(subParams)
-	s, err := Cancel(subscription.ID, &stripe.SubParams{Customer: cust.ID})
+	s, err := Cancel(subscription.ID, nil)
 
 	if err != nil {
 		t.Error(err)
@@ -246,7 +246,6 @@ func TestSubscriptionUpdate(t *testing.T) {
 
 	subscription, _ := New(subParams)
 	updatedSub := &stripe.SubParams{
-		Customer:   cust.ID,
 		NoProrate:  true,
 		Quantity:   13,
 		TaxPercent: 20.0,
@@ -327,7 +326,7 @@ func TestSubscriptionDiscount(t *testing.T) {
 		t.Errorf("Coupon id %q does not match expected id %q\n", target.Discount.Coupon.ID, subParams.Coupon)
 	}
 
-	_, err = discount.DelSub(cust.ID, target.ID)
+	_, err = discount.DelSub(target.ID)
 
 	if err != nil {
 		t.Error(err)
@@ -371,7 +370,23 @@ func TestSubscriptionList(t *testing.T) {
 		New(subParams)
 	}
 
-	i := List(&stripe.SubListParams{Customer: cust.ID})
+	i := List(nil)
+	for i.Next() {
+		if i.Sub() == nil {
+			t.Error("No nil values expected")
+		}
+
+		if i.Meta() == nil {
+			t.Error("No metadata returned")
+		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
+	}
+
+	params := &stripe.SubListParams{Customer: cust.ID, Plan: "test"}
+	params.Filters.AddFilter("limit", "", "3")
+	i = List(params)
 	for i.Next() {
 		if i.Sub() == nil {
 			t.Error("No nil values expected")


### PR DESCRIPTION
This PR adds go support for v1/subs - methods on subscriptions that no longer require a customerID

Changes:
DelSub now only takes in a subscriptionID and not a customerID anymore
All URLs are now directed towards v1/subs rather than v1/cus
All functions have been changed to support if params passed in are `nil` - previously params had to include customerID but now it is possible they are `nil` values
List now takes in optional customer and plan parameters 
Added test to ensure both old and new methods still work
