### PR TITLE
add support for transfer_group param

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -40,8 +40,9 @@ func (cp *ChargeParams) SetSource(sp interface{}) error {
 // For more details see https://stripe.com/docs/api#list_charges.
 type ChargeListParams struct {
 	ListParams
-	Created  int64
-	Customer string
+	Created       int64
+	Customer      string
+	TransferGroup string
 }
 
 // CaptureParams is the set of parameters that can be used when capturing a charge.

--- a/charge.go
+++ b/charge.go
@@ -25,6 +25,7 @@ type ChargeParams struct {
 	Fraud                        FraudReport
 	Source                       *SourceParams
 	Shipping                     *ShippingDetails
+	TransferGroup                string
 }
 
 // SetSource adds valid sources to a ChargeParams object,
@@ -85,6 +86,7 @@ type Charge struct {
 	Statement      string            `json:"statement_descriptor"`
 	Status         string            `json:"status"`
 	Transfer       *Transfer         `json:"transfer"`
+	TransferGroup  string            `json:"transfer_group"`
 	Tx             *Transaction      `json:"balance_transaction"`
 }
 

--- a/charge/client.go
+++ b/charge/client.go
@@ -60,6 +60,10 @@ func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 		body.Add("destination", params.Dest)
 	}
 
+	if params.TransferGroup != "" {
+		body.Add("transfer_group", params.TransferGroup)
+	}
+
 	body.Add("capture", strconv.FormatBool(!params.NoCapture))
 
 	token := c.Key

--- a/charge/client.go
+++ b/charge/client.go
@@ -195,6 +195,10 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 			body.Add("customer", params.Customer)
 		}
 
+		if len(params.TransferGroup) > 0 {
+			body.Add("transfer_group", params.TransferGroup)
+		}
+
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()

--- a/transfer.go
+++ b/transfer.go
@@ -66,6 +66,7 @@ type TransferListParams struct {
 	Created, Date int64
 	Recipient     string
 	Status        TransferStatus
+	TransferGroup string
 }
 
 // Transfer is the resource representing a Stripe transfer.

--- a/transfer.go
+++ b/transfer.go
@@ -52,11 +52,11 @@ type TransferDestination struct {
 // For more details see https://stripe.com/docs/api#create_transfer and https://stripe.com/docs/api#update_transfer.
 type TransferParams struct {
 	Params
-	Amount                                                 int64
-	Fee                                                    uint64
-	Currency                                               Currency
-	Recipient, Desc, Statement, Bank, Card, SourceTx, Dest string
-	SourceType                                             TransferSourceType
+	Amount                                                                int64
+	Fee                                                                   uint64
+	Currency                                                              Currency
+	Recipient, TransferGroup, Desc, Statement, Bank, Card, SourceTx, Dest string
+	SourceType                                                            TransferSourceType
 }
 
 // TransferListParams is the set of parameters that can be used when listing transfers.
@@ -95,6 +95,7 @@ type Transfer struct {
 	SourceTx       *TransactionSource  `json:"source_transaction"`
 	SourceType     TransferSourceType  `json:"source_type"`
 	DestPayment    string              `json:"destination_payment"`
+	TransferGroup  string              `json:"transfer_group"`
 }
 
 // TransferList is a list of transfers as retrieved from a list endpoint.

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -75,6 +75,10 @@ func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 		body.Add("destination", params.Dest)
 	}
 
+	if len(params.TransferGroup) > 0 {
+		body.Add("transfer_group", params.TransferGroup)
+	}
+
 	if len(params.SourceTx) > 0 {
 		body.Add("source_transaction", params.SourceTx)
 	}

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -201,6 +201,10 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 			body.Add("status", string(params.Status))
 		}
 
+		if len(params.TransferGroup) > 0 {
+			body.Add("status", params.TransferGroup)
+		}
+
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()


### PR DESCRIPTION
Adds [transfer_group](https://stripe.com/docs/connect/transfer-group) support to the api client.

Desired functionality:

- [x] create charge w. transfer group
- [x] create transfer w. transfer group
- [x] list charges w. a transfer group
- [x] list transfers w. a transfer group