### PR TITLE
Detect nil in SetHTTPClient

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -97,8 +97,12 @@ var backends Backends
 // SetHTTPClient overrides the default HTTP client.
 // This is useful if you're running in a Google AppEngine environment
 // where the http.DefaultClient is not available.
-func SetHTTPClient(client *http.Client) {
+func SetHTTPClient(client *http.Client) error {
+	if client == nil {
+		return errors.New("Cannot use empty HTTP client.")
+	}
 	httpClient = client
+	return nil
 }
 
 // NewBackends creates a new set of backends with the given HTTP client. You

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -132,3 +132,12 @@ func TestCheckinResponseToError(t *testing.T) {
 func wrapError(serialized []byte) []byte {
 	return []byte(`{"error":` + string(serialized) + `}`)
 }
+
+func TestSetHTTPClient(t *testing.T) {
+	var client *http.Client
+
+	err := stripe.SetHTTPClient(client)
+	if err == nil {
+		t.Fatalf("Expected an error.")
+	}
+}


### PR DESCRIPTION
Detect `nil` when we set our custom `http.Client`.

This patch changes function's return value.
So, let me know what you think.

In other ways, check `nil` in `NewBackends()` like below.

```go
func NewBackends(httpClient *http.Client) *Backends {
        if httpClient == nil {
		// handle error...
		return nil
        }
	return &Backends{
		...
	}
}
```

Thanks!