### PR TITLE
Fix to Pull #247

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -68,7 +68,9 @@ func (b *BankAccount) Display() string {
 // AppendDetails adds the bank account's details to the query string values.
 func (b *BankAccountParams) AppendDetails(values *url.Values) {
 	values.Add("bank_account[country]", b.Country)
-	values.Add("bank_account[routing_number]", b.Routing)
+	if len(b.Routing) > 0 {
+		values.Add("bank_account[routing_number]", b.Routing)
+	}
 	values.Add("bank_account[account_number]", b.Account)
 	if b.AccountHolderName != "" {
 		values.Add("bank_account[account_holder_name]", b.AccountHolderName)


### PR DESCRIPTION
Related to pull #247 , also when need to create token for bank account, routing_number is optional according to documentation [https://stripe.com/docs/api#create_bank_account_token](url)