### PR TITLE
Add trial_period_days to plan update method

### DIFF
--- a/plan/client.go
+++ b/plan/client.go
@@ -98,6 +98,10 @@ func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, erro
 			body.Add("statement_descriptor", params.Statement)
 		}
 
+		if params.TrialPeriod > 0 {
+			body.Add("trial_period_days", strconv.FormatUint(params.TrialPeriod, 10))
+		}
+
 		params.AppendTo(body)
 	}
 

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -104,8 +104,9 @@ func TestPlanUpdate(t *testing.T) {
 	New(planParams)
 
 	updatedPlan := &stripe.PlanParams{
-		Name:      "Updated Name",
-		Statement: "Updated Plan",
+		Name:        "Updated Name",
+		Statement:   "Updated Plan",
+		TrialPeriod: 15,
 	}
 
 	target, err := Update(planParams.ID, updatedPlan)
@@ -120,6 +121,10 @@ func TestPlanUpdate(t *testing.T) {
 
 	if target.Statement != updatedPlan.Statement {
 		t.Errorf("Statement %q does not match expected statement %q\n", target.Statement, updatedPlan.Statement)
+	}
+
+	if target.TrialPeriod != updatedPlan.TrialPeriod {
+		t.Errorf("TrialPeriod %q does not match expected trial period %q\n", target.TrialPeriod, updatedPlan.TrialPeriod)
 	}
 
 	Del(planParams.ID)


### PR DESCRIPTION
Seems to be missing from the plan update and is supported by rest api 
and is documented as allowed, even though its being ignored - https://stripe.com/docs/api/go#update_plan-trial_period_days