### PR TITLE
Include CardParams metadata

### DIFF
--- a/card.go
+++ b/card.go
@@ -190,6 +190,9 @@ func (c *CardParams) AppendDetails(values *RequestValues, creating bool) {
 			values.Add("address_country", c.Country)
 		}
 	}
+
+	c.AppendTo(values)
+
 }
 
 // Display human readable representation of a Card.

--- a/card.go
+++ b/card.go
@@ -191,7 +191,11 @@ func (c *CardParams) AppendDetails(values *RequestValues, creating bool) {
 		}
 	}
 
-	c.AppendTo(values)
+	if len(c.Meta) > 0 {
+		for k, v := range c.Meta {
+			values.Add(fmt.Sprintf("card[metadata[%v]]", k), v)
+		}
+	}
 
 }
 


### PR DESCRIPTION
This PR, fixes https://github.com/stripe/stripe-go/issues/287

To include CardParam meta data in the API request.