### PR TITLE
Start testing Go 1.7 and latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: go
+sudo: false
 go:
   - 1.6
-sudo: false
+  - 1.7
+  - tip
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries

Start testing Go 1.7 and latest (with failures allowed for the latter).

Also start testing OS X and Linux separately.