### PR TITLE
Expose `stripe.PlanList`

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -38,3 +38,9 @@ type Plan struct {
 	Statement     string            `json:"statement_descriptor"`
 	Deleted       bool              `json:"deleted"`
 }
+
+// PlanList is a list of plans as returned from a list endpoint.
+type PlanList struct {
+	ListMeta
+	Values []*Plan `json:"data"`
+}

--- a/plan/client.go
+++ b/plan/client.go
@@ -128,11 +128,6 @@ func List(params *stripe.PlanListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.PlanListParams) *Iter {
-	type planList struct {
-		stripe.ListMeta
-		Values []*stripe.Plan `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -146,7 +141,7 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &planList{}
+		list := &stripe.PlanList{}
 		err := c.B.Call("GET", "/plans", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))


### PR DESCRIPTION
Moves the struct used to represent a list of plans into an exported type
to ease mocking of API endpoints.

Fixes #227.