### PR TITLE
Encode and send `X-Stripe-Client-User-Agent`

### DIFF
--- a/stripe_test.go
+++ b/stripe_test.go
@@ -3,6 +3,7 @@ package stripe_test
 import (
 	"encoding/json"
 	"net/http"
+	"regexp"
 	"runtime"
 	"testing"
 
@@ -36,6 +37,25 @@ func TestCheckinBackendConfigurationNewRequestWithStripeAccount(t *testing.T) {
 	if req.Header.Get("Stripe-Account") != TestMerchantID {
 		t.Fatalf("Expected Stripe-Account %v but got %v.",
 			TestMerchantID, req.Header.Get("Stripe-Account"))
+	}
+}
+
+func TestCheckinUserAgent(t *testing.T) {
+	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	p := &stripe.Params{}
+
+	req, err := c.NewRequest("", "", "", "", nil, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We keep out version constant private to the package, so use a regexp
+	// match instead.
+	expectedPattern := regexp.MustCompile(`^Stripe/v1 GoBindings/[1-9][0-9.]+[0-9]$`)
+
+	match := expectedPattern.MatchString(req.Header.Get("User-Agent"))
+	if !match {
+		t.Fatalf("Expected User-Agent to match pattern %v", expectedPattern)
 	}
 }
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -3,6 +3,7 @@ package stripe_test
 import (
 	"encoding/json"
 	"net/http"
+	"runtime"
 	"testing"
 
 	stripe "github.com/stripe/stripe-go"
@@ -35,6 +36,47 @@ func TestCheckinBackendConfigurationNewRequestWithStripeAccount(t *testing.T) {
 	if req.Header.Get("Stripe-Account") != TestMerchantID {
 		t.Fatalf("Expected Stripe-Account %v but got %v.",
 			TestMerchantID, req.Header.Get("Stripe-Account"))
+	}
+}
+
+func TestCheckinStripeClientUserAgent(t *testing.T) {
+	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	p := &stripe.Params{}
+
+	req, err := c.NewRequest("", "", "", "", nil, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedUserAgent := req.Header.Get("X-Stripe-Client-User-Agent")
+	if encodedUserAgent == "" {
+		t.Fatalf("Expected X-Stripe-Client-User-Agent header to be present.")
+	}
+
+	var userAgent map[string]string
+	err = json.Unmarshal([]byte(encodedUserAgent), &userAgent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//
+	// Just test a few headers that we know to be stable.
+	//
+
+	if userAgent["language"] != "go" {
+		t.Fatalf("Expected X-Stripe-Client-User-Agent/language %v but got %v.",
+			"go", userAgent["language"])
+	}
+
+	if userAgent["language_version"] != runtime.Version() {
+		t.Fatalf("Expected X-Stripe-Client-User-Agent/language_version %v but got %v.",
+			runtime.Version(), userAgent["language_version"])
+	}
+
+	// Anywhere these tests are running can reasonable be expected to have a
+	// `uname` to run, so do this basic check.
+	if userAgent["uname"] == stripe.UnknownPlatform {
+		t.Fatalf("Expected X-Stripe-Client-User-Agent/uname to have a value.")
 	}
 }
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -42,9 +42,8 @@ func TestCheckinBackendConfigurationNewRequestWithStripeAccount(t *testing.T) {
 
 func TestCheckinUserAgent(t *testing.T) {
 	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
-	p := &stripe.Params{}
 
-	req, err := c.NewRequest("", "", "", "", nil, p)
+	req, err := c.NewRequest("", "", "", "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,9 +60,8 @@ func TestCheckinUserAgent(t *testing.T) {
 
 func TestCheckinStripeClientUserAgent(t *testing.T) {
 	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
-	p := &stripe.Params{}
 
-	req, err := c.NewRequest("", "", "", "", nil, p)
+	req, err := c.NewRequest("", "", "", "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
It turns out that the go bindings were not sending our JSON `X-Stripe-Client-User-Agent` like the other bindings. This PR fixes that to put it inline with everything else.

r? @ob-stripe 
cc @stripe/api-libraries 