### PR TITLE
Remove raw PANs from our test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,7 @@ params := &stripe.CustomerParams{
 	Desc:  "Stripe Developer",
 	Email: "gostripe@stripe.com",
 }
-params.SetSource(&stripe.CardParams{
-	Name:   "Go Stripe",
-	Number: "378282246310005",
-	Month:  "06",
-	Year:   "15",
-})
+params.SetSource("tok_1234")
 
 customer, err := customer.New(params)
 ```

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -383,20 +383,9 @@ func TestAccountUpdateWithCardToken(t *testing.T) {
 
 	acct, _ := New(params)
 
-	tokenParams := &stripe.TokenParams{
-		Card: &stripe.CardParams{
-			Number:   "4000056655665556",
-			Month:    "06",
-			Year:     "20",
-			Currency: "usd",
-		},
-	}
-
-	tok, _ := token.New(tokenParams)
-
 	cardParams := &stripe.CardParams{
 		Account: acct.ID,
-		Token:   tok.ID,
+		Token:   "tok_visa_debit",
 	}
 
 	c, err := card.New(cardParams)

--- a/balance/client_test.go
+++ b/balance/client_test.go
@@ -35,11 +35,7 @@ func TestBalanceGetTx(t *testing.T) {
 		Currency: currency.USD,
 		Desc:     "charge transaction",
 	}
-	chargeParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_amex")
 
 	res, _ := charge.New(chargeParams)
 

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -5,7 +5,6 @@ import (
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/customer"
-	"github.com/stripe/stripe-go/token"
 	. "github.com/stripe/stripe-go/utils"
 )
 
@@ -15,20 +14,13 @@ func init() {
 
 func TestCardNew(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
 	cardParams := &stripe.CardParams{
-		Number:   "4242424242424242",
-		Month:    "10",
-		Year:     "20",
 		Customer: cust.ID,
-		CVC:      "1234",
+		Token:    "tok_visa",
 	}
 
 	target, err := New(cardParams)
@@ -45,18 +37,6 @@ func TestCardNew(t *testing.T) {
 		t.Errorf("Unexpected nil or non-empty metadata in card\n")
 	}
 
-	if target.Month != 10 {
-		t.Errorf("Unexpected expiration month %d for card where we set %q\n", target.Month, cardParams.Month)
-	}
-
-	if target.Year != 2020 {
-		t.Errorf("Unexpected expiration year %d for card where we set %q\n", target.Year, cardParams.Year)
-	}
-
-	if target.CVCCheck != Pass {
-		t.Errorf("CVC check %q does not match expected status\n", target.ZipCheck)
-	}
-
 	targetCust, err := customer.Get(cust.ID, nil)
 
 	if err != nil {
@@ -67,30 +47,13 @@ func TestCardNew(t *testing.T) {
 		t.Errorf("Unexpected number of sources %v\n", targetCust.Sources.Count)
 	}
 
-	targetToken, err := token.New(&stripe.TokenParams{
-		Card: &stripe.CardParams{
-			Number: "4000056655665556",
-			Month:  "09",
-			Year:   "2021",
-			CVC:    "123",
-		},
-	})
-
 	targetCard, err := New(&stripe.CardParams{
 		Customer: targetCust.ID,
-		Token:    targetToken.ID,
+		Token:    "tok_visa",
 	})
 
-	if targetCard.LastFour != "5556" {
+	if targetCard.LastFour != "4242" {
 		t.Errorf("Unexpected last four %q for card number %v\n", targetCard.LastFour, cardParams.Number)
-	}
-
-	if targetCard.Month != 9 {
-		t.Errorf("Unexpected expiration month %d for card where we set %q\n", targetCard.Month, targetToken.Card.Month)
-	}
-
-	if targetCard.Year != 2021 {
-		t.Errorf("Unexpected expiration year %d for card where we set %q\n", targetCard.Year, targetToken.Card.Year)
 	}
 
 	customer.Del(cust.ID)
@@ -98,11 +61,7 @@ func TestCardNew(t *testing.T) {
 
 func TestCardGet(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "5200828282828210",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_visa")
 
 	cust, _ := customer.New(customerParams)
 
@@ -112,15 +71,15 @@ func TestCardGet(t *testing.T) {
 		t.Error(err)
 	}
 
-	if target.LastFour != "8210" {
+	if target.LastFour != "4242" {
 		t.Errorf("Unexpected last four %q for card number %v\n", target.LastFour, customerParams.Source.Card.Number)
 	}
 
-	if target.Brand != MasterCard {
+	if target.Brand != Visa {
 		t.Errorf("Card brand %q does not match expected value\n", target.Brand)
 	}
 
-	if target.Funding != Debit {
+	if target.Funding != Credit {
 		t.Errorf("Card funding %q does not match expected value\n", target.Funding)
 	}
 
@@ -129,11 +88,7 @@ func TestCardGet(t *testing.T) {
 
 func TestCardDel(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_visa")
 
 	cust, _ := customer.New(customerParams)
 
@@ -151,12 +106,7 @@ func TestCardDel(t *testing.T) {
 
 func TestCardUpdate(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-		Name:   "Original Name",
-	})
+	customerParams.SetSource("tok_amex")
 
 	cust, err := customer.New(customerParams)
 
@@ -194,19 +144,13 @@ func TestCardUpdate(t *testing.T) {
 
 func TestCardList(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
 	card := &stripe.CardParams{
-		Number:   "4242424242424242",
-		Month:    "10",
-		Year:     "20",
 		Customer: cust.ID,
+		Token:    "tok_visa",
 	}
 
 	New(card)

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stripe/stripe-go/customer"
 	"github.com/stripe/stripe-go/refund"
 	"github.com/stripe/stripe-go/source"
-	"github.com/stripe/stripe-go/token"
 	. "github.com/stripe/stripe-go/utils"
 )
 
@@ -35,12 +34,7 @@ func TestChargeNew(t *testing.T) {
 			},
 		},
 	}
-	chargeParams.SetSource(&stripe.CardParams{
-		Name:   "Stripe Tester",
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_visa")
 
 	target, err := New(chargeParams)
 
@@ -54,10 +48,6 @@ func TestChargeNew(t *testing.T) {
 
 	if target.Currency != chargeParams.Currency {
 		t.Errorf("Currency %q does not match expected currency %q\n", target.Currency, chargeParams.Currency)
-	}
-
-	if target.Source.Card.Name != chargeParams.Source.Card.Name {
-		t.Errorf("Card name %q does not match expected name %q\n", target.Source.Card.Name, chargeParams.Source.Card.Name)
 	}
 
 	if target.Statement != chargeParams.Statement {
@@ -92,12 +82,7 @@ func TestWithoutIdempotentTwoDifferentCharges(t *testing.T) {
 		Statement: "statement",
 		Email:     "a@b.com",
 	}
-	chargeParams.SetSource(&stripe.CardParams{
-		Name:   "Stripe Tester",
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_visa")
 
 	if chargeParams.Params.IdempotencyKey != "" {
 		t.Errorf("The default value of a Params.IdempotencyKey was not blank, and it needs to be. (%q).", chargeParams.Params.IdempotencyKey)
@@ -122,11 +107,7 @@ func TestWithoutIdempotentTwoDifferentCharges(t *testing.T) {
 
 func TestChargeNewWithCustomerAndCard(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_visa")
 
 	cust, _ := customer.New(customerParams)
 
@@ -164,22 +145,11 @@ func TestChargeNewWithCustomerAndCard(t *testing.T) {
 }
 
 func TestChargeNewWithToken(t *testing.T) {
-	tokenParams := &stripe.TokenParams{
-		Card: &stripe.CardParams{
-			Number: "4242424242424242",
-			Month:  "10",
-			Year:   "20",
-		},
-	}
-
-	tok, _ := token.New(tokenParams)
-
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
 		Currency: currency.USD,
 	}
-
-	chargeParams.SetSource(tok.ID)
+	chargeParams.SetSource("tok_visa")
 
 	target, err := New(chargeParams)
 
@@ -194,10 +164,6 @@ func TestChargeNewWithToken(t *testing.T) {
 	if target.Currency != chargeParams.Currency {
 		t.Errorf("Currency %q does not match expected currency %q\n", target.Currency, chargeParams.Currency)
 	}
-
-	if target.Source.Card.ID != tok.Card.ID {
-		t.Errorf("Card Id %q doesn't match card id %q of token %q", target.Source.Card.ID, tok.Card.ID, tok.ID)
-	}
 }
 
 func TestChargeGet(t *testing.T) {
@@ -205,12 +171,7 @@ func TestChargeGet(t *testing.T) {
 		Amount:   1001,
 		Currency: currency.USD,
 	}
-
-	chargeParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_visa")
 
 	res, _ := New(chargeParams)
 
@@ -231,12 +192,7 @@ func TestChargeUpdate(t *testing.T) {
 		Currency: currency.USD,
 		Desc:     "original description",
 	}
-
-	chargeParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_visa")
 
 	res, _ := New(chargeParams)
 
@@ -265,12 +221,7 @@ func TestChargeCapture(t *testing.T) {
 		Currency:  currency.USD,
 		NoCapture: true,
 	}
-
-	chargeParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_visa")
 
 	res, _ := New(chargeParams)
 
@@ -344,12 +295,7 @@ func TestMarkFraudulent(t *testing.T) {
 		Statement: "statement",
 		Email:     "a@b.com",
 	}
-	chargeParams.SetSource(&stripe.CardParams{
-		Name:   "Stripe Tester",
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_visa")
 
 	target, _ := New(chargeParams)
 	refund.New(&stripe.RefundParams{Charge: target.ID})
@@ -368,12 +314,7 @@ func TestMarkSafe(t *testing.T) {
 		Statement: "statement",
 		Email:     "a@b.com",
 	}
-	chargeParams.SetSource(&stripe.CardParams{
-		Name:   "Stripe Tester",
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_visa")
 
 	target, _ := New(chargeParams)
 
@@ -392,12 +333,7 @@ func TestChargeSourceForCard(t *testing.T) {
 		Statement: "statement",
 		Email:     "a@b.com",
 	}
-	chargeParams.SetSource(&stripe.CardParams{
-		Name:   "Stripe Tester",
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_visa")
 
 	ch, _ := New(chargeParams)
 
@@ -415,7 +351,7 @@ func TestChargeSourceForCard(t *testing.T) {
 		t.Error("Source ID is nil for Charge `source` Card property")
 	}
 
-	if card.Display() != "American Express ending in 0005" {
+	if card.Display() != "Visa ending in 4242" {
 		t.Error("Display value did not match expectation")
 	}
 }
@@ -474,12 +410,7 @@ func TestChargeOutcome(t *testing.T) {
 		Statement: "statement",
 		Email:     "a@b.com",
 	}
-	chargeParams.SetSource(&stripe.CardParams{
-		Name:   "Stripe Tester",
-		Number: "4100000000000019",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_chargeDeclinedFraudulent")
 
 	_, err := New(chargeParams)
 
@@ -649,11 +580,7 @@ func TestChargeReviewID(t *testing.T) {
 		Currency: currency.USD,
 	}
 
-	chargeParams.SetSource(&stripe.CardParams{
-		Number: "4000000000009235",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_riskLevelElevated")
 
 	res, err := New(chargeParams)
 	if err != nil {
@@ -675,11 +602,7 @@ func TestChargeReviewExpansion(t *testing.T) {
 		Currency: currency.USD,
 	}
 
-	chargeParams.SetSource(&stripe.CardParams{
-		Number: "4000000000009235",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_riskLevelElevated")
 
 	chargeParams.Expand("review")
 

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -456,11 +456,7 @@ func newDisputedCharge() (*stripe.Charge, error) {
 		Currency: currency.USD,
 	}
 
-	chargeParams.SetSource(&stripe.CardParams{
-		Number: "4000000000000259",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_createDispute")
 
 	res, err := New(chargeParams)
 	if err != nil {

--- a/client/checkin_test.go
+++ b/client/checkin_test.go
@@ -18,15 +18,8 @@ func TestCheckinIdempotency(t *testing.T) {
 	charge := &stripe.ChargeParams{
 		Amount:   100,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Name:   "Go Bindings Cardholder",
-				Number: "4242424242424242",
-				Month:  "12",
-				Year:   "24",
-			},
-		},
 	}
+	charge.SetSource("tok_visa")
 
 	charge.Params.IdempotencyKey = stripe.NewIdempotencyKey()
 
@@ -45,7 +38,6 @@ func TestCheckinIdempotency(t *testing.T) {
 	if first.ID != retry.ID {
 		t.Errorf("First charge ID %q does not match retry charge ID %q", first.ID, retry.ID)
 	}
-
 }
 
 func TestCheckinConnectivity(t *testing.T) {
@@ -95,15 +87,8 @@ func TestCheckinPost(t *testing.T) {
 	charge := &stripe.ChargeParams{
 		Amount:   100,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Name:   "Go Bindings Cardholder",
-				Number: "4242424242424242",
-				Month:  "12",
-				Year:   "24",
-			},
-		},
 	}
+	charge.SetSource("tok_visa")
 
 	target, err := c.Charges.New(charge)
 
@@ -117,10 +102,6 @@ func TestCheckinPost(t *testing.T) {
 
 	if target.Currency != charge.Currency {
 		t.Errorf("Currency %q does not match expected currency %q\n", target.Currency, charge.Currency)
-	}
-
-	if target.Source.Card.Name != charge.Source.Card.Name {
-		t.Errorf("Card name %q does not match expected name %q\n", target.Source.Card.Name, charge.Source.Card.Name)
 	}
 }
 

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -22,12 +22,7 @@ func TestCustomerNew(t *testing.T) {
 		Email:         "a@b.com",
 		BusinessVatID: "123456789",
 	}
-	customerParams.SetSource(&stripe.CardParams{
-		Name:   "Test Card",
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_amex")
 
 	customerParams.AddMeta("key", "value")
 	target, err := New(customerParams)
@@ -64,10 +59,6 @@ func TestCustomerNew(t *testing.T) {
 		t.Errorf("Unexpected number of cards %v\n", target.Sources.Count)
 	}
 
-	if target.Sources.Values[0].Card.Name != customerParams.Source.Card.Name {
-		t.Errorf("Card name %q does not match expected name %q\n", target.Sources.Values[0].Card.Name, customerParams.Source.Card.Name)
-	}
-
 	Del(target.ID)
 }
 
@@ -89,12 +80,7 @@ func TestCustomerNewWithPlan(t *testing.T) {
 		Plan:       planParams.ID,
 		TaxPercent: 10.0,
 	}
-	customerParams.SetSource(&stripe.CardParams{
-		Name:   "Test Card",
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_amex")
 
 	target, err := New(customerParams)
 
@@ -235,11 +221,7 @@ func TestCustomerUpdate(t *testing.T) {
 		Email:         "first@b.com",
 		BusinessVatID: "123456789",
 	}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_amex")
 
 	original, _ := New(customerParams)
 
@@ -249,12 +231,7 @@ func TestCustomerUpdate(t *testing.T) {
 		Email:         "desc@b.com",
 		BusinessVatID: "5555555",
 	}
-	updated.SetSource(&stripe.CardParams{
-		Number: "4242424242424242",
-		Month:  "10",
-		Year:   "20",
-		CVC:    "123",
-	})
+	updated.SetSource("tok_visa")
 
 	target, err := Update(original.ID, updated)
 

--- a/dispute/client_test.go
+++ b/dispute/client_test.go
@@ -20,11 +20,7 @@ func newDisputedCharge() (*stripe.Charge, error) {
 		Currency: currency.USD,
 	}
 
-	chargeParams.SetSource(&stripe.CardParams{
-		Number: "4000000000000259",
-		Month:  "06",
-		Year:   "20",
-	})
+	chargeParams.SetSource("tok_createDispute")
 
 	res, err := charge.New(chargeParams)
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -18,12 +18,7 @@ func ExampleCharge_new() {
 		Amount:   1000,
 		Currency: currency.USD,
 	}
-	params.SetSource(&stripe.CardParams{
-		Name:   "Go Stripe",
-		Number: "4242424242424242",
-		Month:  "10",
-		Year:   "20",
-	})
+	params.SetSource("tok_visa")
 	params.AddMeta("key", "value")
 
 	ch, err := charge.New(params)

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -68,14 +68,8 @@ func createInvoice(t *testing.T, params *stripe.InvoiceParams) (*stripe.Invoice,
 func TestAllInvoicesScenarios(t *testing.T) {
 	customerParams := &stripe.CustomerParams{
 		Email: "test@stripe.com",
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 	}
+	customerParams.SetSource("tok_visa")
 
 	cust, _ := customer.New(customerParams)
 

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -261,16 +261,7 @@ func TestOrderPay(t *testing.T) {
 			Meta: map[string]string{"order_id": "137"},
 		},
 	}
-	params.SetSource(&stripe.CardParams{
-		Name:     "Stripe Tester",
-		Number:   "4242424242424242",
-		Month:    "06",
-		Year:     "20",
-		Address1: "1234 Main Street",
-		Address2: "Apt 1",
-		City:     "Anytown",
-		State:    "CA",
-	})
+	params.SetSource("tok_visa")
 
 	order, err := Pay(o.ID, params)
 
@@ -389,16 +380,7 @@ func TestOrderReturn(t *testing.T) {
 	}
 
 	params := &stripe.OrderPayParams{}
-	params.SetSource(&stripe.CardParams{
-		Name:     "Stripe Tester",
-		Number:   "4242424242424242",
-		Month:    "06",
-		Year:     "20",
-		Address1: "1234 Main Street",
-		Address2: "Apt 1",
-		City:     "Anytown",
-		State:    "CA",
-	})
+	params.SetSource("tok_visa")
 
 	order, err := Pay(o.ID, params)
 

--- a/orderreturn/client_test.go
+++ b/orderreturn/client_test.go
@@ -82,16 +82,7 @@ func TestOrderReturnList(t *testing.T) {
 	}
 
 	params := &stripe.OrderPayParams{}
-	params.SetSource(&stripe.CardParams{
-		Name:     "Stripe Tester",
-		Number:   "4242424242424242",
-		Month:    "06",
-		Year:     "20",
-		Address1: "1234 Main Street",
-		Address2: "Apt 1",
-		City:     "Anytown",
-		State:    "CA",
-	})
+	params.SetSource("tok_visa")
 
 	_, err = order.Pay(o.ID, params)
 	if err != nil {

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -28,12 +28,7 @@ func TestSourceCardNew(t *testing.T) {
 	sourceParams := &stripe.CustomerSourceParams{
 		Customer: cust.ID,
 	}
-	sourceParams.SetSource(&stripe.CardParams{
-		Number: "4242424242424242",
-		Month:  "10",
-		Year:   "20",
-		CVC:    "1234",
-	})
+	sourceParams.SetSource("tok_visa")
 
 	source, err := New(sourceParams)
 
@@ -45,10 +40,6 @@ func TestSourceCardNew(t *testing.T) {
 
 	if target.LastFour != "4242" {
 		t.Errorf("Unexpected last four %q for card number %v\n", target.LastFour, sourceParams.Source.Card.Number)
-	}
-
-	if target.CVCCheck != card.Pass {
-		t.Errorf("CVC check %q does not match expected status\n", target.ZipCheck)
 	}
 
 	targetCust, err := customer.Get(cust.ID, nil)
@@ -106,11 +97,7 @@ func TestSourceCardGet(t *testing.T) {
 	customerParams := &stripe.CustomerParams{
 		Email: "SomethingIdentifiable@gmail.om",
 	}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "4242424242424242",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_visa")
 	cust, err := customer.New(customerParams)
 
 	if err != nil {
@@ -178,11 +165,7 @@ func TestSourceBankAccountGet(t *testing.T) {
 
 func TestSourceCardDel(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_visa")
 
 	cust, _ := customer.New(customerParams)
 
@@ -240,12 +223,7 @@ func TestSourceBankAccountDel(t *testing.T) {
 
 func TestSourceCardUpdate(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-		Name:   "Original Name",
-	})
+	customerParams.SetSource("tok_visa")
 
 	cust, err := customer.New(customerParams)
 
@@ -334,22 +312,14 @@ func TestSourceBankAccountVerify(t *testing.T) {
 
 func TestSourceList(t *testing.T) {
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
 	sourceParams := &stripe.CustomerSourceParams{
 		Customer: cust.ID,
 	}
-	sourceParams.SetSource(&stripe.CardParams{
-		Number: "4242424242424242",
-		Month:  "10",
-		Year:   "20",
-	})
+	sourceParams.SetSource("tok_visa")
 
 	New(sourceParams)
 

--- a/payout/client_test.go
+++ b/payout/client_test.go
@@ -48,17 +48,11 @@ func TestPayoutAllMethods(t *testing.T) {
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "4000000000000077",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 		Destination: &stripe.DestinationParams{
 			Account: acc.ID,
 		},
 	}
+	chargeParams.SetSource("tok_bypassPending")
 
 	_, err = charge.New(chargeParams)
 	if err != nil {

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -18,14 +18,8 @@ func TestRefundNew(t *testing.T) {
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 	}
+	chargeParams.SetSource("tok_visa")
 
 	res, err := charge.New(chargeParams)
 
@@ -122,14 +116,8 @@ func TestRefundGet(t *testing.T) {
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 	}
+	chargeParams.SetSource("tok_visa")
 
 	ch, err := charge.New(chargeParams)
 
@@ -158,14 +146,8 @@ func TestRefundListByCharge(t *testing.T) {
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 	}
+	chargeParams.SetSource("tok_visa")
 
 	ch, err := charge.New(chargeParams)
 

--- a/reversal/client_test.go
+++ b/reversal/client_test.go
@@ -20,14 +20,8 @@ func TestReversalNew(t *testing.T) {
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "4000000000000077",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 	}
+	chargeParams.SetSource("tok_bypassPending")
 
 	charge.New(chargeParams)
 
@@ -67,14 +61,8 @@ func TestReversalGet(t *testing.T) {
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "4000000000000077",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 	}
+	chargeParams.SetSource("tok_bypassPending")
 
 	charge.New(chargeParams)
 

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -20,14 +20,8 @@ func init() {
 func TestSubscriptionNew(t *testing.T) {
 	customerParams := &stripe.CustomerParams{
 		Email: "test@stripe.com",
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 	}
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
@@ -86,15 +80,8 @@ func TestSubscriptionNew(t *testing.T) {
 }
 
 func TestSubscriptionZeroQuantity(t *testing.T) {
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
@@ -138,15 +125,8 @@ func TestSubscriptionZeroQuantity(t *testing.T) {
 }
 
 func TestSubscriptionUpdateZeroQuantity(t *testing.T) {
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
@@ -193,15 +173,8 @@ func TestSubscriptionUpdateZeroQuantity(t *testing.T) {
 }
 
 func TestSubscriptionGet(t *testing.T) {
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
@@ -247,15 +220,8 @@ func TestSubscriptionGet(t *testing.T) {
 }
 
 func TestSubscriptionCancel(t *testing.T) {
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
@@ -302,15 +268,8 @@ func TestSubscriptionCancel(t *testing.T) {
 }
 
 func TestSubscriptionUpdate(t *testing.T) {
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
@@ -375,15 +334,8 @@ func TestSubscriptionDiscount(t *testing.T) {
 
 	coupon.New(couponParams)
 
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
@@ -452,15 +404,8 @@ func TestSubscriptionEmptyDiscount(t *testing.T) {
 
 	coupon.New(couponParams)
 
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 
@@ -519,17 +464,8 @@ func TestSubscriptionEmptyDiscount(t *testing.T) {
 }
 
 func TestSubscriptionList(t *testing.T) {
-	customerParams := &stripe.CustomerParams{
-		Email: "test@stripe.com",
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
-
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 	cust, _ := customer.New(customerParams)
 
 	planParams := &stripe.PlanParams{

--- a/sub/items_test.go
+++ b/sub/items_test.go
@@ -17,15 +17,8 @@ func init() {
 }
 
 func planAndCustomer(t *testing.T) (*stripe.Customer, *stripe.Plan) {
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, err := customer.New(customerParams)
 	if err != nil {

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -18,15 +18,8 @@ func init() {
 }
 
 func createSubItem(t *testing.T) (*stripe.Sub, *stripe.SubItem, func()) {
-	customerParams := &stripe.CustomerParams{
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "378282246310005",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
-	}
+	customerParams := &stripe.CustomerParams{}
+	customerParams.SetSource("tok_amex")
 
 	cust, err := customer.New(customerParams)
 	if err != nil {

--- a/threedsecure/client_test.go
+++ b/threedsecure/client_test.go
@@ -16,12 +16,7 @@ func init() {
 func TestThreeDSecureNew(t *testing.T) {
 	// Test creating a 3D Secure auth
 	customerParams := &stripe.CustomerParams{}
-	customerParams.SetSource(&stripe.CardParams{
-		Name:   "Stripe Tester",
-		Number: "378282246310005",
-		Month:  "06",
-		Year:   "20",
-	})
+	customerParams.SetSource("tok_amex")
 
 	cust, _ := customer.New(customerParams)
 

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -16,7 +16,7 @@ func init() {
 func TestTokenNew(t *testing.T) {
 	tokenParams := &stripe.TokenParams{
 		Card: &stripe.CardParams{
-			Number: "4242424242424242",
+			Number: "4242424242424242", // raw PAN as we're testing token creation
 			Month:  "10",
 			Year:   "20",
 		},
@@ -46,7 +46,7 @@ func TestTokenNew(t *testing.T) {
 
 	tokenParamsCurrency := &stripe.TokenParams{
 		Card: &stripe.CardParams{
-			Number:   "4242424242424242",
+			Number:   "4242424242424242", // raw PAN as we're testing token creation
 			Month:    "10",
 			Year:     "20",
 			Currency: "usd",

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -18,14 +18,8 @@ func TestTransferAllMethods(t *testing.T) {
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
 		Currency: currency.USD,
-		Source: &stripe.SourceParams{
-			Card: &stripe.CardParams{
-				Number: "4000000000000077",
-				Month:  "06",
-				Year:   "20",
-			},
-		},
 	}
+	chargeParams.SetSource("tok_bypassPending")
 
 	charge, err := charge.New(chargeParams)
 	if err != nil {


### PR DESCRIPTION
This PR aims to use the new test tokens such as tok_visa instead or hardcoding raw PANs in the test suite.

There's one last PAN we can't remove for disputes as it hasn't been released yet as a token ready-to-use.

