### PR TITLE
Upgrade the pinned API version to 2017-02-14

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -112,6 +112,7 @@ type FraudDetails struct {
 // ChargeOutcomeRule tells you the Radar rule that blocked the charge, if any.
 type ChargeOutcomeRule struct {
 	Action    string `json:"action"`
+	ID        string `json:"id"`
 	Predicate string `json:"predicate"`
 }
 
@@ -181,6 +182,23 @@ func (c *Charge) UnmarshalJSON(data []byte) error {
 	err := json.Unmarshal(data, &cc)
 	if err == nil {
 		*c = Charge(cc)
+	} else {
+		// the id is surrounded by "\" characters, so strip them
+		c.ID = string(data[1 : len(data)-1])
+	}
+
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a ChargeOutcomeRule.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (c *ChargeOutcomeRule) UnmarshalJSON(data []byte) error {
+	type chargeOutcomeRule ChargeOutcomeRule
+	var cc chargeOutcomeRule
+	err := json.Unmarshal(data, &cc)
+	if err == nil {
+		*c = ChargeOutcomeRule(cc)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		c.ID = string(data[1 : len(data)-1])

--- a/dispute.go
+++ b/dispute.go
@@ -255,6 +255,23 @@ func (e *DisputeEvidenceParams) AppendDetails(values *RequestValues) {
 	}
 }
 
+// UnmarshalJSON handles deserialization of a Dispute.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (t *Dispute) UnmarshalJSON(data []byte) error {
+	type dispute Dispute
+	var dd dispute
+	err := json.Unmarshal(data, &dd)
+	if err == nil {
+		*t = Dispute(dd)
+	} else {
+		// the id is surrounded by "\" characters, so strip them
+		t.ID = string(data[1 : len(data)-1])
+	}
+
+	return nil
+}
+
 // UnmarshalJSON handles deserialization of a File.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.

--- a/stripe.go
+++ b/stripe.go
@@ -20,7 +20,7 @@ const (
 )
 
 // apiversion is the currently supported API version
-const apiversion = "2016-07-06"
+const apiversion = "2017-02-14"
 
 // clientversion is the binding version
 const clientversion = "19.16.0"


### PR DESCRIPTION
Upgrades the pinned API version to [2017-02-14](https://stripe.com/docs/upgrades#2017-02-14) and introduces appropriate changes. This mostly includes adding an `UnmarshalJSON` implementation for dispute and charge outcome's rule, both of which have become fields that are expandable but collapsed by default.

cc @remi-stripe 