### PR TITLE
Support api permissions errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -14,7 +14,7 @@ const (
 	ErrorTypeAuthentication ErrorType = "authentication_error"
 	ErrorTypeCard           ErrorType = "card_error"
 	ErrorTypeInvalidRequest ErrorType = "invalid_request_error"
-	ErrorTypePermissions    ErrorType = "permissions_error"
+	ErrorTypePermission     ErrorType = "more_permissions_required"
 	ErrorTypeRateLimit      ErrorType = "rate_limit_error"
 
 	IncorrectNum  ErrorCode = "incorrect_number"
@@ -94,14 +94,14 @@ func (e *AuthenticationError) Error() string {
 	return e.stripeErr.Error()
 }
 
-// PermissionsError results when you attempt to make an API request
+// PermissionError results when you attempt to make an API request
 // for which your API key doesn't have the right permissions.
-type PermissionsError struct {
+type PermissionError struct {
 	stripeErr *Error
 }
 
 // Error serializes the error object to JSON and returns it as a string.
-func (e *PermissionsError) Error() string {
+func (e *PermissionError) Error() string {
 	return e.stripeErr.Error()
 }
 

--- a/error.go
+++ b/error.go
@@ -14,6 +14,7 @@ const (
 	ErrorTypeAuthentication ErrorType = "authentication_error"
 	ErrorTypeCard           ErrorType = "card_error"
 	ErrorTypeInvalidRequest ErrorType = "invalid_request_error"
+	ErrorTypePermissions    ErrorType = "permissions_error"
 	ErrorTypeRateLimit      ErrorType = "rate_limit_error"
 
 	IncorrectNum  ErrorCode = "incorrect_number"
@@ -90,6 +91,17 @@ type AuthenticationError struct {
 
 // Error serializes the error object to JSON and returns it as a string.
 func (e *AuthenticationError) Error() string {
+	return e.stripeErr.Error()
+}
+
+// PermissionsError results when you attempt to make an API request
+// for which your API key doesn't have the right permissions.
+type PermissionsError struct {
+	stripeErr *Error
+}
+
+// Error serializes the error object to JSON and returns it as a string.
+func (e *PermissionsError) Error() string {
 	return e.stripeErr.Error()
 }
 

--- a/stripe.go
+++ b/stripe.go
@@ -324,6 +324,9 @@ func (s *BackendConfiguration) ResponseToError(res *http.Response, resBody []byt
 	case ErrorTypeAuthentication:
 		stripeErr.Err = &AuthenticationError{stripeErr: stripeErr}
 
+	case ErrorTypePermissions:
+		stripeErr.Err = &PermissionsError{stripeErr: stripeErr}
+
 	case ErrorTypeCard:
 		cardErr := &CardError{stripeErr: stripeErr}
 		stripeErr.Err = cardErr

--- a/stripe.go
+++ b/stripe.go
@@ -324,9 +324,6 @@ func (s *BackendConfiguration) ResponseToError(res *http.Response, resBody []byt
 	case ErrorTypeAuthentication:
 		stripeErr.Err = &AuthenticationError{stripeErr: stripeErr}
 
-	case ErrorTypePermissions:
-		stripeErr.Err = &PermissionsError{stripeErr: stripeErr}
-
 	case ErrorTypeCard:
 		cardErr := &CardError{stripeErr: stripeErr}
 		stripeErr.Err = cardErr
@@ -337,6 +334,9 @@ func (s *BackendConfiguration) ResponseToError(res *http.Response, resBody []byt
 
 	case ErrorTypeInvalidRequest:
 		stripeErr.Err = &InvalidRequestError{stripeErr: stripeErr}
+
+	case ErrorTypePermission:
+		stripeErr.Err = &PermissionError{stripeErr: stripeErr}
 
 	case ErrorTypeRateLimit:
 		stripeErr.Err = &RateLimitError{stripeErr: stripeErr}


### PR DESCRIPTION
One note - our error-checking logic doesn't actually look at the HTTP status code, but rather the error code returned by Stripe. Thus we'll need to ensure that `permissions_error` corresponds to 403.

r? @brandur