### PR TITLE
Introduce `BalanceZero` field for customer parameters

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -9,6 +9,7 @@ import (
 type CustomerParams struct {
 	Params
 	Balance       int64
+	BalanceZero   bool
 	Token, Coupon string
 	Source        *SourceParams
 	Desc, Email   string

--- a/customer/client.go
+++ b/customer/client.go
@@ -114,6 +114,8 @@ func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Custom
 
 		if params.Balance != 0 {
 			body.Add("account_balance", strconv.FormatInt(params.Balance, 10))
+		} else if params.BalanceZero {
+			body.Add("account_balance", "0")
 		}
 
 		if params.Source != nil {

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -214,6 +214,12 @@ func TestCustomerUpdate(t *testing.T) {
 
 	target, err := Update(original.ID, updated)
 
+	updated2 := &stripe.CustomerParams{
+		BalanceZero: true,
+	}
+
+	target2, err := Update(original.ID, updated2)
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -236,6 +242,10 @@ func TestCustomerUpdate(t *testing.T) {
 
 	if target.Sources == nil {
 		t.Errorf("No sources recorded\n")
+	}
+
+	if target2.Balance != 0 {
+		t.Errorf("BalanceZero did not reset the balance to 0: %v\n", target2.Balance)
 	}
 
 	Del(target.ID)


### PR DESCRIPTION
r? @brandur 

Introduces a new field `BalanceZero` for customers so that an already non-zero value can be zeroed out. It's modeled on the `TaxPercentZero` behavior.

I added a test to the existing `TestCustomerUpdate` subpackage. Let me know if you prefer it to be separated.

Fixes #261 