### PR TITLE
Strip duplicate country conditional

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -29,11 +29,6 @@ func writeAccountParams(
 		body.Add("email", params.Email)
 	}
 
-	// Country.
-	if len(params.Country) > 0 {
-		body.Add("country", params.Country)
-	}
-
 	if len(params.DefaultCurrency) > 0 {
 		body.Add("default_currency", params.DefaultCurrency)
 	}


### PR DESCRIPTION
We actually have two of these in `writeAccountParams`. Take one out.

cc @guillaumehenriot 