### PR TITLE
New external accounts can be marked as default from a token

### DIFF
--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -35,6 +35,10 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 	// Use token (if exists) or a dictionary containing a user’s bank account details.
 	if len(params.Token) > 0 {
 		body.Add("external_account", params.Token)
+
+		if params.Default {
+			body.Add("default_for_currency", strconv.FormatBool(params.Default))
+		}
 	} else {
 		body.Add("external_account[object]", "bank_account")
 		body.Add("external_account[country]", params.Country)


### PR DESCRIPTION
Fixed the ability to create a new external account on a managed account from a token and mark it as default at the same time.

r? @brandur 