### PR TITLE
Using SubParams.QuantityZero in subscription update action

### DIFF
--- a/sub/client.go
+++ b/sub/client.go
@@ -153,6 +153,8 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 		if params.Quantity > 0 {
 			body.Add("quantity", strconv.FormatUint(params.Quantity, 10))
+		} else if params.QuantityZero {
+			body.Add("quantity", "0")
 		}
 
 		if params.FeePercent > 0 {


### PR DESCRIPTION
Using the Golang client there isn't a way to update a subscription `Quantity` to `0`. This should hopefully resolve that!

It seems awhile back this functionality was added for creating subscriptions, but never implemented for updating them. Reference: #36 

