### PR TITLE
Rename `user_id` to `account`

### DIFF
--- a/event.go
+++ b/event.go
@@ -9,13 +9,13 @@ import (
 // For more details see https://stripe.com/docs/api#events.
 type Event struct {
 	ID       string     `json:"id"`
+	Account  string     `json:"account"`
 	Live     bool       `json:"livemode"`
 	Created  int64      `json:"created"`
 	Data     *EventData `json:"data"`
 	Webhooks uint64     `json:"pending_webhooks"`
 	Type     string     `json:"type"`
 	Req      string     `json:"request"`
-	UserID   string     `json:"user_id"`
 }
 
 // EventData is the unmarshalled object as a map.


### PR DESCRIPTION
This field is being renamed on a new API version for tomorrow (and we need to bump the version used by stripe-go before bringing it in).

Given that this is mostly a change in how we map our JSON serialization, I haven't changed any tests for this one.

r? @remi-stripe 