### PR TITLE
Add app info to stripe-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,22 @@ if err := i.Err(); err != nil {
 }
 ```
 
+### Writing a Plugin
+
+If you're writing a plugin that uses the library, we'd appreciate it if you
+identified using `stripe.SetAppInfo`:
+
+```go
+stripe.SetAppInfo(&stripe.AppInfo{
+    Name:    "MyAwesomePlugin",
+    URL:     "https://myawesomeplugin.info",
+    Version: "1.2.34",
+})
+```
+
+This information is passed along when the library makes calls to the Stripe
+API.
+
 ## Development
 
 Pull requests from the community are welcome. If you submit one, please keep

--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ stripe.SetAppInfo(&stripe.AppInfo{
 ```
 
 This information is passed along when the library makes calls to the Stripe
-API.
+API. Note that while `Name` is always required, `URL` and `Version` are
+optional.
 
 ## Development
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -54,7 +54,35 @@ func TestCheckinUserAgent(t *testing.T) {
 
 	match := expectedPattern.MatchString(req.Header.Get("User-Agent"))
 	if !match {
-		t.Fatalf("Expected User-Agent to match pattern %v", expectedPattern)
+		t.Fatalf("Expected User-Agent to match pattern %v was %v",
+			expectedPattern, req.Header.Get("User-Agent"))
+	}
+}
+
+func TestCheckinUserAgentWithAppInfo(t *testing.T) {
+	appInfo := &stripe.AppInfo{
+		Name:    "MyAwesomePlugin",
+		URL:     "https://myawesomeplugin.info",
+		Version: "1.2.34",
+	}
+	stripe.SetAppInfo(appInfo)
+	defer stripe.SetAppInfo(nil)
+
+	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+
+	req, err := c.NewRequest("", "", "", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We keep out version constant private to the package, so use a regexp
+	// match instead.
+	expectedPattern := regexp.MustCompile(`^Stripe/v1 GoBindings/[1-9][0-9.]+[0-9] MyAwesomePlugin/1.2.34 \(https://myawesomeplugin.info\)$`)
+
+	match := expectedPattern.MatchString(req.Header.Get("User-Agent"))
+	if !match {
+		t.Fatalf("Expected User-Agent to match pattern %v was %v",
+			expectedPattern, req.Header.Get("User-Agent"))
 	}
 }
 


### PR DESCRIPTION
Adds app info the Go libraries (the idea is already in PHP and Ruby).

r? @ob-stripe 
cc @stripe/api-libraries 

---

~~Note: currently targets the branch in #391 until that's merged.~~