### PR TITLE
Makes routing_number only be sent in POST if set

### DIFF
--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -43,8 +43,11 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 		body.Add("external_account[object]", "bank_account")
 		body.Add("external_account[country]", params.Country)
 		body.Add("external_account[account_number]", params.Account)
-		body.Add("external_account[routing_number]", params.Routing)
 		body.Add("external_account[currency]", params.Currency)
+
+		if len(params.Routing) > 0 {
+			body.Add("external_account[routing_number]", params.Routing)
+		}
 
 		if params.Default {
 			body.Add("external_account[default_for_currency]", strconv.FormatBool(params.Default))


### PR DESCRIPTION
When tokenizing a bank account, the routing number is only required
for US bank accounts. If using an IBAN for `account_number`, then
this field is optional. Prior to this commit, `routing_number` was
always being sent, even as a an empty string which was causing the
following error to be sent back from the Stripe API:

{
  "type":"invalid_request_error",
  "message":"Invalid bic",
  "param":"bank_account",
  "request_id":"req_XXXYYYZZZ",
  "status":400
}

Relevant docs URL: https://stripe.com/docs/api/go#create_bank_account_token-bank_account-routing_number
Signed-off-by: Zach Wick <zwick@stripe.com>