### PR TITLE
support expanding transaction sources

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -11,6 +11,43 @@ type TransactionStatus string
 // "application_fee_refund", "transfer", "transfer_cancel", "transfer_failure".
 type TransactionType string
 
+// TransactionSourceType consts represent valid balance transaction sources.
+type TransactionSourceType string
+
+const (
+	// TransactionSourceCharge is a constant representing a transaction source of charge
+	TransactionSourceCharge TransactionSourceType = "charge"
+
+	// TransactionSourceAdjustment is a constant representing a transaction source of dispute
+	TransactionSourceDispute TransactionSourceType = "dispute"
+
+	// TransactionSourceFee is a constant representing a transaction source of application_fee
+	TransactionSourceFee TransactionSourceType = "application_fee"
+
+	// TransactionSourceRefund is a constant representing a transaction source of refund
+	TransactionSourceRefund TransactionSourceType = "refund"
+
+	// TransactionSourceReversal is a constant representing a transaction source of reversal
+	TransactionSourceReversal TransactionSourceType = "reversal"
+
+	// TransactionSourceTransfer is a constant representing a transaction source of transfer
+	TransactionSourceTransfer TransactionSourceType = "transfer"
+)
+
+// TransactionSource describes the source of a balance Transaction.
+// The Type should indicate which object is fleshed out.
+// For more details see https://stripe.com/docs/api#retrieve_balance_transaction
+type TransactionSource struct {
+	Type     TransactionSourceType `json:"object"`
+	ID       string                `json:"id"`
+	Charge   *Charge               `json:"-"`
+	Dispute  *Dispute              `json:"-"`
+	Fee      *Fee                  `json:"-"`
+	Refund   *Refund               `json:"-"`
+	Reversal *Reversal             `json:"-"`
+	Transfer *Transfer             `json:"-"`
+}
+
 // BalanceParams is the set of parameters that can be used when retrieving a balance.
 // For more details see https://stripe.com/docs/api#balance.
 type BalanceParams struct {
@@ -55,7 +92,7 @@ type Transaction struct {
 	Status     TransactionStatus `json:"status"`
 	Type       TransactionType   `json:"type"`
 	Desc       string            `json:"description"`
-	Src        string            `json:"source"`
+	Src        TransactionSource `json:"source"`
 	Recipient  string            `json:"recipient"`
 }
 
@@ -95,4 +132,41 @@ func (t *Transaction) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TransactionSource.
+// This custom unmarshaling is needed because the specific
+// type of transaction source it refers to is specified in the JSON
+func (s *TransactionSource) UnmarshalJSON(data []byte) error {
+	type source TransactionSource
+	var ss source
+	err := json.Unmarshal(data, &ss)
+	if err == nil {
+		*s = TransactionSource(ss)
+
+		switch s.Type {
+		case TransactionSourceCharge:
+			json.Unmarshal(data, &s.Charge)
+		case TransactionSourceDispute:
+			json.Unmarshal(data, &s.Dispute)
+		case TransactionSourceFee:
+			json.Unmarshal(data, &s.Fee)
+		case TransactionSourceRefund:
+			json.Unmarshal(data, &s.Refund)
+		case TransactionSourceReversal:
+			json.Unmarshal(data, &s.Reversal)
+		case TransactionSourceTransfer:
+			json.Unmarshal(data, &s.Transfer)
+		}
+	} else {
+		// the id is surrounded by "\" characters, so strip them
+		s.ID = string(data[1 : len(data)-1])
+	}
+
+	return nil
+}
+
+// MarshalJSON handles serialization of a TransactionSource.
+func (s *TransactionSource) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.ID)
 }

--- a/balance.go
+++ b/balance.go
@@ -18,7 +18,7 @@ const (
 	// TransactionSourceCharge is a constant representing a transaction source of charge
 	TransactionSourceCharge TransactionSourceType = "charge"
 
-	// TransactionSourceAdjustment is a constant representing a transaction source of dispute
+	// TransactionSourceDispute is a constant representing a transaction source of dispute
 	TransactionSourceDispute TransactionSourceType = "dispute"
 
 	// TransactionSourceFee is a constant representing a transaction source of application_fee


### PR DESCRIPTION
This updates `Transaction.Src` to follow the same pattern as [PaymentSource](https://github.com/stripe/stripe-go/blob/master/payment_source.go#L97) to allow for expanding the polymorphic source property.

Note that there may be other object types that are valid for "source", but because they aren't listed anywhere I only added the ones I was aware of. If an unknown source shows up, it will still fall back gracefully to only having the `ID` field populated.