### PR TITLE
Add support for range queries on list endpoints

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -72,7 +72,10 @@ type TxParams struct {
 // For more details see https://stripe.com/docs/api/#balance_history.
 type TxListParams struct {
 	ListParams
-	Created, Available    int64
+	Created               int64
+	CreatedRange          *RangeQueryParams
+	Available             int64
+	AvailableRange        *RangeQueryParams
 	Currency, Src, Payout string
 	Type                  TransactionType
 }

--- a/balance/client.go
+++ b/balance/client.go
@@ -94,8 +94,16 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
 		}
 
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
+		}
+
 		if params.Available > 0 {
 			body.Add("available_on", strconv.FormatInt(params.Available, 10))
+		}
+
+		if params.AvailableRange != nil {
+			params.AvailableRange.AppendTo(body, "available_on")
 		}
 
 		if len(params.Currency) > 0 {

--- a/charge.go
+++ b/charge.go
@@ -47,6 +47,7 @@ func (cp *ChargeParams) SetSource(sp interface{}) error {
 type ChargeListParams struct {
 	ListParams
 	Created       int64
+	CreatedRange  *RangeQueryParams
 	Customer      string
 	TransferGroup string
 }

--- a/charge/client.go
+++ b/charge/client.go
@@ -212,6 +212,10 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
 		}
 
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
+		}
+
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
 		}

--- a/coupon.go
+++ b/coupon.go
@@ -21,6 +21,7 @@ type CouponParams struct {
 // For more detail see https://stripe.com/docs/api#list_coupons.
 type CouponListParams struct {
 	ListParams
+	Created *RangeQueryParams
 }
 
 // Coupon is the resource representing a Stripe coupon.

--- a/coupon.go
+++ b/coupon.go
@@ -21,7 +21,8 @@ type CouponParams struct {
 // For more detail see https://stripe.com/docs/api#list_coupons.
 type CouponListParams struct {
 	ListParams
-	Created *RangeQueryParams
+	Created      int64
+	CreatedRange *RangeQueryParams
 }
 
 // Coupon is the resource representing a Stripe coupon.

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -135,6 +135,10 @@ func (c Client) List(params *stripe.CouponListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
+		if params.Created != nil {
+			params.Created.AppendTo(body, "created")
+		}
+
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -135,8 +135,12 @@ func (c Client) List(params *stripe.CouponListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.Created != nil {
-			params.Created.AppendTo(body, "created")
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
 		}
 
 		params.AppendTo(body)

--- a/customer.go
+++ b/customer.go
@@ -36,7 +36,8 @@ func (cp *CustomerParams) SetSource(sp interface{}) error {
 // For more details see https://stripe.com/docs/api#list_customers.
 type CustomerListParams struct {
 	ListParams
-	Created int64
+	Created      int64
+	CreatedRange *RangeQueryParams
 }
 
 // Customer is the resource representing a Stripe customer.

--- a/customer/client.go
+++ b/customer/client.go
@@ -193,6 +193,10 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
 		}
 
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
+		}
+
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()

--- a/dispute.go
+++ b/dispute.go
@@ -68,7 +68,8 @@ type DisputeEvidenceParams struct {
 // For more details see https://stripe.com/docs/api#list_disputes.
 type DisputeListParams struct {
 	ListParams
-	Created int64
+	Created      int64
+	CreatedRange *RangeQueryParams
 }
 
 // Dispute is the resource representing a Stripe dispute.

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -3,6 +3,7 @@ package dispute
 
 import (
 	"fmt"
+	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -68,6 +69,14 @@ func (c Client) List(params *stripe.DisputeListParams) *Iter {
 
 	if params != nil {
 		body = &stripe.RequestValues{}
+
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
+		}
 
 		params.AppendTo(body)
 		lp = &params.ListParams

--- a/event.go
+++ b/event.go
@@ -47,7 +47,7 @@ type EventList struct {
 // For more details see https://stripe.com/docs/api#list_events.
 type EventListParams struct {
 	ListParams
-	Created int64
+	Created *RangeQueryParams
 	// Type is one of the values documented at https://stripe.com/docs/api#event_types.
 	Type string
 }

--- a/event.go
+++ b/event.go
@@ -47,7 +47,8 @@ type EventList struct {
 // For more details see https://stripe.com/docs/api#list_events.
 type EventListParams struct {
 	ListParams
-	Created *RangeQueryParams
+	Created      int64
+	CreatedRange *RangeQueryParams
 	// Type is one of the values documented at https://stripe.com/docs/api#event_types.
 	Type string
 }

--- a/event/client.go
+++ b/event/client.go
@@ -2,6 +2,8 @@
 package event
 
 import (
+	"strconv"
+
 	stripe "github.com/stripe/stripe-go"
 )
 
@@ -38,8 +40,12 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.Created != nil {
-			params.Created.AppendTo(body, "created")
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
 		}
 
 		if len(params.Type) > 0 {

--- a/event/client.go
+++ b/event/client.go
@@ -2,8 +2,6 @@
 package event
 
 import (
-	"strconv"
-
 	stripe "github.com/stripe/stripe-go"
 )
 
@@ -40,8 +38,8 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.Created > 0 {
-			body.Add("created", strconv.FormatInt(params.Created, 10))
+		if params.Created != nil {
+			params.Created.AppendTo(body, "created")
 		}
 
 		if len(params.Type) > 0 {

--- a/event/client_test.go
+++ b/event/client_test.go
@@ -37,10 +37,6 @@ func TestEvent(t *testing.T) {
 			t.Errorf("Type is not set\n")
 		}
 
-		if len(e.Req) == 0 {
-			t.Errorf("Request is not set\n")
-		}
-
 		if e.Data == nil {
 			t.Errorf("Data is not set\n")
 		}

--- a/fileupload.go
+++ b/fileupload.go
@@ -29,8 +29,10 @@ type FileUploadParams struct {
 // FileUploadListParams is the set of parameters that can be used when listing
 // file uploads. For more details see https://stripe.com/docs/api#list_file_uploads.
 type FileUploadListParams struct {
-	Purpose FileUploadPurpose
 	ListParams
+	Created      int64
+	CreatedRange *RangeQueryParams
+	Purpose      FileUploadPurpose
 }
 
 // FileUploadPurpose is the purpose of a particular file upload. Allowed values

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -4,6 +4,7 @@ package fileupload
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -79,6 +80,14 @@ func (c Client) List(params *stripe.FileUploadListParams) *Iter {
 
 	if params != nil {
 		body = &stripe.RequestValues{}
+
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
+		}
 
 		if len(params.Purpose) > 0 {
 			body.Add("purpose", string(params.Purpose))

--- a/invoice.go
+++ b/invoice.go
@@ -38,11 +38,12 @@ type InvoiceParams struct {
 // For more details see https://stripe.com/docs/api#list_customer_invoices.
 type InvoiceListParams struct {
 	ListParams
-	Date     int64
-	Customer string
-	Sub      string
-	Billing  InvoiceBilling
-	DueDate  int64
+	Date      int64
+	DateRange *RangeQueryParams
+	Customer  string
+	Sub       string
+	Billing   InvoiceBilling
+	DueDate   int64
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -271,6 +271,10 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 			body.Add("date", strconv.FormatInt(params.Date, 10))
 		}
 
+		if params.DateRange != nil {
+			params.DateRange.AppendTo(body, "date")
+		}
+
 		if len(params.Billing) > 0 {
 			body.Add("billing", string(params.Billing))
 		}

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -18,8 +18,9 @@ type InvoiceItemParams struct {
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
 type InvoiceItemListParams struct {
 	ListParams
-	Created  int64
-	Customer string
+	Created      int64
+	CreatedRange *RangeQueryParams
+	Customer     string
 }
 
 // InvoiceItem is the resource represneting a Stripe invoice item.

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -139,6 +139,10 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
 		}
 
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
+		}
+
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
 		}

--- a/order.go
+++ b/order.go
@@ -109,8 +109,9 @@ type OrderList struct {
 // https://stripe.com/docs/api#list_orders.
 type OrderListParams struct {
 	ListParams
-	IDs    []string
-	Status OrderStatus
+	Created *RangeQueryParams
+	IDs     []string
+	Status  OrderStatus
 }
 
 // StatsuTransitions are the timestamps at which the order status was updated

--- a/order.go
+++ b/order.go
@@ -109,9 +109,10 @@ type OrderList struct {
 // https://stripe.com/docs/api#list_orders.
 type OrderListParams struct {
 	ListParams
-	Created *RangeQueryParams
-	IDs     []string
-	Status  OrderStatus
+	Created      int64
+	CreatedRange *RangeQueryParams
+	IDs          []string
+	Status       OrderStatus
 }
 
 // StatsuTransitions are the timestamps at which the order status was updated

--- a/order/client.go
+++ b/order/client.go
@@ -254,8 +254,12 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.Created != nil {
-			params.Created.AppendTo(body, "created")
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
 		}
 
 		for _, id := range params.IDs {

--- a/order/client.go
+++ b/order/client.go
@@ -254,6 +254,10 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
+		if params.Created != nil {
+			params.Created.AppendTo(body, "created")
+		}
+
 		for _, id := range params.IDs {
 			params.Filters.AddFilter("ids[]", "", id)
 		}

--- a/order_return.go
+++ b/order_return.go
@@ -23,7 +23,9 @@ type OrderReturnList struct {
 // returns. For more details, see: https://stripe.com/docs/api#list_order_returns.
 type OrderReturnListParams struct {
 	ListParams
-	Order string
+	Created      int64
+	CreatedRange *RangeQueryParams
+	Order        string
 }
 
 // UnmarshalJSON handles deserialization of an OrderReturn.

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -1,6 +1,8 @@
 package orderreturn
 
 import (
+	"strconv"
+
 	"github.com/stripe/stripe-go"
 )
 
@@ -22,6 +24,14 @@ func (c Client) List(params *stripe.OrderReturnListParams) *Iter {
 
 	if params != nil {
 		body = &stripe.RequestValues{}
+
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
+		}
 
 		if params.Order != "" {
 			params.Filters.AddFilter("order", "", params.Order)

--- a/params.go
+++ b/params.go
@@ -158,6 +158,44 @@ type ListMeta struct {
 	URL   string `json:"url"`
 }
 
+// RangeQueryParams are a set of generic request parameters that are used on
+// list endpoints to filter their results by some timestamp.
+type RangeQueryParams struct {
+	// GreaterThan specifies that values should be a greater than this
+	// timestamp.
+	GreaterThan int64
+
+	// GreaterThanOrEqual specifies that values should be greater than or equal
+	// to this timestamp.
+	GreaterThanOrEqual int64
+
+	// LesserThan specifies that values should be lesser than this timetamp.
+	LesserThan int64
+
+	// LesserThanOrEqual specifies that values should be lesser than or
+	// equalthis timetamp.
+	LesserThanOrEqual int64
+}
+
+// AppendTo adds the range query parametes to a set of request values.
+func (r *RangeQueryParams) AppendTo(values *RequestValues, name string) {
+	if r.GreaterThan > 0 {
+		values.Add(name+"[gt]", strconv.FormatInt(r.GreaterThan, 10))
+	}
+
+	if r.GreaterThanOrEqual > 0 {
+		values.Add(name+"[gte]", strconv.FormatInt(r.GreaterThanOrEqual, 10))
+	}
+
+	if r.LesserThan > 0 {
+		values.Add(name+"[lt]", strconv.FormatInt(r.LesserThan, 10))
+	}
+
+	if r.LesserThanOrEqual > 0 {
+		values.Add(name+"[lte]", strconv.FormatInt(r.LesserThanOrEqual, 10))
+	}
+}
+
 // Filters is a structure that contains a collection of filters for list-related APIs.
 type Filters struct {
 	f []*filter

--- a/params_test.go
+++ b/params_test.go
@@ -26,48 +26,59 @@ func TestCheckinRangeQueryParamsAppendTo(t *testing.T) {
 		values := &stripe.RequestValues{}
 
 		// Try it with an empty set of parameters
-		params := &stripe.RangeQueryParams{
-			GreaterThan:        10,
-			GreaterThanOrEqual: 20,
-			LesserThan:         30,
-			LesserThanOrEqual:  40,
-		}
+		params := &stripe.RangeQueryParams{GreaterThan: 99}
 		params.AppendTo(values, "created")
 
-		{
-			value := values.Get("created[gt]")
-			if len(value) != 1 || value[0] != "10" {
-				t.Fatalf(
-					"Expected encoded value of 10 for created[gt] but got %v.",
-					value)
-			}
+		value := values.Get("created[gt]")
+		if len(value) != 1 || value[0] != "99" {
+			t.Fatalf(
+				"Expected encoded value of 99 for created[gt] but got %v.",
+				value)
 		}
+	}
 
-		{
-			value := values.Get("created[gte]")
-			if len(value) != 1 || value[0] != "20" {
-				t.Fatalf(
-					"Expected encoded value of 10 for created[gte] but got %v.",
-					value)
-			}
+	{
+		values := &stripe.RequestValues{}
+
+		// Try it with an empty set of parameters
+		params := &stripe.RangeQueryParams{GreaterThanOrEqual: 99}
+		params.AppendTo(values, "created")
+
+		value := values.Get("created[gte]")
+		if len(value) != 1 || value[0] != "99" {
+			t.Fatalf(
+				"Expected encoded value of 99 for created[gte] but got %v.",
+				value)
 		}
+	}
 
-		{
-			value := values.Get("created[lt]")
-			if len(value) != 1 || value[0] != "30" {
-				t.Fatalf(
-					"Expected encoded value of 10 for created[lt] but got %v.",
-					value)
-			}
+	{
+		values := &stripe.RequestValues{}
+
+		// Try it with an empty set of parameters
+		params := &stripe.RangeQueryParams{LesserThan: 99}
+		params.AppendTo(values, "created")
+
+		value := values.Get("created[lt]")
+		if len(value) != 1 || value[0] != "99" {
+			t.Fatalf(
+				"Expected encoded value of 99 for created[lt] but got %v.",
+				value)
 		}
+	}
 
-		{
-			value := values.Get("created[lte]")
-			if len(value) != 1 || value[0] != "40" {
-				t.Fatalf(
-					"Expected encoded value of 10 for created[lte] but got %v.",
-					value)
-			}
+	{
+		values := &stripe.RequestValues{}
+
+		// Try it with an empty set of parameters
+		params := &stripe.RangeQueryParams{LesserThanOrEqual: 99}
+		params.AppendTo(values, "created")
+
+		value := values.Get("created[lte]")
+		if len(value) != 1 || value[0] != "99" {
+			t.Fatalf(
+				"Expected encoded value of 99 for created[lte] but got %v.",
+				value)
 		}
 	}
 }

--- a/params_test.go
+++ b/params_test.go
@@ -9,6 +9,69 @@ import (
 	. "github.com/stripe/stripe-go/testing"
 )
 
+func TestCheckinRangeQueryParamsAppendTo(t *testing.T) {
+	{
+		values := &stripe.RequestValues{}
+
+		// Try it with an empty set of parameters
+		params := &stripe.RangeQueryParams{}
+		params.AppendTo(values, "created")
+
+		if !values.Empty() {
+			t.Fatalf("Expected request values to be empty")
+		}
+	}
+
+	{
+		values := &stripe.RequestValues{}
+
+		// Try it with an empty set of parameters
+		params := &stripe.RangeQueryParams{
+			GreaterThan:        10,
+			GreaterThanOrEqual: 20,
+			LesserThan:         30,
+			LesserThanOrEqual:  40,
+		}
+		params.AppendTo(values, "created")
+
+		{
+			value := values.Get("created[gt]")
+			if len(value) != 1 || value[0] != "10" {
+				t.Fatalf(
+					"Expected encoded value of 10 for created[gt] but got %v.",
+					value)
+			}
+		}
+
+		{
+			value := values.Get("created[gte]")
+			if len(value) != 1 || value[0] != "20" {
+				t.Fatalf(
+					"Expected encoded value of 10 for created[gte] but got %v.",
+					value)
+			}
+		}
+
+		{
+			value := values.Get("created[lt]")
+			if len(value) != 1 || value[0] != "30" {
+				t.Fatalf(
+					"Expected encoded value of 10 for created[lt] but got %v.",
+					value)
+			}
+		}
+
+		{
+			value := values.Get("created[lte]")
+			if len(value) != 1 || value[0] != "40" {
+				t.Fatalf(
+					"Expected encoded value of 10 for created[lte] but got %v.",
+					value)
+			}
+		}
+	}
+}
+
 func TestRequestValues(t *testing.T) {
 	values := &stripe.RequestValues{}
 

--- a/payout.go
+++ b/payout.go
@@ -70,10 +70,12 @@ type PayoutParams struct {
 // For more details see https://stripe.com/docs/api#list_payouts.
 type PayoutListParams struct {
 	ListParams
-	ArrivalDate *RangeQueryParams
-	Created     *RangeQueryParams
-	Destination string
-	Status      PayoutStatus
+	ArrivalDate      int64
+	ArrivalDateRange *RangeQueryParams
+	Created          int64
+	CreatedRange     *RangeQueryParams
+	Destination      string
+	Status           PayoutStatus
 }
 
 // Payout is the resource representing a Stripe payout.

--- a/payout.go
+++ b/payout.go
@@ -70,8 +70,8 @@ type PayoutParams struct {
 // For more details see https://stripe.com/docs/api#list_payouts.
 type PayoutListParams struct {
 	ListParams
-	ArrivalDate int64
-	Created     int64
+	ArrivalDate *RangeQueryParams
+	Created     *RangeQueryParams
 	Destination string
 	Status      PayoutStatus
 }

--- a/payout/client.go
+++ b/payout/client.go
@@ -157,12 +157,12 @@ func (c Client) List(params *stripe.PayoutListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.ArrivalDate > 0 {
-			body.Add("arrival_date", strconv.FormatInt(params.ArrivalDate, 10))
+		if params.ArrivalDate != nil {
+			params.ArrivalDate.AppendTo(body, "arrival_date")
 		}
 
-		if params.Created > 0 {
-			body.Add("created", strconv.FormatInt(params.Created, 10))
+		if params.Created != nil {
+			params.Created.AppendTo(body, "created")
 		}
 
 		if len(params.Destination) > 0 {

--- a/payout/client.go
+++ b/payout/client.go
@@ -157,12 +157,20 @@ func (c Client) List(params *stripe.PayoutListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.ArrivalDate != nil {
-			params.ArrivalDate.AppendTo(body, "arrival_date")
+		if params.ArrivalDate > 0 {
+			body.Add("created", strconv.FormatInt(params.ArrivalDate, 10))
 		}
 
-		if params.Created != nil {
-			params.Created.AppendTo(body, "created")
+		if params.ArrivalDateRange != nil {
+			params.ArrivalDateRange.AppendTo(body, "arrival_date")
+		}
+
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
 		}
 
 		if len(params.Destination) > 0 {

--- a/plan.go
+++ b/plan.go
@@ -20,6 +20,7 @@ type PlanParams struct {
 // For more details see https://stripe.com/docs/api#list_plans.
 type PlanListParams struct {
 	ListParams
+	Created *RangeQueryParams
 }
 
 // Plan is the resource representing a Stripe plan.

--- a/plan.go
+++ b/plan.go
@@ -20,7 +20,8 @@ type PlanParams struct {
 // For more details see https://stripe.com/docs/api#list_plans.
 type PlanListParams struct {
 	ListParams
-	Created *RangeQueryParams
+	Created      int64
+	CreatedRange *RangeQueryParams
 }
 
 // Plan is the resource representing a Stripe plan.

--- a/plan/client.go
+++ b/plan/client.go
@@ -151,8 +151,12 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.Created != nil {
-			params.Created.AppendTo(body, "created")
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
 		}
 
 		params.AppendTo(body)

--- a/plan/client.go
+++ b/plan/client.go
@@ -151,6 +151,10 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
+		if params.Created != nil {
+			params.Created.AppendTo(body, "created")
+		}
+
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()

--- a/sub.go
+++ b/sub.go
@@ -45,10 +45,12 @@ type SubItemsParams struct {
 // For more details see https://stripe.com/docs/api#list_subscriptions.
 type SubListParams struct {
 	ListParams
-	Customer string
-	Plan     string
-	Status   SubStatus
-	Billing  SubBilling
+	Created      int64
+	CreatedRange *RangeQueryParams
+	Customer     string
+	Plan         string
+	Status       SubStatus
+	Billing      SubBilling
 }
 
 // Sub is the resource representing a Stripe subscription.

--- a/sub/client.go
+++ b/sub/client.go
@@ -282,6 +282,14 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
+		}
+
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
 		}

--- a/transfer.go
+++ b/transfer.go
@@ -32,7 +32,8 @@ type TransferParams struct {
 type TransferListParams struct {
 	ListParams
 	Amount        int64
-	Created       *RangeQueryParams
+	Created       int64
+	CreatedRange  *RangeQueryParams
 	Currency      Currency
 	Dest          string
 	TransferGroup string

--- a/transfer.go
+++ b/transfer.go
@@ -32,7 +32,7 @@ type TransferParams struct {
 type TransferListParams struct {
 	ListParams
 	Amount        int64
-	Created       int64
+	Created       *RangeQueryParams
 	Currency      Currency
 	Dest          string
 	TransferGroup string

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -114,8 +114,8 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.Created > 0 {
-			body.Add("created", strconv.FormatInt(params.Created, 10))
+		if params.Created != nil {
+			params.Created.AppendTo(body, "created")
 		}
 
 		if params.Currency != "" {

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -114,8 +114,12 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 	if params != nil {
 		body = &stripe.RequestValues{}
 
-		if params.Created != nil {
-			params.Created.AppendTo(body, "created")
+		if params.Created > 0 {
+			body.Add("created", strconv.FormatInt(params.Created, 10))
+		}
+
+		if params.CreatedRange != nil {
+			params.CreatedRange.AppendTo(body, "created")
 		}
 
 		if params.Currency != "" {


### PR DESCRIPTION
Adds support for "range queries" (the naming comes from the API's
internals) for list endpoints. These are for timestamp parameters that
filter a list by time based on fields like greater than, lesser than or
equal, etc.

~~This patch in particular adds support to event's `created` parameter,
but it's generic enough to extend into other resources.~~ I tried to go
through and add range queries everywhere that they belong. The one 
exception are the four ranges under order's `status_transitions`
subparam, which I decided to skip for now.

This is a breaking change.

Fixes #434.