### PR TITLE
File upload no longer requires the file to be on disk (#374)

### DIFF
--- a/fileupload/client_test.go
+++ b/fileupload/client_test.go
@@ -17,7 +17,7 @@ func init() {
 	stripe.Key = GetTestKey()
 }
 
-func TestFileUploadNewThenGet(t *testing.T) {
+func TestFileUploadNewThenGetWithFile(t *testing.T) {
 	f, err := os.Open("test_data.pdf")
 	if err != nil {
 		t.Errorf("Unable to open test file upload file %v\n", err)
@@ -56,16 +56,16 @@ func TestFileUploadNewThenGet(t *testing.T) {
 	}
 }
 
-func TestInterfaceFileUploadNewThenGet(t *testing.T) {
+func TestFileUploadNewThenGet(t *testing.T) {
 	f, err := os.Open("test_data.pdf")
 	if err != nil {
 		t.Errorf("Unable to open test file upload file %v\n", err)
 	}
 
 	uploadParams := &stripe.FileUploadParams{
-		Purpose:  "dispute_evidence",
-		FileData: f,
-		Filename: f.Name(),
+		Purpose:    "dispute_evidence",
+		FileReader: f,
+		Filename:   f.Name(),
 	}
 
 	target, err := New(uploadParams)

--- a/fileupload/client_test.go
+++ b/fileupload/client_test.go
@@ -56,6 +56,46 @@ func TestFileUploadNewThenGet(t *testing.T) {
 	}
 }
 
+func TestInterfaceFileUploadNewThenGet(t *testing.T) {
+	f, err := os.Open("test_data.pdf")
+	if err != nil {
+		t.Errorf("Unable to open test file upload file %v\n", err)
+	}
+
+	uploadParams := &stripe.FileUploadParams{
+		Purpose:  "dispute_evidence",
+		FileData: f,
+		Filename: f.Name(),
+	}
+
+	target, err := New(uploadParams)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if target.Size != expectedSize {
+		t.Errorf("(POST) Size %v does not match expected size %v\n", target.Size, expectedSize)
+	}
+
+	if target.Purpose != uploadParams.Purpose {
+		t.Errorf("(POST) Purpose %v does not match expected purpose %v\n", target.Purpose, uploadParams.Purpose)
+	}
+
+	if target.Type != expectedType {
+		t.Errorf("(POST) Type %v does not match expected type %v\n", target.Type, expectedType)
+	}
+
+	res, err := Get(target.ID, nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if target.ID != res.ID {
+		t.Errorf("(GET) File upload id %q does not match expected id %q\n", target.ID, res.ID)
+	}
+}
+
 func TestFileUploadList(t *testing.T) {
 	f, err := os.Open("test_data.pdf")
 	if err != nil {


### PR DESCRIPTION
Added support for files to be uploaded from any generic reader so long as a filename can be provided. Also added a test for the new parameters.

The old parameters still work for backwards compatibility, although there is a comment in the code marking them as deprecated.