### PR TITLE
Support setting the sub's quantity to 0 for an upcoming invoice

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -23,6 +23,7 @@ type InvoiceParams struct {
 	SubNoProrate         bool
 	SubProrationDate     int64
 	SubQuantity          uint64
+	SubQuantityZero      bool
 	SubTrialEnd          int64
 	TaxPercent           float64
 	TaxPercentZero       bool

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -204,6 +204,8 @@ func (c Client) GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 
 	if params.SubQuantity > 0 {
 		body.Add("subscription_quantity", strconv.FormatUint(params.SubQuantity, 10))
+	} else if params.SubQuantityZero {
+		body.Add("subscription_quantity", "0")
 	}
 
 	if params.SubTrialEnd > 0 {


### PR DESCRIPTION
When previewing an upcoming invoice, you can also simulate changes to the subscription. Changing the plan for example works. Setting the `quantity` to 0 was not working because this parameter is ignored in the code.

This adds `SubQuantityZero` as a valid parameter, mimicking what we do for the subscription update in the rest of the library.

r? @brandur 