### PR TITLE
Support for creating sources on connected accounts with customer

### DIFF
--- a/source.go
+++ b/source.go
@@ -14,9 +14,9 @@ const (
 	// customer.
 	SourceStatusPending SourceStatus = "pending"
 	// SourceStatusChargeable the source is ready to be charged (once if usage
-	// is `single-use`, repeatidly otherwise).
+	// is `single_use`, repeatidly otherwise).
 	SourceStatusChargeable SourceStatus = "chargeable"
-	// SourceStatusConsumed the source is `single-use` usage and has been
+	// SourceStatusConsumed the source is `single_use` usage and has been
 	// charged already.
 	SourceStatusConsumed SourceStatus = "consumed"
 	// SourceStatusFailed the source is no longer usable.
@@ -49,7 +49,7 @@ type SourceUsage string
 const (
 	// UsageSingleUse the source can only be charged once for the specified
 	// amount and currency.
-	UsageSingleUse SourceUsage = "single-use"
+	UsageSingleUse SourceUsage = "single_use"
 	// UsageReusable the source can be charged multiple times for arbitrary
 	// amounts.
 	UsageReusable SourceUsage = "reusable"
@@ -69,6 +69,8 @@ type RedirectParams struct {
 type SourceObjectParams struct {
 	Params
 	Type     string
+	Usage    SourceUsage
+	Customer string
 	Amount   uint64
 	Currency Currency
 	Flow     SourceFlow

--- a/source/client.go
+++ b/source/client.go
@@ -29,10 +29,16 @@ func (c Client) New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 		body = &stripe.RequestValues{}
 		commonParams = &params.Params
 
-		// Required fields
-		body.Add("type", params.Type)
-
 		// Optional fields
+		if params.Type != "" {
+			body.Add("type", params.Type)
+		}
+		if params.Usage != "" {
+			body.Add("usage", string(params.Usage))
+		}
+		if params.Customer != "" {
+			body.Add("customer", params.Customer)
+		}
 		if params.Currency != "" {
 			body.Add("currency", string(params.Currency))
 		}

--- a/stripe.go
+++ b/stripe.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -208,10 +207,6 @@ func (s BackendConfiguration) Call(method, path, key string, form *RequestValues
 	req, err := s.NewRequest(method, path, key, "application/x-www-form-urlencoded", body, params)
 	if err != nil {
 		return err
-	}
-	dump, err := httputil.DumpRequest(req, true)
-	if err == nil {
-		log.Println(string(dump))
 	}
 
 	if err := s.Do(req, v); err != nil {

--- a/stripe.go
+++ b/stripe.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -207,6 +208,10 @@ func (s BackendConfiguration) Call(method, path, key string, form *RequestValues
 	req, err := s.NewRequest(method, path, key, "application/x-www-form-urlencoded", body, params)
 	if err != nil {
 		return err
+	}
+	dump, err := httputil.DumpRequest(req, true)
+	if err == nil {
+		log.Println(string(dump))
 	}
 
 	if err := s.Do(req, v); err != nil {


### PR DESCRIPTION
Adding support for creating sources with customer as shown by the curl
below:

curl -X POST \
  https://api.stripe.com/v1/sources \
  -H 'authorization: Bearer sk_test_xxxxxxxxxxxxxxxxxx' \
  -H 'content-type: application/x-www-form-urlencoded' \
  -H 'stripe-account: acct_xxxxxxxxxxxxxxxx' \
  -d 'customer=cus_xxxxxxxxxxxxx&usage=single_use'