### PR TITLE
Remove user_id field from event object.

### DIFF
--- a/event.go
+++ b/event.go
@@ -15,7 +15,6 @@ type Event struct {
 	Webhooks uint64     `json:"pending_webhooks"`
 	Type     string     `json:"type"`
 	Req      string     `json:"request"`
-	UserID   string     `json:"user_id"`
 }
 
 // EventData is the unmarshalled object as a map.


### PR DESCRIPTION
According to https://stripe.com/docs/api/go#event_object , there is not a field called `user_id`