### PR TITLE
Introduce `TaxPercentZero` field for invoice and subscription parameters

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -21,6 +21,7 @@ type InvoiceParams struct {
 	SubQuantity          uint64
 	SubTrialEnd          int64
 	TaxPercent           float64
+	TaxPercentZero       bool
 }
 
 // InvoiceListParams is the set of parameters that can be used when listing invoices.

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -52,6 +52,8 @@ func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 
 	if params.TaxPercent > 0 {
 		body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+	} else if params.TaxPercentZero {
+		body.Add("tax_percent", "0")
 	}
 
 	invoice := &stripe.Invoice{}

--- a/sub.go
+++ b/sub.go
@@ -17,6 +17,7 @@ type SubParams struct {
 	Quantity                                        uint64
 	ProrationDate                                   int64
 	FeePercent, TaxPercent                          float64
+	TaxPercentZero                                  bool
 	NoProrate, EndCancel, QuantityZero, TrialEndNow bool
 	BillingCycleAnchor                              int64
 	BillingCycleAnchorNow                           bool

--- a/sub/client.go
+++ b/sub/client.go
@@ -63,6 +63,8 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 
 	if params.TaxPercent > 0 {
 		body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+	} else if params.TaxPercentZero {
+		body.Add("tax_percent", "0")
 	}
 
 	if params.BillingCycleAnchorNow {

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -98,9 +98,10 @@ func TestSubscriptionZeroQuantity(t *testing.T) {
 	plan.New(planParams)
 
 	subParams := &stripe.SubParams{
-		Customer:     cust.ID,
-		Plan:         "test",
-		QuantityZero: true,
+		Customer:       cust.ID,
+		Plan:           "test",
+		QuantityZero:   true,
+		TaxPercentZero: true,
 	}
 
 	target, err := New(subParams)
@@ -115,6 +116,10 @@ func TestSubscriptionZeroQuantity(t *testing.T) {
 
 	if target.Quantity != 0 {
 		t.Errorf("Quantity %v does not match expected quantity %v\n", target.Quantity, 0)
+	}
+
+	if target.TaxPercent != 0 {
+		t.Errorf("Tax percent %v does not match expected tax percent %v\n", target.TaxPercent, 0)
 	}
 
 	customer.Del(cust.ID)


### PR DESCRIPTION
Introduces a new field for `TaxPercentZero` for invoices in
subscriptions so that an already non-zero value can be zeroed out (the
current check prevents a zero from ever making it to the server because
it's not added to the serialized form of parameters).

This might be a little contentious, but I didn't add any tests for the
new fields. Sub's `QuantityZero` field does have a test, but it's sixty
lines long and tests a single conditional branch, which doesn't seem
sustainable to me from the standpoints of either code quality or the
amount of time that it takes to run the suite (given that all of these
are still doing live API calls). Definitely open for discussion if
anyone has strong opinions on the subject.

Fixes #225.

/cc @tetrakai Would you mind taking a review pass on this one? Thanks!