### PR TITLE
Allow bank account operations to keyed to customer

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -32,7 +32,14 @@ type BankAccountParams struct {
 // BankAccountListParams is the set of parameters that can be used when listing bank accounts.
 type BankAccountListParams struct {
 	ListParams
+
+	// The identifier of the parent account under which the bank accounts are
+	// nested. Either AccountID or Customer should be populated.
 	AccountID string
+
+	// The identifier of the parent customer under which the bank accounts are
+	// nested. Either AccountID or Customer should be populated.
+	Customer string
 }
 
 // BankAccount represents a Stripe bank account.

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -76,7 +76,15 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	}
 
 	ba := &stripe.BankAccount{}
-	err := c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	var err error
+
+	if len(params.Customer) > 0 {
+		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else if len(params.AccountID) > 0 {
+		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else {
+		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+	}
 
 	return ba, err
 }
@@ -102,7 +110,15 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 	}
 
 	ba := &stripe.BankAccount{}
-	err := c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	var err error
+
+	if len(params.Customer) > 0 {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
+	} else if len(params.AccountID) > 0 {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else {
+		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+	}
 
 	return ba, err
 }
@@ -121,7 +137,7 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	} else if len(params.AccountID) > 0 {
 		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, nil, nil, ba)
 	} else {
-		err = errors.New("Invalid bank account params: either customer or AccountID need to be set")
+		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
 	}
 
 	return ba, err
@@ -143,7 +159,15 @@ func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BankAccountList{}
-		err := c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, b, p, list)
+		var err error
+
+		if len(params.Customer) > 0 {
+			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts", params.Customer), c.Key, b, p, list)
+		} else if len(params.AccountID) > 0 {
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, b, p, list)
+		} else {
+			err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+		}
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/account"
 	"github.com/stripe/stripe-go/customer"
 	"github.com/stripe/stripe-go/token"
 	. "github.com/stripe/stripe-go/utils"
@@ -44,5 +45,78 @@ func TestBankAccountDel(t *testing.T) {
 		t.Errorf("Bank account id %q expected to be marked as deleted on the returned resource\n", baDel.ID)
 	}
 
+	customer.Del(cust.ID)
+}
+
+func TestBankAccountListByAccount(t *testing.T) {
+	baTok, err := token.New(&stripe.TokenParams{
+		Bank: &stripe.BankAccountParams{
+			Country:           "US",
+			Currency:          "usd",
+			Routing:           "110000000",
+			Account:           "000123456789",
+			AccountHolderName: "Jane Austen",
+			AccountHolderType: "individual",
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	accountParams := &stripe.AccountParams{
+		Managed: true,
+		Country: "CA",
+		ExternalAccount: &stripe.AccountExternalAccountParams{
+			Token: baTok.ID,
+		},
+	}
+	acct, err := account.New(accountParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	iter := List(&stripe.BankAccountListParams{AccountID: acct.ID})
+	if iter.Err() != nil {
+		t.Error(err)
+	}
+	if !iter.Next() {
+		t.Errorf("Expected to find one bank account in list\n")
+	}
+
+	Del(baTok.ID, &stripe.BankAccountParams{AccountID: acct.ID})
+	account.Del(acct.ID)
+}
+
+func TestBankAccountListByCustomer(t *testing.T) {
+	baTok, err := token.New(&stripe.TokenParams{
+		Bank: &stripe.BankAccountParams{
+			Country:           "US",
+			Currency:          "usd",
+			Routing:           "110000000",
+			Account:           "000123456789",
+			AccountHolderName: "Jane Austen",
+			AccountHolderType: "individual",
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource(baTok.ID)
+	cust, _ := customer.New(customerParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	iter := List(&stripe.BankAccountListParams{Customer: cust.ID})
+	if iter.Err() != nil {
+		t.Error(err)
+	}
+	if !iter.Next() {
+		t.Errorf("Expected to find one bank account in list\n")
+	}
+
+	Del(cust.DefaultSource.ID, &stripe.BankAccountParams{Customer: cust.ID})
 	customer.Del(cust.ID)
 }


### PR DESCRIPTION
Currently, we've got bank account operations tied specifically to
accounts, when they actually should be keyable to a customer as well
(for some reason delete was implemented as expected, but this goes for
list/retrieve/create). This meant that some of the code that we had in
our documentation wasn't valid:

    card.List(&stripe.BankAccountListParams{Customer: {CUSTOMER_ID}})

This patch allows the library to switch off of a customer key as well as
an account key.

Fixes #312.