### PR TITLE
adds NoClosed parameter to open an invoice

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -14,6 +14,7 @@ type InvoiceParams struct {
 	Desc, Statement, Sub string
 	Fee                  uint64
 	Closed, Forgive      bool
+	NoClosed             bool
 	SubPlan              string
 	SubNoProrate         bool
 	SubProrationDate     int64

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -133,6 +133,8 @@ func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice
 
 		if params.Closed {
 			body.Add("closed", strconv.FormatBool(true))
+		} else if params.NoClosed {
+			body.Add("closed", strconv.FormatBool(false))
 		}
 
 		if params.Forgive {

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -317,6 +317,34 @@ func TestAllInvoicesScenarios(t *testing.T) {
 		t.Errorf("Invoice subscription %v does not match expected subscription%v\n", nextInvoice.Sub, subscription.ID)
 	}
 
+	closeInvoice := &stripe.InvoiceParams{
+		Closed: true,
+	}
+
+	targetInvoiceClosed, err := Update(targetInvoice.ID, closeInvoice)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if targetInvoiceClosed.Closed != closeInvoice.Closed {
+		t.Errorf("Invoice was not closed as expected and its value is %v", targetInvoiceClosed.Closed)
+	}
+
+	openInvoice := &stripe.InvoiceParams{
+		NoClosed: true,
+	}
+
+	targetInvoiceOpened, err := Update(targetInvoice.ID, openInvoice)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if targetInvoiceOpened.Closed != false {
+		t.Errorf("Invoice was not reponed as expected and its value is %v", targetInvoiceOpened.Closed)
+	}
+
 	_, err = plan.Del(planParams.ID)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
r? @brandur 
fixes #273 

This commit adds a `NoClosed` parameter to the `InvoiceParams` struct to fix the fact that passing a `false` value to `Closed` would be ignored. You just need to pass `true` to this parameter to reopen the invoice.