### PR TITLE
Fix SKU attributes, send product.

### DIFF
--- a/sku.go
+++ b/sku.go
@@ -7,7 +7,6 @@ type SKUParams struct {
 	ID                string
 	Active            *bool
 	Desc              string
-	Name              string
 	Attrs             map[string]string
 	Price             int64
 	Currency          string
@@ -29,7 +28,6 @@ type SKU struct {
 	Updated           int64              `json:"updated"`
 	Live              bool               `json:"livemode"`
 	Active            bool               `json:"active"`
-	Name              string             `json:"name"`
 	Desc              string             `json:"description"`
 	Attrs             map[string]string  `json:"attributes"`
 	Price             int64              `json:"price"`

--- a/sku/client.go
+++ b/sku/client.go
@@ -148,6 +148,10 @@ func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error)
 				fmt.Sprintf("%.2f", params.PackageDimensions.Weight))
 		}
 
+		if params.Product != "" {
+			body.Add("product", params.Product)
+		}
+
 		params.AppendTo(body)
 	}
 


### PR DESCRIPTION
r? @stripe/api-libraries 
cc @jimdanz 

A couple of minor fixes for SKUs:
- We don't have a `Name` attribute on SKUs
- We support updating the product of a SKU, and `sku.Update` should support that as well