### PR TITLE
add the status field to the request for listing subscriptions

### DIFF
--- a/sub.go
+++ b/sub.go
@@ -40,6 +40,7 @@ type SubListParams struct {
 	ListParams
 	Customer string
 	Plan     string
+	Status   SubStatus
 }
 
 // Sub is the resource representing a Stripe subscription.

--- a/sub/client.go
+++ b/sub/client.go
@@ -264,6 +264,10 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 			body.Add("plan", params.Plan)
 		}
 
+		if len(params.Status) > 0 {
+			body.Add("status", string(params.Status))
+		}
+
 		params.AppendTo(body)
 
 		lp = &params.ListParams


### PR DESCRIPTION
I wanted to be able to request subscriptions that had been canceled (potentially other statuses later) and the docs showed how to do it with the "status" field(https://stripe.com/docs/api/go#list_subscriptions), but that field wasn't present in the Go library, so this adds it.

I tested it out locally on my machine and it works.  I didn't actually run `make tests` though because the last PR I submitted I was told "Unfortunately, a large part of the test suite doesn't currently run in CI and is therefore very prone to failure as it falls out of date for one reason or another. This looks good as is!"