### PR TITLE
Remove the `SubProrationDateNow` parameter

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -18,7 +18,6 @@ type InvoiceParams struct {
 	SubPlan              string
 	SubNoProrate         bool
 	SubProrationDate     int64
-	SubProrationDateNow  bool
 	SubQuantity          uint64
 	SubTrialEnd          int64
 	TaxPercent           float64


### PR DESCRIPTION
This appears to have been introduced accidentally and not actually used.

Fixes #352.

r? @ob-stripe Would you mind taking a look at this one? Thank you!