### PR TITLE
support destination hash

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -16,17 +16,17 @@ type FraudReport string
 // For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
 	Params
-	Amount                 uint64
-	Currency               Currency
-	Customer, Token        string
-	Desc, Statement, Email string
-	Dest                   DestinationParams
-	NoCapture              bool
-	Fee                    uint64
-	Fraud                  FraudReport
-	Source                 *SourceParams
-	Shipping               *ShippingDetails
-	TransferGroup          string
+	Amount                       uint64
+	Currency                     Currency
+	Customer, Token              string
+	Desc, Statement, Email, Dest string
+	Destination                  *DestinationParams
+	NoCapture                    bool
+	Fee                          uint64
+	Fraud                        FraudReport
+	Source                       *SourceParams
+	Shipping                     *ShippingDetails
+	TransferGroup                string
 }
 
 type DestinationParams struct {

--- a/charge.go
+++ b/charge.go
@@ -16,16 +16,22 @@ type FraudReport string
 // For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
 	Params
-	Amount                       uint64
-	Currency                     Currency
-	Customer, Token              string
-	Desc, Statement, Email, Dest string
-	NoCapture                    bool
-	Fee                          uint64
-	Fraud                        FraudReport
-	Source                       *SourceParams
-	Shipping                     *ShippingDetails
-	TransferGroup                string
+	Amount                 uint64
+	Currency               Currency
+	Customer, Token        string
+	Desc, Statement, Email string
+	Dest                   DestinationParams
+	NoCapture              bool
+	Fee                    uint64
+	Fraud                  FraudReport
+	Source                 *SourceParams
+	Shipping               *ShippingDetails
+	TransferGroup          string
+}
+
+type DestinationParams struct {
+	Account string
+	Amount  uint64
 }
 
 // SetSource adds valid sources to a ChargeParams object,

--- a/charge/client.go
+++ b/charge/client.go
@@ -56,8 +56,12 @@ func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 		body.Add("receipt_email", params.Email)
 	}
 
-	if len(params.Dest) > 0 {
-		body.Add("destination", params.Dest)
+	if len(params.Dest.Account) > 0 {
+		body.Add("destination[account]", params.Dest.Account)
+	}
+
+	if params.Dest.Amount > 0 {
+		body.Add("destination[amount]", strconv.FormatUint(params.Dest.Amount, 10))
 	}
 
 	if params.TransferGroup != "" {

--- a/charge/client.go
+++ b/charge/client.go
@@ -56,12 +56,25 @@ func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 		body.Add("receipt_email", params.Email)
 	}
 
-	if len(params.Dest.Account) > 0 {
-		body.Add("destination[account]", params.Dest.Account)
+	if len(params.Dest) > 0 &&
+		params.Destination != nil &&
+		params.Destination.Account != params.Dest {
+		err := errors.New("Dest and Destination.Account are both set and not the same")
+		return nil, err
 	}
 
-	if params.Dest.Amount > 0 {
-		body.Add("destination[amount]", strconv.FormatUint(params.Dest.Amount, 10))
+	if len(params.Dest) > 0 {
+		body.Add("destination[account]", params.Dest)
+	}
+
+	if params.Destination != nil {
+		if len(params.Destination.Account) > 0 {
+			body.Add("destination[account]", params.Destination.Account)
+		}
+
+		if params.Destination.Amount > 0 {
+			body.Add("destination[amount]", strconv.FormatUint(params.Destination.Amount, 10))
+		}
 	}
 
 	if params.TransferGroup != "" {


### PR DESCRIPTION
Don't merge right away.

Changes the calling convention for creating destination charges from specifying a destination string to using a struct that supports `destination[amount]` and `destination[account]` to match the new, public API: https://stripe.com/docs/api#create_charge-destination

Making a Charge with the proposed struct looks like this:

```go
  chargeParams := &stripe.ChargeParams{
    Amount:        1000,
    Currency:      "usd",
    TransferGroup: group,
    Dest: stripe.DestinationParams{
      Amount:  500,
      Account: accountId,
    },
  }
```

Thoughts:  I called it `DestinationParams` and went with a `string`/`uint64` because that matched some of the conventions: I considered just calling it `Destination` and using an `*Account` but we only appear to do that on the serialization side (which I think makes sense).

Lemme know if you'd like me to:
1) rename anything
2) still support the string via `Dest` and call the field on the `Charge` struct something like `Destination` so you can opt-in to the new syntax (versus getting, albeit easily fixed, compiler error).
3) pass in a reference to the struct instead of a value