### PR TITLE
Add support for manage accounts to send ID documents for additional owners

### DIFF
--- a/account.go
+++ b/account.go
@@ -453,6 +453,10 @@ func (l *LegalEntity) AppendDetails(values *RequestValues) {
 			}
 
 			owner.Address.AppendDetails(values, fmt.Sprintf("legal_entity[additional_owners][%v][address]", i))
+
+			if owner.Verification.Document != nil {
+				values.Add(fmt.Sprintf("legal_entity[additional_owners][%v][verification][document]", i), owner.Verification.Document.ID)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Additional owners for a managed account in a country that requires them can now submit the ID of their identity document.