### PR TITLE
add support to migrate recipients and update debit_negative_balances property

### DIFF
--- a/account.go
+++ b/account.go
@@ -57,11 +57,11 @@ type AccountParams struct {
 	Country, Email, DefaultCurrency, Statement, BusinessName, BusinessUrl,
 	BusinessPrimaryColor, SupportPhone, SupportEmail, SupportUrl,
 	FromRecipient string
-	ExternalAccount           *AccountExternalAccountParams
-	LegalEntity               *LegalEntity
-	TransferSchedule          *TransferScheduleParams
-	Managed, DebitNegativeBal bool
-	TOSAcceptance             *TOSAcceptanceParams
+	ExternalAccount                               *AccountExternalAccountParams
+	LegalEntity                                   *LegalEntity
+	TransferSchedule                              *TransferScheduleParams
+	Managed, DebitNegativeBal, NoDebitNegativeBal bool
+	TOSAcceptance                                 *TOSAcceptanceParams
 }
 
 // AccountListParams are the parameters allowed during account listing.

--- a/account.go
+++ b/account.go
@@ -55,7 +55,8 @@ const (
 type AccountParams struct {
 	Params
 	Country, Email, DefaultCurrency, Statement, BusinessName, BusinessUrl,
-	BusinessPrimaryColor, SupportPhone, SupportEmail, SupportUrl string
+	BusinessPrimaryColor, SupportPhone, SupportEmail, SupportUrl,
+	FromRecipient string
 	ExternalAccount           *AccountExternalAccountParams
 	LegalEntity               *LegalEntity
 	TransferSchedule          *TransferScheduleParams

--- a/account/client.go
+++ b/account/client.go
@@ -29,6 +29,12 @@ func writeAccountParams(
 		body.Add("email", params.Email)
 	}
 
+	if params.DebitNegativeBal {
+		body.Add("debit_negative_balances", strconv.FormatBool(true))
+	} else if params.NoDebitNegativeBal {
+		body.Add("debit_negative_balances", strconv.FormatBool(false))
+	}
+
 	if len(params.DefaultCurrency) > 0 {
 		body.Add("default_currency", params.DefaultCurrency)
 	}
@@ -98,7 +104,6 @@ func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 
 	if len(params.FromRecipient) == 0 {
 		body.Add("managed", strconv.FormatBool(params.Managed))
-		body.Add("debit_negative_balances", strconv.FormatBool(params.DebitNegativeBal))
 	}
 
 	writeAccountParams(params, body)

--- a/account/client.go
+++ b/account/client.go
@@ -87,12 +87,19 @@ func writeAccountParams(
 	if params.TOSAcceptance != nil {
 		params.TOSAcceptance.AppendDetails(body)
 	}
+
+	if len(params.FromRecipient) > 0 {
+		body.Add("from_recipient", params.FromRecipient)
+	}
 }
 
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 	body := &stripe.RequestValues{}
-	body.Add("managed", strconv.FormatBool(params.Managed))
-	body.Add("debit_negative_balances", strconv.FormatBool(params.DebitNegativeBal))
+
+	if len(params.FromRecipient) == 0 {
+		body.Add("managed", strconv.FormatBool(params.Managed))
+		body.Add("debit_negative_balances", strconv.FormatBool(params.DebitNegativeBal))
+	}
 
 	writeAccountParams(params, body)
 

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stripe/stripe-go/bankaccount"
 	"github.com/stripe/stripe-go/card"
 	"github.com/stripe/stripe-go/currency"
+	"github.com/stripe/stripe-go/recipient"
 	"github.com/stripe/stripe-go/token"
 	. "github.com/stripe/stripe-go/utils"
 )
@@ -151,6 +152,46 @@ func TestAccountReject(t *testing.T) {
 
 	if rejectedAcct.Verification.DisabledReason != "rejected.fraud" {
 		t.Error("Account DisabledReason did not change to rejected.fraud.")
+	}
+}
+
+func TestAccountMigrateFromRecipients(t *testing.T) {
+	recipientParams := &stripe.RecipientParams{
+		Name:  "Recipient Name",
+		Type:  "individual",
+		TaxID: "000000000",
+		Email: "a@b.com",
+		Desc:  "Recipient Desc",
+		Bank: &stripe.BankAccountParams{
+			Country: "US",
+			Routing: "110000000",
+			Account: "000123456789",
+		},
+		Card: &stripe.CardParams{
+			Name:   "Test Debit",
+			Number: "4000056655665556",
+			Month:  "10",
+			Year:   "20",
+		},
+	}
+
+	target, err := recipient.New(recipientParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	target2, err := New(&stripe.AccountParams{FromRecipient: target.ID})
+	if err != nil {
+		t.Error(err)
+	}
+
+	target, err = recipient.Get(target.ID, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if target2.ID != target.MigratedTo.ID {
+		t.Errorf("The new account ID %v does not match the MigratedTo property %v", target2.ID, target.MigratedTo.ID)
 	}
 }
 

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -23,6 +23,7 @@ func TestAccountNew(t *testing.T) {
 		BusinessUrl:          "www.stripe.com",
 		BusinessName:         "Stripe",
 		BusinessPrimaryColor: "#ffffff",
+		DebitNegativeBal:     true,
 		SupportEmail:         "foo@bar.com",
 		SupportUrl:           "www.stripe.com",
 		SupportPhone:         "4151234567",
@@ -211,19 +212,29 @@ func TestAccountGetByID(t *testing.T) {
 
 func TestAccountUpdate(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
-		Country: "CA",
+		Managed:          true,
+		Country:          "CA",
+		DebitNegativeBal: true,
 	}
 
 	acct, _ := New(params)
 
-	params = &stripe.AccountParams{
-		Statement: "Stripe Go",
+	if acct.DebitNegativeBal != true {
+		t.Error("debit_negative_balance was not set to true")
 	}
 
-	_, err := Update(acct.ID, params)
+	params = &stripe.AccountParams{
+		Statement:          "Stripe Go",
+		NoDebitNegativeBal: true,
+	}
+
+	acct, err := Update(acct.ID, params)
 	if err != nil {
 		t.Error(err)
+	}
+
+	if acct.DebitNegativeBal != false {
+		t.Error("debit_negative_balance was not set to false")
 	}
 }
 

--- a/recipient.go
+++ b/recipient.go
@@ -36,6 +36,7 @@ type Recipient struct {
 	Desc        string            `json:"description"`
 	Email       string            `json:"email"`
 	Meta        map[string]string `json:"metadata"`
+	MigratedTo  *Account          `json:"migrated_to"`
 	Name        string            `json:"name"`
 	Cards       *CardList         `json:"cards"`
 	DefaultCard *Card             `json:"default_card"`


### PR DESCRIPTION
r? @brandur 
fixes #281

This commit adds support to allow migrating Recipients to Accounts. It also adds the MigratedTo property to the Recipients so you can retrieve it.