### PR TITLE
Add a StableForm type that can support ordered duplicates

### DIFF
--- a/order/client.go
+++ b/order/client.go
@@ -24,11 +24,11 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 // New POSTs a new order.
 // For more details see https://stripe.com/docs/api#create_order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
-	var body *url.Values
+	var body *stripe.StableForm
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.StableForm{}
 		commonParams = &params.Params
 		// Required fields
 		body.Add("currency", string(params.Currency))

--- a/params_test.go
+++ b/params_test.go
@@ -9,6 +9,36 @@ import (
 	. "github.com/stripe/stripe-go/testing"
 )
 
+func TestStableForm(t *testing.T) {
+	form := &stripe.StableForm{}
+
+	actual := form.Encode()
+	expected := ""
+	if expected != actual {
+		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+
+	form = &stripe.StableForm{}
+	form.Add("foo", "bar")
+
+	actual = form.Encode()
+	expected = "foo=bar"
+	if expected != actual {
+		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+
+	form = &stripe.StableForm{}
+	form.Add("foo", "bar")
+	form.Add("foo", "bar")
+	form.Add("baz", "bar")
+
+	actual = form.Encode()
+	expected = "foo=bar&foo=bar&baz=bar"
+	if expected != actual {
+		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+}
+
 func TestParamsWithExtras(t *testing.T) {
 	testCases := []struct {
 		InitialBody  url.Values

--- a/stripe.go
+++ b/stripe.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -38,7 +37,7 @@ const TotalBackends = 2
 // Backend is an interface for making calls against a Stripe service.
 // This interface exists to enable mocking for during testing if needed.
 type Backend interface {
-	Call(method, path, key string, body *url.Values, params *Params, v interface{}) error
+	Call(method, path, key string, body Form, params *Params, v interface{}) error
 	CallMultipart(method, path, key, boundary string, body io.Reader, params *Params, v interface{}) error
 }
 
@@ -144,9 +143,9 @@ func SetBackend(backend SupportedBackend, b Backend) {
 }
 
 // Call is the Backend.Call implementation for invoking Stripe APIs.
-func (s BackendConfiguration) Call(method, path, key string, form *url.Values, params *Params, v interface{}) error {
+func (s BackendConfiguration) Call(method, path, key string, form Form, params *Params, v interface{}) error {
 	var body io.Reader
-	if form != nil && len(*form) > 0 {
+	if form != nil {
 		data := form.Encode()
 		if strings.ToUpper(method) == "GET" {
 			path += "?" + data


### PR DESCRIPTION
As described in #251, using `url.Values` to contain form values is
problematic for the Stripe API because it depends on "Rack style" form
encoding that requires duplicated parameters to occur in a certain order
for arrays to be correctly encoded.

This patch adds a new type called `StableForm` that encodes parameters
in the order that they were added so that arrays can be properly
supported. It also adds a `Form` interface that's shared between
`StableForm` and `url.Values` so that we can demonstrate this concept
for now without updating every use of `url.Values` everywhere. For
consistency, before the final merge we should probably move to
`StableForm` everywhere and remove the interface (which will produce a
messy diff).

From #251, here's an incorrectly encoded form containing a multi-item array:

```
items[][amount]=0&items[][amount]=0&items[][description]=&items[][description]=&items[][parent]=sku_8KuzQIEccDprsR&items[][parent]=sku_8KbgQAaeg7C2S9&items[][type]=sku&items[][type]=sku
```

And here's the same form encoded with this patch:


```
items[][description]=&items[][type]=sku&items[][amount]=0&items[][parent]=sku_8KuzQIEccDprsR&items[][description]=&items[][type]=sku&items[][amount]=0&items[][parent]=sku_8KbgQAaeg7C2S9
```

/cc @rasmusrygaard Would you mind letting me know what you think about this
approach? Thanks!

/cc @stripe/api-libraries 

Fixes #251.