### PR TITLE
Removes the need to pass DOB and Type to update Legal Entity

### DIFF
--- a/account.go
+++ b/account.go
@@ -327,7 +327,9 @@ type AccountRejectParams struct {
 
 // AppendDetails adds the legal entity to the query string.
 func (l *LegalEntity) AppendDetails(values *RequestValues) {
-	values.Add("legal_entity[type]", string(l.Type))
+	if len(l.Type) > 0 {
+		values.Add("legal_entity[type]", string(l.Type))
+	}
 
 	if len(l.BusinessName) > 0 {
 		values.Add("legal_entity[business_name]", l.BusinessName)
@@ -373,9 +375,17 @@ func (l *LegalEntity) AppendDetails(values *RequestValues) {
 		values.Add("legal_entity[maiden_name]", l.MaidenName)
 	}
 
-	values.Add("legal_entity[dob][day]", strconv.Itoa(l.DOB.Day))
-	values.Add("legal_entity[dob][month]", strconv.Itoa(l.DOB.Month))
-	values.Add("legal_entity[dob][year]", strconv.Itoa(l.DOB.Year))
+	if l.DOB.Day > 0 {
+		values.Add("legal_entity[dob][day]", strconv.Itoa(l.DOB.Day))
+	}
+
+	if l.DOB.Month > 0 {
+		values.Add("legal_entity[dob][month]", strconv.Itoa(l.DOB.Month))
+	}
+
+	if l.DOB.Year > 0 {
+		values.Add("legal_entity[dob][year]", strconv.Itoa(l.DOB.Year))
+	}
 
 	if len(l.SSN) > 0 {
 		values.Add("legal_entity[ssn_last_4]", l.SSN)
@@ -414,9 +424,17 @@ func (l *LegalEntity) AppendDetails(values *RequestValues) {
 			values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][last_name]", i), owner.Last)
 		}
 
-		values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][dob][day]", i), strconv.Itoa(owner.DOB.Day))
-		values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][dob][month]", i), strconv.Itoa(owner.DOB.Month))
-		values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][dob][year]", i), strconv.Itoa(owner.DOB.Year))
+		if owner.DOB.Day > 0 {
+			values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][dob][day]", i), strconv.Itoa(owner.DOB.Day))
+		}
+
+		if owner.DOB.Month > 0 {
+			values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][dob][month]", i), strconv.Itoa(owner.DOB.Month))
+		}
+
+		if owner.DOB.Year > 0 {
+			values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][dob][year]", i), strconv.Itoa(owner.DOB.Year))
+		}
 
 		owner.Address.AppendDetails(values, fmt.Sprintf("legal_entity[additional_owners][%v][address]", i))
 	}

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -273,7 +273,7 @@ func TestAccountUpdateLegalEntity(t *testing.T) {
 	}
 
 	if acct.LegalEntity.Address.Line1 != params.LegalEntity.Address.Line1 {
-		t.Error("The account address line1 %s does not match the params address line1: %s", acct.LegalEntity.Address.Line1, params.LegalEntity.Address.Line1)
+		t.Errorf("The account address line1 %v does not match the params address line1: %v", acct.LegalEntity.Address.Line1, params.LegalEntity.Address.Line1)
 	}
 }
 

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -238,6 +238,45 @@ func TestAccountUpdate(t *testing.T) {
 	}
 }
 
+func TestAccountUpdateLegalEntity(t *testing.T) {
+	params := &stripe.AccountParams{
+		Managed: true,
+		Country: "CA",
+		LegalEntity: &stripe.LegalEntity{
+			Address: stripe.Address{
+				Country: "CA",
+				City:    "Montreal",
+				Zip:     "H2Y 1C6",
+				Line1:   "275, rue Notre-Dame Est",
+				State:   "QC",
+			},
+		},
+	}
+
+	acct, err := New(params)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	params = &stripe.AccountParams{
+		LegalEntity: &stripe.LegalEntity{
+			Address: stripe.Address{
+				Line1: "321, rue Notre-Dame Est",
+			},
+		},
+	}
+
+	acct, err = Update(acct.ID, params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if acct.LegalEntity.Address.Line1 != params.LegalEntity.Address.Line1 {
+		t.Error("The account address line1 %s does not match the params address line1: %s", acct.LegalEntity.Address.Line1, params.LegalEntity.Address.Line1)
+	}
+}
+
 func TestAccountUpdateWithBankAccount(t *testing.T) {
 	params := &stripe.AccountParams{
 		Managed: true,


### PR DESCRIPTION
It fixes #308.

Prior to that we needed to pass Type and the full DOB to update Legal Entity. These parameters are now checked to see if empty like everything else.

r? @brandur 