### PR TITLE
Overhaul the errors subsystem

### DIFF
--- a/error.go
+++ b/error.go
@@ -3,19 +3,18 @@ package stripe
 import "encoding/json"
 
 // ErrorType is the list of allowed values for the error's type.
-// Allowed values are "invalid_request_error", "api_error", "card_error".
 type ErrorType string
 
 // ErrorCode is the list of allowed values for the error's code.
-// Allowed values are "incorrect_number", "invalid_number", "invalid_expiry_month",
-// "invalid_expiry_year", "invalid_cvc", "expired_card", "incorrect_cvc", "incorrect_zip",
-// "card_declined", "missing", "processing_error", "rate_limit".
 type ErrorCode string
 
 const (
-	InvalidRequest ErrorType = "invalid_request_error"
-	APIErr         ErrorType = "api_error"
-	CardErr        ErrorType = "card_error"
+	ErrorTypeAPI            ErrorType = "api_error"
+	ErrorTypeAPIConnection  ErrorType = "api_connection_error"
+	ErrorTypeAuthentication ErrorType = "authentication_error"
+	ErrorTypeCard           ErrorType = "card_error"
+	ErrorTypeInvalidRequest ErrorType = "invalid_request_error"
+	ErrorTypeRateLimit      ErrorType = "rate_limit_error"
 
 	IncorrectNum  ErrorCode = "incorrect_number"
 	InvalidNum    ErrorCode = "invalid_number"
@@ -31,9 +30,9 @@ const (
 	RateLimit     ErrorCode = "rate_limit"
 )
 
-// Error is the response returned when a call is unsuccessful.
+// StripeError is the response returned when a call is unsuccessful.
 // For more details see  https://stripe.com/docs/api#errors.
-type Error struct {
+type StripeError struct {
 	Type           ErrorType `json:"type"`
 	Msg            string    `json:"message"`
 	Code           ErrorCode `json:"code,omitempty"`
@@ -43,8 +42,74 @@ type Error struct {
 	ChargeID       string    `json:"charge,omitempty"`
 }
 
-// Error serializes the Error object and prints the JSON string.
-func (e *Error) Error() string {
+// Error serializes the error object to JSON and returns it as a string.
+func (e *StripeError) Error() string {
 	ret, _ := json.Marshal(e)
 	return string(ret)
+}
+
+// APIConnectionError is a failure to connect to the Stripe API.
+type APIConnectionError struct {
+	StripeError
+}
+
+// Error serializes the error object to JSON and returns it as a string.
+func (e *APIConnectionError) Error() string {
+	return e.StripeError.Error()
+}
+
+// APIError is a catch all for any errors not covered by other types (and
+// should be extremely uncommon).
+type APIError struct {
+	StripeError
+}
+
+// Error serializes the error object to JSON and returns it as a string.
+func (e *APIError) Error() string {
+	return e.StripeError.Error()
+}
+
+// AuthenticationError is a failure to properly authenticate during a request.
+type AuthenticationError struct {
+	StripeError
+}
+
+// Error serializes the error object to JSON and returns it as a string.
+func (e *AuthenticationError) Error() string {
+	return e.StripeError.Error()
+}
+
+// CardError are the most common type of error you should expect to handle.
+// They result when the user enters a card that can't be charged for some
+// reason.
+type CardError struct {
+	StripeError
+	DeclineCode string `json:"decline_code,omitempty"`
+}
+
+// Error serializes the error object to JSON and returns it as a string.
+func (e *CardError) Error() string {
+	return e.StripeError.Error()
+}
+
+// InvalidRequestError is an error that occurs when a request contains invalid
+// parameters.
+type InvalidRequestError struct {
+	StripeError
+}
+
+// Error serializes the error object to JSON and returns it as a string.
+func (e *InvalidRequestError) Error() string {
+	return e.StripeError.Error()
+}
+
+// RateLimitError occurs when the Stripe API is hit to with too many requests
+// too quickly and indicates that the current request has been rate limited.
+type RateLimitError struct {
+	StripeError
+}
+
+// Error serializes the error object to JSON and returns it as a string.
+func (e *RateLimitError) Error() string {
+	return e.StripeError.Error()
 }

--- a/error.go
+++ b/error.go
@@ -38,7 +38,7 @@ const (
 	InvalidRequest ErrorType = ErrorTypeInvalidRequest
 )
 
-// StripeError is the response returned when a call is unsuccessful.
+// Error is the response returned when a call is unsuccessful.
 // For more details see  https://stripe.com/docs/api#errors.
 type Error struct {
 	Type           ErrorType `json:"type"`
@@ -64,66 +64,66 @@ func (e *Error) Error() string {
 
 // APIConnectionError is a failure to connect to the Stripe API.
 type APIConnectionError struct {
-	StripeErr *Error
+	stripeErr *Error
 }
 
 // Error serializes the error object to JSON and returns it as a string.
 func (e *APIConnectionError) Error() string {
-	return e.StripeErr.Error()
+	return e.stripeErr.Error()
 }
 
 // APIError is a catch all for any errors not covered by other types (and
 // should be extremely uncommon).
 type APIError struct {
-	StripeErr *Error
+	stripeErr *Error
 }
 
 // Error serializes the error object to JSON and returns it as a string.
 func (e *APIError) Error() string {
-	return e.StripeErr.Error()
+	return e.stripeErr.Error()
 }
 
 // AuthenticationError is a failure to properly authenticate during a request.
 type AuthenticationError struct {
-	StripeErr *Error
+	stripeErr *Error
 }
 
 // Error serializes the error object to JSON and returns it as a string.
 func (e *AuthenticationError) Error() string {
-	return e.StripeErr.Error()
+	return e.stripeErr.Error()
 }
 
 // CardError are the most common type of error you should expect to handle.
 // They result when the user enters a card that can't be charged for some
 // reason.
 type CardError struct {
-	StripeErr   *Error
+	stripeErr   *Error
 	DeclineCode string `json:"decline_code,omitempty"`
 }
 
 // Error serializes the error object to JSON and returns it as a string.
 func (e *CardError) Error() string {
-	return e.StripeErr.Error()
+	return e.stripeErr.Error()
 }
 
 // InvalidRequestError is an error that occurs when a request contains invalid
 // parameters.
 type InvalidRequestError struct {
-	StripeErr *Error
+	stripeErr *Error
 }
 
 // Error serializes the error object to JSON and returns it as a string.
 func (e *InvalidRequestError) Error() string {
-	return e.StripeErr.Error()
+	return e.stripeErr.Error()
 }
 
 // RateLimitError occurs when the Stripe API is hit to with too many requests
 // too quickly and indicates that the current request has been rate limited.
 type RateLimitError struct {
-	StripeErr *Error
+	stripeErr *Error
 }
 
 // Error serializes the error object to JSON and returns it as a string.
 func (e *RateLimitError) Error() string {
-	return e.StripeErr.Error()
+	return e.stripeErr.Error()
 }

--- a/stripe.go
+++ b/stripe.go
@@ -317,16 +317,16 @@ func (s *BackendConfiguration) ResponseToError(res *http.Response, resBody []byt
 
 	switch stripeErr.Type {
 	case ErrorTypeAPI:
-		stripeErr.Err = &APIError{StripeErr: stripeErr}
+		stripeErr.Err = &APIError{stripeErr: stripeErr}
 
 	case ErrorTypeAPIConnection:
-		stripeErr.Err = &APIConnectionError{StripeErr: stripeErr}
+		stripeErr.Err = &APIConnectionError{stripeErr: stripeErr}
 
 	case ErrorTypeAuthentication:
-		stripeErr.Err = &AuthenticationError{StripeErr: stripeErr}
+		stripeErr.Err = &AuthenticationError{stripeErr: stripeErr}
 
 	case ErrorTypeCard:
-		cardErr := &CardError{StripeErr: stripeErr}
+		cardErr := &CardError{stripeErr: stripeErr}
 		stripeErr.Err = cardErr
 
 		if declineCode, ok := root["decline_code"]; ok {
@@ -334,10 +334,10 @@ func (s *BackendConfiguration) ResponseToError(res *http.Response, resBody []byt
 		}
 
 	case ErrorTypeInvalidRequest:
-		stripeErr.Err = &InvalidRequestError{StripeErr: stripeErr}
+		stripeErr.Err = &InvalidRequestError{stripeErr: stripeErr}
 
 	case ErrorTypeRateLimit:
-		stripeErr.Err = &RateLimitError{StripeErr: stripeErr}
+		stripeErr.Err = &RateLimitError{stripeErr: stripeErr}
 	}
 
 	if LogLevel > 0 {

--- a/stripe.go
+++ b/stripe.go
@@ -262,47 +262,7 @@ func (s *BackendConfiguration) Do(req *http.Request, v interface{}) error {
 	}
 
 	if res.StatusCode >= 400 {
-		// for some odd reason, the Erro structure doesn't unmarshal
-		// initially I thought it was because it's a struct inside of a struct
-		// but even after trying that, it still didn't work
-		// so unmarshalling to a map for now and parsing the results manually
-		// but should investigate later
-		var errMap map[string]interface{}
-		json.Unmarshal(resBody, &errMap)
-
-		e, ok := errMap["error"]
-		if !ok {
-			err := errors.New(string(resBody))
-			if LogLevel > 0 {
-				Logger.Printf("Unparsable error returned from Stripe: %v\n", err)
-			}
-			return err
-		}
-
-		root := e.(map[string]interface{})
-		err := &Error{
-			Type:           ErrorType(root["type"].(string)),
-			Msg:            root["message"].(string),
-			HTTPStatusCode: res.StatusCode,
-			RequestID:      res.Header.Get("Request-Id"),
-		}
-
-		if code, ok := root["code"]; ok {
-			err.Code = ErrorCode(code.(string))
-		}
-
-		if param, ok := root["param"]; ok {
-			err.Param = param.(string)
-		}
-
-		if charge, ok := root["charge"]; ok {
-			err.ChargeID = charge.(string)
-		}
-
-		if LogLevel > 0 {
-			Logger.Printf("Error encountered from Stripe: %v\n", err)
-		}
-		return err
+		return s.ResponseToError(res, resBody)
 	}
 
 	if LogLevel > 2 {
@@ -314,4 +274,79 @@ func (s *BackendConfiguration) Do(req *http.Request, v interface{}) error {
 	}
 
 	return nil
+}
+
+func (s *BackendConfiguration) ResponseToError(res *http.Response, resBody []byte) error {
+	// for some odd reason, the Erro structure doesn't unmarshal
+	// initially I thought it was because it's a struct inside of a struct
+	// but even after trying that, it still didn't work
+	// so unmarshalling to a map for now and parsing the results manually
+	// but should investigate later
+	var errMap map[string]interface{}
+	json.Unmarshal(resBody, &errMap)
+
+	e, ok := errMap["error"]
+	if !ok {
+		err := errors.New(string(resBody))
+		if LogLevel > 0 {
+			Logger.Printf("Unparsable error returned from Stripe: %v\n", err)
+		}
+		return err
+	}
+
+	root := e.(map[string]interface{})
+
+	stripeErr := &StripeError{
+		Type:           ErrorType(root["type"].(string)),
+		Msg:            root["message"].(string),
+		HTTPStatusCode: res.StatusCode,
+		RequestID:      res.Header.Get("Request-Id"),
+	}
+
+	if code, ok := root["code"]; ok {
+		stripeErr.Code = ErrorCode(code.(string))
+	}
+
+	if param, ok := root["param"]; ok {
+		stripeErr.Param = param.(string)
+	}
+
+	if charge, ok := root["charge"]; ok {
+		stripeErr.ChargeID = charge.(string)
+	}
+
+	var err error
+	err = stripeErr
+
+	switch stripeErr.Type {
+	case ErrorTypeAPI:
+		err = &APIError{StripeError: *stripeErr}
+
+	case ErrorTypeAPIConnection:
+		err = &APIConnectionError{StripeError: *stripeErr}
+
+	case ErrorTypeAuthentication:
+		err = &AuthenticationError{StripeError: *stripeErr}
+
+	case ErrorTypeCard:
+		cardErr := &CardError{StripeError: *stripeErr}
+
+		if declineCode, ok := root["decline_code"]; ok {
+			cardErr.DeclineCode = declineCode.(string)
+		}
+
+		err = cardErr
+
+	case ErrorTypeInvalidRequest:
+		err = &InvalidRequestError{StripeError: *stripeErr}
+
+	case ErrorTypeRateLimit:
+		err = &RateLimitError{StripeError: *stripeErr}
+	}
+
+	if LogLevel > 0 {
+		Logger.Printf("Error encountered from Stripe: %v\n", err)
+	}
+
+	return err
 }

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -1,6 +1,8 @@
 package stripe_test
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 
 	stripe "github.com/stripe/stripe-go"
@@ -34,4 +36,86 @@ func TestCheckinBackendConfigurationNewRequestWithStripeAccount(t *testing.T) {
 		t.Fatalf("Expected Stripe-Account %v but got %v.",
 			TestMerchantID, req.Header.Get("Stripe-Account"))
 	}
+}
+
+func TestCheckinResponseToError(t *testing.T) {
+	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+
+	// A test response that includes a status code and request ID.
+	res := &http.Response{
+		Header: http.Header{
+			"Request-Id": []string{"request-id"},
+		},
+		StatusCode: 402,
+	}
+
+	// An error that contains expected fields which we're going to serialize to
+	// JSON and inject into our converstion function.
+	expectedErr := &stripe.StripeError{
+		Code:  stripe.Missing,
+		Msg:   "A generic error",
+		Param: "expiry_date",
+	}
+	bytes, err := json.Marshal(expectedErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A generic Golang error.
+	err = c.ResponseToError(res, wrapError(bytes))
+
+	// An error containing Stripe-specific fields that we cast back from the
+	// generic Golang error.
+	stripeErr := err.(*stripe.StripeError)
+
+	if expectedErr.Code != stripeErr.Code {
+		t.Fatalf("Expected code %v but got %v.", expectedErr.Code, stripeErr.Code)
+	}
+
+	if expectedErr.Msg != stripeErr.Msg {
+		t.Fatalf("Expected message %v but got %v.", expectedErr.Msg, stripeErr.Msg)
+	}
+
+	if expectedErr.Param != stripeErr.Param {
+		t.Fatalf("Expected param %v but got %v.", expectedErr.Param, stripeErr.Param)
+	}
+
+	if res.Header.Get("Request-Id") != stripeErr.RequestID {
+		t.Fatalf("Expected code %v but got %v.", res.Header.Get("Request-Id"), stripeErr.RequestID)
+	}
+
+	if res.StatusCode != stripeErr.HTTPStatusCode {
+		t.Fatalf("Expected code %v but got %v.", res.StatusCode, stripeErr.HTTPStatusCode)
+	}
+
+	// An error with a "type" field which will come back aas a specific error
+	// type.
+	expectedCardErr := &stripe.CardError{
+		StripeError: stripe.StripeError{
+			Msg:  "That card was declined",
+			Type: stripe.ErrorTypeCard,
+		},
+		DeclineCode: "decline-code",
+	}
+	bytes, err = json.Marshal(expectedCardErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.ResponseToError(res, wrapError(bytes))
+	cardErr := err.(*stripe.CardError)
+
+	if expectedCardErr.DeclineCode != cardErr.DeclineCode {
+		t.Fatalf("Expected decline code %v but got %v.", expectedCardErr.DeclineCode, cardErr.DeclineCode)
+	}
+
+	if expectedCardErr.Msg != cardErr.Msg {
+		t.Fatalf("Expected message %v but got %v.", expectedCardErr.Msg, cardErr.Msg)
+	}
+}
+
+// A simple function that allows us to represent an error response from Stripe
+// which comes wrapper in a JSON object with a single field of "error".
+func wrapError(serialized []byte) []byte {
+	return []byte(`{"error":` + string(serialized) + `}`)
 }


### PR DESCRIPTION
Adds specific types for all specific errors that can be returned by the Stripe API. These types are then grafted onto the common `stripe.Error` under the new field `Err` so that a user can access type-specific information about the error.

Usage looks a little like:

``` go
_, err := // Go library call

if err != nil {
    stripeErr := err.(*stripe.Error)

	if cardErr, ok := stripeErr.Err.(*stripe.CardError); ok {
        fmt.Printf("Card was declined with code: %v\n", cardErr.DeclineCode)
    } else {
        fmt.Printf("Other Stripe error occurred: %v\n", stripeErr.Error())
    }

    return nil, err
}
```

The change is designed to overhaul the error system in a way that enables access to important features, conforms to standard library convention (see [`net.OpError`](https://golang.org/pkg/net/#OpError)), and all the while still maintains backwards compatibility.

Presented as an alternative to #253.