### PR TITLE
Add subscription status all as a constant

### DIFF
--- a/sub.go
+++ b/sub.go
@@ -3,7 +3,7 @@ package stripe
 import "encoding/json"
 
 // SubStatus is the list of allowed values for the subscription's status.
-// Allowed values are "trialing", "active", "past_due", "canceled", "unpaid".
+// Allowed values are "trialing", "active", "past_due", "canceled", "unpaid", "all".
 type SubStatus string
 
 // SubBilling is the type of billing method for this subscription's invoices.

--- a/sub/client.go
+++ b/sub/client.go
@@ -14,6 +14,7 @@ const (
 	PastDue  stripe.SubStatus = "past_due"
 	Canceled stripe.SubStatus = "canceled"
 	Unpaid   stripe.SubStatus = "unpaid"
+	All      stripe.SubStatus = "all"
 )
 
 // Client is used to invoke /subscriptions APIs.


### PR DESCRIPTION
From what I can tell, `all` is a valid status value. https://stripe.com/docs/api/go#list_subscriptions-status

Does this seem reasonable?