### PR TITLE
Application fee can be set back to 0 on Invoice and Subscription

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -17,6 +17,7 @@ type InvoiceParams struct {
 	Customer             string
 	Desc, Statement, Sub string
 	Fee                  uint64
+	FeeZero              bool
 	Closed, Forgive      bool
 	NoClosed             bool
 	SubPlan              string

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -58,6 +58,8 @@ func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	token := c.Key
 	if params.Fee > 0 {
 		body.Add("application_fee", strconv.FormatUint(params.Fee, 10))
+	} else if params.FeeZero {
+		body.Add("application_fee", "0")
 	}
 
 	if params.TaxPercent > 0 {

--- a/sub.go
+++ b/sub.go
@@ -22,7 +22,7 @@ type SubParams struct {
 	Quantity                                        uint64
 	ProrationDate                                   int64
 	FeePercent, TaxPercent                          float64
-	TaxPercentZero                                  bool
+	FeePercentZero, TaxPercentZero                  bool
 	NoProrate, EndCancel, QuantityZero, TrialEndNow bool
 	BillingCycleAnchor                              int64
 	BillingCycleAnchorNow                           bool

--- a/sub/client.go
+++ b/sub/client.go
@@ -98,6 +98,8 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 
 		if params.FeePercent > 0 {
 			body.Add("application_fee_percent", strconv.FormatFloat(params.FeePercent, 'f', 2, 64))
+		} else if params.FeePercentZero {
+			body.Add("application_fee_percent", "0")
 		}
 
 		if params.BillingCycleAnchorNow {


### PR DESCRIPTION
Via Stripe Connect, you can set an `application_fee_percent` on a subscription or an `application_fee` on an invoice. This can be set to 0 but as usual the Go library does not support this.

This PR fixes the bug by introducing `FeePercentZero` and `FeeZero`.

r? @brandur 