### PR TITLE
Start test suite refactor + power tests with external API stub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,25 @@ sudo: false
 
 env:
   global:
-    - STRIPE_STUB_PORT=6065
-    - STRIPE_STUB_VERSION=0.1.1
+    - STRIPE_MOCK_VERSION=0.1.13
 
 cache:
   directories:
-    - stripestubs
+    - stripe-mock
 
 before_install:
   - go get -u github.com/stretchr/testify/require
 
   # Unpack and start the Stripe API stub so that the test suite can talk to it
   - |
-    if [ ! -d "stripestubs/stripestub_${STRIPE_STUB_VERSION}" ]; then
-      mkdir -p stripestubs/stripestub_${STRIPE_STUB_VERSION}/
-      curl -L "https://github.com/brandur/stripestub/releases/download/v${STRIPE_STUB_VERSION}/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz" -o "stripestubs/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz"
-      tar -zxf "stripestubs/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz" -C "stripestubs/stripestub_${STRIPE_STUB_VERSION}/"
+    if [ ! -d "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}" ]; then
+      mkdir -p stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/
+      curl -L "https://github.com/brandur/stripe-mock/releases/download/v${STRIPE_MOCK_VERSION}/stripe-mock_${STRIPE_MOCK_VERSION}_linux_amd64.tar.gz" -o "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}_linux_amd64.tar.gz"
+      tar -zxf "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}_linux_amd64.tar.gz" -C "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/"
     fi
   - |
-    stripestubs/stripestub_${STRIPE_STUB_VERSION}/stripestub -port ${STRIPE_STUB_PORT} &
-    STRIPE_STUB_PID=$!
+    stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock > /dev/null &
+    STRIPE_MOCK_PID=$!
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,30 @@ matrix:
   allow_failures:
     - go: tip
   fast_finish: true
+sudo: false
+
+env:
+  global:
+    - STRIPE_STUB_PORT=6065
+    - STRIPE_STUB_VERSION=0.1.1
+
+cache:
+  directories:
+    - stripestubs
+
+before_install:
+  - go get -u github.com/stretchr/testify/require
+
+  # Unpack and start the Stripe API stub so that the test suite can talk to it
+  - |
+    if [ ! -d "stripestubs/stripestub_${STRIPE_STUB_VERSION}" ]; then
+      mkdir -p stripestubs/stripestub_${STRIPE_STUB_VERSION}/
+      curl -L "https://github.com/brandur/stripestub/releases/download/v${STRIPE_STUB_VERSION}/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz" -o "stripestubs/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz"
+      tar -zxf "stripestubs/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz" -C "stripestubs/stripestub_${STRIPE_STUB_VERSION}/"
+    fi
+  - |
+    stripestubs/stripestub_${STRIPE_STUB_VERSION}/stripestub -port ${STRIPE_STUB_PORT} &
+    STRIPE_STUB_PID=$!
+
+script:
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.1.13
+    - STRIPE_MOCK_VERSION=0.1.14
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ check-gofmt:
 checkin:
 	STRIPE_KEY=$(STRIPE_KEY) go test -run "TestCheckin*" ./...
 
+	# Whitelisted sets of tests that use stripestub
+	go test -run "TestPlan*"
+	go test ./plan
+
 test:
 	STRIPE_KEY=$(STRIPE_KEY) go test ./... -p=1
 

--- a/plan.go
+++ b/plan.go
@@ -41,11 +41,11 @@ type PlanListParams struct {
 
 func (p *PlanListParams) AppendTo(values *RequestValues) {
 	if p.Created > 0 {
-		body.Add("created", strconv.FormatInt(p.Created, 10))
+		values.Add("created", strconv.FormatInt(p.Created, 10))
 	}
 
 	if p.CreatedRange != nil {
-		p.CreatedRange.AppendTo(body, "created")
+		p.CreatedRange.AppendTo(values, "created")
 	}
 }
 

--- a/plan.go
+++ b/plan.go
@@ -1,28 +1,12 @@
 package stripe
 
+import (
+	"strconv"
+)
+
 // PlanInterval is the list of allowed values for a plan's interval.
 // Allowed values are "day", "week", "month", "year".
 type PlanInterval string
-
-// PlanParams is the set of parameters that can be used when creating or updating a plan.
-// For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
-type PlanParams struct {
-	Params
-	ID, Name                   string
-	Currency                   Currency
-	Amount                     uint64
-	Interval                   PlanInterval
-	IntervalCount, TrialPeriod uint64
-	Statement                  string
-}
-
-// PlanListParams is the set of parameters that can be used when listing plans.
-// For more details see https://stripe.com/docs/api#list_plans.
-type PlanListParams struct {
-	ListParams
-	Created      int64
-	CreatedRange *RangeQueryParams
-}
 
 // Plan is the resource representing a Stripe plan.
 // For more details see https://stripe.com/docs/api#plans.
@@ -45,4 +29,68 @@ type Plan struct {
 type PlanList struct {
 	ListMeta
 	Values []*Plan `json:"data"`
+}
+
+// PlanListParams is the set of parameters that can be used when listing plans.
+// For more details see https://stripe.com/docs/api#list_plans.
+type PlanListParams struct {
+	ListParams
+	Created      int64
+	CreatedRange *RangeQueryParams
+}
+
+func (p *PlanListParams) AppendTo(values *RequestValues) {
+	if p.Created > 0 {
+		body.Add("created", strconv.FormatInt(p.Created, 10))
+	}
+
+	if p.CreatedRange != nil {
+		p.CreatedRange.AppendTo(body, "created")
+	}
+}
+
+// PlanParams is the set of parameters that can be used when creating or updating a plan.
+// For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
+type PlanParams struct {
+	Params
+	ID, Name                   string
+	Currency                   Currency
+	Amount                     uint64
+	Interval                   PlanInterval
+	IntervalCount, TrialPeriod uint64
+	Statement                  string
+}
+
+func (p *PlanParams) AppendTo(values *RequestValues) {
+	if p.Amount > 0 {
+		values.Add("amount", strconv.FormatUint(p.Amount, 10))
+	}
+
+	if p.Currency != "" {
+		values.Add("currency", string(p.Currency))
+	}
+
+	if p.ID != "" {
+		values.Add("id", p.ID)
+	}
+
+	if p.Interval != "" {
+		values.Add("interval", string(p.Interval))
+	}
+
+	if p.IntervalCount > 0 {
+		values.Add("interval_count", strconv.FormatUint(p.IntervalCount, 10))
+	}
+
+	if p.Name != "" {
+		values.Add("name", p.Name)
+	}
+
+	if len(p.Statement) > 0 {
+		values.Add("statement_descriptor", p.Statement)
+	}
+
+	if p.TrialPeriod > 0 {
+		values.Add("trial_period_days", strconv.FormatUint(p.TrialPeriod, 10))
+	}
 }

--- a/plan/client.go
+++ b/plan/client.go
@@ -120,7 +120,6 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 
 	if params != nil {
 		body = &stripe.RequestValues{}
-		params.Params.AppendTo(body)
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()

--- a/plan/client.go
+++ b/plan/client.go
@@ -4,7 +4,6 @@ package plan
 import (
 	"fmt"
 	"net/url"
-	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -30,23 +29,7 @@ func New(params *stripe.PlanParams) (*stripe.Plan, error) {
 
 func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
 	body := &stripe.RequestValues{}
-	body.Add("id", params.ID)
-	body.Add("name", params.Name)
-	body.Add("amount", strconv.FormatUint(params.Amount, 10))
-	body.Add("currency", string(params.Currency))
-	body.Add("interval", string(params.Interval))
-
-	if params.IntervalCount > 0 {
-		body.Add("interval_count", strconv.FormatUint(params.IntervalCount, 10))
-	}
-
-	if params.TrialPeriod > 0 {
-		body.Add("trial_period_days", strconv.FormatUint(params.TrialPeriod, 10))
-	}
-
-	if len(params.Statement) > 0 {
-		body.Add("statement_descriptor", params.Statement)
-	}
+	params.Params.AppendTo(body)
 	params.AppendTo(body)
 
 	plan := &stripe.Plan{}
@@ -68,6 +51,7 @@ func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) 
 	if params != nil {
 		commonParams = &params.Params
 		body = &stripe.RequestValues{}
+		params.Params.AppendTo(body)
 		params.AppendTo(body)
 	}
 
@@ -90,19 +74,7 @@ func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, erro
 	if params != nil {
 		commonParams = &params.Params
 		body = &stripe.RequestValues{}
-
-		if len(params.Name) > 0 {
-			body.Add("name", params.Name)
-		}
-
-		if len(params.Statement) > 0 {
-			body.Add("statement_descriptor", params.Statement)
-		}
-
-		if params.TrialPeriod > 0 {
-			body.Add("trial_period_days", strconv.FormatUint(params.TrialPeriod, 10))
-		}
-
+		params.Params.AppendTo(body)
 		params.AppendTo(body)
 	}
 
@@ -131,9 +103,7 @@ func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) 
 
 	plan := &stripe.Plan{}
 	qid := url.QueryEscape(id) //Added query escape per commit 9821176
-
 	err := c.B.Call("DELETE", fmt.Sprintf("/plans/%v", qid), c.Key, body, commonParams, plan)
-
 	return plan, err
 }
 
@@ -150,15 +120,7 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 
 	if params != nil {
 		body = &stripe.RequestValues{}
-
-		if params.Created > 0 {
-			body.Add("created", strconv.FormatInt(params.Created, 10))
-		}
-
-		if params.CreatedRange != nil {
-			params.CreatedRange.AppendTo(body, "created")
-		}
-
+		params.Params.AppendTo(body)
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -1,193 +1,47 @@
 package plan
 
 import (
-	"fmt"
 	"testing"
 
+	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/currency"
-	. "github.com/stripe/stripe-go/utils"
+	_ "github.com/stripe/stripe-go/testing"
 )
 
-func init() {
-	stripe.Key = GetTestKey()
-}
-
-func TestPlanNew(t *testing.T) {
-	planParams := &stripe.PlanParams{
-		ID:            "test_plan",
-		Name:          "Test Plan",
-		Amount:        99,
-		Currency:      currency.USD,
-		Interval:      Month,
-		IntervalCount: 3,
-		TrialPeriod:   30,
-		Statement:     "Test Plan",
-	}
-
-	target, err := New(planParams)
-
-	if err != nil {
-		t.Error(err)
-	}
-
-	if target.ID != planParams.ID {
-		t.Errorf("ID %q does not match expected id %q\n", target.ID, planParams.ID)
-	}
-
-	if target.Name != planParams.Name {
-		t.Errorf("Name %q does not match expected name %q\n", target.Name, planParams.Name)
-	}
-
-	if target.Amount != planParams.Amount {
-		t.Errorf("Amount %v does not match expected amount %v\n", target.Amount, planParams.Amount)
-	}
-
-	if target.Currency != planParams.Currency {
-		t.Errorf("Currency %q does not match expected currency %q\n", target.Currency, planParams.Currency)
-	}
-
-	if target.Interval != planParams.Interval {
-		t.Errorf("Interval %q does not match expected interval %q\n", target.Interval, planParams.Interval)
-	}
-
-	if target.IntervalCount != planParams.IntervalCount {
-		t.Errorf("Interval count %v does not match expected interval count %v\n", target.IntervalCount, planParams.IntervalCount)
-	}
-
-	if target.TrialPeriod != planParams.TrialPeriod {
-		t.Errorf("Trial period %v does not match expected trial period %v\n", target.TrialPeriod, planParams.TrialPeriod)
-	}
-
-	if target.Statement != planParams.Statement {
-		t.Errorf("Statement %q does not match expected statement %q\n", target.Statement, planParams.Statement)
-	}
-
-	Del(planParams.ID, nil)
+func TestPlanDel(t *testing.T) {
+	plan, err := Del("gold", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, plan)
 }
 
 func TestPlanGet(t *testing.T) {
-	planParams := &stripe.PlanParams{
-		ID:       "test_plan",
-		Name:     "Test Plan",
-		Amount:   99,
-		Currency: currency.USD,
-		Interval: Month,
-	}
-
-	New(planParams)
-	target, err := Get(planParams.ID, nil)
-
-	if err != nil {
-		t.Error(err)
-	}
-
-	if target.ID != planParams.ID {
-		t.Errorf("Plan id %q does not match expected id %q\n", target.ID, planParams.ID)
-	}
-
-	Del(planParams.ID, nil)
-}
-
-func TestPlanUpdate(t *testing.T) {
-	planParams := &stripe.PlanParams{
-		ID:            "test_plan",
-		Name:          "Original Name",
-		Amount:        99,
-		Currency:      currency.USD,
-		Interval:      Month,
-		IntervalCount: 3,
-		TrialPeriod:   30,
-		Statement:     "Original Plan",
-	}
-
-	New(planParams)
-
-	updatedPlan := &stripe.PlanParams{
-		Name:        "Updated Name",
-		Statement:   "Updated Plan",
-		TrialPeriod: 15,
-	}
-
-	target, err := Update(planParams.ID, updatedPlan)
-
-	if err != nil {
-		t.Error(err)
-	}
-
-	if target.Name != updatedPlan.Name {
-		t.Errorf("Name %q does not match expected name %q\n", target.Name, updatedPlan.Name)
-	}
-
-	if target.Statement != updatedPlan.Statement {
-		t.Errorf("Statement %q does not match expected statement %q\n", target.Statement, updatedPlan.Statement)
-	}
-
-	if target.TrialPeriod != updatedPlan.TrialPeriod {
-		t.Errorf("TrialPeriod %q does not match expected trial period %q\n", target.TrialPeriod, updatedPlan.TrialPeriod)
-	}
-
-	Del(planParams.ID, nil)
-}
-
-func TestPlanDel(t *testing.T) {
-	planParams := &stripe.PlanParams{
-		ID:       "test_plan",
-		Name:     "Test Plan",
-		Amount:   99,
-		Currency: currency.USD,
-		Interval: Month,
-	}
-
-	New(planParams)
-
-	planDel, err := Del(planParams.ID, nil)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !planDel.Deleted {
-		t.Errorf("Plan id %q expected to be marked as deleted on the returned resource\n", planDel.ID)
-	}
+	plan, err := Get("gold", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, plan)
 }
 
 func TestPlanList(t *testing.T) {
-	const runs = 3
-	for i := 0; i < runs; i++ {
-		planParams := &stripe.PlanParams{
-			ID:       fmt.Sprintf("test_%v", i),
-			Name:     fmt.Sprintf("test_%v", i),
-			Amount:   99,
-			Currency: currency.USD,
-			Interval: Month,
-		}
+	i := List(&stripe.PlanListParams{})
 
-		New(planParams)
+	// Verify that we can get at least one plan
+	assert.True(t, i.Next())
+	assert.Nil(t, i.Err())
+	assert.NotNil(t, i.Plan())
+}
+
+func TestPlanNew(t *testing.T) {
+	plan, err := New(&stripe.PlanParams{
+		Name: "Test Plan",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, plan)
+}
+
+func TestPlanUpdate(t *testing.T) {
+	updatedPlan := &stripe.PlanParams{
+		Name: "Updated Name",
 	}
-
-	params := &stripe.PlanListParams{}
-	params.Filters.AddFilter("limit", "", "1")
-
-	plansChecked := 0
-	i := List(params)
-	for i.Next() && plansChecked < runs {
-		target := i.Plan()
-
-		if i.Meta() == nil {
-			t.Error("No metadata returned")
-		}
-
-		if target.Amount != 99 {
-			t.Errorf("Amount %v does not match expected value\n", target.Amount)
-		}
-
-		plansChecked += 1
-	}
-	if err := i.Err(); err != nil {
-		t.Error(err)
-	}
-
-	for i := 0; i < runs; i++ {
-		Del(fmt.Sprintf("test_%v", i), nil)
-	}
+	plan, err := Update("gold", updatedPlan)
+	assert.Nil(t, err)
+	assert.NotNil(t, plan)
 }

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -31,7 +31,11 @@ func TestPlanList(t *testing.T) {
 
 func TestPlanNew(t *testing.T) {
 	plan, err := New(&stripe.PlanParams{
-		Name: "Test Plan",
+		Amount:   1,
+		Currency: "usd",
+		ID:       "sapphire-elite",
+		Interval: "month",
+		Name:     "Sapphire Elite",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, plan)

--- a/plan_test.go
+++ b/plan_test.go
@@ -8,65 +8,63 @@ import (
 )
 
 func TestPlanListParamsAppendTo(t *testing.T) {
-	var body *RequestValues
-	var params PlanListParams
+	testCases := []struct {
+		field  string
+		params *PlanListParams
+		want   interface{}
+	}{
+		{"created", &PlanListParams{Created: 123}, strconv.FormatInt(123, 10)},
+		{
+			"created[gt]",
+			&PlanListParams{CreatedRange: &RangeQueryParams{GreaterThan: 123}},
+			strconv.FormatInt(123, 10),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.field, func(t *testing.T) {
+			body := &RequestValues{}
+			tc.params.AppendTo(body)
+			values := body.ToValues()
+			assert.Equal(t, tc.want, values.Get(tc.field))
+		})
+	}
+}
 
-	// Should run even with an empty set of parameters
-	body = &RequestValues{}
+func TestPlanListParamsAppendTo_Empty(t *testing.T) {
+	body := &RequestValues{}
+	params := &PlanListParams{}
 	params.AppendTo(body)
 	assert.True(t, body.Empty())
-
-	body = &RequestValues{}
-	params = PlanListParams{
-		Created:      123,
-		CreatedRange: &RangeQueryParams{GreaterThan: 123},
-	}
-	params.AppendTo(body)
-
-	values := body.ToValues()
-	assert.Equal(t, strconv.FormatInt(params.Created, 10),
-		values.Get("created"))
-	assert.Equal(t, strconv.FormatInt(params.CreatedRange.GreaterThan, 10),
-		values.Get("created[gt]"))
 }
 
 func TestPlanParamsAppendTo(t *testing.T) {
-	var body *RequestValues
-	var params PlanParams
+	testCases := []struct {
+		field  string
+		params *PlanParams
+		want   interface{}
+	}{
+		{"amount", &PlanParams{Amount: 123}, strconv.FormatUint(123, 10)},
+		{"currency", &PlanParams{Currency: "USD"}, "USD"},
+		{"id", &PlanParams{ID: "sapphire-elite"}, "sapphire-elite"},
+		{"interval", &PlanParams{Interval: "month"}, "month"},
+		{"interval_count", &PlanParams{IntervalCount: 3}, strconv.FormatUint(3, 10)},
+		{"name", &PlanParams{Name: "Sapphire Elite"}, "Sapphire Elite"},
+		{"statement_descriptor", &PlanParams{Statement: "Sapphire Elite"}, "Sapphire Elite"},
+		{"trial_period_days", &PlanParams{TrialPeriod: 123}, strconv.FormatUint(123, 10)},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.field, func(t *testing.T) {
+			body := &RequestValues{}
+			tc.params.AppendTo(body)
+			values := body.ToValues()
+			assert.Equal(t, tc.want, values.Get(tc.field))
+		})
+	}
+}
 
-	// Should run even with an empty set of parameters
-	body = &RequestValues{}
+func TestPlanParamsAppendTo_Empty(t *testing.T) {
+	body := &RequestValues{}
+	params := &PlanParams{}
 	params.AppendTo(body)
 	assert.True(t, body.Empty())
-
-	body = &RequestValues{}
-	params = PlanParams{
-		Amount:        99,
-		Currency:      Currency("usd"),
-		ID:            "test_plan",
-		Interval:      PlanInterval("month"),
-		IntervalCount: 3,
-		Name:          "Test Plan",
-		Statement:     "Test Plan",
-		TrialPeriod:   30,
-	}
-	params.AppendTo(body)
-
-	values := body.ToValues()
-	assert.Equal(t, strconv.FormatUint(params.Amount, 10),
-		values.Get("amount"))
-	assert.Equal(t, string(params.Currency),
-		values.Get("currency"))
-	assert.Equal(t, params.ID,
-		values.Get("id"))
-	assert.Equal(t, string(params.Interval),
-		values.Get("interval"))
-	assert.Equal(t, strconv.FormatUint(params.IntervalCount, 10),
-		values.Get("interval_count"))
-	assert.Equal(t, params.Name,
-		values.Get("name"))
-	assert.Equal(t, params.Statement,
-		values.Get("statement_descriptor"))
-	assert.Equal(t, strconv.FormatUint(params.TrialPeriod, 10),
-		values.Get("trial_period_days"))
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -1,0 +1,40 @@
+package stripe
+
+import (
+	"strconv"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestPlanParamsAppendTo(t *testing.T) {
+	var body *RequestValues
+	var params PlanParams
+
+	// Should run even with an empty set of parameters
+	body = &RequestValues{}
+	params.AppendTo(body)
+	assert.True(t, body.Empty())
+
+	body = &RequestValues{}
+	params = PlanParams{
+		Amount:        99,
+		Currency:      Currency("usd"),
+		ID:            "test_plan",
+		Interval:      PlanInterval("month"),
+		IntervalCount: 3,
+		Name:          "Test Plan",
+		Statement:     "Test Plan",
+		TrialPeriod:   30,
+	}
+	params.AppendTo(body)
+	values := body.ToValues()
+	assert.Equal(t, strconv.FormatUint(params.Amount, 10), values.Get("amount"))
+	assert.Equal(t, string(params.Currency), values.Get("currency"))
+	assert.Equal(t, params.ID, values.Get("id"))
+	assert.Equal(t, string(params.Interval), values.Get("interval"))
+	assert.Equal(t, strconv.FormatUint(params.IntervalCount, 10), values.Get("interval_count"))
+	assert.Equal(t, params.Name, values.Get("name"))
+	assert.Equal(t, params.Statement, values.Get("statement_descriptor"))
+	assert.Equal(t, strconv.FormatUint(params.TrialPeriod, 10), values.Get("trial_period_days"))
+}

--- a/plan_test.go
+++ b/plan_test.go
@@ -7,6 +7,29 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
+func TestPlanListParamsAppendTo(t *testing.T) {
+	var body *RequestValues
+	var params PlanListParams
+
+	// Should run even with an empty set of parameters
+	body = &RequestValues{}
+	params.AppendTo(body)
+	assert.True(t, body.Empty())
+
+	body = &RequestValues{}
+	params = PlanListParams{
+		Created:      123,
+		CreatedRange: &RangeQueryParams{GreaterThan: 123},
+	}
+	params.AppendTo(body)
+
+	values := body.ToValues()
+	assert.Equal(t, strconv.FormatInt(params.Created, 10),
+		values.Get("created"))
+	assert.Equal(t, strconv.FormatInt(params.CreatedRange.GreaterThan, 10),
+		values.Get("created[gt]"))
+}
+
 func TestPlanParamsAppendTo(t *testing.T) {
 	var body *RequestValues
 	var params PlanParams
@@ -28,13 +51,22 @@ func TestPlanParamsAppendTo(t *testing.T) {
 		TrialPeriod:   30,
 	}
 	params.AppendTo(body)
+
 	values := body.ToValues()
-	assert.Equal(t, strconv.FormatUint(params.Amount, 10), values.Get("amount"))
-	assert.Equal(t, string(params.Currency), values.Get("currency"))
-	assert.Equal(t, params.ID, values.Get("id"))
-	assert.Equal(t, string(params.Interval), values.Get("interval"))
-	assert.Equal(t, strconv.FormatUint(params.IntervalCount, 10), values.Get("interval_count"))
-	assert.Equal(t, params.Name, values.Get("name"))
-	assert.Equal(t, params.Statement, values.Get("statement_descriptor"))
-	assert.Equal(t, strconv.FormatUint(params.TrialPeriod, 10), values.Get("trial_period_days"))
+	assert.Equal(t, strconv.FormatUint(params.Amount, 10),
+		values.Get("amount"))
+	assert.Equal(t, string(params.Currency),
+		values.Get("currency"))
+	assert.Equal(t, params.ID,
+		values.Get("id"))
+	assert.Equal(t, string(params.Interval),
+		values.Get("interval"))
+	assert.Equal(t, strconv.FormatUint(params.IntervalCount, 10),
+		values.Get("interval_count"))
+	assert.Equal(t, params.Name,
+		values.Get("name"))
+	assert.Equal(t, params.Statement,
+		values.Get("statement_descriptor"))
+	assert.Equal(t, strconv.FormatUint(params.TrialPeriod, 10),
+		values.Get("trial_period_days"))
 }

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,5 +1,13 @@
 package testing
 
+import (
+	"log"
+	"net/http"
+	"os"
+
+	stripe "github.com/stripe/stripe-go"
+)
+
 // This file should contain any testing helpers that should be commonly
 // available across all tests in the Stripe package.
 //
@@ -11,3 +19,17 @@ const (
 	// simple tests.
 	TestMerchantID = "acct_xxxx"
 )
+
+func init() {
+	port := os.Getenv("STRIPE_STUB_PORT")
+	if port == "" {
+		log.Fatalf("Please specify STRIPE_STUB_PORT. See README for setup instructions.")
+	}
+
+	stripe.Key = "sk_test_myTestKey"
+	stripe.SetBackend("api", stripe.BackendConfiguration{
+		stripe.APIBackend,
+		"http://localhost:" + port + "/v1",
+		&http.Client{},
+	})
+}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"log"
 	"net/http"
 	"os"
 
@@ -23,7 +22,7 @@ const (
 func init() {
 	port := os.Getenv("STRIPE_STUB_PORT")
 	if port == "" {
-		log.Fatalf("Please specify STRIPE_STUB_PORT. See README for setup instructions.")
+		port = "12111"
 	}
 
 	stripe.Key = "sk_test_myTestKey"
@@ -32,4 +31,6 @@ func init() {
 		"http://localhost:" + port + "/v1",
 		&http.Client{},
 	})
+
+	// TODO: sample connection and version check
 }


### PR DESCRIPTION
In the style of https://github.com/stripe/stripe-ruby/pull/553 starts to move toward an external API stub [1] executable to power the test suite. This will allow us to start turning more tests back on in CI (currently the vast majority of them don't run).

I've also left some inline notes that annotate how I've also changed our testing strategy in a few places. The end goal are tests that are _much_ faster, _much_ more reliable, and _not_ totally broken (because they don't get to run in CI).

This is an experimental prototype for demonstrative purposes and should not be merged.

[1] https://github.com/stripe/stripe-mock