### PR TITLE
Fix the Subscription TrialPeriod param to use proper value

### DIFF
--- a/sub/client.go
+++ b/sub/client.go
@@ -66,7 +66,7 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 		}
 
 		if params.TrialPeriod > 0 {
-			body.Add("trial_period_days", strconv.FormatInt(params.TrialEnd, 10))
+			body.Add("trial_period_days", strconv.FormatInt(params.TrialPeriod, 10))
 		}
 
 		if params.TrialEndNow {


### PR DESCRIPTION
This resolves the typo outlined in the following issue: https://github.com/stripe/stripe-go/issues/355

It seems like this might be a thing to add test coverage for? I'm not familiar enough with the library to know the best way to approach that.