### PR TITLE
Add a RequestValues type that can support ordered duplicates

### DIFF
--- a/account.go
+++ b/account.go
@@ -3,7 +3,6 @@ package stripe
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"strconv"
 )
 
@@ -274,7 +273,7 @@ type AccountRejectParams struct {
 }
 
 // AppendDetails adds the legal entity to the query string.
-func (l *LegalEntity) AppendDetails(values *url.Values) {
+func (l *LegalEntity) AppendDetails(values *RequestValues) {
 	values.Add("legal_entity[type]", string(l.Type))
 
 	if len(l.BusinessName) > 0 {
@@ -397,7 +396,7 @@ func (l *LegalEntity) AppendDetails(values *url.Values) {
 }
 
 // AppendDetails adds the transfer schedule to the query string.
-func (t *TransferScheduleParams) AppendDetails(values *url.Values) {
+func (t *TransferScheduleParams) AppendDetails(values *RequestValues) {
 	if t.Delay > 0 {
 		values.Add("transfer_schedule[delay_days]", strconv.FormatUint(t.Delay, 10))
 	} else if t.MinimumDelay {
@@ -413,7 +412,7 @@ func (t *TransferScheduleParams) AppendDetails(values *url.Values) {
 }
 
 // AppendDetails adds the terms of service acceptance to the query string.
-func (t *TOSAcceptanceParams) AppendDetails(values *url.Values) {
+func (t *TOSAcceptanceParams) AppendDetails(values *RequestValues) {
 	if t.Date > 0 {
 		values.Add("tos_acceptance[date]", strconv.FormatInt(t.Date, 10))
 	}

--- a/account/client.go
+++ b/account/client.go
@@ -2,7 +2,6 @@
 package account
 
 import (
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -20,7 +19,7 @@ func New(params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func writeAccountParams(
-	params *stripe.AccountParams, body *url.Values,
+	params *stripe.AccountParams, body *stripe.RequestValues,
 ) {
 	if len(params.Country) > 0 {
 		body.Add("country", params.Country)
@@ -96,10 +95,9 @@ func writeAccountParams(
 }
 
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
-	body := &url.Values{
-		"managed":                 {strconv.FormatBool(params.Managed)},
-		"debit_negative_balances": {strconv.FormatBool(params.DebitNegativeBal)},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("managed", strconv.FormatBool(params.Managed))
+	body.Add("debit_negative_balances", strconv.FormatBool(params.DebitNegativeBal))
 
 	writeAccountParams(params, body)
 
@@ -133,12 +131,12 @@ func GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func (c Client) GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -154,12 +152,12 @@ func Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		writeAccountParams(params, body)
 
@@ -194,7 +192,7 @@ func Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, err
 }
 
 func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	if len(params.Reason) > 0 {
 		body.Add("reason", params.Reason)
 	}
@@ -210,21 +208,21 @@ func List(params *stripe.AccountListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.AccountListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.AccountList{}
-		err := c.B.Call("GET", "/accounts", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/accounts", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/balance/client.go
+++ b/balance/client.go
@@ -2,7 +2,6 @@
 package balance
 
 import (
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -35,12 +34,12 @@ func Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 }
 
 func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -57,12 +56,12 @@ func GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, error) {
 }
 
 func (c Client) GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -79,12 +78,12 @@ func List(params *stripe.TxListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.TxListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -115,9 +114,9 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TransactionList{}
-		err := c.B.Call("GET", "/balance/history", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/balance/history", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -3,7 +3,6 @@ package stripe
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 )
 
 // BankAccountStatus is the list of allowed values for the bank account's status.
@@ -66,7 +65,7 @@ func (b *BankAccount) Display() string {
 }
 
 // AppendDetails adds the bank account's details to the query string values.
-func (b *BankAccountParams) AppendDetails(values *url.Values) {
+func (b *BankAccountParams) AppendDetails(values *RequestValues) {
 	values.Add("bank_account[country]", b.Country)
 	if len(b.Routing) > 0 {
 		values.Add("bank_account[routing_number]", b.Routing)

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -4,7 +4,6 @@ package bankaccount
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -30,7 +29,7 @@ func New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 
 func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 
 	// Use token (if exists) or a dictionary containing a user’s bank account details.
 	if len(params.Token) > 0 {
@@ -67,12 +66,12 @@ func Get(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 }
 
 func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -88,12 +87,12 @@ func Update(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, e
 }
 
 func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Default {
 			body.Add("default_for_currency", strconv.FormatBool(params.Default))
@@ -134,7 +133,7 @@ func List(params *stripe.BankAccountListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.BankAccountListParams) *Iter {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -142,9 +141,9 @@ func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BankAccountList{}
-		err := c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, &b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -3,7 +3,6 @@ package bitcoinreceiver
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -22,10 +21,9 @@ func New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) 
 }
 
 func (c Client) New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
-	body := &url.Values{
-		"amount":   {strconv.FormatUint(params.Amount, 10)},
-		"currency": {string(params.Currency)},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("amount", strconv.FormatUint(params.Amount, 10))
+	body.Add("currency", string(params.Currency))
 
 	if len(params.Desc) > 0 {
 		body.Add("description", params.Desc)
@@ -71,7 +69,7 @@ func Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.Bitc
 }
 
 func (c Client) Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.BitcoinReceiver, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 
 	if len(params.Desc) > 0 {
 		body.Add("description", params.Desc)
@@ -100,12 +98,12 @@ func List(params *stripe.BitcoinReceiverListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		body.Add("filled", strconv.FormatBool(!params.NotFilled))
 		body.Add("active", strconv.FormatBool(!params.NotActive))
@@ -116,9 +114,9 @@ func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinReceiverList{}
-		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -3,7 +3,6 @@ package bitcointransaction
 
 import (
 	"fmt"
-	"net/url"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -21,12 +20,12 @@ func List(params *stripe.BitcoinTransactionListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
@@ -37,9 +36,9 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinTransactionList{}
-		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, &b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/card.go
+++ b/card.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"fmt"
-	"net/url"
 )
 
 // CardBrand is the list of allowed values for the card's brand.
@@ -95,7 +94,7 @@ type CardList struct {
 // AppendDetails adds the card's details to the query string values.
 // When creating a new card, the parameters are passed as a dictionary, but
 // on updates they are simply the parameter name.
-func (c *CardParams) AppendDetails(values *url.Values, creating bool) {
+func (c *CardParams) AppendDetails(values *RequestValues, creating bool) {
 	if creating {
 		if len(c.Token) > 0 && len(c.Account) > 0 {
 			values.Add("external_account", c.Token)

--- a/card/client.go
+++ b/card/client.go
@@ -4,7 +4,6 @@ package card
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -42,7 +41,7 @@ func New(params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	params.AppendDetails(body, true)
 	params.AppendTo(body)
 
@@ -72,12 +71,12 @@ func Get(id string, params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -104,7 +103,7 @@ func Update(id string, params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	params.AppendDetails(body, false)
 	params.AppendTo(body)
 
@@ -157,7 +156,7 @@ func List(params *stripe.CardListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CardListParams) *Iter {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -165,16 +164,16 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CardList{}
 		var err error
 
 		if len(params.Account) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, &b, p, list)
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, b, p, list)
 		} else if len(params.Customer) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards", params.Customer), c.Key, &b, p, list)
+			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards", params.Customer), c.Key, b, p, list)
 		} else if len(params.Recipient) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", params.Recipient), c.Key, &b, p, list)
+			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", params.Recipient), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 		}

--- a/charge.go
+++ b/charge.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"encoding/json"
-	"net/url"
 )
 
 // Currency is the list of supported currencies.
@@ -117,7 +116,7 @@ type ShippingDetails struct {
 }
 
 // AppendDetails adds the shipping details to the query string.
-func (s *ShippingDetails) AppendDetails(values *url.Values) {
+func (s *ShippingDetails) AppendDetails(values *RequestValues) {
 	values.Add("shipping[name]", s.Name)
 
 	values.Add("shipping[address][line1]", s.Address.Line1)

--- a/charge/client.go
+++ b/charge/client.go
@@ -4,7 +4,6 @@ package charge
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -28,10 +27,9 @@ func New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
-	body := &url.Values{
-		"amount":   {strconv.FormatUint(params.Amount, 10)},
-		"currency": {string(params.Currency)},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("amount", strconv.FormatUint(params.Amount, 10))
+	body.Add("currency", string(params.Currency))
 
 	if params.Source == nil && len(params.Customer) == 0 {
 		err := errors.New("Invalid charge params: either customer or a source must be set")
@@ -88,12 +86,12 @@ func Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -110,12 +108,12 @@ func Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Desc) > 0 {
 			body.Add("description", params.Desc)
@@ -141,13 +139,13 @@ func Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	token := c.Key
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Amount > 0 {
 			body.Add("amount", strconv.FormatUint(params.Amount, 10))
@@ -178,12 +176,12 @@ func List(params *stripe.ChargeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ChargeListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -198,9 +196,9 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ChargeList{}
-		err := c.B.Call("GET", "/charges", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/charges", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {
@@ -240,12 +238,12 @@ func UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, er
 }
 
 func (c Client) UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Evidence != nil {
 			params.Evidence.AppendDetails(body)

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -2,8 +2,6 @@
 package countryspec
 
 import (
-	"net/url"
-
 	stripe "github.com/stripe/stripe-go"
 )
 
@@ -32,21 +30,21 @@ func List(params *stripe.CountrySpecListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CountrySpecListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CountrySpecList{}
-		err := c.B.Call("GET", "/country_specs", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/country_specs", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -3,7 +3,6 @@ package coupon
 
 import (
 	"errors"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -30,9 +29,8 @@ func New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 	// TODO: this doesn't check that the params are not nil.
 
-	body := &url.Values{
-		"duration": {string(params.Duration)},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("duration", string(params.Duration))
 
 	if len(params.ID) > 0 {
 		body.Add("id", params.ID)
@@ -76,12 +74,12 @@ func Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -99,7 +97,7 @@ func Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 }
 
 func (c Client) Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 
 	params.AppendTo(body)
 
@@ -129,21 +127,21 @@ func List(params *stripe.CouponListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CouponListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CouponList{}
-		err := c.B.Call("GET", "/coupons", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/coupons", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/customer.go
+++ b/customer.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"encoding/json"
-	"net/url"
 )
 
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
@@ -69,7 +68,7 @@ type CustomerShippingDetails struct {
 }
 
 // AppendDetails adds the shipping details to the query string.
-func (s *CustomerShippingDetails) AppendDetails(values *url.Values) {
+func (s *CustomerShippingDetails) AppendDetails(values *RequestValues) {
 	values.Add("shipping[name]", s.Name)
 
 	values.Add("shipping[address][line1]", s.Address.Line1)

--- a/customer/client.go
+++ b/customer/client.go
@@ -2,7 +2,6 @@
 package customer
 
 import (
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -21,11 +20,11 @@ func New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 }
 
 func (c Client) New(params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		if params.Balance != 0 {
 			body.Add("account_balance", strconv.FormatInt(params.Balance, 10))
 		}
@@ -80,11 +79,11 @@ func Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		commonParams = &params.Params
 		params.AppendTo(body)
 	}
@@ -102,12 +101,12 @@ func Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) 
 }
 
 func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Balance != 0 {
 			body.Add("account_balance", strconv.FormatInt(params.Balance, 10))
@@ -165,12 +164,12 @@ func List(params *stripe.CustomerListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CustomerListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -181,9 +180,9 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CustomerList{}
-		err := c.B.Call("GET", "/customers", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/customers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/dispute.go
+++ b/dispute.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"encoding/json"
-	"net/url"
 )
 
 // DisputeReason is the list of allowed values for a discount's reason.
@@ -119,7 +118,7 @@ type File struct {
 }
 
 // AppendDetails adds the dispute evidence details to the query string values.
-func (e *DisputeEvidenceParams) AppendDetails(values *url.Values) {
+func (e *DisputeEvidenceParams) AppendDetails(values *RequestValues) {
 	if len(e.ProductDesc) > 0 {
 		values.Add("evidence[product_description]", e.ProductDesc)
 	}

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -3,7 +3,6 @@ package dispute
 
 import (
 	"fmt"
-	"net/url"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -41,12 +40,12 @@ func Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 }
 
 func (c Client) Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -63,21 +62,21 @@ func List(params *stripe.DisputeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.DisputeListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.DisputeList{}
-		err := c.B.Call("GET", "/disputes", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/disputes", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {
@@ -108,12 +107,12 @@ func Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 }
 
 func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Evidence != nil {
 			params.Evidence.AppendDetails(body)

--- a/event/client.go
+++ b/event/client.go
@@ -2,7 +2,6 @@
 package event
 
 import (
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -34,12 +33,12 @@ func List(params *stripe.EventListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.EventListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -54,9 +53,9 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.EventList{}
-		err := c.B.Call("GET", "/events", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/events", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/fee/client.go
+++ b/fee/client.go
@@ -3,7 +3,6 @@ package fee
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -22,12 +21,12 @@ func Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
 }
 
 func (c Client) Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -44,12 +43,12 @@ func List(params *stripe.FeeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.FeeListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -64,9 +63,9 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeList{}
-		err := c.B.Call("GET", "/application_fees", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/application_fees", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -3,7 +3,6 @@ package feerefund
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -22,7 +21,7 @@ func New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 }
 
 func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 
 	if params.Amount > 0 {
 		body.Add("amount", strconv.FormatUint(params.Amount, 10))
@@ -47,7 +46,7 @@ func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefun
 		return nil, fmt.Errorf("params cannot be nil, and params.Fee must be set")
 	}
 
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	params.AppendTo(body)
 
 	refund := &stripe.FeeRefund{}
@@ -63,7 +62,7 @@ func Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error
 }
 
 func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	params.AppendTo(body)
 
 	refund := &stripe.FeeRefund{}
@@ -79,7 +78,7 @@ func List(params *stripe.FeeRefundListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -87,9 +86,9 @@ func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeRefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.Fee), c.Key, &b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.Fee), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -4,7 +4,6 @@ package fileupload
 import (
 	"bytes"
 	"fmt"
-	"net/url"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -51,13 +50,13 @@ func Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error)
 }
 
 func (c Client) Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
 
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -74,12 +73,12 @@ func List(params *stripe.FileUploadListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.FileUploadListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Purpose) > 0 {
 			body.Add("purpose", string(params.Purpose))
@@ -90,9 +89,9 @@ func (c Client) List(params *stripe.FileUploadListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FileUploadList{}
-		err := c.B.Call("GET", "/files", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/files", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -3,7 +3,6 @@ package invoice
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -27,9 +26,8 @@ func New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	body := &url.Values{
-		"customer": {params.Customer},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("customer", params.Customer)
 
 	if len(params.Desc) > 0 {
 		body.Add("description", params.Desc)
@@ -69,12 +67,12 @@ func Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -91,12 +89,12 @@ func Pay(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Pay(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -113,13 +111,13 @@ func Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	token := c.Key
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Desc) > 0 {
 			body.Add("description", params.Desc)
@@ -167,9 +165,8 @@ func GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	body := &url.Values{
-		"customer": {params.Customer},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("customer", params.Customer)
 
 	if len(params.Sub) > 0 {
 		body.Add("subscription", params.Sub)
@@ -210,12 +207,12 @@ func List(params *stripe.InvoiceListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.InvoiceListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
@@ -230,9 +227,9 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceList{}
-		err := c.B.Call("GET", "/invoices", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/invoices", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {
@@ -250,7 +247,7 @@ func ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 }
 
 func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -266,9 +263,9 @@ func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &LineIter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &LineIter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceLineList{}
-		err := c.B.Call("GET", fmt.Sprintf("/invoices/%v/lines", params.ID), c.Key, &b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/invoices/%v/lines", params.ID), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -2,7 +2,6 @@
 package invoiceitem
 
 import (
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -21,11 +20,10 @@ func New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 }
 
 func (c Client) New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	body := &url.Values{
-		"customer": {params.Customer},
-		"amount":   {strconv.FormatInt(params.Amount, 10)},
-		"currency": {string(params.Currency)},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("customer", params.Customer)
+	body.Add("amount", strconv.FormatInt(params.Amount, 10))
+	body.Add("currency", string(params.Currency))
 
 	if len(params.Invoice) > 0 {
 		body.Add("invoice", params.Invoice)
@@ -58,12 +56,12 @@ func Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 }
 
 func (c Client) Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -80,12 +78,12 @@ func Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, e
 }
 
 func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Amount != 0 {
 			body.Add("amount", strconv.FormatInt(params.Amount, 10))
@@ -128,12 +126,12 @@ func List(params *stripe.InvoiceItemListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -148,9 +146,9 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceItemList{}
-		err := c.B.Call("GET", "/invoiceitems", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/invoiceitems", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/iter.go
+++ b/iter.go
@@ -1,12 +1,11 @@
 package stripe
 
 import (
-	"net/url"
 	"reflect"
 )
 
 // Query is the function used to get a page listing.
-type Query func(url.Values) ([]interface{}, ListMeta, error)
+type Query func(*RequestValues) ([]interface{}, ListMeta, error)
 
 // Iter provides a convenient interface
 // for iterating over the elements
@@ -18,7 +17,7 @@ type Query func(url.Values) ([]interface{}, ListMeta, error)
 // across multiple goroutines.
 type Iter struct {
 	query  Query
-	qs     url.Values
+	qs     *RequestValues
 	values []interface{}
 	meta   ListMeta
 	params ListParams
@@ -27,7 +26,7 @@ type Iter struct {
 }
 
 // GetIter returns a new Iter for a given query and its options.
-func GetIter(params *ListParams, qs *url.Values, query Query) *Iter {
+func GetIter(params *ListParams, qs *RequestValues, query Query) *Iter {
 	iter := &Iter{}
 	iter.query = query
 
@@ -39,9 +38,9 @@ func GetIter(params *ListParams, qs *url.Values, query Query) *Iter {
 
 	q := qs
 	if q == nil {
-		q = &url.Values{}
+		q = &RequestValues{}
 	}
-	iter.qs = *q
+	iter.qs = q
 
 	iter.getPage()
 	return iter

--- a/iter_test.go
+++ b/iter_test.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"errors"
-	"net/url"
 	"reflect"
 	"testing"
 )
@@ -182,7 +181,7 @@ type testQuery []struct {
 	e error
 }
 
-func (tq *testQuery) query(url.Values) ([]interface{}, ListMeta, error) {
+func (tq *testQuery) query(*RequestValues) ([]interface{}, ListMeta, error) {
 	x := (*tq)[0]
 	*tq = (*tq)[1:]
 	return x.v, x.m, x.e

--- a/order/client.go
+++ b/order/client.go
@@ -3,7 +3,6 @@ package order
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -104,11 +103,11 @@ func Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) 
 // Update updates an order's properties.
 // For more details see https://stripe.com/docs/api#update_order.
 func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Coupon != "" {
 			body.Add("coupon", params.Coupon)
@@ -140,11 +139,11 @@ func Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 // Pay pays an order
 // For more details see https://stripe.com/docs/api#pay_order.
 func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		commonParams = &params.Params
 		if params.Source == nil && len(params.Customer) == 0 {
 			err := errors.New("Invalid order pay params: either customer or a source must be set")
@@ -219,11 +218,11 @@ func Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 }
 
 func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		commonParams = &params.Params
 		params.AppendTo(body)
 	}
@@ -240,12 +239,12 @@ func List(params *stripe.OrderListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.OrderListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		for _, id := range params.IDs {
 			params.Filters.AddFilter("ids[]", "", id)
@@ -260,9 +259,9 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderList{}
-		err := c.B.Call("GET", "/orders", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/orders", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {
@@ -295,11 +294,11 @@ func Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, e
 // Return returns all or part of an order.
 // For more details see https://stripe.com/docs/api#return_order.
 func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Items) > 0 {
 			for _, item := range params.Items {

--- a/order/client.go
+++ b/order/client.go
@@ -24,11 +24,11 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 // New POSTs a new order.
 // For more details see https://stripe.com/docs/api#create_order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
-	var body *stripe.StableForm
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.StableForm{}
+		body = &stripe.RequestValues{}
 		commonParams = &params.Params
 		// Required fields
 		body.Add("currency", string(params.Currency))

--- a/order/client.go
+++ b/order/client.go
@@ -24,11 +24,11 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 // New POSTs a new order.
 // For more details see https://stripe.com/docs/api#create_order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
-	var body *url.Values
+	var body *stripe.StableForm
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.StableForm{}
 		commonParams = &params.Params
 		// Required fields
 		body.Add("currency", string(params.Currency))

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -1,8 +1,6 @@
 package orderreturn
 
 import (
-	"net/url"
-
 	"github.com/stripe/stripe-go"
 )
 
@@ -18,12 +16,12 @@ func List(params *stripe.OrderReturnListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.OrderReturnListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Order != "" {
 			params.Filters.AddFilter("order", "", params.Order)
@@ -34,9 +32,9 @@ func (c Client) List(params *stripe.OrderReturnListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderReturnList{}
-		err := c.B.Call("GET", "/order_returns", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/order_returns", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/params.go
+++ b/params.go
@@ -15,8 +15,9 @@ const (
 	endbefore  = "ending_before"
 )
 
-// RequestValues is a Form implementation that allows duplicate keys and
-// encodes its entries in the same order that they were added.
+// RequestValues is a collection of values that can be submitted along with a
+// request that specifically allows for duplicate keys and encodes its entries
+// in the same order that they were added.
 type RequestValues struct {
 	values []formValue
 }
@@ -26,8 +27,7 @@ func (f *RequestValues) Add(key, val string) {
 	f.values = append(f.values, formValue{key, val})
 }
 
-// Encode encodes the form's values into “URL encoded” form
-// ("bar=baz&foo=quux").
+// Encode encodes the values into “URL encoded” form ("bar=baz&foo=quux").
 func (f *RequestValues) Encode() string {
 	var buf bytes.Buffer
 	for _, v := range f.values {
@@ -41,7 +41,19 @@ func (f *RequestValues) Encode() string {
 	return buf.String()
 }
 
+// Set sets the first instance of a parameter for the given key to the given
+// value. If no parameters exist with the key, a new one is added.
+//
+// Note that Set is O(n) and may be quite slow for a very large parameter list.
 func (f *RequestValues) Set(key, val string) {
+	for i, v := range f.values {
+		if v.Key == key {
+			f.values[i].Value = val
+			return
+		}
+	}
+
+	f.Add(key, val)
 }
 
 // A key/value tuple for use in the RequestValues type.

--- a/params.go
+++ b/params.go
@@ -41,6 +41,11 @@ func (f *RequestValues) Encode() string {
 	return buf.String()
 }
 
+// Empty returns true if no parameters have been set.
+func (f *RequestValues) Empty() bool {
+	return len(f.values) == 0
+}
+
 // Set sets the first instance of a parameter for the given key to the given
 // value. If no parameters exist with the key, a new one is added.
 //

--- a/params.go
+++ b/params.go
@@ -41,6 +41,9 @@ func (f *RequestValues) Encode() string {
 	return buf.String()
 }
 
+func (f *RequestValues) Set(key, val string) {
+}
+
 // A key/value tuple for use in the RequestValues type.
 type formValue struct {
 	Key   string
@@ -97,6 +100,17 @@ type ListMeta struct {
 // Filters is a structure that contains a collection of filters for list-related APIs.
 type Filters struct {
 	f []*filter
+}
+
+// AppendTo adds the list of filters to the query string values.
+func (f *Filters) AppendTo(values *RequestValues) {
+	for _, v := range f.f {
+		if len(v.Op) > 0 {
+			values.Add(fmt.Sprintf("%v[%v]", v.Key, v.Op), v.Val)
+		} else {
+			values.Add(v.Key, v.Val)
+		}
+	}
 }
 
 // filter is the structure that contains a filter for list-related APIs.
@@ -177,7 +191,7 @@ func (p *ListParams) Expand(f string) {
 }
 
 // AppendTo adds the common parameters to the query string values.
-func (p *ListParams) AppendTo(body *url.Values) {
+func (p *ListParams) AppendTo(body *RequestValues) {
 	if len(p.Filters.f) > 0 {
 		p.Filters.AppendTo(body)
 	}
@@ -210,16 +224,5 @@ func (p *ListParams) AppendTo(body *url.Values) {
 func (p *ListParams) ToParams() *Params {
 	return &Params{
 		StripeAccount: p.StripeAccount,
-	}
-}
-
-// AppendTo adds the list of filters to the query string values.
-func (f *Filters) AppendTo(values *url.Values) {
-	for _, v := range f.f {
-		if len(v.Op) > 0 {
-			values.Add(fmt.Sprintf("%v[%v]", v.Key, v.Op), v.Val)
-		} else {
-			values.Add(v.Key, v.Val)
-		}
 	}
 }

--- a/params.go
+++ b/params.go
@@ -15,27 +15,20 @@ const (
 	endbefore  = "ending_before"
 )
 
-// Form is an abstraction of a type that can have a series of values added to
-// it and then subsequently be encoded for use in an HTTP request.
-type Form interface {
-	Add(key, value string)
-	Encode() string
-}
-
-// StableForm is a Form implementation that allows duplicate keys and encodes
-// its entries in the same order that they were added.
-type StableForm struct {
+// RequestValues is a Form implementation that allows duplicate keys and
+// encodes its entries in the same order that they were added.
+type RequestValues struct {
 	values []formValue
 }
 
 // Add adds a key/value tuple to the form.
-func (f *StableForm) Add(key, val string) {
+func (f *RequestValues) Add(key, val string) {
 	f.values = append(f.values, formValue{key, val})
 }
 
 // Encode encodes the form's values into “URL encoded” form
 // ("bar=baz&foo=quux").
-func (f *StableForm) Encode() string {
+func (f *RequestValues) Encode() string {
 	var buf bytes.Buffer
 	for _, v := range f.values {
 		if buf.Len() > 0 {
@@ -48,7 +41,7 @@ func (f *StableForm) Encode() string {
 	return buf.String()
 }
 
-// A key/value tuple for use in the StableForm type.
+// A key/value tuple for use in the RequestValues type.
 type formValue struct {
 	Key   string
 	Value string
@@ -162,7 +155,7 @@ func (f *Filters) AddFilter(key, op, value string) {
 }
 
 // AppendTo adds the common parameters to the query string values.
-func (p *Params) AppendTo(body Form) {
+func (p *Params) AppendTo(body *RequestValues) {
 	for k, v := range p.Meta {
 		body.Add(fmt.Sprintf("metadata[%v]", k), v)
 	}

--- a/params_test.go
+++ b/params_test.go
@@ -1,7 +1,6 @@
 package stripe_test
 
 import (
-	"net/url"
 	"reflect"
 	"testing"
 
@@ -57,19 +56,19 @@ func TestRequestValues(t *testing.T) {
 
 func TestParamsWithExtras(t *testing.T) {
 	testCases := []struct {
-		InitialBody  url.Values
+		InitialBody  [][2]string
 		Extras       [][2]string
-		ExpectedBody url.Values
+		ExpectedBody [][2]string
 	}{
 		{
-			InitialBody:  url.Values{"foo": {"bar"}},
+			InitialBody:  [][2]string{{"foo", "bar"}},
 			Extras:       [][2]string{},
-			ExpectedBody: url.Values{"foo": {"bar"}},
+			ExpectedBody: [][2]string{{"foo", "bar"}},
 		},
 		{
-			InitialBody:  url.Values{"foo": {"bar"}},
+			InitialBody:  [][2]string{{"foo", "bar"}},
 			Extras:       [][2]string{{"foo", "baz"}, {"other", "thing"}},
-			ExpectedBody: url.Values{"foo": {"bar", "baz"}, "other": {"thing"}},
+			ExpectedBody: [][2]string{{"foo", "bar"}, {"foo", "baz"}, {"other", "thing"}},
 		},
 	}
 
@@ -80,40 +79,31 @@ func TestParamsWithExtras(t *testing.T) {
 			p.AddExtra(extra[0], extra[1])
 		}
 
-		body := fromURLValues(testCase.InitialBody)
+		body := valuesFromArray(testCase.InitialBody)
 		p.AppendTo(body)
 
-		if !reflect.DeepEqual(body, fromURLValues(testCase.ExpectedBody)) {
-			t.Fatalf("Expected body of %v but got %v.", testCase.ExpectedBody, body)
+		expected := valuesFromArray(testCase.ExpectedBody)
+		if !reflect.DeepEqual(body, expected) {
+			t.Fatalf("Expected body of %v but got %v.", expected, body)
 		}
 	}
-}
-
-func fromURLValues(urlValues url.Values) *stripe.RequestValues {
-	body := &stripe.RequestValues{}
-	for k, values := range urlValues {
-		for _, v := range values {
-			body.Add(k, v)
-		}
-	}
-	return body
 }
 
 func TestCheckinListParamsExpansion(t *testing.T) {
 	testCases := []struct {
-		InitialBody  url.Values
+		InitialBody  [][2]string
 		Expand       []string
-		ExpectedBody url.Values
+		ExpectedBody [][2]string
 	}{
 		{
-			InitialBody:  url.Values{"foo": {"bar"}},
+			InitialBody:  [][2]string{{"foo", "bar"}},
 			Expand:       []string{},
-			ExpectedBody: url.Values{"foo": {"bar"}},
+			ExpectedBody: [][2]string{{"foo", "bar"}},
 		},
 		{
-			InitialBody:  url.Values{"foo": {"bar", "baz"}},
+			InitialBody:  [][2]string{{"foo", "bar"}, {"foo", "baz"}},
 			Expand:       []string{"data", "data.foo"},
-			ExpectedBody: url.Values{"foo": {"bar", "baz"}, "expand[]": {"data", "data.foo"}},
+			ExpectedBody: [][2]string{{"foo", "bar"}, {"foo", "baz"}, {"expand[]", "data"}, {"expand[]", "data.foo"}},
 		},
 	}
 
@@ -124,11 +114,12 @@ func TestCheckinListParamsExpansion(t *testing.T) {
 			p.Expand(exp)
 		}
 
-		body := fromURLValues(testCase.InitialBody)
+		body := valuesFromArray(testCase.InitialBody)
 		p.AppendTo(body)
 
-		if !reflect.DeepEqual(body, fromURLValues(testCase.ExpectedBody)) {
-			t.Fatalf("Expected body of %v but got %v.", testCase.ExpectedBody, body)
+		expected := valuesFromArray(testCase.ExpectedBody)
+		if !reflect.DeepEqual(body, expected) {
+			t.Fatalf("Expected body of %v but got %v.", expected, body)
 		}
 	}
 }
@@ -168,4 +159,15 @@ func TestCheckinParamsSetStripeAccount(t *testing.T) {
 	if p.Account != "" {
 		t.Fatalf("Expected empty Account but got %v.", TestMerchantID)
 	}
+}
+
+// Converts a collection of key/value tuples in a two dimensional slice/array
+// into RequestValues form. The purpose of this is that it's much cleaner to
+// initialize the array all at once on a single line.
+func valuesFromArray(arr [][2]string) *stripe.RequestValues {
+	body := &stripe.RequestValues{}
+	for _, v := range arr {
+		body.Add(v[0], v[1])
+	}
+	return body
 }

--- a/params_test.go
+++ b/params_test.go
@@ -9,6 +9,36 @@ import (
 	. "github.com/stripe/stripe-go/testing"
 )
 
+func TestStableForm(t *testing.T) {
+	form := &stripe.StableForm{}
+
+	actual := form.Encode()
+	expected := ""
+	if expected != actual {
+		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+
+	form = &stripe.StableForm{}
+	form.Add("foo", "bar")
+
+	actual = form.Encode()
+	expected = "foo=bar"
+	if expected != actual {
+		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+
+	form = &stripe.StableForm{}
+	form.Add("foo", "bar")
+	form.Add("foo", "bar")
+	form.Add("baz", "bar")
+
+	actual = form.Encode()
+	expected = "foo=bar&foo=bar&baz=bar"
+	if expected != actual {
+		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+}
+
 func TestParamsWithExtras(t *testing.T) {
 	testCases := []struct {
 		InitialBody  url.Values

--- a/params_test.go
+++ b/params_test.go
@@ -9,30 +9,30 @@ import (
 	. "github.com/stripe/stripe-go/testing"
 )
 
-func TestStableForm(t *testing.T) {
-	form := &stripe.StableForm{}
+func TestRequestValues(t *testing.T) {
+	values := &stripe.RequestValues{}
 
-	actual := form.Encode()
+	actual := values.Encode()
 	expected := ""
 	if expected != actual {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
 	}
 
-	form = &stripe.StableForm{}
-	form.Add("foo", "bar")
+	values = &stripe.RequestValues{}
+	values.Add("foo", "bar")
 
-	actual = form.Encode()
+	actual = values.Encode()
 	expected = "foo=bar"
 	if expected != actual {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
 	}
 
-	form = &stripe.StableForm{}
-	form.Add("foo", "bar")
-	form.Add("foo", "bar")
-	form.Add("baz", "bar")
+	values = &stripe.RequestValues{}
+	values.Add("foo", "bar")
+	values.Add("foo", "bar")
+	values.Add("baz", "bar")
 
-	actual = form.Encode()
+	actual = values.Encode()
 	expected = "foo=bar&foo=bar&baz=bar"
 	if expected != actual {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
@@ -64,13 +64,23 @@ func TestParamsWithExtras(t *testing.T) {
 			p.AddExtra(extra[0], extra[1])
 		}
 
-		body := testCase.InitialBody
-		p.AppendTo(&body)
+		body := fromURLValues(testCase.InitialBody)
+		p.AppendTo(body)
 
-		if !reflect.DeepEqual(body, testCase.ExpectedBody) {
+		if !reflect.DeepEqual(body, fromURLValues(testCase.ExpectedBody)) {
 			t.Fatalf("Expected body of %v but got %v.", testCase.ExpectedBody, body)
 		}
 	}
+}
+
+func fromURLValues(urlValues url.Values) *stripe.RequestValues {
+	body := &stripe.RequestValues{}
+	for k, values := range urlValues {
+		for _, v := range values {
+			body.Add(k, v)
+		}
+	}
+	return body
 }
 
 func TestCheckinListParamsExpansion(t *testing.T) {
@@ -98,10 +108,10 @@ func TestCheckinListParamsExpansion(t *testing.T) {
 			p.Expand(exp)
 		}
 
-		body := testCase.InitialBody
-		p.AppendTo(&body)
+		body := fromURLValues(testCase.InitialBody)
+		p.AppendTo(body)
 
-		if !reflect.DeepEqual(body, testCase.ExpectedBody) {
+		if !reflect.DeepEqual(body, fromURLValues(testCase.ExpectedBody)) {
 			t.Fatalf("Expected body of %v but got %v.", testCase.ExpectedBody, body)
 		}
 	}

--- a/params_test.go
+++ b/params_test.go
@@ -17,6 +17,10 @@ func TestRequestValues(t *testing.T) {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
 	}
 
+	if !values.Empty() {
+		t.Fatalf("Expected values to be empty.")
+	}
+
 	values = &stripe.RequestValues{}
 	values.Add("foo", "bar")
 
@@ -24,6 +28,10 @@ func TestRequestValues(t *testing.T) {
 	expected = "foo=bar"
 	if expected != actual {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+
+	if values.Empty() {
+		t.Fatalf("Expected values to not be empty.")
 	}
 
 	values = &stripe.RequestValues{}

--- a/params_test.go
+++ b/params_test.go
@@ -37,6 +37,22 @@ func TestRequestValues(t *testing.T) {
 	if expected != actual {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
 	}
+
+	values.Set("foo", "firstbar")
+
+	actual = values.Encode()
+	expected = "foo=firstbar&foo=bar&baz=bar"
+	if expected != actual {
+		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+
+	values.Set("new", "appended")
+
+	actual = values.Encode()
+	expected = "foo=firstbar&foo=bar&baz=bar&new=appended"
+	if expected != actual {
+		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
 }
 
 func TestParamsWithExtras(t *testing.T) {

--- a/payment_source.go
+++ b/payment_source.go
@@ -3,7 +3,6 @@ package stripe
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 )
 
 // SourceParams is a union struct used to describe an
@@ -16,7 +15,7 @@ type SourceParams struct {
 // AppendDetails adds the source's details to the query string values.
 // For cards: when creating a new one, the parameters are passed as a dictionary, but
 // on updates they are simply the parameter name.
-func (sp *SourceParams) AppendDetails(values *url.Values, creating bool) {
+func (sp *SourceParams) AppendDetails(values *RequestValues, creating bool) {
 	if len(sp.Token) > 0 {
 		values.Add("source", sp.Token)
 	} else if sp.Card != nil {

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -4,7 +4,6 @@ package paymentsource
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -23,7 +22,7 @@ func New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 }
 
 func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	params.Source.AppendDetails(body, true)
 	params.AppendTo(body)
 
@@ -46,12 +45,12 @@ func Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 }
 
 func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -74,7 +73,7 @@ func Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSour
 }
 
 func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	params.Source.AppendDetails(body, false)
 	params.AppendTo(body)
 
@@ -116,7 +115,7 @@ func List(params *stripe.SourceListParams) *Iter {
 }
 
 func (s Client) List(params *stripe.SourceListParams) *Iter {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -124,12 +123,12 @@ func (s Client) List(params *stripe.SourceListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SourceList{}
 		var err error
 
 		if len(params.Customer) > 0 {
-			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", params.Customer), s.Key, &b, p, list)
+			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", params.Customer), s.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid source params: customer needs to be set")
 		}
@@ -150,7 +149,7 @@ func Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource
 }
 
 func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	body.Add("amounts[]", strconv.Itoa(int(params.Amounts[0])))
 	body.Add("amounts[]", strconv.Itoa(int(params.Amounts[1])))
 

--- a/plan/client.go
+++ b/plan/client.go
@@ -2,7 +2,6 @@
 package plan
 
 import (
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -28,13 +27,12 @@ func New(params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
-	body := &url.Values{
-		"id":       {params.ID},
-		"name":     {params.Name},
-		"amount":   {strconv.FormatUint(params.Amount, 10)},
-		"currency": {string(params.Currency)},
-		"interval": {string(params.Interval)},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("id", params.ID)
+	body.Add("name", params.Name)
+	body.Add("amount", strconv.FormatUint(params.Amount, 10))
+	body.Add("currency", string(params.Currency))
+	body.Add("interval", string(params.Interval))
 
 	if params.IntervalCount > 0 {
 		body.Add("interval_count", strconv.FormatUint(params.IntervalCount, 10))
@@ -62,12 +60,12 @@ func Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -84,12 +82,12 @@ func Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Name) > 0 {
 			body.Add("name", params.Name)
@@ -128,21 +126,21 @@ func List(params *stripe.PlanListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.PlanListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PlanList{}
-		err := c.B.Call("GET", "/plans", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/plans", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/product/client.go
+++ b/product/client.go
@@ -2,7 +2,6 @@ package product
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -23,11 +22,11 @@ func New(params *stripe.ProductParams) (*stripe.Product, error) {
 // New POSTs a new product.
 // For more details see https://stripe.com/docs/api#create_product.
 func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		// Required fields
 		body.Add("name", params.Name)
@@ -98,11 +97,11 @@ func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 // Update updates a product's properties.
 // For more details see https://stripe.com/docs/api#update_product.
 func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Name) > 0 {
 			body.Add("name", params.Name)
@@ -155,12 +154,12 @@ func List(params *stripe.ProductListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ProductListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Active != nil {
 			params.Filters.AddFilter("active", "", strconv.FormatBool(*params.Active))
@@ -185,9 +184,9 @@ func (c Client) List(params *stripe.ProductListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ProductList{}
-		err := c.B.Call("GET", "/products", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/products", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -2,7 +2,6 @@
 package recipient
 
 import (
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -26,10 +25,9 @@ func New(params *stripe.RecipientParams) (*stripe.Recipient, error) {
 }
 
 func (c Client) New(params *stripe.RecipientParams) (*stripe.Recipient, error) {
-	body := &url.Values{
-		"name": {params.Name},
-		"type": {string(params.Type)},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("name", params.Name)
+	body.Add("type", string(params.Type))
 
 	if params.Bank != nil {
 		if len(params.Bank.Token) > 0 {
@@ -71,12 +69,12 @@ func Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 }
 
 func (c Client) Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -93,12 +91,12 @@ func Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error
 }
 
 func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Name) > 0 {
 			body.Add("name", params.Name)
@@ -163,12 +161,12 @@ func List(params *stripe.RecipientListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.RecipientListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Verified {
 			body.Add("verified", strconv.FormatBool(true))
@@ -179,9 +177,9 @@ func (c Client) List(params *stripe.RecipientListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RecipientList{}
-		err := c.B.Call("GET", "/recipients", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/recipients", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/refund/client.go
+++ b/refund/client.go
@@ -3,7 +3,6 @@ package refund
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -28,7 +27,7 @@ func New(params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 
 	if params.Amount > 0 {
 		body.Add("amount", strconv.FormatUint(params.Amount, 10))
@@ -65,7 +64,7 @@ func Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	params.AppendTo(body)
 
 	refund := &stripe.Refund{}
@@ -81,7 +80,7 @@ func Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 
 	params.AppendTo(body)
 
@@ -98,7 +97,7 @@ func List(params *stripe.RefundListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.RefundListParams) *Iter {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -106,9 +105,9 @@ func (c Client) List(params *stripe.RefundListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/refunds"), c.Key, &b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/refunds"), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -3,7 +3,6 @@ package reversal
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -21,7 +20,7 @@ func New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 }
 
 func (c Client) New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 
 	if params.Amount > 0 {
 		body.Add("amount", strconv.FormatUint(params.Amount, 10))
@@ -49,7 +48,7 @@ func (c Client) Get(id string, params *stripe.ReversalParams) (*stripe.Reversal,
 		return nil, fmt.Errorf("params cannot be nil, and params.Transfer must be set")
 	}
 
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	params.AppendTo(body)
 
 	reversal := &stripe.Reversal{}
@@ -64,7 +63,7 @@ func Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) 
 }
 
 func (c Client) Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 
 	params.AppendTo(body)
 
@@ -80,7 +79,7 @@ func List(params *stripe.ReversalListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ReversalListParams) *Iter {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -88,9 +87,9 @@ func (c Client) List(params *stripe.ReversalListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ReversalList{}
-		err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals", params.Transfer), c.Key, &b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals", params.Transfer), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/sku/client.go
+++ b/sku/client.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -23,11 +22,11 @@ func New(params *stripe.SKUParams) (*stripe.SKU, error) {
 // New POSTs a new SKU.
 // For more details see https://stripe.com/docs/api#create_sku.
 func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		// Required fields
 		body.Add("price", strconv.FormatInt(params.Price, 10))
@@ -98,11 +97,11 @@ func Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 // Update updates a SKU's properties.
 // For more details see https://stripe.com/docs/api#update_sku.
 func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		// Required fields
 		if params.Price > 0 {
@@ -166,12 +165,12 @@ func Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 
 func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	sku := &stripe.SKU{}
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 	err := c.B.Call("GET", "/skus/"+id, c.Key, body, commonParams, sku)
@@ -186,12 +185,12 @@ func List(params *stripe.SKUListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.SKUListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Active != nil {
 			params.Filters.AddFilter(
@@ -221,9 +220,9 @@ func (c Client) List(params *stripe.SKUListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SKUList{}
-		err := c.B.Call("GET", "/skus", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/skus", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/stripe.go
+++ b/stripe.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -38,7 +37,7 @@ const TotalBackends = 2
 // Backend is an interface for making calls against a Stripe service.
 // This interface exists to enable mocking for during testing if needed.
 type Backend interface {
-	Call(method, path, key string, body *url.Values, params *Params, v interface{}) error
+	Call(method, path, key string, body Form, params *Params, v interface{}) error
 	CallMultipart(method, path, key, boundary string, body io.Reader, params *Params, v interface{}) error
 }
 
@@ -144,9 +143,9 @@ func SetBackend(backend SupportedBackend, b Backend) {
 }
 
 // Call is the Backend.Call implementation for invoking Stripe APIs.
-func (s BackendConfiguration) Call(method, path, key string, form *url.Values, params *Params, v interface{}) error {
+func (s BackendConfiguration) Call(method, path, key string, form Form, params *Params, v interface{}) error {
 	var body io.Reader
-	if form != nil && len(*form) > 0 {
+	if form != nil {
 		data := form.Encode()
 		if strings.ToUpper(method) == "GET" {
 			path += "?" + data

--- a/stripe.go
+++ b/stripe.go
@@ -145,7 +145,7 @@ func SetBackend(backend SupportedBackend, b Backend) {
 // Call is the Backend.Call implementation for invoking Stripe APIs.
 func (s BackendConfiguration) Call(method, path, key string, form *RequestValues, params *Params, v interface{}) error {
 	var body io.Reader
-	if form != nil {
+	if form != nil && !form.Empty() {
 		data := form.Encode()
 		if strings.ToUpper(method) == "GET" {
 			path += "?" + data

--- a/stripe.go
+++ b/stripe.go
@@ -37,7 +37,7 @@ const TotalBackends = 2
 // Backend is an interface for making calls against a Stripe service.
 // This interface exists to enable mocking for during testing if needed.
 type Backend interface {
-	Call(method, path, key string, body Form, params *Params, v interface{}) error
+	Call(method, path, key string, body *RequestValues, params *Params, v interface{}) error
 	CallMultipart(method, path, key, boundary string, body io.Reader, params *Params, v interface{}) error
 }
 
@@ -143,7 +143,7 @@ func SetBackend(backend SupportedBackend, b Backend) {
 }
 
 // Call is the Backend.Call implementation for invoking Stripe APIs.
-func (s BackendConfiguration) Call(method, path, key string, form Form, params *Params, v interface{}) error {
+func (s BackendConfiguration) Call(method, path, key string, form *RequestValues, params *Params, v interface{}) error {
 	var body io.Reader
 	if form != nil {
 		data := form.Encode()

--- a/sub/client.go
+++ b/sub/client.go
@@ -3,7 +3,6 @@ package sub
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -30,16 +29,14 @@ func New(params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 	token := c.Key
 
 	if params != nil {
-
-		body = &url.Values{
-			"plan":     {params.Plan},
-			"customer": {params.Customer},
-		}
+		body = &stripe.RequestValues{}
+		body.Add("plan", params.Plan)
+		body.Add("customer", params.Customer)
 
 		if len(params.Token) > 0 {
 			body.Add("card", params.Token)
@@ -97,11 +94,11 @@ func Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 		commonParams = &params.Params
 	}
@@ -119,12 +116,12 @@ func Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 	token := c.Key
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Plan) > 0 {
 			body.Add("plan", params.Plan)
@@ -189,11 +186,11 @@ func Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.EndCancel {
 			body.Add("at_period_end", strconv.FormatBool(true))
@@ -216,12 +213,12 @@ func List(params *stripe.SubListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.SubListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
@@ -237,9 +234,9 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubList{}
-		err := c.B.Call("GET", "/subscriptions", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/subscriptions", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/token.go
+++ b/token.go
@@ -1,9 +1,5 @@
 package stripe
 
-import (
-	"net/url"
-)
-
 // TokenType is the list of allowed values for a token's type.
 // Allowed values are "card", "bank_account".
 type TokenType string
@@ -44,6 +40,6 @@ type PIIParams struct {
 }
 
 // AppendDetails adds the PII data's details to the query string values.
-func (p *PIIParams) AppendDetails(values *url.Values) {
+func (p *PIIParams) AppendDetails(values *RequestValues) {
 	values.Add("pii[personal_id_number]", p.PersonalIDNumber)
 }

--- a/token/client.go
+++ b/token/client.go
@@ -3,7 +3,6 @@ package token
 
 import (
 	"errors"
-	"net/url"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -27,7 +26,7 @@ func New(params *stripe.TokenParams) (*stripe.Token, error) {
 }
 
 func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
-	body := &url.Values{}
+	body := &stripe.RequestValues{}
 	token := c.Key
 
 	if len(params.Customer) > 0 {
@@ -64,12 +63,12 @@ func Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 }
 
 func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -3,7 +3,6 @@ package transfer
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
@@ -50,10 +49,9 @@ func New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 }
 
 func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
-	body := &url.Values{
-		"amount":   {strconv.FormatInt(params.Amount, 10)},
-		"currency": {string(params.Currency)},
-	}
+	body := &stripe.RequestValues{}
+	body.Add("amount", strconv.FormatInt(params.Amount, 10))
+	body.Add("currency", string(params.Currency))
 
 	if len(params.Recipient) > 0 {
 		body.Add("recipient", params.Recipient)
@@ -103,12 +101,12 @@ func Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 }
 
 func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -125,13 +123,13 @@ func Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) 
 }
 
 func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
 
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if len(params.Desc) > 0 {
 			body.Add("description", params.Desc)
@@ -153,13 +151,13 @@ func Cancel(id string, params *stripe.TransferParams) (*stripe.Transfer, error) 
 }
 
 func (c Client) Cancel(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
 
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 		params.AppendTo(body)
 	}
 
@@ -176,12 +174,12 @@ func List(params *stripe.TransferListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.TransferListParams) *Iter {
-	var body *url.Values
+	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &url.Values{}
+		body = &stripe.RequestValues{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -204,9 +202,9 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b url.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TransferList{}
-		err := c.B.Call("GET", "/transfers", c.Key, &b, p, list)
+		err := c.B.Call("GET", "/transfers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {


### PR DESCRIPTION
As described in #251, using url.Values to contain form values is
problematic for the Stripe API because it depends on "Rack style" form
encoding that requires duplicated parameters to occur in a certain order
for arrays to be correctly encoded.

This pull continues the solution introduced in #252 by applying the new type
across every file. As a result, the commit is a bit of a mess so I'm going to
rely on the design #252 having been reviewed already.

Replaces #252. Fixes #251.