### PR TITLE
Expose remaining lists consistently

### DIFF
--- a/account.go
+++ b/account.go
@@ -141,6 +141,12 @@ const (
 	AccountTypeCard AccountType = "card"
 )
 
+// AccountList is a list of accounts as returned from a list endpoint.
+type AccountList struct {
+	ListMeta
+	Values []*Account `json:"data"`
+}
+
 // ExternalAccountList is a list of external accounts that may be either bank
 // accounts or cards.
 type ExternalAccountList struct {

--- a/account/client.go
+++ b/account/client.go
@@ -210,11 +210,6 @@ func List(params *stripe.AccountListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.AccountListParams) *Iter {
-	type accountList struct {
-		stripe.ListMeta
-		Values []*stripe.Account `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -228,7 +223,7 @@ func (c Client) List(params *stripe.AccountListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &accountList{}
+		list := &stripe.AccountList{}
 		err := c.B.Call("GET", "/accounts", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/balance.go
+++ b/balance.go
@@ -59,6 +59,12 @@ type Transaction struct {
 	Recipient  string            `json:"recipient"`
 }
 
+// TransactionList is a list of transactions as returned from a list endpoint.
+type TransactionList struct {
+	ListMeta
+	Values []*Transaction `json:"data"`
+}
+
 // Amount is a structure wrapping an amount value and its currency.
 type Amount struct {
 	Value    int64    `json:"amount"`

--- a/balance/client.go
+++ b/balance/client.go
@@ -116,12 +116,7 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		type transactionList struct {
-			stripe.ListMeta
-			Values []*stripe.Transaction `json:"data"`
-		}
-
-		list := &transactionList{}
+		list := &stripe.TransactionList{}
 		err := c.B.Call("GET", "/balance/history", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/bitcoin_receiver.go
+++ b/bitcoin_receiver.go
@@ -53,6 +53,12 @@ type BitcoinReceiver struct {
 	Transactions          *BitcoinTransactionList `json:"transactions"`
 }
 
+// BitcoinReceiverList is a list of bitcoin receivers as retrieved from a list endpoint.
+type BitcoinReceiverList struct {
+	ListMeta
+	Values []*BitcoinReceiver `json:"data"`
+}
+
 // Display human readable representation of a BitcoinReceiver.
 func (br *BitcoinReceiver) Display() string {
 	var filled string

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -100,11 +100,6 @@ func List(params *stripe.BitcoinReceiverListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
-	type receiverList struct {
-		stripe.ListMeta
-		Values []*stripe.BitcoinReceiver `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -122,7 +117,7 @@ func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &receiverList{}
+		list := &stripe.BitcoinReceiverList{}
 		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -21,11 +21,6 @@ func List(params *stripe.BitcoinTransactionListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
-	type receiverList struct {
-		stripe.ListMeta
-		Values []*stripe.BitcoinTransaction `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -43,7 +38,7 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &receiverList{}
+		list := &stripe.BitcoinTransactionList{}
 		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/charge.go
+++ b/charge.go
@@ -86,6 +86,12 @@ type Charge struct {
 	Tx             *Transaction      `json:"balance_transaction"`
 }
 
+// ChargeList is a list of charges as retrieved from a list endpoint.
+type ChargeList struct {
+	ListMeta
+	Values []*Charge `json:"data"`
+}
+
 // FraudDetails is the structure detailing fraud status.
 type FraudDetails struct {
 	UserReport   FraudReport `json:"user_report"`

--- a/charge/client.go
+++ b/charge/client.go
@@ -178,11 +178,6 @@ func List(params *stripe.ChargeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ChargeListParams) *Iter {
-	type chargeList struct {
-		stripe.ListMeta
-		Values []*stripe.Charge `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -204,7 +199,7 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &chargeList{}
+		list := &stripe.ChargeList{}
 		err := c.B.Call("GET", "/charges", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/countryspec.go
+++ b/countryspec.go
@@ -21,6 +21,12 @@ type CountrySpec struct {
 	VerificationFields             map[LegalEntityType]VerificationFieldsList `json:"verification_fields"`
 }
 
+// CountrySpecList is a list of country specs as retrieved from a list endpoint.
+type CountrySpecList struct {
+	ListMeta
+	Values []*CountrySpec `json:"data"`
+}
+
 // CountrySpecListParams are the parameters allowed during CountrySpec listing.
 type CountrySpecListParams struct {
 	ListParams

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -32,11 +32,6 @@ func List(params *stripe.CountrySpecListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CountrySpecListParams) *Iter {
-	type countrySpecList struct {
-		stripe.ListMeta
-		Values []*stripe.CountrySpec `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -50,7 +45,7 @@ func (c Client) List(params *stripe.CountrySpecListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &countrySpecList{}
+		list := &stripe.CountrySpecList{}
 		err := c.B.Call("GET", "/country_specs", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/coupon.go
+++ b/coupon.go
@@ -42,6 +42,12 @@ type Coupon struct {
 	Deleted        bool              `json:"deleted"`
 }
 
+// CouponList is a list of coupons as retrieved from a list endpoint.
+type CouponList struct {
+	ListMeta
+	Values []*Coupon `json:"data"`
+}
+
 // UnmarshalJSON handles deserialization of a Coupon.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -129,11 +129,6 @@ func List(params *stripe.CouponListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CouponListParams) *Iter {
-	type couponList struct {
-		stripe.ListMeta
-		Values []*stripe.Coupon `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -147,7 +142,7 @@ func (c Client) List(params *stripe.CouponListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &couponList{}
+		list := &stripe.CouponList{}
 		err := c.B.Call("GET", "/coupons", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/customer.go
+++ b/customer.go
@@ -55,6 +55,12 @@ type Customer struct {
 	Shipping      *CustomerShippingDetails `json:"shipping"`
 }
 
+// CustomerList is a list of customers as retrieved from a list endpoint.
+type CustomerList struct {
+	ListMeta
+	Values []*Customer `json:"data"`
+}
+
 // CustomerShippingDetails is the structure containing shipping information.
 type CustomerShippingDetails struct {
 	Name    string  `json:"name"`

--- a/customer/client.go
+++ b/customer/client.go
@@ -165,11 +165,6 @@ func List(params *stripe.CustomerListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CustomerListParams) *Iter {
-	type customerList struct {
-		stripe.ListMeta
-		Values []*stripe.Customer `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -187,7 +182,7 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &customerList{}
+		list := &stripe.CustomerList{}
 		err := c.B.Call("GET", "/customers", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/dispute.go
+++ b/dispute.go
@@ -62,6 +62,12 @@ type Dispute struct {
 	Meta            map[string]string `json:"metadata"`
 }
 
+// DisputeList is a list of disputes as retrieved from a list endpoint.
+type DisputeList struct {
+	ListMeta
+	Values []*Dispute `json:"data"`
+}
+
 // EvidenceDetails is the structure representing more details about
 // the dispute.
 type EvidenceDetails struct {

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -63,11 +63,6 @@ func List(params *stripe.DisputeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.DisputeListParams) *Iter {
-	type disputeList struct {
-		stripe.ListMeta
-		Values []*stripe.Dispute `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -81,7 +76,7 @@ func (c Client) List(params *stripe.DisputeListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &disputeList{}
+		list := &stripe.DisputeList{}
 		err := c.B.Call("GET", "/disputes", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/event.go
+++ b/event.go
@@ -25,6 +25,12 @@ type EventData struct {
 	Obj  map[string]interface{}
 }
 
+// EventList is a list of events as retrieved from a list endpoint.
+type EventList struct {
+	ListMeta
+	Values []*Event `json:"data"`
+}
+
 // EventListParams is the set of parameters that can be used when listing events.
 // For more details see https://stripe.com/docs/api#list_events.
 type EventListParams struct {

--- a/event/client.go
+++ b/event/client.go
@@ -34,11 +34,6 @@ func List(params *stripe.EventListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.EventListParams) *Iter {
-	type eventList struct {
-		stripe.ListMeta
-		Values []*stripe.Event `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -60,7 +55,7 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &eventList{}
+		list := &stripe.EventList{}
 		err := c.B.Call("GET", "/events", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/fee.go
+++ b/fee.go
@@ -34,6 +34,12 @@ type Fee struct {
 	AmountRefunded uint64         `json:"amount_refunded"`
 }
 
+// FeeList is a list of fees as retrieved from a list endpoint.
+type FeeList struct {
+	ListMeta
+	Values []*Fee `json:"data"`
+}
+
 // UnmarshalJSON handles deserialization of a Fee.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.

--- a/fee/client.go
+++ b/fee/client.go
@@ -44,11 +44,6 @@ func List(params *stripe.FeeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.FeeListParams) *Iter {
-	type feeList struct {
-		stripe.ListMeta
-		Values []*stripe.Fee `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -70,7 +65,7 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &feeList{}
+		list := &stripe.FeeList{}
 		err := c.B.Call("GET", "/application_fees", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/fileupload.go
+++ b/fileupload.go
@@ -39,6 +39,12 @@ type FileUpload struct {
 	Type    string            `json:"type"`
 }
 
+// FileUploadList is a list of file uploads as retrieved from a list endpoint.
+type FileUploadList struct {
+	ListMeta
+	Values []*FileUpload `json:"data"`
+}
+
 // AppendDetails adds the file upload details to an io.ReadWriter. It returns
 // the boundary string for a multipart/form-data request and an error (if one
 // exists).

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -74,11 +74,6 @@ func List(params *stripe.FileUploadListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.FileUploadListParams) *Iter {
-	type fileUploadList struct {
-		stripe.ListMeta
-		Values []*stripe.FileUpload `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -96,7 +91,7 @@ func (c Client) List(params *stripe.FileUploadListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &fileUploadList{}
+		list := &stripe.FileUploadList{}
 		err := c.B.Call("GET", "/files", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/invoice.go
+++ b/invoice.go
@@ -74,6 +74,12 @@ type Invoice struct {
 	Meta         map[string]string `json:"metadata"`
 }
 
+// InvoiceList is a list of invoices as retrieved from a list endpoint.
+type InvoiceList struct {
+	ListMeta
+	Values []*Invoice `json:"data"`
+}
+
 // InvoiceLine is the resource representing a Stripe invoice line item.
 // For more details see https://stripe.com/docs/api#invoice_line_item_object.
 type InvoiceLine struct {

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -210,11 +210,6 @@ func List(params *stripe.InvoiceListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.InvoiceListParams) *Iter {
-	type invoiceList struct {
-		stripe.ListMeta
-		Values []*stripe.Invoice `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -236,7 +231,7 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &invoiceList{}
+		list := &stripe.InvoiceList{}
 		err := c.B.Call("GET", "/invoices", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -39,6 +39,12 @@ type InvoiceItem struct {
 	Deleted      bool              `json:"deleted"`
 }
 
+// InvoiceItemList is a list of invoice items as retrieved from a list endpoint.
+type InvoiceItemList struct {
+	ListMeta
+	Values []*InvoiceItem `json:"data"`
+}
+
 // UnmarshalJSON handles deserialization of an InvoiceItem.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -128,11 +128,6 @@ func List(params *stripe.InvoiceItemListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
-	type invoiceItemList struct {
-		stripe.ListMeta
-		Values []*stripe.InvoiceItem `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -154,7 +149,7 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &invoiceItemList{}
+		list := &stripe.InvoiceItemList{}
 		err := c.B.Call("GET", "/invoiceitems", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/order.go
+++ b/order.go
@@ -78,6 +78,12 @@ type Order struct {
 	Updated                int64             `json:"updated"`
 }
 
+// OrderList is a list of orders as retrieved from a list endpoint.
+type OrderList struct {
+	ListMeta
+	Values []*Order `json:"data"`
+}
+
 // OrderListParams is the set of parameters that can be used when
 // listing orders. For more details, see:
 // https://stripe.com/docs/api#list_orders.

--- a/order/client.go
+++ b/order/client.go
@@ -239,11 +239,6 @@ func List(params *stripe.OrderListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.OrderListParams) *Iter {
-	type orderList struct {
-		stripe.ListMeta
-		Values []*stripe.Order `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -265,7 +260,7 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &orderList{}
+		list := &stripe.OrderList{}
 		err := c.B.Call("GET", "/orders", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/product.go
+++ b/product.go
@@ -49,6 +49,12 @@ type Product struct {
 	Skus              *SKUList           `json:"skus"`
 }
 
+// ProductList is a list of products as retrieved from a list endpoint.
+type ProductList struct {
+	ListMeta
+	Values []*Product `json:"data"`
+}
+
 // ProductListParams is the set of parameters that can be used when
 // listing products. For more details, see:
 // https://stripe.com/docs/api#list_products.

--- a/product/client.go
+++ b/product/client.go
@@ -155,11 +155,6 @@ func List(params *stripe.ProductListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ProductListParams) *Iter {
-	type productList struct {
-		stripe.ListMeta
-		Values []*stripe.Product `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -191,7 +186,7 @@ func (c Client) List(params *stripe.ProductListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &productList{}
+		list := &stripe.ProductList{}
 		err := c.B.Call("GET", "/products", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/recipient.go
+++ b/recipient.go
@@ -42,6 +42,12 @@ type Recipient struct {
 	Deleted     bool              `json:"deleted"`
 }
 
+// RecipientList is a list of recipients as retrieved from a list endpoint.
+type RecipientList struct {
+	ListMeta
+	Values []*Recipient `json:"data"`
+}
+
 // UnmarshalJSON handles deserialization of a Recipient.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -163,11 +163,6 @@ func List(params *stripe.RecipientListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.RecipientListParams) *Iter {
-	type recipientList struct {
-		stripe.ListMeta
-		Values []*stripe.Recipient `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -185,7 +180,7 @@ func (c Client) List(params *stripe.RecipientListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &recipientList{}
+		list := &stripe.RecipientList{}
 		err := c.B.Call("GET", "/recipients", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/sku/client.go
+++ b/sku/client.go
@@ -186,11 +186,6 @@ func List(params *stripe.SKUListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.SKUListParams) *Iter {
-	type skuList struct {
-		stripe.ListMeta
-		Values []*stripe.SKU `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -227,7 +222,7 @@ func (c Client) List(params *stripe.SKUListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &skuList{}
+		list := &stripe.SKUList{}
 		err := c.B.Call("GET", "/skus", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))

--- a/transfer.go
+++ b/transfer.go
@@ -65,6 +65,12 @@ type Transfer struct {
 	SourceType TransferSourceType `json:"source_type"`
 }
 
+// TransferList is a list of transfers as retrieved from a list endpoint.
+type TransferList struct {
+	ListMeta
+	Values []*Transfer `json:"data"`
+}
+
 // UnmarshalJSON handles deserialization of a Transfer.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -176,11 +176,6 @@ func List(params *stripe.TransferListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.TransferListParams) *Iter {
-	type transferList struct {
-		stripe.ListMeta
-		Values []*stripe.Transfer `json:"data"`
-	}
-
 	var body *url.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -210,7 +205,7 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &transferList{}
+		list := &stripe.TransferList{}
 		err := c.B.Call("GET", "/transfers", c.Key, &b, p, list)
 
 		ret := make([]interface{}, len(list.Values))


### PR DESCRIPTION
This expands on the solution to #227 and makes the change across the board to all remaining private `type <entity>List` structs. Including:

 - `AccountList`
 - `BitcoinReceiverList`
 - `ChargeList`
 - `CountrySpecList`
 - `CouponList`
 - `CustomerList`
 - `DisputeList`
 - `EventList`
 - `FeeList`
 - `FileUploadList`
 - `InvoiceList` (this is the one I need now)
 - `OrderList`
 - `ProductList`
 - `RecipientList`
 - `TransactionList`

A couple had already been exposed, but the private type was still being used internally, these have been cleaned up and made consistent with the rest:

 - `BitcoinTransactionList`
 - `SKUList`

I split each of these changes up across many commits, so you can cherry-pick if you so desire. (all I really need atm is `InvoiceList`, but this consistency should future-proof the rest)