### PR TITLE
Move STRIPE_KEY into code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
+# This is a testmode key for this test account:
+#
+#     ID:    cuD9Rwx8pgmRZRpVe02lsuR9cwp2Bzf7
+#     Email: test+bindings@stripe.com
+#
+STRIPE_KEY=tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I
+
 all: checkin vet check-gofmt
 
 check-gofmt:
 	scripts/check_gofmt.sh
 
 checkin:
-	go test -run "TestCheckin*" ./client
+	STRIPE_KEY=$(STRIPE_KEY) go test -run "TestCheckin*" ./client
 
 test:
-	go test ./... -p=1
+	STRIPE_KEY=$(STRIPE_KEY) go test ./... -p=1
 
 build:
 	go build ./...


### PR DESCRIPTION
Right now `STRIPE_KEY` gets pulled from an encrypted Travis variable
which has a few disadvantages:

* It's really opaque. I have to go to Splunk to reverse engineer which
  merchant it belongs to every time I need to look at it (the Travis secret
  is not reversible, even to us).

* It means there's no easy local testbed. Everyone who tries to run the
  Go test suite needs to go find their own merchant to use. This is
  painful.

Storing keys in plaintext like this is of course a little weird, but
we're already doing it in pretty much every other library, and it's a
testmode key on an account that's test-only.

r? @ob-stripe 