### PR TITLE
Fix issue #324: Refund.Charge should be a *Charge

### DIFF
--- a/refund.go
+++ b/refund.go
@@ -35,7 +35,7 @@ type Refund struct {
 	Created       int64             `json:"created"`
 	Currency      Currency          `json:"currency"`
 	Tx            *Transaction      `json:"balance_transaction"`
-	Charge        string            `json:"charge"`
+	Charge        *Charge           `json:"charge"`
 	Meta          map[string]string `json:"metadata"`
 	Reason        RefundReason      `json:"reason"`
 	ReceiptNumber string            `json:"receipt_number"`

--- a/refund_test.go
+++ b/refund_test.go
@@ -1,0 +1,71 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRefundUnmarshal(t *testing.T) {
+	refundData := map[string]interface{}{
+		"id":     "re_1234",
+		"object": "refund",
+		"charge": "ch_1234",
+	}
+
+	bytes, err := json.Marshal(&refundData)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var refund Refund
+	err = json.Unmarshal(bytes, &refund)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if refund.ID != "re_1234" {
+		t.Errorf("Problem deserializing refund, got ID %v", refund.ID)
+	}
+
+	if refund.Charge == nil {
+		t.Errorf("Problem deserializing refund, didn't get a Charge")
+	}
+
+	if refund.Charge.ID != "ch_1234" {
+		t.Errorf("Problem deserializing refund.charge, wrong value for ID")
+	}
+}
+
+func TestRefundUnmarshalExpandedCharge(t *testing.T) {
+	refundData := map[string]interface{}{
+		"id":     "re_1234",
+		"object": "refund",
+		"charge": map[string]interface{}{
+			"id":     "ch_1234",
+			"object": "charge",
+		},
+	}
+
+	bytes, err := json.Marshal(&refundData)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var refund Refund
+	err = json.Unmarshal(bytes, &refund)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if refund.ID != "re_1234" {
+		t.Errorf("Problem deserializing refund, got ID %v", refund.ID)
+	}
+
+	if refund.Charge == nil {
+		t.Errorf("Problem deserializing refund, didn't get a Charge")
+	}
+
+	if refund.Charge.ID != "ch_1234" {
+		t.Errorf("Problem deserializing refund.charge, wrong value for ID")
+	}
+}


### PR DESCRIPTION
This flips the type of Refund.Charge to be a *Charge instead of a
string. 'charge' is expandable when querying for refunds, so the type
needs to be the object.

Unfortunately this is a breaking change for people already using
Refund.Charge.