### PR TITLE
Bump the supported API version to 2017-05-25

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -23,7 +23,7 @@ const (
 )
 
 // apiversion is the currently supported API version
-const apiversion = "2017-04-06"
+const apiversion = "2017-05-25"
 
 // clientversion is the binding version
 const clientversion = "21.5.1"


### PR DESCRIPTION
All the necessary changes are already in master.

r? @remi-stripe 