### PR TITLE
allow update of debit_negative_balance and managed flags

### DIFF
--- a/account.go
+++ b/account.go
@@ -59,7 +59,7 @@ type AccountParams struct {
 	ExternalAccount           *AccountExternalAccountParams
 	LegalEntity               *LegalEntity
 	TransferSchedule          *TransferScheduleParams
-	Managed, DebitNegativeBal bool
+	Managed, DebitNegativeBal *bool
 	TOSAcceptance             *TOSAcceptanceParams
 }
 

--- a/account/client.go
+++ b/account/client.go
@@ -91,8 +91,18 @@ func writeAccountParams(
 
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 	body := &stripe.RequestValues{}
-	body.Add("managed", strconv.FormatBool(params.Managed))
-	body.Add("debit_negative_balances", strconv.FormatBool(params.DebitNegativeBal))
+
+	managed := false
+	if params.Managed != nil {
+		managed = *params.Managed
+	}
+	body.Add("managed", strconv.FormatBool(managed))
+
+	debitNegativeBalance := false
+	if params.DebitNegativeBal != nil {
+		managed = *params.DebitNegativeBal
+	}
+	body.Add("debit_negative_balances", strconv.FormatBool(debitNegativeBalance))
 
 	writeAccountParams(params, body)
 
@@ -154,11 +164,15 @@ func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account
 		commonParams = &params.Params
 		body = &stripe.RequestValues{}
 
-		writeAccountParams(params, body)
-
-		if params.TOSAcceptance != nil {
-			params.TOSAcceptance.AppendDetails(body)
+		if params.Managed != nil {
+			body.Add("managed", strconv.FormatBool(*params.Managed))
 		}
+
+		if params.DebitNegativeBal != nil {
+			body.Add("debit_negative_balances", strconv.FormatBool(*params.DebitNegativeBal))
+		}
+
+		writeAccountParams(params, body)
 
 		params.AppendTo(body)
 	}

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -16,8 +16,9 @@ func init() {
 }
 
 func TestAccountNew(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed:              true,
+		Managed:              &managed,
 		Country:              "CA",
 		BusinessUrl:          "www.stripe.com",
 		BusinessName:         "Stripe",
@@ -48,8 +49,9 @@ func TestAccountNew(t *testing.T) {
 }
 
 func TestAccountLegalEntity(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed: true,
+		Managed: &managed,
 		Country: "US",
 		LegalEntity: &stripe.LegalEntity{
 			Type:          stripe.Company,
@@ -83,8 +85,9 @@ func TestAccountLegalEntity(t *testing.T) {
 }
 
 func TestAccountDelete(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed:              true,
+		Managed:              &managed,
 		Country:              "CA",
 		BusinessUrl:          "www.stripe.com",
 		BusinessName:         "Stripe",
@@ -119,8 +122,9 @@ func TestAccountDelete(t *testing.T) {
 }
 
 func TestAccountReject(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed:              true,
+		Managed:              &managed,
 		Country:              "CA",
 		BusinessUrl:          "www.stripe.com",
 		BusinessName:         "Stripe",
@@ -155,8 +159,9 @@ func TestAccountReject(t *testing.T) {
 }
 
 func TestAccountGetByID(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed: true,
+		Managed: &managed,
 		Country: "CA",
 	}
 
@@ -169,8 +174,9 @@ func TestAccountGetByID(t *testing.T) {
 }
 
 func TestAccountUpdate(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed: true,
+		Managed: &managed,
 		Country: "CA",
 	}
 
@@ -187,8 +193,9 @@ func TestAccountUpdate(t *testing.T) {
 }
 
 func TestAccountUpdateWithBankAccount(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed: true,
+		Managed: &managed,
 		Country: "CA",
 	}
 
@@ -210,8 +217,9 @@ func TestAccountUpdateWithBankAccount(t *testing.T) {
 }
 
 func TestAccountAddExternalAccountsDefault(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed: true,
+		Managed: &managed,
 		Country: "CA",
 		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Country:  "US",
@@ -268,8 +276,9 @@ func TestAccountAddExternalAccountsDefault(t *testing.T) {
 }
 
 func TestAccountUpdateWithToken(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed: true,
+		Managed: &managed,
 		Country: "CA",
 	}
 
@@ -298,8 +307,9 @@ func TestAccountUpdateWithToken(t *testing.T) {
 }
 
 func TestAccountUpdateWithCardToken(t *testing.T) {
+	managed := true
 	params := &stripe.AccountParams{
-		Managed: true,
+		Managed: &managed,
 		Country: "US",
 	}
 


### PR DESCRIPTION
There doesn't seem to be a way to update debit_negative_balance for Managed accounts. 

Since we only want to update it if its set, we need to convert the fields to a pointer. 

r @brandur 