### PR TITLE
Add invoicing params

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -6,6 +6,10 @@ import "encoding/json"
 // Allowed values are "invoiceitem", "subscription".
 type InvoiceLineType string
 
+// InvoiceBilling is the type of billing method for this invoice.
+// Currently supported values are "send_invoice" and "charge_automatically".
+type InvoiceBilling string
+
 // InvoiceParams is the set of parameters that can be used when creating or updating an invoice.
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
@@ -22,14 +26,19 @@ type InvoiceParams struct {
 	SubTrialEnd          int64
 	TaxPercent           float64
 	TaxPercentZero       bool
+	Billing              InvoiceBilling
+	DueDate              int64
+	DaysUntilDue         uint64
+	Paid                 bool
 }
 
 // InvoiceListParams is the set of parameters that can be used when listing invoices.
 // For more details see https://stripe.com/docs/api#list_customer_invoices.
 type InvoiceListParams struct {
 	ListParams
-	Date     int64
-	Customer string
+	Date         int64
+	Customer     string
+	Subscription string
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.
@@ -73,6 +82,9 @@ type Invoice struct {
 	Sub           string            `json:"subscription"`
 	Webhook       int64             `json:"webhooks_delivered_at"`
 	Meta          map[string]string `json:"metadata"`
+	Billing       InvoiceBilling    `json:"billing"`
+	DueDate       int64             `json:"due_date"`
+	Number        string            `json:"number"`
 }
 
 // InvoiceList is a list of invoices as retrieved from a list endpoint.

--- a/invoice.go
+++ b/invoice.go
@@ -36,9 +36,9 @@ type InvoiceParams struct {
 // For more details see https://stripe.com/docs/api#list_customer_invoices.
 type InvoiceListParams struct {
 	ListParams
-	Date         int64
-	Customer     string
-	Subscription string
+	Date     int64
+	Customer string
+	Sub      string
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -29,6 +29,18 @@ func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	body := &stripe.RequestValues{}
 	body.Add("customer", params.Customer)
 
+	if len(params.Billing) > 0 {
+		body.Add("billing", params.Billing)
+	}
+
+	if params.daysUntilDue > 0 {
+		body.Add("days_until_due", strconv.FormatUint(params.DaysUntilDue, 10))
+	}
+
+	if params.dueDate > 0 {
+		body.Add("due_date", strconv.FormatInt(params.dueDate, 10))
+	}
+
 	if len(params.Desc) > 0 {
 		body.Add("description", params.Desc)
 	}
@@ -118,6 +130,10 @@ func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice
 	if params != nil {
 		commonParams = &params.Params
 		body = &stripe.RequestValues{}
+
+		if params.Paid {
+			body.Add("paid", strconv.FormatBool(true))
+		}
 
 		if len(params.Desc) > 0 {
 			body.Add("description", params.Desc)

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -30,15 +30,15 @@ func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	body.Add("customer", params.Customer)
 
 	if len(params.Billing) > 0 {
-		body.Add("billing", params.Billing)
+		body.Add("billing", string(params.Billing))
 	}
 
-	if params.daysUntilDue > 0 {
+	if params.DaysUntilDue > 0 {
 		body.Add("days_until_due", strconv.FormatUint(params.DaysUntilDue, 10))
 	}
 
-	if params.dueDate > 0 {
-		body.Add("due_date", strconv.FormatInt(params.dueDate, 10))
+	if params.DueDate > 0 {
+		body.Add("due_date", strconv.FormatInt(params.DueDate, 10))
 	}
 
 	if len(params.Desc) > 0 {
@@ -234,6 +234,10 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
+		}
+
+		if len(params.Sub) > 0 {
+			body.Add("subscription", params.Sub)
 		}
 
 		if params.Date > 0 {

--- a/sub.go
+++ b/sub.go
@@ -6,6 +6,10 @@ import "encoding/json"
 // Allowed values are "trialing", "active", "past_due", "canceled", "unpaid".
 type SubStatus string
 
+// SubBilling is the type of billing method for this subscription's invoices.
+// Currently supported values are "send_invoice" and "charge_automatically".
+type SubBilling string
+
 // SubParams is the set of parameters that can be used when creating or updating a subscription.
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubParams struct {
@@ -22,6 +26,8 @@ type SubParams struct {
 	BillingCycleAnchor                              int64
 	BillingCycleAnchorNow                           bool
 	Items                                           []*SubItemsParams
+	Billing                                         SubBilling
+	DaysUntilDue                                    uint64
 }
 
 // SubItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription
@@ -46,25 +52,27 @@ type SubListParams struct {
 // Sub is the resource representing a Stripe subscription.
 // For more details see https://stripe.com/docs/api#subscriptions.
 type Sub struct {
-	ID          string            `json:"id"`
-	EndCancel   bool              `json:"cancel_at_period_end"`
-	Customer    *Customer         `json:"customer"`
-	Plan        *Plan             `json:"plan"`
-	Quantity    uint64            `json:"quantity"`
-	Status      SubStatus         `json:"status"`
-	FeePercent  float64           `json:"application_fee_percent"`
-	Canceled    int64             `json:"canceled_at"`
-	Created     int64             `json:"created"`
-	Start       int64             `json:"start"`
-	PeriodEnd   int64             `json:"current_period_end"`
-	PeriodStart int64             `json:"current_period_start"`
-	Discount    *Discount         `json:"discount"`
-	Ended       int64             `json:"ended_at"`
-	Meta        map[string]string `json:"metadata"`
-	TaxPercent  float64           `json:"tax_percent"`
-	TrialEnd    int64             `json:"trial_end"`
-	TrialStart  int64             `json:"trial_start"`
-	Items       *SubItemList      `json:"items"`
+	ID           string            `json:"id"`
+	EndCancel    bool              `json:"cancel_at_period_end"`
+	Customer     *Customer         `json:"customer"`
+	Plan         *Plan             `json:"plan"`
+	Quantity     uint64            `json:"quantity"`
+	Status       SubStatus         `json:"status"`
+	FeePercent   float64           `json:"application_fee_percent"`
+	Canceled     int64             `json:"canceled_at"`
+	Created      int64             `json:"created"`
+	Start        int64             `json:"start"`
+	PeriodEnd    int64             `json:"current_period_end"`
+	PeriodStart  int64             `json:"current_period_start"`
+	Discount     *Discount         `json:"discount"`
+	Ended        int64             `json:"ended_at"`
+	Meta         map[string]string `json:"metadata"`
+	TaxPercent   float64           `json:"tax_percent"`
+	TrialEnd     int64             `json:"trial_end"`
+	TrialStart   int64             `json:"trial_start"`
+	Items        *SubItemList      `json:"items"`
+	Billing      SubBilling        `json:"billing"`
+	DaysUntilDue uint64            `json:"days_until_due"`
 }
 
 // SubList is a list object for subscriptions.

--- a/sub/client.go
+++ b/sub/client.go
@@ -56,10 +56,10 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 		}
 
 		if len(params.Billing) > 0 {
-			body.Add("billing", params.Billing)
+			body.Add("billing", string(params.Billing))
 		}
 
-		if params.daysUntilDue > 0 {
+		if params.DaysUntilDue > 0 {
 			body.Add("days_until_due", strconv.FormatUint(params.DaysUntilDue, 10))
 		}
 
@@ -178,10 +178,10 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 		}
 
 		if len(params.Billing) > 0 {
-			body.Add("billing", params.Billing)
+			body.Add("billing", string(params.Billing))
 		}
 
-		if params.daysUntilDue > 0 {
+		if params.DaysUntilDue > 0 {
 			body.Add("days_until_due", strconv.FormatUint(params.DaysUntilDue, 10))
 		}
 

--- a/sub/client.go
+++ b/sub/client.go
@@ -55,6 +55,14 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 			body.Add("plan", params.Plan)
 		}
 
+		if len(params.Billing) > 0 {
+			body.Add("billing", params.Billing)
+		}
+
+		if params.daysUntilDue > 0 {
+			body.Add("days_until_due", strconv.FormatUint(params.DaysUntilDue, 10))
+		}
+
 		if len(params.Token) > 0 {
 			body.Add("card", params.Token)
 		} else if params.Card != nil {
@@ -167,6 +175,14 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 		if params.NoProrate {
 			body.Add("prorate", strconv.FormatBool(false))
+		}
+
+		if len(params.Billing) > 0 {
+			body.Add("billing", params.Billing)
+		}
+
+		if params.daysUntilDue > 0 {
+			body.Add("days_until_due", strconv.FormatUint(params.DaysUntilDue, 10))
 		}
 
 		if len(params.Token) > 0 {

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -19,6 +19,7 @@ func init() {
 
 func TestSubscriptionNew(t *testing.T) {
 	customerParams := &stripe.CustomerParams{
+		Email: "test@stripe.com",
 		Source: &stripe.SourceParams{
 			Card: &stripe.CardParams{
 				Number: "378282246310005",
@@ -46,6 +47,8 @@ func TestSubscriptionNew(t *testing.T) {
 		Quantity:           10,
 		TaxPercent:         20.0,
 		BillingCycleAnchor: time.Now().AddDate(0, 0, 12).Unix(),
+		Billing:            "send_invoice",
+		DaysUntilDue:       30,
 	}
 
 	target, err := New(subParams)
@@ -60,6 +63,14 @@ func TestSubscriptionNew(t *testing.T) {
 
 	if target.Quantity != subParams.Quantity {
 		t.Errorf("Quantity %v does not match expected quantity %v\n", target.Quantity, subParams.Quantity)
+	}
+
+	if target.Billing != subParams.Billing {
+		t.Errorf("Billing %v does not match expected %v\n", target.Billing, subParams.Billing)
+	}
+
+	if target.DaysUntilDue != subParams.DaysUntilDue {
+		t.Errorf("DaysUntilDue %v does not match expected %v\n", target.DaysUntilDue, subParams.DaysUntilDue)
 	}
 
 	if target.TaxPercent != subParams.TaxPercent {
@@ -322,15 +333,25 @@ func TestSubscriptionUpdate(t *testing.T) {
 
 	subscription, _ := New(subParams)
 	updatedSub := &stripe.SubParams{
-		NoProrate:  true,
-		Quantity:   13,
-		TaxPercent: 20.0,
+		NoProrate:    true,
+		Quantity:     13,
+		TaxPercent:   20.0,
+		Billing:      "send_invoice",
+		DaysUntilDue: 12,
 	}
 
 	target, err := Update(subscription.ID, updatedSub)
 
 	if err != nil {
 		t.Error(err)
+	}
+
+	if target.Billing != updatedSub.Billing {
+		t.Errorf("Billing %v does not match expected %v\n", target.Billing, updatedSub.Billing)
+	}
+
+	if target.DaysUntilDue != updatedSub.DaysUntilDue {
+		t.Errorf("DaysUntilDue %v does not match expected %v\n", target.DaysUntilDue, updatedSub.DaysUntilDue)
 	}
 
 	if target.Quantity != updatedSub.Quantity {


### PR DESCRIPTION
This PR adds and tests new invoicing related parameters:

Subscription model: billing, days_until_due
Subscription create: billing, days_until_due
Subscription update: billing, days_until_due

Invoice model: billing, due_date, number
Invoice create: billing, days_until_due, due_date
Invoice update: paid
Invoice list: subscription

