### PR TITLE
Coupon allowed on order creation and optional description

### DIFF
--- a/order.go
+++ b/order.go
@@ -17,6 +17,7 @@ const (
 
 type OrderParams struct {
 	Params
+	Coupon   string
 	Currency Currency
 	Customer string
 	Email    string

--- a/order/client.go
+++ b/order/client.go
@@ -29,7 +29,11 @@ func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
 	if params != nil {
 		body = &stripe.RequestValues{}
 		commonParams = &params.Params
-		// Required fields
+
+		if params.Coupon != "" {
+			body.Add("coupon", params.Coupon)
+		}
+
 		body.Add("currency", string(params.Currency))
 
 		if params.Customer != "" {

--- a/order/client.go
+++ b/order/client.go
@@ -46,7 +46,10 @@ func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
 
 		if len(params.Items) > 0 {
 			for _, item := range params.Items {
-				body.Add("items[][description]", item.Description)
+				if item.Description != "" {
+					body.Add("items[][description]", item.Description)
+				}
+
 				body.Add("items[][type]", string(item.Type))
 				body.Add("items[][amount]", strconv.FormatInt(item.Amount, 10))
 				if item.Currency != "" {

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -144,6 +144,8 @@ func TestOrder(t *testing.T) {
 	if o.Meta["foo"] != "bar" {
 		t.Error("Order metadata not set")
 	}
+
+	coupon.Del(c.ID)
 }
 
 func TestOrderUpdate(t *testing.T) {

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -59,7 +59,16 @@ func CreateTestProductAndSku(t *testing.T) *stripe.SKU {
 func TestOrder(t *testing.T) {
 	sku := CreateTestProductAndSku(t)
 
+	couponParams := &stripe.CouponParams{
+		Amount:   99,
+		Currency: currency.USD,
+		Duration: coupon.Once,
+	}
+
+	c, err := coupon.New(couponParams)
+
 	o, err := New(&stripe.OrderParams{
+		Coupon:   c.ID,
 		Currency: "usd",
 		Items: []*stripe.OrderItemParams{
 			{


### PR DESCRIPTION
Adds support for the `coupon` parameter on order [creation](https://stripe.com/docs/api#create_order-coupon). Also only send the description for an Order Item if it's set. Today, if you don't set it you get an error even though it's [optional](https://stripe.com/docs/api#create_order-items-description).