### PR TITLE
Subitem List Fix

### DIFF
--- a/subitem/client.go
+++ b/subitem/client.go
@@ -135,11 +135,11 @@ func (c Client) Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 
 // List returns a list of subscriptions.
 // For more details see https://stripe.com/docs/api#list_subscriptions.
-func List(params *stripe.SubListParams) *Iter {
+func List(params *stripe.SubItemListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SubListParams) *Iter {
+func (c Client) List(params *stripe.SubItemListParams) *Iter {
 	var body *stripe.RequestValues
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -147,12 +147,8 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if len(params.Customer) > 0 {
-			body.Add("customer", params.Customer)
-		}
-
-		if len(params.Plan) > 0 {
-			body.Add("plan", params.Plan)
+		if len(params.Sub) > 0 {
+			body.Add("subscription", params.Sub)
 		}
 
 		params.AppendTo(body)


### PR DESCRIPTION
1. Update Subitem List client to use the SubItemListParams
2. Pass subscription to the request params directly from the SubItemListParams rather than the Filters.