### PR TITLE
Added a template for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+Please only file issues here that you believe represent actual bugs or feature requests for the Stripe Go library.
+
+If you're having general trouble with your Stripe integration, please reach out to support using the form at https://support.stripe.com/ (preferred) or via email to support@stripe.com.
+
+If you are reporting a bug, please include your Go version and the version of the Stripe Go library you're using, as well as any other details that may be helpful in reproducing the problem.


### PR DESCRIPTION
r? @brandur-stripe

This adds a template for GitHub issues, similar to the one we added for stripe-php.