### PR TITLE
Add parameters when calling `pay` on an invoice

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -127,6 +127,14 @@ type InvoiceLineList struct {
 	Values []*InvoiceLine `json:"data"`
 }
 
+// InvoicePayParams is the set of parameters that can be used when
+// paying invoices. For more details, see:
+// https://stripe.com/docs/api#pay_invoice.
+type InvoicePayParams struct {
+	Params
+	Source string
+}
+
 // UnmarshalJSON handles deserialization of an Invoice.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -96,17 +96,22 @@ func (c Client) Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, e
 
 // Pay pays an invoice.
 // For more details see https://stripe.com/docs/api#pay_invoice.
-func Pay(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
+func Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 	return getC().Pay(id, params)
 }
 
-func (c Client) Pay(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
+func (c Client) Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 	var body *stripe.RequestValues
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
 		body = &stripe.RequestValues{}
+
+		if params.Source != "" {
+			body.Add("source", params.Source)
+		}
+
 		params.AppendTo(body)
 	}
 

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -488,11 +488,11 @@ func TestAllInvoicesScenarios(t *testing.T) {
 		t.Errorf("Invoice was not reponed as expected and its value is %v", targetInvoiceOpened.Closed)
 	}
 
-	paidInvoice := &stripe.InvoiceParams{
-		Paid: true,
+	payInvoice := &stripe.InvoicePayParams{
+		Source: cust.Sources.Values[0].Card.ID,
 	}
 
-	targetInvoicePaid, err := Update(targetInvoiceClosed.ID, paidInvoice)
+	targetInvoicePaid, err := Pay(targetInvoice.ID, payInvoice)
 
 	if err != nil {
 		t.Error(err)
@@ -502,7 +502,7 @@ func TestAllInvoicesScenarios(t *testing.T) {
 		t.Errorf("Updated invoice paid status %v does not match expected true\n", targetInvoiceUpdated.Paid)
 	}
 
-	_, err = plan.Del(planParams.ID)
+	_, err = plan.Del(planParams.ID, nil)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @ark-stripe

Users can now provide a `source` parameter when paying invoices. Previously, the Go library let users pass creation/update params when calling `Pay` which is not what we want. This PR adds a new `InvoicePayParams` struct to handle parameters for this specific API request. Currently, the only accepted parameter is `Source`.
