### PR TITLE
Compile all tests in CI (even if they're not run)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ check-gofmt:
 	scripts/check_gofmt.sh
 
 checkin:
-	STRIPE_KEY=$(STRIPE_KEY) go test -run "TestCheckin*" ./client
+	STRIPE_KEY=$(STRIPE_KEY) go test -run "TestCheckin*" ./...
 
 test:
 	STRIPE_KEY=$(STRIPE_KEY) go test ./... -p=1

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -93,7 +93,7 @@ func TestCustomerNewWithPlan(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = plan.Del(planParams.ID)
+	_, err = plan.Del(planParams.ID, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/ephemeralkey/client_test.go
+++ b/ephemeralkey/client_test.go
@@ -7,7 +7,6 @@ import (
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/customer"
-	"github.com/stripe/stripe-go/ephemeralkey"
 	. "github.com/stripe/stripe-go/utils"
 )
 
@@ -21,7 +20,7 @@ func TestEphemeralKeyCreate(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 
-	k, err := ephemeralkey.New(&stripe.EphemeralKeyParams{
+	k, err := New(&stripe.EphemeralKeyParams{
 		Customer:      cust.ID,
 		StripeVersion: "2017-05-25",
 	})
@@ -41,7 +40,7 @@ func TestEphemeralKeyCreate(t *testing.T) {
 		t.Fatal("Incorrect associated object Type for ephkey")
 	}
 
-	k, err = ephemeralkey.New(&stripe.EphemeralKeyParams{
+	k, err = New(&stripe.EphemeralKeyParams{
 		Customer: cust.ID,
 	})
 	if err.Error() != "params.StripeVersion must be specified" {
@@ -75,7 +74,7 @@ func TestEphemeralKeyDelete(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 
-	k, err := ephemeralkey.New(&stripe.EphemeralKeyParams{
+	k, err := New(&stripe.EphemeralKeyParams{
 		Customer:      cust.ID,
 		StripeVersion: "2017-05-25",
 	})
@@ -83,7 +82,7 @@ func TestEphemeralKeyDelete(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 
-	k, err = ephemeralkey.Del(k.ID)
+	k, err = Del(k.ID)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/loginlink/client_test.go
+++ b/loginlink/client_test.go
@@ -1,8 +1,6 @@
 package loginlink
 
 import (
-	"testing"
-
 	stripe "github.com/stripe/stripe-go"
 	. "github.com/stripe/stripe-go/utils"
 )

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -34,7 +34,7 @@ func TestRefundNew(t *testing.T) {
 		t.Error(err)
 	}
 
-	if ref.Charge != res.ID {
+	if ref.Charge.ID != res.ID {
 		t.Errorf("Refund charge %q does not match expected value %v\n", ref.Charge, res.ID)
 	}
 
@@ -64,7 +64,7 @@ func TestRefundNew(t *testing.T) {
 		t.Errorf("Refund transaction not set\n")
 	}
 
-	if target.Refunds.Values[0].Charge != target.ID {
+	if target.Refunds.Values[0].Charge.ID != target.ID {
 		t.Errorf("Refund charge %q does not match expected value %v\n", target.Refunds.Values[0].Charge, target.ID)
 	}
 
@@ -137,7 +137,7 @@ func TestRefundGet(t *testing.T) {
 		t.Error(err)
 	}
 
-	if target.Charge != ch.ID {
+	if target.Charge.ID != ch.ID {
 		t.Errorf("Refund charge %q does not match expected value %v\n", target.Charge, ch.ID)
 	}
 }
@@ -173,7 +173,7 @@ func TestRefundListByCharge(t *testing.T) {
 			t.Errorf("Amount %v does not match expected value\n", target.Amount)
 		}
 
-		if target.Charge != ch.ID {
+		if target.Charge.ID != ch.ID {
 			t.Errorf("Refund charge %q does not match expected value %q\n", target.Charge, ch.ID)
 		}
 

--- a/reversal/client_test.go
+++ b/reversal/client_test.go
@@ -1,14 +1,7 @@
 package reversal
 
 import (
-	"fmt"
-	"testing"
-
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/charge"
-	"github.com/stripe/stripe-go/currency"
-	"github.com/stripe/stripe-go/recipient"
-	"github.com/stripe/stripe-go/transfer"
 	. "github.com/stripe/stripe-go/utils"
 )
 
@@ -16,6 +9,9 @@ func init() {
 	stripe.Key = GetTestKey()
 }
 
+// These tests need to be refactored to no longer use recipients. Create
+// transfers for a target account instead.
+/*
 func TestReversalNew(t *testing.T) {
 	chargeParams := &stripe.ChargeParams{
 		Amount:   1000,
@@ -98,3 +94,4 @@ func TestReversalGet(t *testing.T) {
 
 	fmt.Printf("%+v\n", target)
 }
+*/

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -76,7 +76,7 @@ func TestSubscriptionNew(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 }
 
 func TestSubscriptionZeroQuantity(t *testing.T) {
@@ -121,7 +121,7 @@ func TestSubscriptionZeroQuantity(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 }
 
 func TestSubscriptionUpdateZeroQuantity(t *testing.T) {
@@ -169,7 +169,7 @@ func TestSubscriptionUpdateZeroQuantity(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 }
 
 func TestSubscriptionGet(t *testing.T) {
@@ -216,7 +216,7 @@ func TestSubscriptionGet(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 }
 
 func TestSubscriptionCancel(t *testing.T) {
@@ -264,7 +264,7 @@ func TestSubscriptionCancel(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 }
 
 func TestSubscriptionUpdate(t *testing.T) {
@@ -322,7 +322,7 @@ func TestSubscriptionUpdate(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 }
 
 func TestSubscriptionDiscount(t *testing.T) {
@@ -391,7 +391,7 @@ func TestSubscriptionDiscount(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 	coupon.Del("sub_coupon")
 }
 
@@ -459,7 +459,7 @@ func TestSubscriptionEmptyDiscount(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 	coupon.Del("sub_coupon")
 }
 
@@ -578,5 +578,5 @@ func TestSubscriptionList(t *testing.T) {
 	}
 
 	customer.Del(cust.ID)
-	plan.Del("test")
+	plan.Del("test", nil)
 }

--- a/webhook/client_handler_test.go
+++ b/webhook/client_handler_test.go
@@ -1,11 +1,12 @@
-package webhook
+package webhook_test
 
 import (
 	"fmt"
-	"github.com/stripe/stripe-go/webhook"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/stripe/stripe-go/webhook"
 )
 
 func Example() {


### PR DESCRIPTION
This patch changes the CI based test command from `./client` to `./...`.
For now, the `TestCheckin*` filter is still applied, meaning that no
additional tests are run, but the change is that at least now we try to
compile every single subpackage in the project.

It turns out that there were quite a few basic syntax errors that had
creeped into various packages, and even on some of our newer ones, which
suggests that people probably aren't even checking tests locally before
sending to CI (meaning that they have never successfully run even one
time).

Anyway, unfortunately this is still far from a perfect fix, but brings
us a step closer to something a little more sane.

r? @remi-stripe