### PR TITLE
Truncate tax_percent to four decimals instead of two

### DIFF
--- a/customer/client.go
+++ b/customer/client.go
@@ -66,7 +66,7 @@ func (c Client) New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 		}
 
 		if params.TaxPercent > 0 {
-			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 4, 64))
 		} else if params.TaxPercentZero {
 			body.Add("tax_percent", "0")
 		}

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -49,7 +49,7 @@ func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	}
 
 	if params.TaxPercent > 0 {
-		body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+		body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 4, 64))
 	} else if params.TaxPercentZero {
 		body.Add("tax_percent", "0")
 	}
@@ -146,7 +146,7 @@ func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice
 		}
 
 		if params.TaxPercent > 0 {
-			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 4, 64))
 		} else if params.TaxPercentZero {
 			body.Add("tax_percent", "0")
 		}

--- a/sub/client.go
+++ b/sub/client.go
@@ -76,7 +76,7 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 		}
 
 		if params.TaxPercent > 0 {
-			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 4, 64))
 		} else if params.TaxPercentZero {
 			body.Add("tax_percent", "0")
 		}
@@ -200,7 +200,7 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 		}
 
 		if params.TaxPercent > 0 {
-			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 2, 64))
+			body.Add("tax_percent", strconv.FormatFloat(params.TaxPercent, 'f', 4, 64))
 		} else if params.TaxPercentZero {
 			body.Add("tax_percent", "0")
 		}


### PR DESCRIPTION
We used to only support two decimals for tax_percent, but realized later
that we needed four. The API was updated to properly support this, but
the Go bindings continued to truncate to two.

This patch fixes that problem.

Fixes #350.

r? @grey-stripe Hey Marc, can you take a look at this? Thanks!