### PR TITLE
Balance history can be filtered by Payout and not Transfer

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -72,9 +72,9 @@ type TxParams struct {
 // For more details see https://stripe.com/docs/api/#balance_history.
 type TxListParams struct {
 	ListParams
-	Created, Available      int64
-	Currency, Src, Transfer string
-	Type                    TransactionType
+	Created, Available    int64
+	Currency, Src, Payout string
+	Type                  TransactionType
 }
 
 // Balance is the resource representing your Stripe balance.

--- a/balance/client.go
+++ b/balance/client.go
@@ -102,14 +102,13 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 			body.Add("currency", params.Currency)
 		}
 
+		if len(params.Payout) > 0 {
+			body.Add("payout", params.Payout)
+		}
+
 		if len(params.Src) > 0 {
 			body.Add("source", params.Src)
 		}
-
-		if len(params.Transfer) > 0 {
-			body.Add("transfer", params.Transfer)
-		}
-
 		if len(params.Type) > 0 {
 			body.Add("type", string(params.Type))
 		}


### PR DESCRIPTION
This fixes something I missed when doing the Payout/Transfer split. When listing all balance transactions bundled in a payout you need to pass the payout id, po_XXXXX, in the `payout` parameter instead of `transfer.

r? @brandur-stripe