### PR TITLE
Add `NoDiscountable` to `InvoiceItemsParams`

### DIFF
--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -11,6 +11,7 @@ type InvoiceItemParams struct {
 	Currency           Currency
 	Invoice, Desc, Sub string
 	Discountable       bool
+	NoDiscountable     bool
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -39,6 +39,8 @@ func (c Client) New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 
 	if params.Discountable {
 		body.Add("discountable", strconv.FormatBool(true))
+	} else if params.NoDiscountable {
+		body.Add("discountable", strconv.FormatBool(false))
 	}
 
 	params.AppendTo(body)


### PR DESCRIPTION
Currently, `Discountable` cannot be explicitly set to `false`, which is
a problem because for certain types of invoice items it will be
implicitly set to true on the server side.

This patch adds `NoDiscountable` which allows an explicit `false`. This
is modeled after current SDK convention (for exmpale `NoClosed` as part
of `InvoiceParams`).

Fixes #329.

r? @kyleconroy Hey Kyle, would you mind taking a look at this? Thanks!