### PR TITLE
Add invoicing params to Invoice and Subscription list methods

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -39,6 +39,8 @@ type InvoiceListParams struct {
 	Date     int64
 	Customer string
 	Sub      string
+	Billing  InvoiceBilling
+	DueDate  int64
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -244,6 +244,14 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 			body.Add("date", strconv.FormatInt(params.Date, 10))
 		}
 
+		if len(params.Billing) > 0 {
+			body.Add("billing", string(params.Billing))
+		}
+
+		if params.DueDate > 0 {
+			body.Add("due_date", strconv.FormatInt(params.DueDate, 10))
+		}
+
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -1,6 +1,7 @@
 package invoice
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,6 +16,50 @@ import (
 
 func init() {
 	stripe.Key = GetTestKey()
+}
+
+func createInvoiceItem(t *testing.T, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, *stripe.InvoiceItemParams) {
+	var out *stripe.InvoiceItem
+
+	out, err := invoiceitem.New(params)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if out.Customer.ID != params.Customer {
+		t.Errorf("Item customer %q does not match expected customer %q\n", out.Customer.ID, params.Customer)
+	}
+
+	if out.Desc != params.Desc {
+		t.Errorf("Item description %q does not match expected description %q\n", out.Desc, params.Desc)
+	}
+
+	if out.Amount != params.Amount {
+		t.Errorf("Item amount %v does not match expected amount %v\n", out.Amount, params.Amount)
+	}
+
+	if out.Currency != params.Currency {
+		t.Errorf("Item currency %q does not match expected currency %q\n", out.Currency, params.Currency)
+	}
+
+	if out.Date == 0 {
+		t.Errorf("Item date is not set\n")
+	}
+
+	return out, params
+}
+
+func createInvoice(t *testing.T, params *stripe.InvoiceParams) (*stripe.Invoice, *stripe.InvoiceParams) {
+	var out *stripe.Invoice
+
+	out, err := New(params)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	return out, params
 }
 
 // Invoices are somewhat painful to test since you need
@@ -34,55 +79,54 @@ func TestAllInvoicesScenarios(t *testing.T) {
 
 	cust, _ := customer.New(customerParams)
 
-	item := &stripe.InvoiceItemParams{
+	targetItem, _ := createInvoiceItem(t, &stripe.InvoiceItemParams{
 		Customer: cust.ID,
 		Amount:   100,
 		Currency: currency.USD,
-		Desc:     "Test Item",
-	}
-
-	targetItem, err := invoiceitem.New(item)
-
-	if err != nil {
-		t.Error(err)
-	}
-
-	if targetItem.Customer.ID != item.Customer {
-		t.Errorf("Item customer %q does not match expected customer %q\n", targetItem.Customer.ID, item.Customer)
-	}
-
-	if targetItem.Desc != item.Desc {
-		t.Errorf("Item description %q does not match expected description %q\n", targetItem.Desc, item.Desc)
-	}
-
-	if targetItem.Amount != item.Amount {
-		t.Errorf("Item amount %v does not match expected amount %v\n", targetItem.Amount, item.Amount)
-	}
-
-	if targetItem.Currency != item.Currency {
-		t.Errorf("Item currency %q does not match expected currency %q\n", targetItem.Currency, item.Currency)
-	}
-
-	if targetItem.Date == 0 {
-		t.Errorf("Item date is not set\n")
-	}
+		Desc:     "Test InvoiceItem - send_invoice",
+	})
 
 	dueDate := time.Now().AddDate(0, 0, 12).Unix()
 
-	invoiceParams := &stripe.InvoiceParams{
+	targetInvoice, invoiceParams := createInvoice(t, &stripe.InvoiceParams{
 		Customer:   cust.ID,
-		Desc:       "Desc",
+		Desc:       "Test Invoice with send_invoice",
 		Statement:  "Statement",
 		TaxPercent: 20.0,
 		Billing:    "send_invoice",
 		DueDate:    dueDate,
-	}
+	})
 
-	targetInvoice, err := New(invoiceParams)
+	createInvoiceItem(t, &stripe.InvoiceItemParams{
+		Customer: cust.ID,
+		Amount:   200,
+		Currency: currency.USD,
+		Desc:     "Test InvoiceItem - earlier",
+	})
 
-	if err != nil {
-		t.Error(err)
-	}
+	createInvoice(t, &stripe.InvoiceParams{
+		Customer:   cust.ID,
+		Desc:       "Test Invoice with send_invoice and earlier due_date",
+		Statement:  "Statement",
+		TaxPercent: 20.0,
+		Billing:    "send_invoice",
+		DueDate:    dueDate - 1,
+	})
+
+	createInvoiceItem(t, &stripe.InvoiceItemParams{
+		Customer: cust.ID,
+		Amount:   300,
+		Currency: currency.USD,
+		Desc:     "Test InvoiceItem - charge_automatically",
+	})
+
+	createInvoice(t, &stripe.InvoiceParams{
+		Customer:   cust.ID,
+		Desc:       "Test Invoice with charge_automatically",
+		Statement:  "Statement",
+		TaxPercent: 20.0,
+		Billing:    "charge_automatically",
+	})
 
 	if targetInvoice.Customer.ID != invoiceParams.Customer {
 		t.Errorf("Invoice customer %q does not match expected customer %q\n", targetInvoice.Customer.ID, invoiceParams.Customer)
@@ -250,6 +294,84 @@ func TestAllInvoicesScenarios(t *testing.T) {
 	}
 	if err := i.Err(); err != nil {
 		t.Error(err)
+	}
+
+	billingFilter := stripe.InvoiceBilling("charge_automatically")
+	i = List(&stripe.InvoiceListParams{Customer: cust.ID, Billing: billingFilter})
+	for i.Next() {
+		if i.Invoice() == nil {
+			t.Error("No nil values expected")
+		}
+		if i.Invoice().Billing != billingFilter {
+			t.Errorf("Billing %v does not match expected %v\n", i.Invoice().Billing, billingFilter)
+		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
+	}
+
+	count := 0
+	expectedCount := 2
+	billingFilter = stripe.InvoiceBilling("send_invoice")
+	i = List(&stripe.InvoiceListParams{Customer: cust.ID, Billing: billingFilter})
+	for i.Next() {
+		count += 1
+		if i.Invoice() == nil {
+			t.Error("No nil values expected")
+		}
+		if i.Invoice().Billing != billingFilter {
+			t.Errorf("Billing %v does not match expected %v\n", i.Invoice().Billing, billingFilter)
+		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
+	}
+	if count != expectedCount {
+		t.Errorf("Filtering by billing=%v returned %v entries, expected %v", billingFilter, count, expectedCount)
+	}
+
+	count = 0
+	expectedCount = 1
+	dueDateFilter := dueDate - 1
+	dueDateParams := &stripe.InvoiceListParams{Customer: cust.ID}
+	dueDateParams.Filters.AddFilter("due_date[gt]", "", strconv.FormatInt(dueDateFilter, 10))
+	i = List(dueDateParams)
+	for i.Next() {
+		count += 1
+		if i.Invoice() == nil {
+			t.Error("No nil values expected")
+		}
+		if i.Invoice().DueDate <= dueDateFilter {
+			t.Errorf("Invoice days until due %v is not greater than %v\n", i.Invoice().DueDate, dueDateFilter)
+		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
+	}
+	if count != expectedCount {
+		t.Errorf("Filtering by billing=%v due_date[gt]=%v returned %v entries, expected %v", billingFilter, dueDateFilter, count, expectedCount)
+	}
+
+	count = 0
+	expectedCount = 2
+	dueDateFilter = dueDate + 1
+	dueDateParams = &stripe.InvoiceListParams{Customer: cust.ID}
+	dueDateParams.Filters.AddFilter("due_date[lt]", "", strconv.FormatInt(dueDateFilter, 10))
+	i = List(dueDateParams)
+	for i.Next() {
+		count += 1
+		if i.Invoice() == nil {
+			t.Error("No nil values expected")
+		}
+		if i.Invoice().DueDate >= dueDateFilter {
+			t.Errorf("Invoice days until due %v is not less than %v\n", i.Invoice().DueDate, dueDateFilter)
+		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
+	}
+	if count != expectedCount {
+		t.Errorf("Filtering by billing=%v due_date[lt]=%v returned %v entries, expected %v", billingFilter, dueDateFilter, count, expectedCount)
 	}
 
 	il := ListLines(&stripe.InvoiceLineListParams{ID: targetInvoice.ID, Customer: cust.ID})

--- a/sub.go
+++ b/sub.go
@@ -48,6 +48,7 @@ type SubListParams struct {
 	Customer string
 	Plan     string
 	Status   SubStatus
+	Billing  SubBilling
 }
 
 // Sub is the resource representing a Stripe subscription.

--- a/sub/client.go
+++ b/sub/client.go
@@ -291,6 +291,10 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 			body.Add("status", string(params.Status))
 		}
 
+		if len(params.Billing) > 0 {
+			body.Add("billing", string(params.Billing))
+		}
+
 		params.AppendTo(body)
 
 		lp = &params.ListParams

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -520,6 +520,7 @@ func TestSubscriptionEmptyDiscount(t *testing.T) {
 
 func TestSubscriptionList(t *testing.T) {
 	customerParams := &stripe.CustomerParams{
+		Email: "test@stripe.com",
 		Source: &stripe.SourceParams{
 			Card: &stripe.CardParams{
 				Number: "378282246310005",
@@ -542,12 +543,25 @@ func TestSubscriptionList(t *testing.T) {
 	plan.New(planParams)
 
 	subParams := &stripe.SubParams{
+		Customer:     cust.ID,
+		Plan:         "test",
+		Quantity:     10,
+		Billing:      "send_invoice",
+		DaysUntilDue: 30,
+	}
+
+	for i := 0; i < 3; i++ {
+		New(subParams)
+	}
+
+	subParams = &stripe.SubParams{
 		Customer: cust.ID,
 		Plan:     "test",
 		Quantity: 10,
+		Billing:  "charge_automatically",
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 3; i++ {
 		New(subParams)
 	}
 
@@ -575,6 +589,40 @@ func TestSubscriptionList(t *testing.T) {
 
 	if err := i.Err(); err != nil {
 		t.Error(err)
+	}
+
+	count := 0
+	expectedCount := 3
+	params = &stripe.SubListParams{Customer: cust.ID, Plan: "test", Billing: "send_invoice"}
+	i = List(params)
+	for i.Next() {
+		count += 1
+		if i.Sub().Billing != params.Billing {
+			t.Errorf("Billing %v does not match expected %v\n", i.Sub().Billing, params.Billing)
+		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
+	}
+	if count != expectedCount {
+		t.Errorf("Filtering by billing=%v returned %v entries, expected %v", params.Billing, count, expectedCount)
+	}
+
+	count = 0
+	expectedCount = 3
+	params = &stripe.SubListParams{Customer: cust.ID, Plan: "test", Billing: "charge_automatically"}
+	i = List(params)
+	for i.Next() {
+		count += 1
+		if i.Sub().Billing != params.Billing {
+			t.Errorf("Billing %v does not match expected %v\n", i.Sub().Billing, params.Billing)
+		}
+	}
+	if err := i.Err(); err != nil {
+		t.Error(err)
+	}
+	if count != expectedCount {
+		t.Errorf("Filtering by billing=%v returned %v entries, expected %v", params.Billing, count, expectedCount)
 	}
 
 	i = List(nil)

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -625,8 +625,10 @@ func TestSubscriptionList(t *testing.T) {
 		t.Errorf("Filtering by billing=%v returned %v entries, expected %v", params.Billing, count, expectedCount)
 	}
 
+	count = 0
 	i = List(nil)
-	for i.Next() {
+	for i.Next() && count < 20 {
+		count += 1
 		if i.Sub() == nil {
 			t.Error("No nil values expected")
 		}


### PR DESCRIPTION
#### This change:
- Adds `billing` and `due_date` filters to Invoice list parameters.
- Adds `billing` filter to Subscription list parameters.
- Refactors `invoice/client_test.go` to add helper methods to create test objects (for testing list filters).
- Changes `sub/client_test.go` to create both `charge_automatically` and `send_invoice` Subscriptions (for testing list filters).
- Caps the number of results iterated over when testing `List(nil)` for subs, since accounts with lots of test data will try to iterate over everything AFAICT

#### Testing:
```
go test ./sub
go test ./invoice
```
both pass.

Note that the Travis CI tests seem to be breaking on this branch due to unrelated (?) reasons.


