### PR TITLE
Split sub item param structs into two.

### DIFF
--- a/sub.go
+++ b/sub.go
@@ -24,8 +24,8 @@ type SubParams struct {
 	Items                                           []*SubItemsParams
 }
 
-// SubItemsParams is the set of parameters that can be used when creating or updating a subscription item.
-// For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
+// SubItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription
+// For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubItemsParams struct {
 	Params
 	ID                    string

--- a/sub.go
+++ b/sub.go
@@ -21,7 +21,17 @@ type SubParams struct {
 	NoProrate, EndCancel, QuantityZero, TrialEndNow bool
 	BillingCycleAnchor                              int64
 	BillingCycleAnchorNow                           bool
-	Items                                           []*SubItemParams
+	Items                                           []*SubItemsParams
+}
+
+// SubItemsParams is the set of parameters that can be used when creating or updating a subscription item.
+// For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
+type SubItemsParams struct {
+	Params
+	ID                    string
+	Quantity              uint64
+	Plan                  string
+	Deleted, QuantityZero bool
 }
 
 // SubListParams is the set of parameters that can be used when listing active subscriptions.

--- a/sub/client.go
+++ b/sub/client.go
@@ -154,12 +154,6 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 				} else if item.QuantityZero {
 					body.Add(key+"[quantity]", "0")
 				}
-				if item.NoProrate {
-					body.Add(key+"[prorate]", strconv.FormatBool(false))
-				}
-				if item.ProrationDate > 0 {
-					body.Add(key+"[proration_date]", strconv.FormatInt(item.ProrationDate, 10))
-				}
 			}
 		}
 

--- a/sub/items_test.go
+++ b/sub/items_test.go
@@ -54,7 +54,7 @@ func TestSubscriptionCreateUpdateWithItems(t *testing.T) {
 	// Create
 	subParams := &stripe.SubParams{
 		Customer: cust.ID,
-		Items: []*stripe.SubItemParams{
+		Items: []*stripe.SubItemsParams{
 			{
 				Plan:     p.ID,
 				Quantity: 1,
@@ -82,7 +82,7 @@ func TestSubscriptionCreateUpdateWithItems(t *testing.T) {
 
 	// Update
 	subParams = &stripe.SubParams{
-		Items: []*stripe.SubItemParams{
+		Items: []*stripe.SubItemsParams{
 			{
 				ID:       item.ID,
 				Quantity: 2,
@@ -106,7 +106,7 @@ func TestSubscriptionCreateUpdateWithItems(t *testing.T) {
 
 	// Update with zero
 	subParams = &stripe.SubParams{
-		Items: []*stripe.SubItemParams{
+		Items: []*stripe.SubItemsParams{
 			{
 				ID:           item.ID,
 				QuantityZero: true,
@@ -130,7 +130,7 @@ func TestSubscriptionCreateZeroQuantityWithItems(t *testing.T) {
 
 	subParams := &stripe.SubParams{
 		Customer: cust.ID,
-		Items: []*stripe.SubItemParams{
+		Items: []*stripe.SubItemsParams{
 			{
 				Plan:         p.ID,
 				QuantityZero: true,

--- a/subitem.go
+++ b/subitem.go
@@ -10,7 +10,6 @@ type SubItemParams struct {
 	Plan                    string
 	ProrationDate           int64
 	NoProrate, QuantityZero bool
-	Deleted                 bool
 }
 
 // SubItemListParams is the set of parameters that can be used when listing invoice items.

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -49,7 +49,7 @@ func createSubItem(t *testing.T) (*stripe.Sub, *stripe.SubItem, func()) {
 
 	subParams := &stripe.SubParams{
 		Customer: cust.ID,
-		Items: []*stripe.SubItemParams{
+		Items: []*stripe.SubItemsParams{
 			{
 				Plan:     p.ID,
 				Quantity: 1,


### PR DESCRIPTION
We were sharing a single struct between two API calls. This made things
confusing, as certain parameters were not allowed. Also remove the
per-item proration parameters, as those are not supported.