### PR TITLE
charge: add Review type, expansion on charge

### DIFF
--- a/account.go
+++ b/account.go
@@ -7,15 +7,15 @@ import (
 )
 
 // LegalEntityType describes the types for a legal entity.
-// Current values are "individual", "company".
+// Allowed values are "individual", "company".
 type LegalEntityType string
 
 // IdentityVerificationStatus describes the different statuses for identity verification.
-// Current values are "pending", "verified", "unverified".
+// Allowed values are "pending", "verified", "unverified".
 type IdentityVerificationStatus string
 
 // Interval describes the payout interval.
-// Current values are "manual", "daily", "weekly", "monthly".
+// Allowed values are "manual", "daily", "weekly", "monthly".
 type Interval string
 
 const (
@@ -179,6 +179,7 @@ type ExternalAccount struct {
 func (ea *ExternalAccount) UnmarshalJSON(b []byte) error {
 	type externalAccount ExternalAccount
 	var account externalAccount
+
 	err := json.Unmarshal(b, &account)
 	if err != nil {
 		return err

--- a/charge.go
+++ b/charge.go
@@ -77,6 +77,7 @@ type Charge struct {
 	Paid           bool              `json:"paid"`
 	Refunded       bool              `json:"refunded"`
 	Refunds        *RefundList       `json:"refunds"`
+	Review         *Review           `json:"review"`
 	Shipping       *ShippingDetails  `json:"shipping"`
 	Source         *PaymentSource    `json:"source"`
 	SourceTransfer *Transfer         `json:"source_transfer"`

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -641,3 +641,65 @@ func TestChargeSourceForSourceObject(t *testing.T) {
 		t.Error("Display value did not match expectation")
 	}
 }
+
+func TestChargeReviewID(t *testing.T) {
+	chargeParams := &stripe.ChargeParams{
+		Amount:   1000,
+		Currency: currency.USD,
+	}
+
+	chargeParams.SetSource(&stripe.CardParams{
+		Number: "4000000000009235",
+		Month:  "06",
+		Year:   "20",
+	})
+
+	res, err := New(chargeParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res.Review == nil {
+		t.Error("There should be a review on the charge")
+	}
+
+	if res.Review.ID == "" {
+		t.Error("There should be a review ID on the charge")
+	}
+}
+
+func TestChargeReviewExpansion(t *testing.T) {
+	chargeParams := &stripe.ChargeParams{
+		Amount:   1000,
+		Currency: currency.USD,
+	}
+
+	chargeParams.SetSource(&stripe.CardParams{
+		Number: "4000000000009235",
+		Month:  "06",
+		Year:   "20",
+	})
+
+	chargeParams.Expand("review")
+
+	res, err := New(chargeParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res.Review == nil {
+		t.Error("There should be a review on the charge")
+	}
+
+	if res.Review.ID == "" {
+		t.Error("There should be a review ID on the charge")
+	}
+
+	if !res.Review.Open {
+		t.Error("The review should be open")
+	}
+
+	if res.Review.Live {
+		t.Error("The review should be in test-mode")
+	}
+}

--- a/review.go
+++ b/review.go
@@ -1,0 +1,41 @@
+package stripe
+
+import "encoding/json"
+
+// Reason describes the reason why the review is open or closed.
+// Allowed values are "rule", "manual", "approved", "refunded",
+// "refunded_as_fraud", "disputed".
+type ReasonType string
+
+const (
+	ReasonRule            ReasonType = "rule"
+	ReasonManual          ReasonType = "manual"
+	ReasonApproved        ReasonType = "approved"
+	ReasonRefunded        ReasonType = "refunded"
+	ReasonRefundedAsFraud ReasonType = "refunded_as_fraud"
+	ReasonDisputed        ReasonType = "disputed"
+)
+
+type Review struct {
+	Charge  *Charge    `json:"charge"`
+	Created int64      `json:"created"`
+	ID      string     `json:"id"`
+	Live    bool       `json:"livemode"`
+	Open    bool       `json:"open"`
+	Reason  ReasonType `json:"reason"`
+}
+
+func (r *Review) UnmarshalJSON(data []byte) error {
+	type review Review
+	var rr review
+
+	err := json.Unmarshal(data, &rr)
+	if err == nil {
+		*r = Review(rr)
+	} else {
+		// Otherwise...we have to strip the escaping
+		r.ID = string(data[1 : len(data)-1])
+	}
+
+	return nil
+}


### PR DESCRIPTION
## What's in here

This pull request adds support for the `Review` resource (available as a `review` parameter in the `/v1/charges` response), the parameter supports both string IDs and expansion as other Stripe resources. The documentation for the resource has been added to the site here: https://stripe.com/docs/api#reviews.

r? @brandur 
