### PR TITLE
Add `tax_percent` paramter to customer create

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -8,17 +8,19 @@ import (
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
 	Params
-	Balance       int64
-	BalanceZero   bool
-	Token, Coupon string
-	Source        *SourceParams
-	Desc, Email   string
-	Plan          string
-	Quantity      uint64
-	TrialEnd      int64
-	DefaultSource string
-	Shipping      *CustomerShippingDetails
-	BusinessVatID string
+	Balance        int64
+	BalanceZero    bool
+	Token, Coupon  string
+	Source         *SourceParams
+	Desc, Email    string
+	Plan           string
+	Quantity       uint64
+	TrialEnd       int64
+	DefaultSource  string
+	Shipping       *CustomerShippingDetails
+	BusinessVatID  string
+	TaxPercent     float64
+	TaxPercentZero bool
 }
 
 // SetSource adds valid sources to a CustomerParams object,

--- a/customer/client.go
+++ b/customer/client.go
@@ -65,6 +65,12 @@ func (c Client) New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 			body.Add("business_vat_id", params.BusinessVatID)
 		}
 
+		if params.TaxPercent > 0 {
+			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+		} else if params.TaxPercentZero {
+			body.Add("tax_percent", "0")
+		}
+
 		commonParams = &params.Params
 
 		params.AppendTo(body)

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -5,7 +5,9 @@ import (
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/coupon"
+	"github.com/stripe/stripe-go/currency"
 	"github.com/stripe/stripe-go/discount"
+	"github.com/stripe/stripe-go/plan"
 	. "github.com/stripe/stripe-go/utils"
 )
 
@@ -67,6 +69,48 @@ func TestCustomerNew(t *testing.T) {
 	}
 
 	Del(target.ID)
+}
+
+func TestCustomerNewWithPlan(t *testing.T) {
+	planParams := &stripe.PlanParams{
+		ID:       "test",
+		Name:     "Test Plan",
+		Amount:   99,
+		Currency: currency.USD,
+		Interval: plan.Month,
+	}
+
+	_, err := plan.New(planParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	customerParams := &stripe.CustomerParams{
+		Plan:       planParams.ID,
+		TaxPercent: 10.0,
+	}
+	customerParams.SetSource(&stripe.CardParams{
+		Name:   "Test Card",
+		Number: "378282246310005",
+		Month:  "06",
+		Year:   "20",
+	})
+
+	target, err := New(customerParams)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = Del(target.ID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = plan.Del(planParams.ID)
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestCustomerNewWithShipping(t *testing.T) {


### PR DESCRIPTION
It seems that this field is missing for the customer create method. This
change reflects the pattern that we already have for `tax_percent` in
`sub.go`.

Fixes #264.