### PR TITLE
Introduce new reflection package to do form encoding

### DIFF
--- a/account.go
+++ b/account.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // LegalEntityType describes the types for a legal entity.
@@ -273,7 +275,7 @@ type Address struct {
 	Town string `json:"town"`
 }
 
-func (a *Address) AppendDetails(values *RequestValues, prefix string) {
+func (a *Address) AppendDetails(values *form.Values, prefix string) {
 	if len(a.Line1) > 0 {
 		values.Add(prefix+"[line1]", a.Line1)
 	}
@@ -359,7 +361,7 @@ type AccountRejectParams struct {
 }
 
 // AppendDetails adds the legal entity to the query string.
-func (l *LegalEntity) AppendDetails(values *RequestValues) {
+func (l *LegalEntity) AppendDetails(values *form.Values) {
 	if len(l.Type) > 0 {
 		values.Add("legal_entity[type]", string(l.Type))
 	}
@@ -487,7 +489,7 @@ func (l *LegalEntity) AppendDetails(values *RequestValues) {
 }
 
 // AppendDetails adds the payout schedule to the query string.
-func (t *PayoutScheduleParams) AppendDetails(values *RequestValues) {
+func (t *PayoutScheduleParams) AppendDetails(values *form.Values) {
 	if t.Delay > 0 {
 		values.Add("payout_schedule[delay_days]", strconv.FormatUint(t.Delay, 10))
 	} else if t.MinimumDelay {
@@ -503,7 +505,7 @@ func (t *PayoutScheduleParams) AppendDetails(values *RequestValues) {
 }
 
 // AppendDetails adds the terms of service acceptance to the query string.
-func (t *TOSAcceptanceParams) AppendDetails(values *RequestValues) {
+func (t *TOSAcceptanceParams) AppendDetails(values *form.Values) {
 	if t.Date > 0 {
 		values.Add("tos_acceptance[date]", strconv.FormatInt(t.Date, 10))
 	}

--- a/account/client.go
+++ b/account/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /account APIs.
@@ -19,7 +20,7 @@ func New(params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func writeAccountParams(
-	params *stripe.AccountParams, body *stripe.RequestValues,
+	params *stripe.AccountParams, body *form.Values,
 ) {
 	if len(params.Country) > 0 {
 		body.Add("country", params.Country)
@@ -104,7 +105,7 @@ func writeAccountParams(
 }
 
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	// Type is now required on creation and not allowed on update
 	// It can't be passed if you pass `from_recipient` though
@@ -144,12 +145,12 @@ func GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func (c Client) GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -165,12 +166,12 @@ func Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		writeAccountParams(params, body)
 
@@ -205,7 +206,7 @@ func Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, err
 }
 
 func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	if len(params.Reason) > 0 {
 		body.Add("reason", params.Reason)
 	}
@@ -221,19 +222,19 @@ func List(params *stripe.AccountListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.AccountListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.AccountList{}
 		err := c.B.Call("GET", "/accounts", c.Key, b, p, list)
 

--- a/account_test.go
+++ b/account_test.go
@@ -3,6 +3,8 @@ package stripe
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 func TestAccountUnmarshal(t *testing.T) {
@@ -66,8 +68,8 @@ func TestAccountUnmarshal(t *testing.T) {
 }
 
 func TestAddressAppendDetails(t *testing.T) {
-	actual := &RequestValues{}
-	expected := &RequestValues{}
+	actual := &form.Values{}
+	expected := &form.Values{}
 
 	address := &Address{}
 	address.AppendDetails(actual, "test_address")

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -3,6 +3,7 @@ package applepaydomain
 
 import (
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /apple_pay/domains and ApplePayDomain-related APIs.
@@ -17,7 +18,7 @@ func New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 }
 
 func (c Client) New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("domain_name", params.DomainName)
 
 	params.AppendTo(body)
@@ -33,11 +34,11 @@ func Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 }
 
 func (c Client) Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 		params.AppendTo(body)
 	}
@@ -66,19 +67,19 @@ func List(params *stripe.ApplePayDomainListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ApplePayDomainListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplePayDomainList{}
 		err := c.B.Call("GET", "/apple_pay/domains", c.Key, b, p, list)
 

--- a/balance/client.go
+++ b/balance/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -39,12 +40,12 @@ func Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 }
 
 func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -61,12 +62,12 @@ func GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, error) {
 }
 
 func (c Client) GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -83,12 +84,12 @@ func List(params *stripe.TxListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.TxListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -126,7 +127,7 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TransactionList{}
 		err := c.B.Call("GET", "/balance/history", c.Key, b, p, list)
 

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -3,6 +3,8 @@ package stripe
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // BankAccountStatus is the list of allowed values for the bank account's status.
@@ -72,7 +74,7 @@ func (b *BankAccount) Display() string {
 }
 
 // AppendDetails adds the bank account's details to the query string values.
-func (b *BankAccountParams) AppendDetails(values *RequestValues) {
+func (b *BankAccountParams) AppendDetails(values *form.Values) {
 	values.Add("bank_account[country]", b.Country)
 	if len(b.Routing) > 0 {
 		values.Add("bank_account[routing_number]", b.Routing)

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /bank_accounts APIs.
@@ -29,7 +30,7 @@ func New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 
 func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	isCustomer := len(params.Customer) > 0
 
 	var sourceType string
@@ -84,12 +85,12 @@ func Get(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 }
 
 func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -113,12 +114,12 @@ func Update(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, e
 }
 
 func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Default {
 			body.Add("default_for_currency", strconv.FormatBool(params.Default))
@@ -167,7 +168,7 @@ func List(params *stripe.BankAccountListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.BankAccountListParams) *Iter {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -175,7 +176,7 @@ func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BankAccountList{}
 		var err error
 

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /bitcoin/receivers APIs.
@@ -21,7 +22,7 @@ func New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) 
 }
 
 func (c Client) New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("amount", strconv.FormatUint(params.Amount, 10))
 	body.Add("currency", string(params.Currency))
 
@@ -69,7 +70,7 @@ func Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.Bitc
 }
 
 func (c Client) Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.BitcoinReceiver, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	if len(params.Desc) > 0 {
 		body.Add("description", params.Desc)
@@ -98,12 +99,12 @@ func List(params *stripe.BitcoinReceiverListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		body.Add("filled", strconv.FormatBool(!params.NotFilled))
 		body.Add("active", strconv.FormatBool(!params.NotActive))
@@ -114,7 +115,7 @@ func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinReceiverList{}
 		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, b, p, list)
 

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /bitcoin/receivers/:receiver_id/transactions APIs.
@@ -20,12 +21,12 @@ func List(params *stripe.BitcoinTransactionListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
@@ -36,7 +37,7 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinTransactionList{}
 		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, b, p, list)
 

--- a/card.go
+++ b/card.go
@@ -2,8 +2,9 @@ package stripe
 
 import (
 	"encoding/json"
-
 	"fmt"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // CardBrand is the list of allowed values for the card's brand.
@@ -100,7 +101,7 @@ type CardList struct {
 // AppendDetails adds the card's details to the query string values.
 // When creating a new card, the parameters are passed as a dictionary, but
 // on updates they are simply the parameter name.
-func (c *CardParams) AppendDetails(values *RequestValues, creating bool) {
+func (c *CardParams) AppendDetails(values *form.Values, creating bool) {
 	if creating {
 		if len(c.Token) > 0 && len(c.Account) > 0 {
 			values.Add("external_account", c.Token)

--- a/card/client.go
+++ b/card/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -41,7 +42,7 @@ func New(params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	params.AppendDetails(body, true)
 	params.AppendTo(body)
 
@@ -71,12 +72,12 @@ func Get(id string, params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -103,7 +104,7 @@ func Update(id string, params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	params.AppendDetails(body, false)
 	params.AppendTo(body)
 
@@ -156,7 +157,7 @@ func List(params *stripe.CardListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CardListParams) *Iter {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -164,7 +165,7 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CardList{}
 		var err error
 

--- a/charge.go
+++ b/charge.go
@@ -2,6 +2,8 @@ package stripe
 
 import (
 	"encoding/json"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // Currency is the list of supported currencies.
@@ -138,7 +140,7 @@ type ShippingDetails struct {
 }
 
 // AppendDetails adds the shipping details to the query string.
-func (s *ShippingDetails) AppendDetails(values *RequestValues) {
+func (s *ShippingDetails) AppendDetails(values *form.Values) {
 	values.Add("shipping[name]", s.Name)
 
 	values.Add("shipping[address][line1]", s.Address.Line1)

--- a/charge/client.go
+++ b/charge/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -27,7 +28,7 @@ func New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("amount", strconv.FormatUint(params.Amount, 10))
 	body.Add("currency", string(params.Currency))
 
@@ -107,12 +108,12 @@ func Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -129,12 +130,12 @@ func Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Desc) > 0 {
 			body.Add("description", params.Desc)
@@ -160,13 +161,13 @@ func Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	token := c.Key
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Amount > 0 {
 			body.Add("amount", strconv.FormatUint(params.Amount, 10))
@@ -201,12 +202,12 @@ func List(params *stripe.ChargeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ChargeListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -229,7 +230,7 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ChargeList{}
 		err := c.B.Call("GET", "/charges", c.Key, b, p, list)
 
@@ -271,12 +272,12 @@ func UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, er
 }
 
 func (c Client) UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Evidence != nil {
 			params.Evidence.AppendDetails(body)

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -3,6 +3,7 @@ package countryspec
 
 import (
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /country_specs and countryspec-related APIs.
@@ -30,19 +31,19 @@ func List(params *stripe.CountrySpecListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CountrySpecListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CountrySpecList{}
 		err := c.B.Call("GET", "/country_specs", c.Key, b, p, list)
 

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -30,7 +31,7 @@ func New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 	// TODO: this doesn't check that the params are not nil.
 
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("duration", string(params.Duration))
 
 	if len(params.ID) > 0 {
@@ -75,12 +76,12 @@ func Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -98,7 +99,7 @@ func Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 }
 
 func (c Client) Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	params.AppendTo(body)
 
@@ -128,12 +129,12 @@ func List(params *stripe.CouponListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CouponListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -148,7 +149,7 @@ func (c Client) List(params *stripe.CouponListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CouponList{}
 		err := c.B.Call("GET", "/coupons", c.Key, b, p, list)
 

--- a/customer.go
+++ b/customer.go
@@ -2,6 +2,8 @@ package stripe
 
 import (
 	"encoding/json"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
@@ -75,7 +77,7 @@ type CustomerShippingDetails struct {
 }
 
 // AppendDetails adds the shipping details to the query string.
-func (s *CustomerShippingDetails) AppendDetails(values *RequestValues) {
+func (s *CustomerShippingDetails) AppendDetails(values *form.Values) {
 	values.Add("shipping[name]", s.Name)
 
 	values.Add("shipping[address][line1]", s.Address.Line1)

--- a/customer/client.go
+++ b/customer/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /customers APIs.
@@ -20,11 +21,11 @@ func New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 }
 
 func (c Client) New(params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		if params.Balance != 0 {
 			body.Add("account_balance", strconv.FormatInt(params.Balance, 10))
 		}
@@ -89,11 +90,11 @@ func Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 		params.AppendTo(body)
 	}
@@ -111,12 +112,12 @@ func Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) 
 }
 
 func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Balance != 0 {
 			body.Add("account_balance", strconv.FormatInt(params.Balance, 10))
@@ -182,12 +183,12 @@ func List(params *stripe.CustomerListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.CustomerListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -202,7 +203,7 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CustomerList{}
 		err := c.B.Call("GET", "/customers", c.Key, b, p, list)
 

--- a/dispute.go
+++ b/dispute.go
@@ -2,6 +2,8 @@ package stripe
 
 import (
 	"encoding/json"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // DisputeReason is the list of allowed values for a discount's reason.
@@ -150,7 +152,7 @@ type File struct {
 }
 
 // AppendDetails adds the dispute evidence details to the query string values.
-func (e *DisputeEvidenceParams) AppendDetails(values *RequestValues) {
+func (e *DisputeEvidenceParams) AppendDetails(values *form.Values) {
 	if len(e.ProductDesc) > 0 {
 		values.Add("evidence[product_description]", e.ProductDesc)
 	}

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -41,12 +42,12 @@ func Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 }
 
 func (c Client) Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -63,12 +64,12 @@ func List(params *stripe.DisputeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.DisputeListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -83,7 +84,7 @@ func (c Client) List(params *stripe.DisputeListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.DisputeList{}
 		err := c.B.Call("GET", "/disputes", c.Key, b, p, list)
 
@@ -116,12 +117,12 @@ func Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 }
 
 func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Evidence != nil {
 			params.Evidence.AppendDetails(body)

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /ephemeral_keys APIs.
@@ -27,7 +28,7 @@ func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 		return nil, fmt.Errorf("params.StripeVersion must be specified")
 	}
 
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	if len(params.Customer) > 0 {
 		body.Add("customer", params.Customer)

--- a/event/client.go
+++ b/event/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /events APIs.
@@ -33,12 +34,12 @@ func List(params *stripe.EventListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.EventListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -57,7 +58,7 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.EventList{}
 		err := c.B.Call("GET", "/events", c.Key, b, p, list)
 

--- a/fee/client.go
+++ b/fee/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke application_fees APIs.
@@ -21,12 +22,12 @@ func Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
 }
 
 func (c Client) Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -43,12 +44,12 @@ func List(params *stripe.FeeListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.FeeListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -63,7 +64,7 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeList{}
 		err := c.B.Call("GET", "/application_fees", c.Key, b, p, list)
 

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /application_fees/refunds APIs.
@@ -21,7 +22,7 @@ func New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 }
 
 func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	if params.Amount > 0 {
 		body.Add("amount", strconv.FormatUint(params.Amount, 10))
@@ -46,7 +47,7 @@ func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefun
 		return nil, fmt.Errorf("params cannot be nil, and params.Fee must be set")
 	}
 
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	params.AppendTo(body)
 
 	refund := &stripe.FeeRefund{}
@@ -62,7 +63,7 @@ func Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error
 }
 
 func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	params.AppendTo(body)
 
 	refund := &stripe.FeeRefund{}
@@ -78,7 +79,7 @@ func List(params *stripe.FeeRefundListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -86,7 +87,7 @@ func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeRefundList{}
 		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.Fee), c.Key, b, p, list)
 

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -51,13 +52,13 @@ func Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error)
 }
 
 func (c Client) Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
 
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -74,12 +75,12 @@ func List(params *stripe.FileUploadListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.FileUploadListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -98,7 +99,7 @@ func (c Client) List(params *stripe.FileUploadListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FileUploadList{}
 		err := c.B.Call("GET", "/files", c.Key, b, p, list)
 

--- a/form/form.go
+++ b/form/form.go
@@ -67,7 +67,19 @@ func reflectValue(values *RequestValues, val reflect.Value, names []string) {
 		values.Add(formatName(names), strconv.FormatInt(val.Int(), 10))
 
 	case reflect.Interface:
-		panic("Interfaces not handled by encoder")
+		if val.IsNil() {
+			return
+		}
+		reflectValue(values, val.Elem(), names)
+
+	case reflect.Map:
+		for _, keyVal := range val.MapKeys() {
+			if keyVal.Kind() != reflect.String {
+				panic("Don't support serializing maps with non-string keys")
+			}
+
+			reflectValue(values, val.MapIndex(keyVal), append(names, keyVal.String()))
+		}
 
 	case reflect.String:
 		values.Add(formatName(names), val.String())

--- a/form/form.go
+++ b/form/form.go
@@ -31,6 +31,11 @@ func reflectValue(values *RequestValues, val reflect.Value, names []string) {
 		val = val.Elem()
 	}
 
+	// Do nothing if this is a zero value
+	if !val.IsValid() {
+		return
+	}
+
 	t := val.Type()
 
 	switch val.Kind() {

--- a/form/form.go
+++ b/form/form.go
@@ -27,16 +27,6 @@ func formatName(names []string) string {
 }
 
 func reflectValue(values *RequestValues, val reflect.Value, names []string) {
-	// Dereference a pointer if necessary
-	if val.Kind() == reflect.Ptr {
-		val = val.Elem()
-	}
-
-	// Do nothing if this is a nil pointer
-	if !val.IsValid() {
-		return
-	}
-
 	t := val.Type()
 
 	// Also do nothing if this is the type's zero value
@@ -80,6 +70,12 @@ func reflectValue(values *RequestValues, val reflect.Value, names []string) {
 
 			reflectValue(values, val.MapIndex(keyVal), append(names, keyVal.String()))
 		}
+
+	case reflect.Ptr:
+		if val.IsNil() {
+			return
+		}
+		reflectValue(values, val.Elem(), names)
 
 	case reflect.String:
 		values.Add(formatName(names), val.String())

--- a/form/form.go
+++ b/form/form.go
@@ -10,7 +10,6 @@ import (
 const tagName = "form"
 
 func AppendTo(values *RequestValues, i interface{}) {
-	//v := reflect.ValueOf(i).Elem()
 	reflectValue(values, reflect.ValueOf(i), nil)
 }
 

--- a/form/form.go
+++ b/form/form.go
@@ -1,0 +1,146 @@
+package form
+
+import (
+	"bytes"
+	"net/url"
+	"reflect"
+)
+
+const tagName = "form"
+
+func AppendTo(values *RequestValues, i interface{}) {
+	//v := reflect.ValueOf(i).Elem()
+	reflectValue(values, reflect.ValueOf(i), nil)
+}
+
+func formatName(names []string) string {
+	if len(names) < 1 {
+		panic("Not allowed 0-length names slice")
+	}
+
+	fullName := names[0]
+	for i := 1; i < len(names); i++ {
+		fullName += "[" + names[i] + "]"
+	}
+	return fullName
+}
+
+func reflectValue(values *RequestValues, val reflect.Value, names []string) {
+	// Dereference a pointer if necessary
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	t := val.Type()
+
+	switch val.Kind() {
+	case reflect.String:
+		values.Add(formatName(names), val.Interface().(string))
+
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			tag := field.Tag.Get(tagName)
+			if tag == "" {
+				continue
+			}
+			formName := tag
+			reflectValue(values, val.Field(i), append(names, formName))
+		}
+	}
+
+}
+
+// ---
+
+// RequestValues is a collection of values that can be submitted along with a
+// request that specifically allows for duplicate keys and encodes its entries
+// in the same order that they were added.
+type RequestValues struct {
+	values []formValue
+}
+
+// Add adds a key/value tuple to the form.
+func (f *RequestValues) Add(key, val string) {
+	f.values = append(f.values, formValue{key, val})
+}
+
+// Encode encodes the values into “URL encoded” form ("bar=baz&foo=quux").
+func (f *RequestValues) Encode() string {
+	var buf bytes.Buffer
+	for _, v := range f.values {
+		if buf.Len() > 0 {
+			buf.WriteByte('&')
+		}
+		buf.WriteString(url.QueryEscape(v.Key))
+		buf.WriteString("=")
+		buf.WriteString(url.QueryEscape(v.Value))
+	}
+	return buf.String()
+}
+
+// Empty returns true if no parameters have been set.
+func (f *RequestValues) Empty() bool {
+	return len(f.values) == 0
+}
+
+// Set sets the first instance of a parameter for the given key to the given
+// value. If no parameters exist with the key, a new one is added.
+//
+// Note that Set is O(n) and may be quite slow for a very large parameter list.
+func (f *RequestValues) Set(key, val string) {
+	for i, v := range f.values {
+		if v.Key == key {
+			f.values[i].Value = val
+			return
+		}
+	}
+
+	f.Add(key, val)
+}
+
+// Get retrieves the list of values for the given key.  If no values exist
+// for the key, nil will be returned.
+//
+// Note that Get is O(n) and may be quite slow for a very large parameter list.
+func (f *RequestValues) Get(key string) []string {
+	var results []string
+	for i, v := range f.values {
+		if v.Key == key {
+			results = append(results, f.values[i].Value)
+		}
+	}
+	return results
+}
+
+// ToValues converts an instance of RequestValues into an instance of
+// url.Values. This can be useful in cases where it's useful to make an
+// unordered comparison of two sets of request values.
+//
+// Note that url.Values is incapable of representing certain Rack form types in
+// a cohesive way. For example, an array of maps in Rack is encoded with a
+// string like:
+//
+//     arr[][foo]=foo0&arr[][bar]=bar0&arr[][foo]=foo1&arr[][bar]=bar1
+//
+// Because url.Values is a map, values will be handled in a way that's grouped
+// by their key instead of in the order they were added. Therefore the above
+// may by encoded to something like (maps are unordered so the actual result is
+// somewhat non-deterministic):
+//
+//     arr[][foo]=foo0&arr[][foo]=foo1&arr[][bar]=bar0&arr[][bar]=bar1
+//
+// And thus result in an incorrect request to Stripe.
+func (f *RequestValues) ToValues() url.Values {
+	values := url.Values{}
+	for _, v := range f.values {
+		values.Add(v.Key, v.Value)
+	}
+	return values
+}
+
+// A key/value tuple for use in the RequestValues type.
+type formValue struct {
+	Key   string
+	Value string
+}

--- a/form/form.go
+++ b/form/form.go
@@ -15,6 +15,12 @@ type formOptions struct {
 	// encoding, array items should be index like `arr[0]=...&arr[1]=...`
 	// (normally it'd be `arr[]=...`).
 	IndexedArray bool
+
+	// Zero indicates a field that's specifically defined to workaround the
+	// fact because 0 is the "zero value" of all int/float types, we can't
+	// properly encode an explicit 0. It indicates that an explicit zero should
+	// be sent.
+	Zero bool
 }
 
 func AppendTo(values *RequestValues, i interface{}) {
@@ -122,6 +128,12 @@ func parseTag(tag string) (string, *formOptions) {
 				options = &formOptions{}
 			}
 			options.IndexedArray = true
+
+		case "zero":
+			if options == nil {
+				options = &formOptions{}
+			}
+			options.Zero = true
 		}
 	}
 

--- a/form/form.go
+++ b/form/form.go
@@ -111,18 +111,21 @@ func reflectValue(values *RequestValues, val reflect.Value, names []string, opti
 }
 
 func parseTag(tag string) (string, *formOptions) {
+	var options *formOptions
 	parts := strings.Split(tag, ",")
-	formName := parts[0]
-	options := &formOptions{}
+	name := parts[0]
 
 	for i := 1; i < len(parts); i++ {
 		switch parts[i] {
 		case "indexed":
+			if options == nil {
+				options = &formOptions{}
+			}
 			options.IndexedArray = true
 		}
 	}
 
-	return formName, options
+	return name, options
 }
 
 // ---

--- a/form/form.go
+++ b/form/form.go
@@ -34,7 +34,7 @@ type formOptions struct {
 	Zero bool
 }
 
-func AppendTo(values *RequestValues, i interface{}) {
+func AppendTo(values *Values, i interface{}) {
 	reflectValue(values, reflect.ValueOf(i), nil, nil)
 }
 
@@ -50,7 +50,7 @@ func formatName(names []string) string {
 	return fullName
 }
 
-func reflectValue(values *RequestValues, val reflect.Value, names []string, options *formOptions) {
+func reflectValue(values *Values, val reflect.Value, names []string, options *formOptions) {
 	t := val.Type()
 
 	// Also do nothing if this is the type's zero value
@@ -186,20 +186,20 @@ func parseTag(tag string) (string, *formOptions) {
 
 // ---
 
-// RequestValues is a collection of values that can be submitted along with a
+// Values is a collection of values that can be submitted along with a
 // request that specifically allows for duplicate keys and encodes its entries
 // in the same order that they were added.
-type RequestValues struct {
+type Values struct {
 	values []formValue
 }
 
 // Add adds a key/value tuple to the form.
-func (f *RequestValues) Add(key, val string) {
+func (f *Values) Add(key, val string) {
 	f.values = append(f.values, formValue{key, val})
 }
 
 // Encode encodes the values into “URL encoded” form ("bar=baz&foo=quux").
-func (f *RequestValues) Encode() string {
+func (f *Values) Encode() string {
 	var buf bytes.Buffer
 	for _, v := range f.values {
 		if buf.Len() > 0 {
@@ -213,7 +213,7 @@ func (f *RequestValues) Encode() string {
 }
 
 // Empty returns true if no parameters have been set.
-func (f *RequestValues) Empty() bool {
+func (f *Values) Empty() bool {
 	return len(f.values) == 0
 }
 
@@ -221,7 +221,7 @@ func (f *RequestValues) Empty() bool {
 // value. If no parameters exist with the key, a new one is added.
 //
 // Note that Set is O(n) and may be quite slow for a very large parameter list.
-func (f *RequestValues) Set(key, val string) {
+func (f *Values) Set(key, val string) {
 	for i, v := range f.values {
 		if v.Key == key {
 			f.values[i].Value = val
@@ -236,7 +236,7 @@ func (f *RequestValues) Set(key, val string) {
 // for the key, nil will be returned.
 //
 // Note that Get is O(n) and may be quite slow for a very large parameter list.
-func (f *RequestValues) Get(key string) []string {
+func (f *Values) Get(key string) []string {
 	var results []string
 	for i, v := range f.values {
 		if v.Key == key {
@@ -246,7 +246,7 @@ func (f *RequestValues) Get(key string) []string {
 	return results
 }
 
-// ToValues converts an instance of RequestValues into an instance of
+// ToValues converts an instance of Values into an instance of
 // url.Values. This can be useful in cases where it's useful to make an
 // unordered comparison of two sets of request values.
 //
@@ -264,7 +264,7 @@ func (f *RequestValues) Get(key string) []string {
 //     arr[][foo]=foo0&arr[][foo]=foo1&arr[][bar]=bar0&arr[][bar]=bar1
 //
 // And thus result in an incorrect request to Stripe.
-func (f *RequestValues) ToValues() url.Values {
+func (f *Values) ToValues() url.Values {
 	values := url.Values{}
 	for _, v := range f.values {
 		values.Add(v.Key, v.Value)
@@ -272,7 +272,7 @@ func (f *RequestValues) ToValues() url.Values {
 	return values
 }
 
-// A key/value tuple for use in the RequestValues type.
+// A key/value tuple for use in the Values type.
 type formValue struct {
 	Key   string
 	Value string

--- a/form/form.go
+++ b/form/form.go
@@ -40,13 +40,19 @@ func reflectValue(values *RequestValues, val reflect.Value, names []string) {
 	t := val.Type()
 
 	// Also do nothing if this is the type's zero value
-	if val.Interface() == reflect.Zero(t).Interface() {
+	if t.Comparable() && val.Interface() == reflect.Zero(t).Interface() {
 		return
 	}
 
 	switch val.Kind() {
-	case reflect.Array:
-		panic("Arrays not handled by encoder")
+	case reflect.Array, reflect.Slice:
+		// formatName automatically adds square brackets, so just pass an empty
+		// string into the breadcrumb trail
+		arrNames := append(names, "")
+
+		for i := 0; i < val.Len(); i++ {
+			reflectValue(values, val.Index(i), arrNames)
+		}
 
 	case reflect.Bool:
 		values.Add(formatName(names), strconv.FormatBool(val.Bool()))

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -10,6 +10,9 @@ type testStruct struct {
 	Array    [3]string  `form:"array"`
 	ArrayPtr *[3]string `form:"array_ptr"`
 
+	ArrayIndexed    [3]string  `form:"array_indexed,indexed"`
+	ArrayIndexedPtr *[3]string `form:"array_indexed_ptr,indexed"`
+
 	Bool    bool  `form:"bool"`
 	BoolPtr *bool `form:"bool_ptr"`
 
@@ -38,6 +41,9 @@ type testStruct struct {
 	String    string  `form:"string"`
 	StringPtr *string `form:"string_ptr"`
 
+	SliceIndexed    []string  `form:"slice_indexed,indexed"`
+	SliceIndexedPtr *[]string `form:"slice_indexed_ptr,indexed"`
+
 	SubStruct    testSubStruct  `form:"substruct"`
 	SubStructPtr *testSubStruct `form:"substruct_ptr"`
 
@@ -62,6 +68,8 @@ type testSubSubStruct struct {
 }
 
 func TestAppendTo(t *testing.T) {
+	var arrayVal [3]string = [3]string{"1", "2", "3"}
+
 	var boolVal bool = true
 
 	var float32Val float32 = 1.2345
@@ -73,6 +81,8 @@ func TestAppendTo(t *testing.T) {
 	var int16Val int16 = 123
 	var int32Val int32 = 123
 	var int64Val int64 = 123
+
+	var sliceVal []string = []string{"1", "2", "3"}
 
 	var stringVal string = "123"
 
@@ -93,6 +103,8 @@ func TestAppendTo(t *testing.T) {
 		data  *testStruct
 		want  interface{}
 	}{
+		{"array_indexed[2]", &testStruct{ArrayIndexed: arrayVal}, "3"},
+
 		{"bool", &testStruct{Bool: boolVal}, "true"},
 		{"bool_ptr", &testStruct{BoolPtr: &boolVal}, "true"},
 
@@ -130,6 +142,8 @@ func TestAppendTo(t *testing.T) {
 			}},
 			"baz",
 		},
+
+		{"slice_indexed[2]", &testStruct{SliceIndexed: sliceVal}, "3"},
 
 		{"string", &testStruct{String: stringVal}, stringVal},
 		{"string_ptr", &testStruct{StringPtr: &stringVal}, stringVal},

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -1,33 +1,141 @@
 package form
 
 import (
-	"fmt"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 )
 
 type testStruct struct {
+	Bool    bool  `form:"bool"`
+	BoolPtr *bool `form:"bool_ptr"`
+
+	Float32    float32  `form:"float32"`
+	Float32Ptr *float32 `form:"float32_ptr"`
+
+	Float64    float64  `form:"float64"`
+	Float64Ptr *float64 `form:"float64_ptr"`
+
+	Int      int    `form:"int"`
+	IntPtr   *int   `form:"int_ptr"`
+	Int8     int8   `form:"int8"`
+	Int8Ptr  *int8  `form:"int8_ptr"`
+	Int16    int16  `form:"int16"`
+	Int16Ptr *int16 `form:"int16_ptr"`
+	Int32    int32  `form:"int32"`
+	Int32Ptr *int32 `form:"int32_ptr"`
+	Int64    int64  `form:"int64"`
+	Int64Ptr *int64 `form:"int64_ptr"`
+
+	Uuint      uint    `form:"uint"`
+	UuintPtr   *uint   `form:"uint_ptr"`
+	Uuint8     uint8   `form:"uint8"`
+	Uuint8Ptr  *uint8  `form:"uint8_ptr"`
+	Uuint16    uint16  `form:"uint16"`
+	Uuint16Ptr *uint16 `form:"uint16_ptr"`
+	Uuint32    uint32  `form:"uint32"`
+	Uuint32Ptr *uint32 `form:"uint32_ptr"`
+	Uuint64    uint64  `form:"uint64"`
+	Uuint64Ptr *uint64 `form:"uint64_ptr"`
+
 	String    string  `form:"string"`
 	StringPtr *string `form:"string_ptr"`
+
+	SubStruct    testSubStruct  `form:"substruct"`
+	SubStructPtr *testSubStruct `form:"substruct_ptr"`
+}
+
+type testSubStruct struct {
+	SubSubStruct testSubSubStruct `form:"subsubstruct"`
+}
+
+type testSubSubStruct struct {
+	String string `form:"string"`
 }
 
 func TestAppendTo(t *testing.T) {
-	stringVal := "123"
+	var boolVal bool = true
+
+	var float32Val float32 = 1.2345
+
+	var float64Val float64 = 1.2345
+
+	var intVal int = 123
+	var int8Val int8 = 123
+	var int16Val int16 = 123
+	var int32Val int32 = 123
+	var int64Val int64 = 123
+
+	var uintVal uint = 123
+	var uint8Val uint8 = 123
+	var uint16Val uint16 = 123
+	var uint32Val uint32 = 123
+	var uint64Val uint64 = 123
+
+	var stringVal string = "123"
+
+	var subStructVal testSubStruct = testSubStruct{
+		SubSubStruct: testSubSubStruct{
+			String: "123",
+		},
+	}
 
 	testCases := []struct {
 		field string
 		data  *testStruct
 		want  interface{}
 	}{
+		{"bool", &testStruct{Bool: boolVal}, "true"},
+		{"bool_ptr", &testStruct{BoolPtr: &boolVal}, "true"},
+
+		{"float32", &testStruct{Float32: float32Val}, "1.2345"},
+		{"float32_ptr", &testStruct{Float32Ptr: &float32Val}, "1.2345"},
+
+		{"float64", &testStruct{Float64: float64Val}, "1.2345"},
+		{"float64_ptr", &testStruct{Float64Ptr: &float64Val}, "1.2345"},
+
+		{"int", &testStruct{Int: intVal}, "123"},
+		{"int_ptr", &testStruct{IntPtr: &intVal}, "123"},
+		{"int8", &testStruct{Int8: int8Val}, "123"},
+		{"int8_ptr", &testStruct{Int8Ptr: &int8Val}, "123"},
+		{"int16", &testStruct{Int16: int16Val}, "123"},
+		{"int16_ptr", &testStruct{Int16Ptr: &int16Val}, "123"},
+		{"int32", &testStruct{Int32: int32Val}, "123"},
+		{"int32_ptr", &testStruct{Int32Ptr: &int32Val}, "123"},
+		{"int64", &testStruct{Int64: int64Val}, "123"},
+		{"int64_ptr", &testStruct{Int64Ptr: &int64Val}, "123"},
+
+		{"uint", &testStruct{Uuint: uintVal}, "123"},
+		{"uint_ptr", &testStruct{UuintPtr: &uintVal}, "123"},
+		{"uint8", &testStruct{Uuint8: uint8Val}, "123"},
+		{"uint8_ptr", &testStruct{Uuint8Ptr: &uint8Val}, "123"},
+		{"uint16", &testStruct{Uuint16: uint16Val}, "123"},
+		{"uint16_ptr", &testStruct{Uuint16Ptr: &uint16Val}, "123"},
+		{"uint32", &testStruct{Uuint32: uint32Val}, "123"},
+		{"uint32_ptr", &testStruct{Uuint32Ptr: &uint32Val}, "123"},
+		{"uint64", &testStruct{Uuint64: uint64Val}, "123"},
+		{"uint64_ptr", &testStruct{Uuint64Ptr: &uint64Val}, "123"},
+
 		{"string", &testStruct{String: stringVal}, stringVal},
 		{"string_ptr", &testStruct{StringPtr: &stringVal}, stringVal},
+
+		{"substruct[subsubstruct][string]", &testStruct{SubStruct: subStructVal}, "123"},
+		{"substruct_ptr[subsubstruct][string]", &testStruct{SubStructPtr: &subStructVal}, "123"},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {
 			form := &RequestValues{}
 			AppendTo(form, tc.data)
-			assert.Equal(t, tc.want, form.ToValues().Get(tc.field))
+			values := form.ToValues()
+			//fmt.Printf("values = %+v", values)
+			assert.Equal(t, tc.want, values.Get(tc.field))
 		})
 	}
+}
+
+func TestAppendTo_ZeroValues(t *testing.T) {
+	form := &RequestValues{}
+	data := &testStruct{}
+	AppendTo(form, data)
+	assert.Equal(t, &RequestValues{}, form)
 }

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -176,7 +176,7 @@ func TestAppendTo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {
-			form := &RequestValues{}
+			form := &Values{}
 			AppendTo(form, tc.data)
 			values := form.ToValues()
 			t.Logf("values = %+v", values)
@@ -210,7 +210,7 @@ func TestAppendTo_DuplicatedNames(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {
-			form := &RequestValues{}
+			form := &Values{}
 			AppendTo(form, tc.data)
 			values := form.ToValues()
 			//fmt.Printf("values = %+v", values)
@@ -224,10 +224,10 @@ func TestAppendTo_DuplicatedNames(t *testing.T) {
 }
 
 func TestAppendTo_ZeroValues(t *testing.T) {
-	form := &RequestValues{}
+	form := &Values{}
 	data := &testStruct{}
 	AppendTo(form, data)
-	assert.Equal(t, &RequestValues{}, form)
+	assert.Equal(t, &Values{}, form)
 }
 
 func TestParseTag(t *testing.T) {

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -8,6 +8,10 @@ import (
 )
 
 type testStruct struct {
+	// Note that only a pointer can implement the Appender interface, so only
+	// the pointer of testAppender is checked.
+	Appender *testAppender `form:"appender"`
+
 	Array    [3]string  `form:"array"`
 	ArrayPtr *[3]string `form:"array_ptr"`
 
@@ -66,6 +70,14 @@ type testStruct struct {
 	Zeroed bool `form:"zeroed,zero"`
 }
 
+type testAppender struct {
+	String string
+}
+
+func (a *testAppender) AppendTo(values *Values, prefix string) {
+	values.Add(prefix, a.String)
+}
+
 type testSubStruct struct {
 	SubSubStruct testSubSubStruct `form:"subsubstruct"`
 }
@@ -110,6 +122,8 @@ func TestAppendTo(t *testing.T) {
 		data  *testStruct
 		want  interface{}
 	}{
+		{"appender", &testStruct{Appender: &testAppender{String: "123"}}, "123"},
+
 		{"array_indexed[2]", &testStruct{ArrayIndexed: arrayVal}, "3"},
 
 		{"bool", &testStruct{Bool: boolVal}, "true"},

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -217,3 +217,27 @@ func TestAppendTo_ZeroValues(t *testing.T) {
 	AppendTo(form, data)
 	assert.Equal(t, &RequestValues{}, form)
 }
+
+func TestParseTag(t *testing.T) {
+	testCases := []struct {
+		tag         string
+		wantName    string
+		wantOptions *formOptions
+	}{
+		{"id", "id", nil},
+		{"id,indexed", "id", &formOptions{IndexedArray: true}},
+
+		// invalid invocations
+		{"id,", "id", nil},
+		{"id,,", "id", nil},
+		{"id,foo", "id", nil},
+		{"id,foo=bar", "id", nil},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.tag, func(t *testing.T) {
+			name, options := parseTag(tc.tag)
+			assert.Equal(t, tc.wantName, name)
+			assert.Equal(t, tc.wantOptions, options)
+		})
+	}
+}

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -3,21 +3,31 @@ package form
 import (
 	"fmt"
 	"testing"
+
+	assert "github.com/stretchr/testify/require"
 )
 
 type testStruct struct {
-	StringField    string  `form:"string_field"`
-	StringPtrField *string `form:"string_ptr_field"`
+	String    string  `form:"string"`
+	StringPtr *string `form:"string_ptr"`
 }
 
 func TestAppendTo(t *testing.T) {
 	stringVal := "123"
 
-	values := &RequestValues{}
-	s := &testStruct{
-		StringField:    stringVal,
-		StringPtrField: &stringVal,
+	testCases := []struct {
+		field string
+		data  *testStruct
+		want  interface{}
+	}{
+		{"string", &testStruct{String: stringVal}, stringVal},
+		{"string_ptr", &testStruct{StringPtr: &stringVal}, stringVal},
 	}
-	AppendTo(values, s)
-	fmt.Printf("values = %+v", values)
+	for _, tc := range testCases {
+		t.Run(tc.field, func(t *testing.T) {
+			form := &RequestValues{}
+			AppendTo(form, tc.data)
+			assert.Equal(t, tc.want, form.ToValues().Get(tc.field))
+		})
+	}
 }

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -1,0 +1,23 @@
+package form
+
+import (
+	"fmt"
+	"testing"
+)
+
+type testStruct struct {
+	StringField    string  `form:"string_field"`
+	StringPtrField *string `form:"string_ptr_field"`
+}
+
+func TestAppendTo(t *testing.T) {
+	stringVal := "123"
+
+	values := &RequestValues{}
+	s := &testStruct{
+		StringField:    stringVal,
+		StringPtrField: &stringVal,
+	}
+	AppendTo(values, s)
+	fmt.Printf("values = %+v", values)
+}

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -33,6 +33,8 @@ type testStruct struct {
 	Int64    int64  `form:"int64"`
 	Int64Ptr *int64 `form:"int64_ptr"`
 
+	Inverted bool `form:"inverted,invert"`
+
 	Map map[string]interface{} `form:"map"`
 
 	Slice    []string  `form:"slice"`
@@ -57,6 +59,8 @@ type testStruct struct {
 	Uuint32Ptr *uint32 `form:"uint32_ptr"`
 	Uuint64    uint64  `form:"uint64"`
 	Uuint64Ptr *uint64 `form:"uint64_ptr"`
+
+	Zeroed bool `form:"zeroed,zero"`
 }
 
 type testSubStruct struct {
@@ -125,6 +129,8 @@ func TestAppendTo(t *testing.T) {
 		{"int64", &testStruct{Int64: int64Val}, "123"},
 		{"int64_ptr", &testStruct{Int64Ptr: &int64Val}, "123"},
 
+		{"inverted", &testStruct{Inverted: true}, "false"},
+
 		// Tests map
 		{
 			"map[foo]",
@@ -161,13 +167,15 @@ func TestAppendTo(t *testing.T) {
 		{"uint32_ptr", &testStruct{Uuint32Ptr: &uint32Val}, "123"},
 		{"uint64", &testStruct{Uuint64: uint64Val}, "123"},
 		{"uint64_ptr", &testStruct{Uuint64Ptr: &uint64Val}, "123"},
+
+		{"zeroed", &testStruct{Zeroed: true}, "0"},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {
 			form := &RequestValues{}
 			AppendTo(form, tc.data)
 			values := form.ToValues()
-			//fmt.Printf("values = %+v", values)
+			t.Logf("values = %+v", values)
 			assert.Equal(t, tc.want, values.Get(tc.field))
 		})
 	}

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -226,6 +226,7 @@ func TestParseTag(t *testing.T) {
 	}{
 		{"id", "id", nil},
 		{"id,indexed", "id", &formOptions{IndexedArray: true}},
+		{"id,zero", "id", &formOptions{Zero: true}},
 
 		// invalid invocations
 		{"id,", "id", nil},

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -16,6 +16,8 @@ type testStruct struct {
 	Bool    bool  `form:"bool"`
 	BoolPtr *bool `form:"bool_ptr"`
 
+	Emptied bool `form:"emptied,empty"`
+
 	Float32    float32  `form:"float32"`
 	Float32Ptr *float32 `form:"float32_ptr"`
 
@@ -111,6 +113,8 @@ func TestAppendTo(t *testing.T) {
 
 		{"bool", &testStruct{Bool: boolVal}, "true"},
 		{"bool_ptr", &testStruct{BoolPtr: &boolVal}, "true"},
+
+		{"emptied", &testStruct{Emptied: true}, ""},
 
 		{"float32", &testStruct{Float32: float32Val}, "1.2345"},
 		{"float32_ptr", &testStruct{Float32Ptr: &float32Val}, "1.2345"},
@@ -233,6 +237,7 @@ func TestParseTag(t *testing.T) {
 		wantOptions *formOptions
 	}{
 		{"id", "id", nil},
+		{"id,empty", "id", &formOptions{Empty: true}},
 		{"id,indexed", "id", &formOptions{IndexedArray: true}},
 		{"id,zero", "id", &formOptions{Zero: true}},
 

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -113,10 +113,22 @@ func TestAppendTo(t *testing.T) {
 		{"int64", &testStruct{Int64: int64Val}, "123"},
 		{"int64_ptr", &testStruct{Int64Ptr: &int64Val}, "123"},
 
+		// Tests map
 		{
 			"map[foo]",
-			&testStruct{Map: map[string]interface{}{"foo": "bar"}},
+			&testStruct{Map: map[string]interface{}{
+				"foo": "bar",
+			}},
 			"bar",
+		},
+
+		// Tests map nested inside of another map
+		{
+			"map[foo][bar]",
+			&testStruct{Map: map[string]interface{}{
+				"foo": map[string]interface{}{"bar": "baz"},
+			}},
+			"baz",
 		},
 
 		{"string", &testStruct{String: stringVal}, stringVal},
@@ -160,6 +172,15 @@ func TestAppendTo_DuplicatedNames(t *testing.T) {
 		{"array_ptr[]", &testStruct{ArrayPtr: &arrayVal}, sliceVal},
 		{"slice[]", &testStruct{Slice: sliceVal}, sliceVal},
 		{"slice_ptr[]", &testStruct{SlicePtr: &sliceVal}, sliceVal},
+
+		// Tests slice nested inside of map nested inside of another map
+		{
+			"map[foo][bar][]",
+			&testStruct{Map: map[string]interface{}{
+				"foo": map[string]interface{}{"bar": sliceVal},
+			}},
+			sliceVal,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -30,6 +30,8 @@ type testStruct struct {
 	Int64    int64  `form:"int64"`
 	Int64Ptr *int64 `form:"int64_ptr"`
 
+	Map map[string]interface{} `form:"map"`
+
 	Slice    []string  `form:"slice"`
 	SlicePtr *[]string `form:"slice_ptr"`
 
@@ -110,6 +112,12 @@ func TestAppendTo(t *testing.T) {
 		{"int32_ptr", &testStruct{Int32Ptr: &int32Val}, "123"},
 		{"int64", &testStruct{Int64: int64Val}, "123"},
 		{"int64_ptr", &testStruct{Int64Ptr: &int64Val}, "123"},
+
+		{
+			"map[foo]",
+			&testStruct{Map: map[string]interface{}{"foo": "bar"}},
+			"bar",
+		},
 
 		{"string", &testStruct{String: stringVal}, stringVal},
 		{"string_ptr", &testStruct{StringPtr: &stringVal}, stringVal},

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -26,7 +27,7 @@ func New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("customer", params.Customer)
 
 	if len(params.Billing) > 0 {
@@ -79,12 +80,12 @@ func Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -101,12 +102,12 @@ func Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Source != "" {
 			body.Add("source", params.Source)
@@ -128,13 +129,13 @@ func Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	token := c.Key
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Paid {
 			body.Add("paid", strconv.FormatBool(true))
@@ -188,7 +189,7 @@ func GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("customer", params.Customer)
 
 	if len(params.SubItems) > 0 {
@@ -252,12 +253,12 @@ func List(params *stripe.InvoiceListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.InvoiceListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Customer) > 0 {
 			body.Add("customer", params.Customer)
@@ -288,7 +289,7 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceList{}
 		err := c.B.Call("GET", "/invoices", c.Key, b, p, list)
 
@@ -308,7 +309,7 @@ func ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 }
 
 func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -324,7 +325,7 @@ func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &LineIter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &LineIter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceLineList{}
 		err := c.B.Call("GET", fmt.Sprintf("/invoices/%v/lines", params.ID), c.Key, b, p, list)
 

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /invoiceitems APIs.
@@ -20,7 +21,7 @@ func New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 }
 
 func (c Client) New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("customer", params.Customer)
 	body.Add("amount", strconv.FormatInt(params.Amount, 10))
 	body.Add("currency", string(params.Currency))
@@ -58,12 +59,12 @@ func Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 }
 
 func (c Client) Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -80,12 +81,12 @@ func Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, e
 }
 
 func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Amount != 0 {
 			body.Add("amount", strconv.FormatInt(params.Amount, 10))
@@ -128,12 +129,12 @@ func List(params *stripe.InvoiceItemListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -152,7 +153,7 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceItemList{}
 		err := c.B.Call("GET", "/invoiceitems", c.Key, b, p, list)
 

--- a/iter.go
+++ b/iter.go
@@ -2,10 +2,12 @@ package stripe
 
 import (
 	"reflect"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // Query is the function used to get a page listing.
-type Query func(*RequestValues) ([]interface{}, ListMeta, error)
+type Query func(*form.Values) ([]interface{}, ListMeta, error)
 
 // Iter provides a convenient interface
 // for iterating over the elements
@@ -17,7 +19,7 @@ type Query func(*RequestValues) ([]interface{}, ListMeta, error)
 // across multiple goroutines.
 type Iter struct {
 	query  Query
-	qs     *RequestValues
+	qs     *form.Values
 	values []interface{}
 	meta   ListMeta
 	params ListParams
@@ -26,7 +28,7 @@ type Iter struct {
 }
 
 // GetIter returns a new Iter for a given query and its options.
-func GetIter(params *ListParams, qs *RequestValues, query Query) *Iter {
+func GetIter(params *ListParams, qs *form.Values, query Query) *Iter {
 	iter := &Iter{}
 	iter.query = query
 
@@ -38,7 +40,7 @@ func GetIter(params *ListParams, qs *RequestValues, query Query) *Iter {
 
 	q := qs
 	if q == nil {
-		q = &RequestValues{}
+		q = &form.Values{}
 	}
 	iter.qs = q
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 func TestIterEmpty(t *testing.T) {
@@ -181,7 +183,7 @@ type testQuery []struct {
 	e error
 }
 
-func (tq *testQuery) query(*RequestValues) ([]interface{}, ListMeta, error) {
+func (tq *testQuery) query(*form.Values) ([]interface{}, ListMeta, error) {
 	x := (*tq)[0]
 	*tq = (*tq)[1:]
 	return x.v, x.m, x.e

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /login_links APIs.
@@ -21,7 +22,7 @@ func New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 }
 
 func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	loginLink := &stripe.LoginLink{}
 	var err error

--- a/order/client.go
+++ b/order/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /orders APIs.
@@ -23,11 +24,11 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 // New POSTs a new order.
 // For more details see https://stripe.com/docs/api#create_order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 
 		if params.Coupon != "" {
@@ -110,11 +111,11 @@ func Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) 
 // Update updates an order's properties.
 // For more details see https://stripe.com/docs/api#update_order.
 func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 
 		if params.Coupon != "" {
@@ -147,11 +148,11 @@ func Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 // Pay pays an order
 // For more details see https://stripe.com/docs/api#pay_order.
 func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 		if params.Source == nil && len(params.Customer) == 0 {
 			err := errors.New("Invalid order pay params: either customer or a source must be set")
@@ -226,11 +227,11 @@ func Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 }
 
 func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 		params.AppendTo(body)
 	}
@@ -247,12 +248,12 @@ func List(params *stripe.OrderListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.OrderListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -275,7 +276,7 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderList{}
 		err := c.B.Call("GET", "/orders", c.Key, b, p, list)
 
@@ -310,11 +311,11 @@ func Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, e
 // Return returns all or part of an order.
 // For more details see https://stripe.com/docs/api#return_order.
 func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Items) > 0 {
 			for _, item := range params.Items {

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /orders APIs.
@@ -18,12 +19,12 @@ func List(params *stripe.OrderReturnListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.OrderReturnListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -42,7 +43,7 @@ func (c Client) List(params *stripe.OrderReturnListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderReturnList{}
 		err := c.B.Call("GET", "/order_returns", c.Key, b, p, list)
 

--- a/params.go
+++ b/params.go
@@ -1,7 +1,6 @@
 package stripe
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -9,104 +8,14 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
 	startafter = "starting_after"
 	endbefore  = "ending_before"
 )
-
-// RequestValues is a collection of values that can be submitted along with a
-// request that specifically allows for duplicate keys and encodes its entries
-// in the same order that they were added.
-type RequestValues struct {
-	values []formValue
-}
-
-// Add adds a key/value tuple to the form.
-func (f *RequestValues) Add(key, val string) {
-	f.values = append(f.values, formValue{key, val})
-}
-
-// Encode encodes the values into “URL encoded” form ("bar=baz&foo=quux").
-func (f *RequestValues) Encode() string {
-	var buf bytes.Buffer
-	for _, v := range f.values {
-		if buf.Len() > 0 {
-			buf.WriteByte('&')
-		}
-		buf.WriteString(url.QueryEscape(v.Key))
-		buf.WriteString("=")
-		buf.WriteString(url.QueryEscape(v.Value))
-	}
-	return buf.String()
-}
-
-// Empty returns true if no parameters have been set.
-func (f *RequestValues) Empty() bool {
-	return len(f.values) == 0
-}
-
-// Set sets the first instance of a parameter for the given key to the given
-// value. If no parameters exist with the key, a new one is added.
-//
-// Note that Set is O(n) and may be quite slow for a very large parameter list.
-func (f *RequestValues) Set(key, val string) {
-	for i, v := range f.values {
-		if v.Key == key {
-			f.values[i].Value = val
-			return
-		}
-	}
-
-	f.Add(key, val)
-}
-
-// Get retrieves the list of values for the given key.  If no values exist
-// for the key, nil will be returned.
-//
-// Note that Get is O(n) and may be quite slow for a very large parameter list.
-func (f *RequestValues) Get(key string) []string {
-	var results []string
-	for i, v := range f.values {
-		if v.Key == key {
-			results = append(results, f.values[i].Value)
-		}
-	}
-	return results
-}
-
-// ToValues converts an instance of RequestValues into an instance of
-// url.Values. This can be useful in cases where it's useful to make an
-// unordered comparison of two sets of request values.
-//
-// Note that url.Values is incapable of representing certain Rack form types in
-// a cohesive way. For example, an array of maps in Rack is encoded with a
-// string like:
-//
-//     arr[][foo]=foo0&arr[][bar]=bar0&arr[][foo]=foo1&arr[][bar]=bar1
-//
-// Because url.Values is a map, values will be handled in a way that's grouped
-// by their key instead of in the order they were added. Therefore the above
-// may by encoded to something like (maps are unordered so the actual result is
-// somewhat non-deterministic):
-//
-//     arr[][foo]=foo0&arr[][foo]=foo1&arr[][bar]=bar0&arr[][bar]=bar1
-//
-// And thus result in an incorrect request to Stripe.
-func (f *RequestValues) ToValues() url.Values {
-	values := url.Values{}
-	for _, v := range f.values {
-		values.Add(v.Key, v.Value)
-	}
-	return values
-}
-
-// A key/value tuple for use in the RequestValues type.
-type formValue struct {
-	Key   string
-	Value string
-}
 
 // Params is the structure that contains the common properties
 // of any *Params structure.
@@ -178,7 +87,7 @@ type RangeQueryParams struct {
 }
 
 // AppendTo adds the range query parametes to a set of request values.
-func (r *RangeQueryParams) AppendTo(values *RequestValues, name string) {
+func (r *RangeQueryParams) AppendTo(values *form.Values, name string) {
 	if r.GreaterThan > 0 {
 		values.Add(name+"[gt]", strconv.FormatInt(r.GreaterThan, 10))
 	}
@@ -202,7 +111,7 @@ type Filters struct {
 }
 
 // AppendTo adds the list of filters to the query string values.
-func (f *Filters) AppendTo(values *RequestValues) {
+func (f *Filters) AppendTo(values *form.Values) {
 	for _, v := range f.f {
 		if len(v.Op) > 0 {
 			values.Add(fmt.Sprintf("%v[%v]", v.Key, v.Op), v.Val)
@@ -268,7 +177,7 @@ func (f *Filters) AddFilter(key, op, value string) {
 }
 
 // AppendTo adds the common parameters to the query string values.
-func (p *Params) AppendTo(body *RequestValues) {
+func (p *Params) AppendTo(body *form.Values) {
 	for k, v := range p.Meta {
 		body.Add(fmt.Sprintf("metadata[%v]", k), v)
 	}
@@ -290,7 +199,7 @@ func (p *ListParams) Expand(f string) {
 }
 
 // AppendTo adds the common parameters to the query string values.
-func (p *ListParams) AppendTo(body *RequestValues) {
+func (p *ListParams) AppendTo(body *form.Values) {
 	if len(p.Filters.f) > 0 {
 		p.Filters.AppendTo(body)
 	}

--- a/params.go
+++ b/params.go
@@ -163,18 +163,18 @@ type ListMeta struct {
 type RangeQueryParams struct {
 	// GreaterThan specifies that values should be a greater than this
 	// timestamp.
-	GreaterThan int64
+	GreaterThan int64 `form:"gt"`
 
 	// GreaterThanOrEqual specifies that values should be greater than or equal
 	// to this timestamp.
-	GreaterThanOrEqual int64
+	GreaterThanOrEqual int64 `form:"gte"`
 
 	// LesserThan specifies that values should be lesser than this timetamp.
-	LesserThan int64
+	LesserThan int64 `form:"lt"`
 
 	// LesserThanOrEqual specifies that values should be lesser than or
 	// equalthis timetamp.
-	LesserThanOrEqual int64
+	LesserThanOrEqual int64 `form:"lte"`
 }
 
 // AppendTo adds the range query parametes to a set of request values.

--- a/params_test.go
+++ b/params_test.go
@@ -1,17 +1,17 @@
 package stripe_test
 
 import (
-	"net/url"
 	"reflect"
 	"testing"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 	. "github.com/stripe/stripe-go/testing"
 )
 
 func TestCheckinRangeQueryParamsAppendTo(t *testing.T) {
 	{
-		values := &stripe.RequestValues{}
+		values := &form.Values{}
 
 		// Try it with an empty set of parameters
 		params := &stripe.RangeQueryParams{}
@@ -23,7 +23,7 @@ func TestCheckinRangeQueryParamsAppendTo(t *testing.T) {
 	}
 
 	{
-		values := &stripe.RequestValues{}
+		values := &form.Values{}
 
 		// Try it with an empty set of parameters
 		params := &stripe.RangeQueryParams{GreaterThan: 99}
@@ -38,7 +38,7 @@ func TestCheckinRangeQueryParamsAppendTo(t *testing.T) {
 	}
 
 	{
-		values := &stripe.RequestValues{}
+		values := &form.Values{}
 
 		// Try it with an empty set of parameters
 		params := &stripe.RangeQueryParams{GreaterThanOrEqual: 99}
@@ -53,7 +53,7 @@ func TestCheckinRangeQueryParamsAppendTo(t *testing.T) {
 	}
 
 	{
-		values := &stripe.RequestValues{}
+		values := &form.Values{}
 
 		// Try it with an empty set of parameters
 		params := &stripe.RangeQueryParams{LesserThan: 99}
@@ -68,7 +68,7 @@ func TestCheckinRangeQueryParamsAppendTo(t *testing.T) {
 	}
 
 	{
-		values := &stripe.RequestValues{}
+		values := &form.Values{}
 
 		// Try it with an empty set of parameters
 		params := &stripe.RangeQueryParams{LesserThanOrEqual: 99}
@@ -80,125 +80,6 @@ func TestCheckinRangeQueryParamsAppendTo(t *testing.T) {
 				"Expected encoded value of 99 for created[lte] but got %v.",
 				value)
 		}
-	}
-}
-
-func TestRequestValues(t *testing.T) {
-	values := &stripe.RequestValues{}
-
-	actual := values.Encode()
-	expected := ""
-	if expected != actual {
-		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
-	}
-
-	if !values.Empty() {
-		t.Fatalf("Expected values to be empty.")
-	}
-
-	values = &stripe.RequestValues{}
-	values.Add("foo", "bar")
-
-	actual = values.Encode()
-	expected = "foo=bar"
-	if expected != actual {
-		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
-	}
-
-	if values.Empty() {
-		t.Fatalf("Expected values to not be empty.")
-	}
-
-	got := values.Get("foo")
-	if len(got) != 1 {
-		t.Fatalf("Expected 1 result from Get, got %v.", len(got))
-	}
-	if got[0] != "bar" {
-		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
-	}
-
-	values = &stripe.RequestValues{}
-	values.Add("foo", "bar")
-	values.Add("foo", "bar")
-	values.Add("baz", "bar")
-
-	actual = values.Encode()
-	expected = "foo=bar&foo=bar&baz=bar"
-	if expected != actual {
-		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
-	}
-
-	got = values.Get("foo")
-	if len(got) != 2 {
-		t.Fatalf("Expected 2 results from Get, got %v.", len(got))
-	}
-	if got[0] != "bar" {
-		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
-	}
-	if got[1] != "bar" {
-		t.Fatalf("Expected 'bar' result from Get, got %v.", got[1])
-	}
-	got = values.Get("baz")
-	if len(got) != 1 {
-		t.Fatalf("Expected 1 result from Get, got %v.", len(got))
-	}
-	if got[0] != "bar" {
-		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
-	}
-
-	values.Set("foo", "firstbar")
-
-	actual = values.Encode()
-	expected = "foo=firstbar&foo=bar&baz=bar"
-	if expected != actual {
-		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
-	}
-	got = values.Get("foo")
-	if len(got) != 2 {
-		t.Fatalf("Expected 2 results from Get, got %v.", len(got))
-	}
-	if got[0] != "firstbar" {
-		t.Fatalf("Expected 'firstbar' result from Get, got %v.", got[0])
-	}
-	if got[1] != "bar" {
-		t.Fatalf("Expected 'bar' result from Get, got %v.", got[1])
-	}
-	got = values.Get("baz")
-	if len(got) != 1 {
-		t.Fatalf("Expected 1 result from Get, got %v.", len(got))
-	}
-	if got[0] != "bar" {
-		t.Fatalf("Expected 'bar' result from Get, got %v.", got[0])
-	}
-
-	values.Set("new", "appended")
-
-	actual = values.Encode()
-	expected = "foo=firstbar&foo=bar&baz=bar&new=appended"
-	if expected != actual {
-		t.Fatalf("Expected encoded value of %v but got %v.", expected, actual)
-	}
-
-	urlValues := values.ToValues()
-	expectedURLValues := url.Values{
-		"baz": {"bar"},
-		"foo": {"firstbar", "bar"},
-		"new": {"appended"},
-	}
-	if !reflect.DeepEqual(urlValues, expectedURLValues) {
-		t.Fatalf("Expected body of %v but got %v.", expectedURLValues, urlValues)
-	}
-	got = values.Get("new")
-	if len(got) != 1 {
-		t.Fatalf("Expected 1 result from Get, got %v.", len(got))
-	}
-	if got[0] != "appended" {
-		t.Fatalf("Expected 'appended' result from Get, got %v.", got[0])
-	}
-
-	got = values.Get("boguskey")
-	if got != nil {
-		t.Fatalf("Expected nil, got %v", got)
 	}
 }
 
@@ -310,10 +191,10 @@ func TestCheckinParamsSetStripeAccount(t *testing.T) {
 }
 
 // Converts a collection of key/value tuples in a two dimensional slice/array
-// into RequestValues form. The purpose of this is that it's much cleaner to
+// into form.Values form. The purpose of this is that it's much cleaner to
 // initialize the array all at once on a single line.
-func valuesFromArray(arr [][2]string) *stripe.RequestValues {
-	body := &stripe.RequestValues{}
+func valuesFromArray(arr [][2]string) *form.Values {
+	body := &form.Values{}
 	for _, v := range arr {
 		body.Add(v[0], v[1])
 	}

--- a/payment_source.go
+++ b/payment_source.go
@@ -3,6 +3,8 @@ package stripe
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // SourceParams is a union struct used to describe an
@@ -15,7 +17,7 @@ type SourceParams struct {
 // AppendDetails adds the source's details to the query string values.
 // For cards: when creating a new one, the parameters are passed as a dictionary, but
 // on updates they are simply the parameter name.
-func (sp *SourceParams) AppendDetails(values *RequestValues, creating bool) {
+func (sp *SourceParams) AppendDetails(values *form.Values, creating bool) {
 	if len(sp.Token) > 0 {
 		values.Add("source", sp.Token)
 	} else if sp.Card != nil {

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /sources APIs.
@@ -22,7 +23,7 @@ func New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 }
 
 func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	params.Source.AppendDetails(body, true)
 	params.AppendTo(body)
 
@@ -45,12 +46,12 @@ func Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 }
 
 func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -73,7 +74,7 @@ func Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSour
 }
 
 func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	params.Source.AppendDetails(body, false)
 	params.AppendTo(body)
 
@@ -115,7 +116,7 @@ func List(params *stripe.SourceListParams) *Iter {
 }
 
 func (s Client) List(params *stripe.SourceListParams) *Iter {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -123,7 +124,7 @@ func (s Client) List(params *stripe.SourceListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SourceList{}
 		var err error
 
@@ -149,7 +150,7 @@ func Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource
 }
 
 func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("amounts[]", strconv.Itoa(int(params.Amounts[0])))
 	body.Add("amounts[]", strconv.Itoa(int(params.Amounts[1])))
 

--- a/payout/client.go
+++ b/payout/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -48,7 +49,7 @@ func New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 func (c Client) New(params *stripe.PayoutParams) (*stripe.Payout, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("amount", strconv.FormatInt(params.Amount, 10))
 	body.Add("currency", string(params.Currency))
 
@@ -83,12 +84,12 @@ func Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 func (c Client) Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -105,12 +106,12 @@ func Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -127,13 +128,13 @@ func Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
 
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -150,12 +151,12 @@ func List(params *stripe.PayoutListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.PayoutListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.ArrivalDate > 0 {
 			body.Add("created", strconv.FormatInt(params.ArrivalDate, 10))
@@ -186,7 +187,7 @@ func (c Client) List(params *stripe.PayoutListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PayoutList{}
 		err := c.B.Call("GET", "/payouts", c.Key, b, p, list)
 

--- a/plan.go
+++ b/plan.go
@@ -1,9 +1,5 @@
 package stripe
 
-import (
-	"strconv"
-)
-
 // PlanInterval is the list of allowed values for a plan's interval.
 // Allowed values are "day", "week", "month", "year".
 type PlanInterval string
@@ -39,16 +35,6 @@ type PlanListParams struct {
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 
-func (p *PlanListParams) AppendTo(values *RequestValues) {
-	if p.Created > 0 {
-		values.Add("created", strconv.FormatInt(p.Created, 10))
-	}
-
-	if p.CreatedRange != nil {
-		p.CreatedRange.AppendTo(values, "created")
-	}
-}
-
 // PlanParams is the set of parameters that can be used when creating or updating a plan.
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
@@ -61,38 +47,4 @@ type PlanParams struct {
 	IntervalCount uint64       `form:"interval_count"`
 	TrialPeriod   uint64       `form:"trial_period_days"`
 	Statement     string       `form:"statement_descriptor"`
-}
-
-func (p *PlanParams) AppendTo(values *RequestValues) {
-	if p.Amount > 0 {
-		values.Add("amount", strconv.FormatUint(p.Amount, 10))
-	}
-
-	if p.Currency != "" {
-		values.Add("currency", string(p.Currency))
-	}
-
-	if p.ID != "" {
-		values.Add("id", p.ID)
-	}
-
-	if p.Interval != "" {
-		values.Add("interval", string(p.Interval))
-	}
-
-	if p.IntervalCount > 0 {
-		values.Add("interval_count", strconv.FormatUint(p.IntervalCount, 10))
-	}
-
-	if p.Name != "" {
-		values.Add("name", p.Name)
-	}
-
-	if len(p.Statement) > 0 {
-		values.Add("statement_descriptor", p.Statement)
-	}
-
-	if p.TrialPeriod > 0 {
-		values.Add("trial_period_days", strconv.FormatUint(p.TrialPeriod, 10))
-	}
 }

--- a/plan.go
+++ b/plan.go
@@ -35,8 +35,8 @@ type PlanList struct {
 // For more details see https://stripe.com/docs/api#list_plans.
 type PlanListParams struct {
 	ListParams
-	Created      int64
-	CreatedRange *RangeQueryParams
+	Created      int64             `form:"created"`
+	CreatedRange *RangeQueryParams `form:"created"`
 }
 
 func (p *PlanListParams) AppendTo(values *RequestValues) {
@@ -53,12 +53,14 @@ func (p *PlanListParams) AppendTo(values *RequestValues) {
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
 	Params
-	ID, Name                   string
-	Currency                   Currency
-	Amount                     uint64
-	Interval                   PlanInterval
-	IntervalCount, TrialPeriod uint64
-	Statement                  string
+	ID            string       `form:"id"`
+	Name          string       `form:"name"`
+	Currency      Currency     `form:"currency"`
+	Amount        uint64       `form:"amount"`
+	Interval      PlanInterval `form:"interval"`
+	IntervalCount uint64       `form:"interval_count"`
+	TrialPeriod   uint64       `form:"trial_period_days"`
+	Statement     string       `form:"statement_descriptor"`
 }
 
 func (p *PlanParams) AppendTo(values *RequestValues) {

--- a/plan/client.go
+++ b/plan/client.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -28,7 +29,7 @@ func New(params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	params.Params.AppendTo(body)
 	params.AppendTo(body)
 
@@ -45,12 +46,12 @@ func Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.Params.AppendTo(body)
 		params.AppendTo(body)
 	}
@@ -68,12 +69,12 @@ func Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.Params.AppendTo(body)
 		params.AppendTo(body)
 	}
@@ -91,11 +92,11 @@ func Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		params.AppendTo(body)
 		commonParams = &params.Params
@@ -114,18 +115,18 @@ func List(params *stripe.PlanListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.PlanListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 		lp = &params.ListParams
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PlanList{}
 		err := c.B.Call("GET", "/plans", c.Key, b, p, list)
 

--- a/plan_test.go
+++ b/plan_test.go
@@ -23,7 +23,7 @@ func TestPlanListParamsAppendTo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {
-			body := &form.RequestValues{}
+			body := &form.Values{}
 			form.AppendTo(body, tc.params)
 			values := body.ToValues()
 			assert.Equal(t, tc.want, values.Get(tc.field))
@@ -32,7 +32,7 @@ func TestPlanListParamsAppendTo(t *testing.T) {
 }
 
 func TestPlanListParamsAppendTo_Empty(t *testing.T) {
-	body := &RequestValues{}
+	body := &form.Values{}
 	params := &PlanListParams{}
 	params.AppendTo(body)
 	assert.True(t, body.Empty())
@@ -55,7 +55,7 @@ func TestPlanParamsAppendTo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {
-			body := &form.RequestValues{}
+			body := &form.Values{}
 			form.AppendTo(body, tc.params)
 			values := body.ToValues()
 			assert.Equal(t, tc.want, values.Get(tc.field))
@@ -64,7 +64,7 @@ func TestPlanParamsAppendTo(t *testing.T) {
 }
 
 func TestPlanParamsAppendTo_Empty(t *testing.T) {
-	body := &form.RequestValues{}
+	body := &form.Values{}
 	params := &PlanParams{}
 	form.AppendTo(body, params)
 	assert.True(t, body.Empty())

--- a/plan_test.go
+++ b/plan_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/form"
 )
 
 func TestPlanListParamsAppendTo(t *testing.T) {
@@ -22,8 +23,8 @@ func TestPlanListParamsAppendTo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {
-			body := &RequestValues{}
-			tc.params.AppendTo(body)
+			body := &form.RequestValues{}
+			form.AppendTo(body, tc.params)
 			values := body.ToValues()
 			assert.Equal(t, tc.want, values.Get(tc.field))
 		})
@@ -54,8 +55,8 @@ func TestPlanParamsAppendTo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {
-			body := &RequestValues{}
-			tc.params.AppendTo(body)
+			body := &form.RequestValues{}
+			form.AppendTo(body, tc.params)
 			values := body.ToValues()
 			assert.Equal(t, tc.want, values.Get(tc.field))
 		})
@@ -63,8 +64,8 @@ func TestPlanParamsAppendTo(t *testing.T) {
 }
 
 func TestPlanParamsAppendTo_Empty(t *testing.T) {
-	body := &RequestValues{}
+	body := &form.RequestValues{}
 	params := &PlanParams{}
-	params.AppendTo(body)
+	form.AppendTo(body, params)
 	assert.True(t, body.Empty())
 }

--- a/product/client.go
+++ b/product/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /products APIs.
@@ -22,11 +23,11 @@ func New(params *stripe.ProductParams) (*stripe.Product, error) {
 // New POSTs a new product.
 // For more details see https://stripe.com/docs/api#create_product.
 func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		// Required fields
 		body.Add("name", params.Name)
@@ -101,11 +102,11 @@ func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 // Update updates a product's properties.
 // For more details see https://stripe.com/docs/api#update_product.
 func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Name) > 0 {
 			body.Add("name", params.Name)
@@ -173,12 +174,12 @@ func List(params *stripe.ProductListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ProductListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Active != nil {
 			params.Filters.AddFilter("active", "", strconv.FormatBool(*params.Active))
@@ -203,7 +204,7 @@ func (c Client) List(params *stripe.ProductListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ProductList{}
 		err := c.B.Call("GET", "/products", c.Key, b, p, list)
 

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -28,12 +29,12 @@ func Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 }
 
 func (c Client) Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -50,12 +51,12 @@ func Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error
 }
 
 func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Name) > 0 {
 			body.Add("name", params.Name)
@@ -120,12 +121,12 @@ func List(params *stripe.RecipientListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.RecipientListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Verified {
 			body.Add("verified", strconv.FormatBool(true))
@@ -136,7 +137,7 @@ func (c Client) List(params *stripe.RecipientListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RecipientList{}
 		err := c.B.Call("GET", "/recipients", c.Key, b, p, list)
 

--- a/refund/client.go
+++ b/refund/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -27,7 +28,7 @@ func New(params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	if params.Amount > 0 {
 		body.Add("amount", strconv.FormatUint(params.Amount, 10))
@@ -64,12 +65,12 @@ func Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -86,7 +87,7 @@ func Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	params.AppendTo(body)
 
@@ -103,7 +104,7 @@ func List(params *stripe.RefundListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.RefundListParams) *Iter {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -111,7 +112,7 @@ func (c Client) List(params *stripe.RefundListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RefundList{}
 		err := c.B.Call("GET", fmt.Sprintf("/refunds"), c.Key, b, p, list)
 

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /transfers/reversals APIs.
@@ -20,7 +21,7 @@ func New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 }
 
 func (c Client) New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	if params.Amount > 0 {
 		body.Add("amount", strconv.FormatUint(params.Amount, 10))
@@ -48,7 +49,7 @@ func (c Client) Get(id string, params *stripe.ReversalParams) (*stripe.Reversal,
 		return nil, fmt.Errorf("params cannot be nil, and params.Transfer must be set")
 	}
 
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	params.AppendTo(body)
 
 	reversal := &stripe.Reversal{}
@@ -63,7 +64,7 @@ func Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) 
 }
 
 func (c Client) Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 
 	params.AppendTo(body)
 
@@ -79,7 +80,7 @@ func List(params *stripe.ReversalListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.ReversalListParams) *Iter {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
@@ -87,7 +88,7 @@ func (c Client) List(params *stripe.ReversalListParams) *Iter {
 	lp = &params.ListParams
 	p = params.ToParams()
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ReversalList{}
 		err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals", params.Transfer), c.Key, b, p, list)
 

--- a/sku/client.go
+++ b/sku/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /skus APIs.
@@ -22,11 +23,11 @@ func New(params *stripe.SKUParams) (*stripe.SKU, error) {
 // New POSTs a new SKU.
 // For more details see https://stripe.com/docs/api#create_sku.
 func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		// Required fields
 		body.Add("price", strconv.FormatInt(params.Price, 10))
@@ -97,11 +98,11 @@ func Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 // Update updates a SKU's properties.
 // For more details see https://stripe.com/docs/api#update_sku.
 func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		// Required fields
 		if params.Price > 0 {
@@ -173,12 +174,12 @@ func Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 
 func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	sku := &stripe.SKU{}
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 	err := c.B.Call("GET", "/skus/"+id, c.Key, body, commonParams, sku)
@@ -193,12 +194,12 @@ func List(params *stripe.SKUListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.SKUListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Active != nil {
 			params.Filters.AddFilter(
@@ -228,7 +229,7 @@ func (c Client) List(params *stripe.SKUListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SKUList{}
 		err := c.B.Call("GET", "/skus", c.Key, b, p, list)
 

--- a/source/client.go
+++ b/source/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /sources APIs.
@@ -22,11 +23,11 @@ func New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 // New POSTs a new source.
 // For more details see https://stripe.com/docs/api#create_source.
 func (c Client) New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 
 		// Optional fields
@@ -112,11 +113,11 @@ func Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 // Get returns the details of a source
 // For more details see https://stripe.com/docs/api#retrieve_source.
 func (c Client) Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 		params.AppendTo(body)
 	}
@@ -133,11 +134,11 @@ func Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error
 }
 
 func (c Client) Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 
 		// Optional fields

--- a/stripe.go
+++ b/stripe.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -67,7 +69,7 @@ func (a *AppInfo) formatUserAgent() string {
 // Backend is an interface for making calls against a Stripe service.
 // This interface exists to enable mocking for during testing if needed.
 type Backend interface {
-	Call(method, path, key string, body *RequestValues, params *Params, v interface{}) error
+	Call(method, path, key string, body *form.Values, params *Params, v interface{}) error
 	CallMultipart(method, path, key, boundary string, body io.Reader, params *Params, v interface{}) error
 }
 
@@ -193,7 +195,7 @@ func SetBackend(backend SupportedBackend, b Backend) {
 }
 
 // Call is the Backend.Call implementation for invoking Stripe APIs.
-func (s BackendConfiguration) Call(method, path, key string, form *RequestValues, params *Params, v interface{}) error {
+func (s BackendConfiguration) Call(method, path, key string, form *form.Values, params *Params, v interface{}) error {
 	var body io.Reader
 	if form != nil && !form.Empty() {
 		data := form.Encode()

--- a/sub/client.go
+++ b/sub/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -30,12 +31,12 @@ func New(params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 	token := c.Key
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		body.Add("customer", params.Customer)
 
 		if len(params.Items) > 0 {
@@ -124,11 +125,11 @@ func Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 		commonParams = &params.Params
 	}
@@ -146,12 +147,12 @@ func Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 	token := c.Key
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Items) > 0 {
 			for i, item := range params.Items {
@@ -248,11 +249,11 @@ func Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 }
 
 func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.EndCancel {
 			body.Add("at_period_end", strconv.FormatBool(true))
@@ -275,12 +276,12 @@ func List(params *stripe.SubListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.SubListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -312,7 +313,7 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubList{}
 		err := c.B.Call("GET", "/subscriptions", c.Key, b, p, list)
 

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /subscriptions APIs.
@@ -21,12 +22,12 @@ func New(params *stripe.SubItemParams) (*stripe.SubItem, error) {
 }
 
 func (c Client) New(params *stripe.SubItemParams) (*stripe.SubItem, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 	token := c.Key
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		body.Add("subscription", params.Sub)
 
 		if len(params.Plan) > 0 {
@@ -54,11 +55,11 @@ func Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
 }
 
 func (c Client) Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 		commonParams = &params.Params
 	}
@@ -76,12 +77,12 @@ func Update(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
 }
 
 func (c Client) Update(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 	token := c.Key
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Plan) > 0 {
 			body.Add("plan", params.Plan)
@@ -118,11 +119,11 @@ func Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
 }
 
 func (c Client) Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 		commonParams = &params.Params
 	}
@@ -140,12 +141,12 @@ func List(params *stripe.SubItemListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.SubItemListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if len(params.Sub) > 0 {
 			body.Add("subscription", params.Sub)
@@ -157,7 +158,7 @@ func (c Client) List(params *stripe.SubItemListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubItemList{}
 		err := c.B.Call("GET", "/subscription_items", c.Key, b, p, list)
 

--- a/threedsecure/client.go
+++ b/threedsecure/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /3d_secure APIs.
@@ -20,7 +21,7 @@ func New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 }
 
 func (c Client) New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("amount", strconv.FormatUint(params.Amount, 10))
 	body.Add("card", params.Card)
 	body.Add("currency", string(params.Currency))
@@ -44,11 +45,11 @@ func Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, er
 }
 
 func (c Client) Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		commonParams = &params.Params
 		params.AppendTo(body)
 	}

--- a/token.go
+++ b/token.go
@@ -1,5 +1,9 @@
 package stripe
 
+import (
+	"github.com/stripe/stripe-go/form"
+)
+
 // TokenType is the list of allowed values for a token's type.
 // Allowed values are "card", "bank_account".
 type TokenType string
@@ -40,6 +44,6 @@ type PIIParams struct {
 }
 
 // AppendDetails adds the PII data's details to the query string values.
-func (p *PIIParams) AppendDetails(values *RequestValues) {
+func (p *PIIParams) AppendDetails(values *form.Values) {
 	values.Add("pii[personal_id_number]", p.PersonalIDNumber)
 }

--- a/token/client.go
+++ b/token/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -26,7 +27,7 @@ func New(params *stripe.TokenParams) (*stripe.Token, error) {
 }
 
 func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	token := c.Key
 
 	if len(params.Customer) > 0 {
@@ -63,12 +64,12 @@ func Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 }
 
 func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
 )
 
 const (
@@ -27,7 +28,7 @@ func New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 }
 
 func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
-	body := &stripe.RequestValues{}
+	body := &form.Values{}
 	body.Add("amount", strconv.FormatInt(params.Amount, 10))
 	body.Add("currency", string(params.Currency))
 
@@ -61,12 +62,12 @@ func Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 }
 
 func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 		params.AppendTo(body)
 	}
 
@@ -83,13 +84,13 @@ func Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) 
 }
 
 func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var commonParams *stripe.Params
 
 	if params != nil {
 		commonParams = &params.Params
 
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		params.AppendTo(body)
 	}
@@ -107,12 +108,12 @@ func List(params *stripe.TransferListParams) *Iter {
 }
 
 func (c Client) List(params *stripe.TransferListParams) *Iter {
-	var body *stripe.RequestValues
+	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
 	if params != nil {
-		body = &stripe.RequestValues{}
+		body = &form.Values{}
 
 		if params.Created > 0 {
 			body.Add("created", strconv.FormatInt(params.Created, 10))
@@ -139,7 +140,7 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 		p = params.ToParams()
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *stripe.RequestValues) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TransferList{}
 		err := c.B.Call("GET", "/transfers", c.Key, b, p, list)
 


### PR DESCRIPTION
Builds on top of #424, but adds a new reflection package that's able to form-encode a parameters struct using tags on its fields (similar to how the `json` package works).

There's a fairly extensive test suite, but we also use the parameter test suite introduced in #424 to verify that we get the results we expect for `PlanParams` and `ParamListParams`.

Still do to:

* ~~Handled integer-indexed arrays like for `legal_entity[additional_owners]`.~~ Done.
* ~~Handle "zero" fields (e.g. `QuantityZero` versus `Quantity`) that we're introduced to work around the fact that we can't detect an unset and zeroed value.~~ Done.
* ~~Handle "empty" fields (e.g. `AdditionalOwnersEmpty` vs `AdditionalOwners`.~~ Done.
* ~~Handle "no" fields (e.g. `NoProration`).~~ Done.

cc @remi-stripe @ob-stripe @stripe/api-libraries Thoughts on this sort of approach?

---

Note: targets the branch in #424 until we can get that merged.