### PR TITLE
Adds verify source endpoint

### DIFF
--- a/paymentsource.go
+++ b/paymentsource.go
@@ -33,8 +33,9 @@ type CustomerSourceParams struct {
 // For more details see https://stripe.com/docs/guides/ach-beta
 type SourceVerifyParams struct {
 	Params   `form:"*"`
-	Amounts  [2]uint8 `form:"amounts"`
-	Customer string   `form:"-"` // Goes in the URL
+	Amounts  [2]int64 `form:"amounts"` // Amounts is used when verifying bank accounts
+	Customer string   `form:"-"`       // Goes in the URL
+	Values   []string `form:"values"`  // Values is used when verifying sources
 }
 
 // SetSource adds valid sources to a CustomerSourceParams object,

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -161,8 +161,10 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 
 	if len(params.Customer) > 0 {
 		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v/verify", params.Customer, id), s.Key, body, &params.Params, source)
+	} else if len(params.Values) > 0 {
+		err = s.B.Call("POST", fmt.Sprintf("/sources/%v/verify", id), s.Key, body, &params.Params, source)
 	} else {
-		err = errors.New("Only customer bank accounts can be verified in this manner.")
+		err = errors.New("Only customer bank accounts or sources can be verified in this manner.")
 	}
 
 	return source, err

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -54,7 +54,15 @@ func TestSourceUpdate(t *testing.T) {
 func TestSourceVerify(t *testing.T) {
 	source, err := Verify("ba_123", &stripe.SourceVerifyParams{
 		Customer: "cus_123",
-		Amounts:  [2]uint8{32, 45},
+		Amounts:  [2]int64{32, 45},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, source)
+}
+
+func TestSourceObjectVerify(t *testing.T) {
+	source, err := Verify("src_123", &stripe.SourceVerifyParams{
+		Values: []string{"32", "45"},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, source)

--- a/source.go
+++ b/source.go
@@ -35,6 +35,10 @@ const (
 type SourceFlow string
 
 const (
+	// FlowCodeVerification a verification code should be communicated by the
+	// customer to authenticate the source.
+	FlowCodeVerification SourceFlow = "code_verification"
+
 	// FlowNone no particular authentication is involved the source should
 	// become chargeable directly or asyncrhonously.
 	FlowNone SourceFlow = "none"
@@ -45,10 +49,6 @@ const (
 
 	// FlowRedirect a redirect is required to authenticate the source.
 	FlowRedirect SourceFlow = "redirect"
-
-	// FlowVerification a verification code should be communicated by the
-	// customer to authenticate the source.
-	FlowVerification SourceFlow = "verification"
 )
 
 // SourceUsage represents the possible usages of a source object.
@@ -171,40 +171,40 @@ type ReceiverFlow struct {
 	RefundAttributesStatus RefundAttributesStatus `json:"refund_attributes_status"`
 }
 
-// VerificationFlowStatus represents the possible statuses of a verification
+// CodeVerificationFlowStatus represents the possible statuses of a code verification
 // flow.
-type VerificationFlowStatus string
+type CodeVerificationFlowStatus string
 
 const (
-	VerificationFlowStatusFailed    VerificationFlowStatus = "failed"
-	VerificationFlowStatusPending   VerificationFlowStatus = "pending"
-	VerificationFlowStatusSucceeded VerificationFlowStatus = "succeeded"
+	CodeVerificationFlowStatusFailed    CodeVerificationFlowStatus = "failed"
+	CodeVerificationFlowStatusPending   CodeVerificationFlowStatus = "pending"
+	CodeVerificationFlowStatusSucceeded CodeVerificationFlowStatus = "succeeded"
 )
 
-// ReceiverFlow informs of the state of a verification authentication flow.
-type VerificationFlow struct {
-	AttemptsRemaining uint64             `json:"attempts_remaining"`
-	Status            RedirectFlowStatus `json:"status"`
+// CodeVerificationFlow informs of the state of a verification authentication flow.
+type CodeVerificationFlow struct {
+	AttemptsRemaining uint64                     `json:"attempts_remaining"`
+	Status            CodeVerificationFlowStatus `json:"status"`
 }
 
 type Source struct {
-	Amount              int64             `json:"amount"`
-	ClientSecret        string            `json:"client_secret"`
-	Created             int64             `json:"created"`
-	Currency            Currency          `json:"currency"`
-	Flow                SourceFlow        `json:"flow"`
-	ID                  string            `json:"id"`
-	Live                bool              `json:"livemode"`
-	Meta                map[string]string `json:"metadata"`
-	Owner               SourceOwner       `json:"owner"`
-	Receiver            *ReceiverFlow     `json:"receiver,omitempty"`
-	Redirect            *RedirectFlow     `json:"redirect,omitempty"`
-	StatementDescriptor string            `json:"statement_descriptor"`
-	Status              SourceStatus      `json:"status"`
-	Type                string            `json:"type"`
+	Amount              int64                 `json:"amount"`
+	ClientSecret        string                `json:"client_secret"`
+	CodeVerification    *CodeVerificationFlow `json:"code_verification,omitempty"`
+	Created             int64                 `json:"created"`
+	Currency            Currency              `json:"currency"`
+	Flow                SourceFlow            `json:"flow"`
+	ID                  string                `json:"id"`
+	Live                bool                  `json:"livemode"`
+	Meta                map[string]string     `json:"metadata"`
+	Owner               SourceOwner           `json:"owner"`
+	Receiver            *ReceiverFlow         `json:"receiver,omitempty"`
+	Redirect            *RedirectFlow         `json:"redirect,omitempty"`
+	StatementDescriptor string                `json:"statement_descriptor"`
+	Status              SourceStatus          `json:"status"`
+	Type                string                `json:"type"`
 	TypeData            map[string]interface{}
-	Usage               SourceUsage       `json:"usage"`
-	Verification        *VerificationFlow `json:"verification,omitempty"`
+	Usage               SourceUsage `json:"usage"`
 }
 
 // AppendTo implements custom encoding logic for SourceObjectParams so that the special


### PR DESCRIPTION
r? @will-stripe
cc @stripe/api-libraries @stan-stripe @remi-stripe 

This PR adds support for the `/v1/sources/src_.../verify` endpoint.

AFAIK, only `ach_debit` sources use this endpoint at the moment, so I hardcoded `Values` as `[2]uint8`. I guess that in the future, other source types might expect different types for the `values` parameter, and we might want to anticipate on that.

Putting the PR up for review, but I'll leave it to you to decide whether we should merge as-is or wait.
