### PR TITLE
Add 'Get' method to RequestValues

### DIFF
--- a/params.go
+++ b/params.go
@@ -62,11 +62,11 @@ func (f *RequestValues) Set(key, val string) {
 }
 
 // Get retrieves the list of values for the given key.  If no values exist
-// for the key, an empty list will be returned.
+// for the key, nil will be returned.
 //
 // Note that Get is O(n) and may be quite slow for a very large parameter list.
 func (f *RequestValues) Get(key string) []string {
-	results := []string{}
+	var results []string
 	for i, v := range f.values {
 		if v.Key == key {
 			results = append(results, f.values[i].Value)

--- a/params.go
+++ b/params.go
@@ -61,6 +61,20 @@ func (f *RequestValues) Set(key, val string) {
 	f.Add(key, val)
 }
 
+// Get retrieves the list of values for the given key.  If no values exist
+// for the key, an empty list will be returned.
+//
+// Note that Get is O(n) and may be quite slow for a very large parameter list.
+func (f *RequestValues) Get(key string) []string {
+	results := []string{}
+	for i, v := range f.values {
+		if v.Key == key {
+			results = append(results, f.values[i].Value)
+		}
+	}
+	return results
+}
+
 // ToValues converts an instance of RequestValues into an instance of
 // url.Values. This can be useful in cases where it's useful to make an
 // unordered comparison of two sets of request values.

--- a/params_test.go
+++ b/params_test.go
@@ -35,6 +35,14 @@ func TestRequestValues(t *testing.T) {
 		t.Fatalf("Expected values to not be empty.")
 	}
 
+	got := values.Get("foo")
+	if got.length != 1 {
+		t.Fatalf("Expected 1 result from Get, got %v.", got.length)
+	}
+	if got[0] != "bar" {
+		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
+	}
+
 	values = &stripe.RequestValues{}
 	values.Add("foo", "bar")
 	values.Add("foo", "bar")
@@ -46,12 +54,47 @@ func TestRequestValues(t *testing.T) {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
 	}
 
+	got = values.Get("foo")
+	if got.length != 2 {
+		t.Fatalf("Expected 2 results from Get, got %v.", got.length)
+	}
+	if got[0] != "bar" {
+		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
+	}
+	if got[1] != "bar" {
+		t.Fatalf("Expected 'bar' result from Get, got %v.", got[1])
+	}
+	got = values.Get("baz")
+	if got.length != 1 {
+		t.Fatalf("Expected 1 result from Get, got %v.", got.length)
+	}
+	if got[0] != "bar" {
+		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
+	}
+
 	values.Set("foo", "firstbar")
 
 	actual = values.Encode()
 	expected = "foo=firstbar&foo=bar&baz=bar"
 	if expected != actual {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
+	}
+	got = values.Get("foo")
+	if got.length != 2 {
+		t.Fatalf("Expected 2 results from Get, got %v.", got.length)
+	}
+	if got[0] != "firstbar" {
+		t.Fatalf("Expected 'firstbar' result from Get, got %v.", got[0])
+	}
+	if got[1] != "bar" {
+		t.Fatalf("Expected 'bar' result from Get, got %v.", got[1])
+	}
+	got = values.Get("baz")
+	if got.length != 1 {
+		t.Fatalf("Expected 1 result from Get, got %v.", got.length)
+	}
+	if got[0] != "bar" {
+		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
 	}
 
 	values.Set("new", "appended")
@@ -70,6 +113,13 @@ func TestRequestValues(t *testing.T) {
 	}
 	if !reflect.DeepEqual(urlValues, expectedURLValues) {
 		t.Fatalf("Expected body of %v but got %v.", expectedURLValues, urlValues)
+	}
+	got = values.Get("new")
+	if got.length != 1 {
+		t.Fatalf("Expected 1 result from Get, got %v.", got.length)
+	}
+	if got[0] != "appended" {
+		t.Fatalf("Expected 'appended' result from Get, got %v.", got[0])
 	}
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -121,6 +121,11 @@ func TestRequestValues(t *testing.T) {
 	if got[0] != "appended" {
 		t.Fatalf("Expected 'appended' result from Get, got %v.", got[0])
 	}
+
+	got = values.Get("boguskey")
+	if got != nil {
+		t.Fatalf("Expected nil, got %v", got)
+	}
 }
 
 func TestParamsWithExtras(t *testing.T) {

--- a/params_test.go
+++ b/params_test.go
@@ -36,8 +36,8 @@ func TestRequestValues(t *testing.T) {
 	}
 
 	got := values.Get("foo")
-	if got.length != 1 {
-		t.Fatalf("Expected 1 result from Get, got %v.", got.length)
+	if len(got) != 1 {
+		t.Fatalf("Expected 1 result from Get, got %v.", len(got))
 	}
 	if got[0] != "bar" {
 		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
@@ -55,8 +55,8 @@ func TestRequestValues(t *testing.T) {
 	}
 
 	got = values.Get("foo")
-	if got.length != 2 {
-		t.Fatalf("Expected 2 results from Get, got %v.", got.length)
+	if len(got) != 2 {
+		t.Fatalf("Expected 2 results from Get, got %v.", len(got))
 	}
 	if got[0] != "bar" {
 		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
@@ -65,8 +65,8 @@ func TestRequestValues(t *testing.T) {
 		t.Fatalf("Expected 'bar' result from Get, got %v.", got[1])
 	}
 	got = values.Get("baz")
-	if got.length != 1 {
-		t.Fatalf("Expected 1 result from Get, got %v.", got.length)
+	if len(got) != 1 {
+		t.Fatalf("Expected 1 result from Get, got %v.", len(got))
 	}
 	if got[0] != "bar" {
 		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
@@ -80,8 +80,8 @@ func TestRequestValues(t *testing.T) {
 		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
 	}
 	got = values.Get("foo")
-	if got.length != 2 {
-		t.Fatalf("Expected 2 results from Get, got %v.", got.length)
+	if len(got) != 2 {
+		t.Fatalf("Expected 2 results from Get, got %v.", len(got))
 	}
 	if got[0] != "firstbar" {
 		t.Fatalf("Expected 'firstbar' result from Get, got %v.", got[0])
@@ -90,8 +90,8 @@ func TestRequestValues(t *testing.T) {
 		t.Fatalf("Expected 'bar' result from Get, got %v.", got[1])
 	}
 	got = values.Get("baz")
-	if got.length != 1 {
-		t.Fatalf("Expected 1 result from Get, got %v.", got.length)
+	if len(got) != 1 {
+		t.Fatalf("Expected 1 result from Get, got %v.", len(got))
 	}
 	if got[0] != "bar" {
 		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
@@ -115,8 +115,8 @@ func TestRequestValues(t *testing.T) {
 		t.Fatalf("Expected body of %v but got %v.", expectedURLValues, urlValues)
 	}
 	got = values.Get("new")
-	if got.length != 1 {
-		t.Fatalf("Expected 1 result from Get, got %v.", got.length)
+	if len(got) != 1 {
+		t.Fatalf("Expected 1 result from Get, got %v.", len(got))
 	}
 	if got[0] != "appended" {
 		t.Fatalf("Expected 'appended' result from Get, got %v.", got[0])


### PR DESCRIPTION
fixes #401 
@brandur-stripe I wasn't able to run the tests so I'm not 100% sure this works, but it seems right :)

the error I get when I do a `make test`:
```
./params_test.go:38: values.Get undefined (type *stripe.RequestValues has no field or method Get)
[a few more of the same]
```
presumably because I'm building against the released version of stripe-go, and not the modified one that has my new method?  Sorry if this is an obvious thing, I'm a Go n00b.