### PR TITLE
Add support for the new account type

### DIFF
--- a/account.go
+++ b/account.go
@@ -65,11 +65,12 @@ type AccountParams struct {
 	Country, Email, DefaultCurrency, Statement, BusinessName, BusinessUrl,
 	BusinessPrimaryColor, SupportPhone, SupportEmail, SupportUrl,
 	FromRecipient, PayoutStatement string
-	ExternalAccount                               *AccountExternalAccountParams
-	LegalEntity                                   *LegalEntity
-	PayoutSchedule                                *PayoutScheduleParams
-	Managed, DebitNegativeBal, NoDebitNegativeBal bool
-	TOSAcceptance                                 *TOSAcceptanceParams
+	ExternalAccount                      *AccountExternalAccountParams
+	LegalEntity                          *LegalEntity
+	PayoutSchedule                       *PayoutScheduleParams
+	DebitNegativeBal, NoDebitNegativeBal bool
+	TOSAcceptance                        *TOSAcceptanceParams
+	Type                                 AccountType
 }
 
 // AccountListParams are the parameters allowed during account listing.
@@ -116,8 +117,8 @@ type Account struct {
 	SupportEmail         string               `json:"support_email"`
 	SupportUrl           string               `json:"support_url"`
 	ProductDesc          string               `json:"product_description"`
-	Managed              bool                 `json:"managed"`
 	DebitNegativeBal     bool                 `json:"debit_negative_balances"`
+	Type                 AccountType
 	Keys                 *struct {
 		Secret  string `json:"secret"`
 		Publish string `json:"publishable"`
@@ -139,17 +140,31 @@ type Account struct {
 	Meta           map[string]string `json:"metadata"`
 }
 
-// AccountType is the type of an external account.
+// ExternalAccountType is the type of an external account.
+type ExternalAccountType string
+
+const (
+	// ExternalAccountTypeBankAccount is a constant value representing an external
+	// account which is a bank account.
+	ExternalAccountTypeBankAccount ExternalAccountType = "bank_account"
+
+	// ExternalAccountTypeCard is a constant value representing an external account
+	// which is a card.
+	ExternalAccountTypeCard ExternalAccountType = "card"
+)
+
+// AccountType is the type of an account.
 type AccountType string
 
 const (
-	// AccountTypeBankAccount is a constant value representing an external
-	// account which is a bank account.
-	AccountTypeBankAccount AccountType = "bank_account"
+	// AccountTypeCustom is a constant value representing an account of type custom.
+	AccountTypeCustom AccountType = "custom"
 
-	// AccountTypeCard is a constant value representing an external account
-	// which is a card.
-	AccountTypeCard AccountType = "card"
+	// AccountTypeExpress is a constant value representing an account of type custom.
+	AccountTypeExpress AccountType = "express"
+
+	// AccountTypeStandard is a constant value representing an account of type custom.
+	AccountTypeStandard AccountType = "standard"
 )
 
 // AccountList is a list of accounts as returned from a list endpoint.
@@ -172,8 +187,8 @@ type ExternalAccountList struct {
 // attached to an account. It contains fields that will be conditionally
 // populated depending on its type.
 type ExternalAccount struct {
-	Type AccountType `json:"object"`
-	ID   string      `json:"id"`
+	Type ExternalAccountType `json:"object"`
+	ID   string              `json:"id"`
 
 	// A bank account attached to an account. Populated only if the external
 	// account is a bank account.
@@ -197,9 +212,9 @@ func (ea *ExternalAccount) UnmarshalJSON(b []byte) error {
 	*ea = ExternalAccount(account)
 
 	switch ea.Type {
-	case AccountTypeBankAccount:
+	case ExternalAccountTypeBankAccount:
 		err = json.Unmarshal(b, &ea.BankAccount)
-	case AccountTypeCard:
+	case ExternalAccountTypeCard:
 		err = json.Unmarshal(b, &ea.Card)
 	}
 	return err

--- a/account/client.go
+++ b/account/client.go
@@ -107,7 +107,10 @@ func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 	body := &stripe.RequestValues{}
 
 	// Type is now required on creation and not allowed on update
-	body.Add("type", string(params.Type))
+	// It can't be passed if you pass `from_recipient` though
+	if len(params.FromRecipient) == 0 {
+		body.Add("type", string(params.Type))
+	}
 
 	writeAccountParams(params, body)
 

--- a/account/client.go
+++ b/account/client.go
@@ -106,9 +106,8 @@ func writeAccountParams(
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 	body := &stripe.RequestValues{}
 
-	if len(params.FromRecipient) == 0 {
-		body.Add("managed", strconv.FormatBool(params.Managed))
-	}
+	// Type is now required on creation and not allowed on update
+	body.Add("type", string(params.Type))
 
 	writeAccountParams(params, body)
 

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -17,7 +17,7 @@ func init() {
 
 func TestAccountNew(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed:              true,
+		Type:                 stripe.AccountTypeCustom,
 		Country:              "CA",
 		BusinessUrl:          "www.stripe.com",
 		BusinessName:         "Stripe",
@@ -50,7 +50,7 @@ func TestAccountNew(t *testing.T) {
 
 func TestAccountLegalEntity(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "US",
 		LegalEntity: &stripe.LegalEntity{
 			Type:          stripe.Company,
@@ -85,7 +85,7 @@ func TestAccountLegalEntity(t *testing.T) {
 
 func TestAccountDelete(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed:              true,
+		Type:                 stripe.AccountTypeCustom,
 		Country:              "CA",
 		BusinessUrl:          "www.stripe.com",
 		BusinessName:         "Stripe",
@@ -121,7 +121,7 @@ func TestAccountDelete(t *testing.T) {
 
 func TestAccountReject(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed:              true,
+		Type:                 stripe.AccountTypeCustom,
 		Country:              "CA",
 		BusinessUrl:          "www.stripe.com",
 		BusinessName:         "Stripe",
@@ -157,7 +157,7 @@ func TestAccountReject(t *testing.T) {
 
 func TestAccountGetByID(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "CA",
 	}
 
@@ -171,7 +171,7 @@ func TestAccountGetByID(t *testing.T) {
 
 func TestAccountUpdate(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed:          true,
+		Type:             stripe.AccountTypeCustom,
 		Country:          "CA",
 		DebitNegativeBal: true,
 	}
@@ -199,7 +199,7 @@ func TestAccountUpdate(t *testing.T) {
 
 func TestAccountUpdateLegalEntity(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "CA",
 		LegalEntity: &stripe.LegalEntity{
 			Address: stripe.Address{
@@ -238,7 +238,7 @@ func TestAccountUpdateLegalEntity(t *testing.T) {
 
 func TestAccountNoAdditionalOwners(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "GB",
 		LegalEntity: &stripe.LegalEntity{
 			Type: "company",
@@ -266,7 +266,7 @@ func TestAccountNoAdditionalOwners(t *testing.T) {
 
 func TestAccountUpdateWithBankAccount(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "CA",
 	}
 
@@ -289,7 +289,7 @@ func TestAccountUpdateWithBankAccount(t *testing.T) {
 
 func TestAccountAddExternalAccountsDefault(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "CA",
 		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Country:  "US",
@@ -347,7 +347,7 @@ func TestAccountAddExternalAccountsDefault(t *testing.T) {
 
 func TestAccountUpdateWithToken(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "CA",
 	}
 
@@ -377,7 +377,7 @@ func TestAccountUpdateWithToken(t *testing.T) {
 
 func TestAccountUpdateWithCardToken(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "US",
 	}
 

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -64,7 +64,7 @@ func TestBankAccountListByAccount(t *testing.T) {
 	}
 
 	accountParams := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "CA",
 		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Token: baTok.ID,

--- a/payout/client_test.go
+++ b/payout/client_test.go
@@ -16,7 +16,7 @@ func init() {
 
 func TestPayoutAllMethods(t *testing.T) {
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type:    stripe.AccountTypeCustom,
 		Country: "US",
 		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Country:  "US",

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -33,7 +33,7 @@ func TestTransferAllMethods(t *testing.T) {
 	}
 
 	params := &stripe.AccountParams{
-		Managed: true,
+		Type: stripe.AccountTypeCustom,
 		Country: "US",
 		LegalEntity: &stripe.LegalEntity{
 			Type: stripe.Individual,

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -33,7 +33,7 @@ func TestTransferAllMethods(t *testing.T) {
 	}
 
 	params := &stripe.AccountParams{
-		Type: stripe.AccountTypeCustom,
+		Type:    stripe.AccountTypeCustom,
 		Country: "US",
 		LegalEntity: &stripe.LegalEntity{
 			Type: stripe.Individual,


### PR DESCRIPTION
When creating an account via the API, you should now pass the `type` parameter explicitly instead of `managed`.

r? @brandur 