### PR TITLE
Add TaxPercentZero logic to update methods

### DIFF
--- a/invoice/client.go
+++ b/invoice/client.go
@@ -147,6 +147,8 @@ func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice
 
 		if params.TaxPercent > 0 {
 			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+		} else if params.TaxPercentZero {
+			body.Add("tax_percent", "0")
 		}
 
 		params.AppendTo(body)

--- a/sub/client.go
+++ b/sub/client.go
@@ -149,6 +149,8 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 	if params.TaxPercent > 0 {
 		body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+	} else if params.TaxPercentZero {
+		body.Add("tax_percent", "0")
 	}
 
 	if params.ProrationDate > 0 {


### PR DESCRIPTION
Follows up #226 by adding `TaxPercentZero` handling to the update
methods for invoices and subscriptions.