### PR TITLE
Fix Del methods to always take an extra parameter and be named Del

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ $resource$, err := $resource$.Get(id, stripe.$Resource$Params)
 $resource$, err := $resource$.Update(stripe.$Resource$Params)
 
 // Delete
-err := $resource$.Del(id)
+resourceDeleted, err := $resource$.Del(id, stripe.$Resource$Params)
 
 // List
 i := $resource$.List(stripe.$Resource$ListParams)
@@ -224,7 +224,7 @@ $resource$, err := sc.$Resource$s.Get(id, stripe.$Resource$Params)
 $resource$, err := sc.$Resource$s.Update(stripe.$Resource$Params)
 
 // Delete
-err := sc.$Resource$s.Del(id)
+resourceDeleted, err := sc.$Resource$s.Del(id, stripe.$Resource$Params)
 
 // List
 i := sc.$Resource$s.List(stripe.$Resource$ListParams)

--- a/account/client.go
+++ b/account/client.go
@@ -188,13 +188,23 @@ func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account
 }
 
 // Del deletes an account
-func Del(id string) (*stripe.Account, error) {
-	return getC().Del(id)
+func Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
+	return getC().Del(id, params)
 }
 
-func (c Client) Del(id string) (*stripe.Account, error) {
+func (c Client) Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	acct := &stripe.Account{}
-	err := c.B.Call("DELETE", "/accounts/"+id, c.Key, nil, nil, acct)
+	err := c.B.Call("DELETE", "/accounts/"+id, c.Key, body, commonParams, acct)
 
 	return acct, err
 }

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -109,7 +109,7 @@ func TestAccountDelete(t *testing.T) {
 		t.Error(err)
 	}
 
-	acctDel, err := Del(acct.ID)
+	acctDel, err := Del(acct.ID, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -49,13 +49,23 @@ func (c Client) Get(id string, params *stripe.ApplePayDomainParams) (*stripe.App
 }
 
 // Del removes an ApplePayDomain.
-func Del(id string) (*stripe.ApplePayDomain, error) {
-	return getC().Del(id)
+func Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
+	return getC().Del(id, params)
 }
 
-func (c Client) Del(id string) (*stripe.ApplePayDomain, error) {
+func (c Client) Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("DELETE", "/apple_pay/domains/"+id, c.Key, nil, nil, domain)
+	err := c.B.Call("DELETE", "/apple_pay/domains/"+id, c.Key, body, commonParams, domain)
 
 	return domain, err
 }

--- a/applepaydomain/client_test.go
+++ b/applepaydomain/client_test.go
@@ -54,7 +54,7 @@ func TestApplePayDomain(t *testing.T) {
 	}
 
 	// Testing to delete an ApplePayDomain
-	domain3, err := Del(domain2.ID)
+	domain3, err := Del(domain2.ID, nil)
 	if !domain3.Deleted {
 		t.Errorf("Domain id %v expected to be marked as deleted on the returned resource\n", domain3.ID)
 	}

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -147,13 +147,23 @@ func Del(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 }
 
 func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	ba := &stripe.BankAccount{}
 	var err error
 
 	if len(params.Customer) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, nil, &params.Params, ba)
+		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
 	} else if len(params.AccountID) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, nil, nil, ba)
+		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
 	}

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -45,7 +45,7 @@ func TestBankAccountDel(t *testing.T) {
 		t.Errorf("Bank account id %q expected to be marked as deleted on the returned resource\n", baDel.ID)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestBankAccountListByAccount(t *testing.T) {
@@ -84,7 +84,7 @@ func TestBankAccountListByAccount(t *testing.T) {
 	}
 
 	Del(baTok.ID, &stripe.BankAccountParams{AccountID: acct.ID})
-	account.Del(acct.ID)
+	account.Del(acct.ID, nil)
 }
 
 func TestBankAccountListByCustomer(t *testing.T) {
@@ -118,5 +118,5 @@ func TestBankAccountListByCustomer(t *testing.T) {
 	}
 
 	Del(cust.DefaultSource.ID, &stripe.BankAccountParams{Customer: cust.ID})
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }

--- a/card/client.go
+++ b/card/client.go
@@ -133,15 +133,25 @@ func Del(id string, params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	card := &stripe.Card{}
 	var err error
 
 	if len(params.Account) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/external_accounts/%v", params.Account, id), c.Key, nil, &params.Params, card)
+		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/external_accounts/%v", params.Account, id), c.Key, body, commonParams, card)
 	} else if len(params.Customer) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/cards/%v", params.Customer, id), c.Key, nil, &params.Params, card)
+		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/cards/%v", params.Customer, id), c.Key, body, commonParams, card)
 	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/recipients/%v/cards/%v", params.Recipient, id), c.Key, nil, &params.Params, card)
+		err = c.B.Call("DELETE", fmt.Sprintf("/recipients/%v/cards/%v", params.Recipient, id), c.Key, body, commonParams, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -56,7 +56,7 @@ func TestCardNew(t *testing.T) {
 		t.Errorf("Unexpected last four %q for card number %v\n", targetCard.LastFour, cardParams.Number)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestCardGet(t *testing.T) {
@@ -83,7 +83,7 @@ func TestCardGet(t *testing.T) {
 		t.Errorf("Card funding %q does not match expected value\n", target.Funding)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestCardDel(t *testing.T) {
@@ -101,7 +101,7 @@ func TestCardDel(t *testing.T) {
 		t.Errorf("Card id %q expected to be marked as deleted on the returned resource\n", cardDel.ID)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestCardUpdate(t *testing.T) {
@@ -139,7 +139,7 @@ func TestCardUpdate(t *testing.T) {
 		t.Errorf("Unexpected expiration year %d for card where we set %q\n", target.Year, cardParams.Year)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestCardList(t *testing.T) {
@@ -169,5 +169,5 @@ func TestCardList(t *testing.T) {
 		t.Error(err)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -110,13 +110,23 @@ func (c Client) Update(id string, params *stripe.CouponParams) (*stripe.Coupon, 
 
 // Del removes a coupon.
 // For more details see https://stripe.com/docs/api#delete_coupon.
-func Del(id string) (*stripe.Coupon, error) {
-	return getC().Del(id)
+func Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
+	return getC().Del(id, params)
 }
 
-func (c Client) Del(id string) (*stripe.Coupon, error) {
+func (c Client) Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("DELETE", "/coupons/"+url.QueryEscape(id), c.Key, nil, nil, coupon)
+	err := c.B.Call("DELETE", "/coupons/"+url.QueryEscape(id), c.Key, body, commonParams, coupon)
 
 	return coupon, err
 }

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -58,7 +58,7 @@ func TestCouponNew(t *testing.T) {
 		t.Errorf("Coupon is not valid, but was expecting it to be\n")
 	}
 
-	Del(target.ID)
+	Del(target.ID, nil)
 }
 
 func TestCouponGet(t *testing.T) {
@@ -83,7 +83,7 @@ func TestCouponGet(t *testing.T) {
 		t.Errorf("Percent %v does not match expected percent %v\n", target.Percent, couponParams.Percent)
 	}
 
-	Del(target.ID)
+	Del(target.ID, nil)
 }
 
 func TestCouponUpdate(t *testing.T) {
@@ -111,7 +111,7 @@ func TestCouponUpdate(t *testing.T) {
 		t.Errorf("Meta %v does not match expected Meta %v\n", target.Meta, updateParams.Meta)
 	}
 
-	Del(target.ID)
+	Del(target.ID, nil)
 }
 
 func TestCouponList(t *testing.T) {
@@ -140,7 +140,7 @@ func TestCouponList(t *testing.T) {
 	}
 
 	for i := 0; i < 5; i++ {
-		Del(fmt.Sprintf("test_%v", i))
+		Del(fmt.Sprintf("test_%v", i), nil)
 	}
 }
 
@@ -155,7 +155,7 @@ func TestCouponDel(t *testing.T) {
 		t.Error(err)
 	}
 
-	coupon, err := Del(target.ID)
+	coupon, err := Del(target.ID, nil)
 	if !coupon.Deleted {
 		t.Errorf("Coupon id %v expected to be marked as deleted on the returned resource\n", coupon.ID)
 	}

--- a/customer/client.go
+++ b/customer/client.go
@@ -164,13 +164,23 @@ func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Custom
 
 // Del removes a customer.
 // For more details see https://stripe.com/docs/api#delete_customer.
-func Del(id string) (*stripe.Customer, error) {
-	return getC().Del(id)
+func Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
+	return getC().Del(id, params)
 }
 
-func (c Client) Del(id string) (*stripe.Customer, error) {
+func (c Client) Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	cust := &stripe.Customer{}
-	err := c.B.Call("DELETE", "/customers/"+id, c.Key, nil, nil, cust)
+	err := c.B.Call("DELETE", "/customers/"+id, c.Key, body, commonParams, cust)
 
 	return cust, err
 }

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -59,7 +59,7 @@ func TestCustomerNew(t *testing.T) {
 		t.Errorf("Unexpected number of cards %v\n", target.Sources.Count)
 	}
 
-	Del(target.ID)
+	Del(target.ID, nil)
 }
 
 func TestCustomerNewWithPlan(t *testing.T) {
@@ -88,7 +88,7 @@ func TestCustomerNewWithPlan(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = Del(target.ID)
+	_, err = Del(target.ID, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -123,7 +123,7 @@ func TestCustomerNewWithShipping(t *testing.T) {
 		t.Errorf("Shipping address line 1 %q does not match expected address line 1 %v\n", target.Shipping.Address.Line1, customerParams.Shipping.Address.Line1)
 	}
 
-	Del(target.ID)
+	Del(target.ID, nil)
 }
 
 func TestCustomerUpdateWithShipping(t *testing.T) {
@@ -172,7 +172,7 @@ func TestCustomerUpdateWithShipping(t *testing.T) {
 		t.Errorf("Shipping address zip %q does not match expected address zip %v\n", target.Shipping.Address.Zip, customerParams.Shipping.Address.Zip)
 	}
 
-	Del(target.ID)
+	Del(target.ID, nil)
 }
 
 func TestCustomerGet(t *testing.T) {
@@ -188,13 +188,13 @@ func TestCustomerGet(t *testing.T) {
 		t.Errorf("Customer id %q does not match expected id %q\n", target.ID, res.ID)
 	}
 
-	Del(res.ID)
+	Del(res.ID, nil)
 }
 
 func TestCustomerDel(t *testing.T) {
 	res, _ := New(nil)
 
-	customerDel, err := Del(res.ID)
+	customerDel, err := Del(res.ID, nil)
 
 	if err != nil {
 		t.Error(err)
@@ -269,7 +269,7 @@ func TestCustomerUpdate(t *testing.T) {
 		t.Errorf("BalanceZero did not reset the balance to 0: %v\n", target2.Balance)
 	}
 
-	Del(target.ID)
+	Del(target.ID, nil)
 }
 
 func TestCustomerDiscount(t *testing.T) {
@@ -303,7 +303,7 @@ func TestCustomerDiscount(t *testing.T) {
 		t.Errorf("Coupon id %q does not match expected id %q\n", target.Discount.Coupon.ID, customerParams.Coupon)
 	}
 
-	discountDel, err := discount.Del(target.ID)
+	discountDel, err := discount.Del(target.ID, nil)
 
 	if err != nil {
 		t.Error(err)
@@ -313,8 +313,8 @@ func TestCustomerDiscount(t *testing.T) {
 		t.Errorf("Discount expected to be marked as deleted on the returned resource\n")
 	}
 
-	Del(target.ID)
-	coupon.Del("customer_coupon")
+	Del(target.ID, nil)
+	coupon.Del("customer_coupon", nil)
 }
 
 func TestCustomerEmptyDiscount(t *testing.T) {
@@ -362,8 +362,8 @@ func TestCustomerEmptyDiscount(t *testing.T) {
 		t.Errorf("A discount %v was found, but was expected to have been deleted\n", target.Discount)
 	}
 
-	Del(target.ID)
-	coupon.Del("customer_coupon")
+	Del(target.ID, nil)
+	coupon.Del("customer_coupon", nil)
 }
 
 func TestCustomerList(t *testing.T) {
@@ -389,6 +389,6 @@ func TestCustomerList(t *testing.T) {
 	}
 
 	for _, v := range customers {
-		Del(v)
+		Del(v, nil)
 	}
 }

--- a/discount/client.go
+++ b/discount/client.go
@@ -15,26 +15,46 @@ type Client struct {
 
 // Del removes a discount from a customer.
 // For more details see https://stripe.com/docs/api#delete_discount.
-func Del(customerID string) (*stripe.Discount, error) {
-	return getC().Del(customerID)
+func Del(customerID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
+	return getC().Del(customerID, params)
 }
 
-func (c Client) Del(customerID string) (*stripe.Discount, error) {
+func (c Client) Del(customerID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", fmt.Sprintf("/customers/%v/discount", customerID), c.Key, nil, nil, discount)
+	err := c.B.Call("DELETE", fmt.Sprintf("/customers/%v/discount", customerID), c.Key, body, commonParams, discount)
 
 	return discount, err
 }
 
 // DelSub removes a discount from a customer's subscription.
 // For more details see https://stripe.com/docs/api#delete_subscription_discount.
-func DelSub(subscriptionID string) (*stripe.Discount, error) {
-	return getC().DelSub(subscriptionID)
+func DelSub(subscriptionID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
+	return getC().DelSub(subscriptionID, params)
 }
 
-func (c Client) DelSub(subscriptionID string) (*stripe.Discount, error) {
+func (c Client) DelSub(subscriptionID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", fmt.Sprintf("/subscriptions/%v/discount", subscriptionID), c.Key, nil, nil, discount)
+	err := c.B.Call("DELETE", fmt.Sprintf("/subscriptions/%v/discount", subscriptionID), c.Key, body, commonParams, discount)
 
 	return discount, err
 }

--- a/discounts.go
+++ b/discounts.go
@@ -1,5 +1,10 @@
 package stripe
 
+// DiscountParams is the set of parameters that can be used when deleting a discount.
+type DiscountParams struct {
+  Params
+}
+
 // Discount is the resource representing a Stripe discount.
 // For more details see https://stripe.com/docs/api#discounts.
 type Discount struct {
@@ -10,3 +15,4 @@ type Discount struct {
 	Sub      string  `json:"subscription"`
 	Deleted  bool    `json:"deleted"`
 }
+

--- a/discounts.go
+++ b/discounts.go
@@ -2,7 +2,7 @@ package stripe
 
 // DiscountParams is the set of parameters that can be used when deleting a discount.
 type DiscountParams struct {
-  Params
+	Params
 }
 
 // Discount is the resource representing a Stripe discount.
@@ -15,4 +15,3 @@ type Discount struct {
 	Sub      string  `json:"subscription"`
 	Deleted  bool    `json:"deleted"`
 }
-

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -50,15 +50,25 @@ func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 
 // Del removes an ephemeral key.
 // For more details see https://stripe.com/docs/api#delete_ephemeral_key.
-func Del(id string) (*stripe.EphemeralKey, error) {
-	return getC().Del(id)
+func Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
+	return getC().Del(id, params)
 }
 
 // Del removes an ephemeral key.
 // For more details see https://stripe.com/docs/api#delete_ephemeral_key.
-func (c Client) Del(id string) (*stripe.EphemeralKey, error) {
+func (c Client) Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call("DELETE", "/ephemeral_keys/"+id, c.Key, nil, nil, ephemeralKey)
+	err := c.B.Call("DELETE", "/ephemeral_keys/"+id, c.Key, body, commonParams, ephemeralKey)
 
 	return ephemeralKey, err
 }

--- a/ephemeralkey/client_test.go
+++ b/ephemeralkey/client_test.go
@@ -82,7 +82,7 @@ func TestEphemeralKeyDelete(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 
-	k, err = Del(k.ID)
+	k, err = Del(k.ID, nil)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -70,7 +70,7 @@ func ExampleInvoice_update() {
 func ExampleCustomer_delete() {
 	stripe.Key = "sk_key"
 
-	customerDel, err := customer.Del("cus_example_id")
+	customerDel, err := customer.Del("cus_example_id", nil)
 
 	if err != nil {
 		log.Fatal(err)

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -382,7 +382,7 @@ func TestAllInvoicesScenarios(t *testing.T) {
 		t.Error(err)
 	}
 
-	iiDel, err := invoiceitem.Del(targetItem.ID)
+	iiDel, err := invoiceitem.Del(targetItem.ID, nil)
 
 	if err != nil {
 		t.Error(err)
@@ -507,5 +507,5 @@ func TestAllInvoicesScenarios(t *testing.T) {
 		t.Error(err)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -110,13 +110,23 @@ func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.Inv
 
 // Del removes an invoice item.
 // For more details see https://stripe.com/docs/api#delete_invoiceitem.
-func Del(id string) (*stripe.InvoiceItem, error) {
-	return getC().Del(id)
+func Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
+	return getC().Del(id, params)
 }
 
-func (c Client) Del(id string) (*stripe.InvoiceItem, error) {
+func (c Client) Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	ii := &stripe.InvoiceItem{}
-	err := c.B.Call("DELETE", "/invoiceitems/"+id, c.Key, nil, nil, ii)
+	err := c.B.Call("DELETE", "/invoiceitems/"+id, c.Key, body, commonParams, ii)
 
 	return ii, err
 }

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -145,7 +145,7 @@ func TestOrder(t *testing.T) {
 		t.Error("Order metadata not set")
 	}
 
-	coupon.Del(c.ID)
+	coupon.Del(c.ID, nil)
 }
 
 func TestOrderUpdate(t *testing.T) {
@@ -225,7 +225,7 @@ func TestOrderUpdate(t *testing.T) {
 		t.Errorf("Order metadata not updated: %v", updated.Meta["foo"])
 	}
 
-	coupon.Del(c.ID)
+	coupon.Del(c.ID, nil)
 }
 
 func TestOrderPay(t *testing.T) {

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -96,11 +96,21 @@ func Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 }
 
 func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	source := &stripe.PaymentSource{}
 	var err error
 
 	if len(params.Customer) > 0 {
-		err = s.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), s.Key, nil, &params.Params, source)
+		err = s.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), s.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -52,7 +52,7 @@ func TestSourceCardNew(t *testing.T) {
 		t.Errorf("Unexpected number of sources %v\n", targetCust.Sources.Count)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestSourceBankAccountNew(t *testing.T) {
@@ -120,7 +120,7 @@ func TestSourceCardGet(t *testing.T) {
 		t.Errorf("Card brand %q does not match expected value\n", target.Brand)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestSourceBankAccountGet(t *testing.T) {
@@ -178,7 +178,7 @@ func TestSourceCardDel(t *testing.T) {
 		t.Errorf("Source id %q expected to be marked as deleted on the returned resource\n", sourceDel.ID)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestSourceBankAccountDel(t *testing.T) {
@@ -251,7 +251,7 @@ func TestSourceCardUpdate(t *testing.T) {
 		t.Errorf("Card name %q does not match expected name %q\n", target.Name, sourceParams.Source.Card.Name)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestSourceBankAccountVerify(t *testing.T) {
@@ -307,7 +307,7 @@ func TestSourceBankAccountVerify(t *testing.T) {
 		t.Errorf("Status (%q) does not match expected (%q) ", target.Status, bankaccount.VerifiedAccount)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestSourceList(t *testing.T) {
@@ -343,7 +343,7 @@ func TestSourceList(t *testing.T) {
 		t.Error(err)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 }
 
 func TestSourceObjectNewGet(t *testing.T) {

--- a/payout/client_test.go
+++ b/payout/client_test.go
@@ -148,5 +148,5 @@ func TestPayoutAllMethods(t *testing.T) {
 		t.Errorf("Expected 4 payouts on %q but got %q\n", acc.ID, nbPayouts)
 	}
 
-	account.Del(acc.ID)
+	account.Del(acc.ID, nil)
 }

--- a/product/client.go
+++ b/product/client.go
@@ -231,14 +231,27 @@ func (i *Iter) Product() *stripe.Product {
 
 // Delete deletes a product
 // For more details see https://stripe.com/docs/api#delete_product.
-func Delete(id string) error {
-	return getC().Delete(id)
+func Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
+	return getC().Del(id, params)
 }
 
 // Delete deletes a product.
 // For more details see https://stripe.com/docs/api#delete_product.
-func (c Client) Delete(id string) error {
-	return c.B.Call("DELETE", "/products/"+id, c.Key, nil, nil, nil)
+func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
+	product := &stripe.Product{}
+	err := c.B.Call("DELETE", "/products/"+id, c.Key, body, commonParams, product)
+
+	return product, err
 }
 
 func getC() Client {

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -199,7 +199,7 @@ func TestProductDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
-	err = Delete(p.ID)
+	_, err = Del(p.ID, nil)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -102,13 +102,23 @@ func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recip
 
 // Del removes a recipient.
 // For more details see https://stripe.com/docs/api#delete_recipient.
-func Del(id string) (*stripe.Recipient, error) {
-	return getC().Del(id)
+func Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
+	return getC().Del(id, params)
 }
 
-func (c Client) Del(id string) (*stripe.Recipient, error) {
+func (c Client) Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("DELETE", "/recipients/"+id, c.Key, nil, nil, recipient)
+	err := c.B.Call("DELETE", "/recipients/"+id, c.Key, body, commonParams, recipient)
 
 	return recipient, err
 }

--- a/sku/client.go
+++ b/sku/client.go
@@ -256,14 +256,27 @@ func (i *Iter) SKU() *stripe.SKU {
 
 // Delete destroys a SKU.
 // For more details see https://stripe.com/docs/api#delete_sku.
-func Delete(id string) error {
-	return getC().Delete(id)
+func Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
+	return getC().Del(id, params)
 }
 
 // Delete destroys a SKU.
 // For more details see https://stripe.com/docs/api#delete_sku.
-func (c Client) Delete(id string) error {
-	return c.B.Call("DELETE", "/skus/"+id, c.Key, nil, nil, nil)
+func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
+	var body *stripe.RequestValues
+	var commonParams *stripe.Params
+
+	if params != nil {
+		body = &stripe.RequestValues{}
+
+		params.AppendTo(body)
+		commonParams = &params.Params
+	}
+
+	sku := &stripe.SKU{}
+	err := c.B.Call("DELETE", "/skus/"+id, c.Key, body, commonParams, sku)
+
+	return sku, err
 }
 
 func getC() Client {

--- a/sku/client_test.go
+++ b/sku/client_test.go
@@ -152,7 +152,7 @@ func TestSKUDelete(t *testing.T) {
 		Product:   p.ID,
 	})
 
-	err = Delete(sku.ID)
+	_, err = Del(sku.ID, nil)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -374,7 +374,7 @@ func TestSubscriptionDiscount(t *testing.T) {
 		t.Errorf("Coupon id %q does not match expected id %q\n", target.Discount.Coupon.ID, subParams.Coupon)
 	}
 
-	_, err = discount.DelSub(target.ID)
+	_, err = discount.DelSub(target.ID, nil)
 
 	if err != nil {
 		t.Error(err)

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -75,7 +75,7 @@ func TestSubscriptionNew(t *testing.T) {
 		t.Errorf("PeriodEnd %v does not match expected BillingCycleAnchor %v\n", target.PeriodEnd, subParams.BillingCycleAnchor)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
 }
 
@@ -120,7 +120,7 @@ func TestSubscriptionZeroQuantity(t *testing.T) {
 		t.Errorf("Tax percent %v does not match expected tax percent %v\n", target.TaxPercent, 0)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
 }
 
@@ -168,7 +168,7 @@ func TestSubscriptionUpdateZeroQuantity(t *testing.T) {
 		t.Errorf("TaxPercent %f does not match expected tax_percent %f\n", target.TaxPercent, updatedSub.TaxPercent)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
 }
 
@@ -215,7 +215,7 @@ func TestSubscriptionGet(t *testing.T) {
 		t.Errorf("Subscription id %q does not match expected id %q\n", target.ID, subscription.ID)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
 }
 
@@ -263,7 +263,7 @@ func TestSubscriptionCancel(t *testing.T) {
 		t.Errorf("Subscription.Canceled %v expected to be non 0\n", s.Canceled)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
 }
 
@@ -321,7 +321,7 @@ func TestSubscriptionUpdate(t *testing.T) {
 		t.Errorf("TaxPercent %f does not match expected tax_percent %f\n", target.TaxPercent, updatedSub.TaxPercent)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
 }
 
@@ -390,9 +390,9 @@ func TestSubscriptionDiscount(t *testing.T) {
 		t.Errorf("A discount %v was found, but was expected to have been deleted\n", target.Discount)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
-	coupon.Del("sub_coupon")
+	coupon.Del("sub_coupon", nil)
 }
 
 func TestSubscriptionEmptyDiscount(t *testing.T) {
@@ -458,9 +458,9 @@ func TestSubscriptionEmptyDiscount(t *testing.T) {
 		t.Errorf("A discount %v was found, but was expected to have been deleted\n", target.Discount)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
-	coupon.Del("sub_coupon")
+	coupon.Del("sub_coupon", nil)
 }
 
 func TestSubscriptionList(t *testing.T) {
@@ -577,6 +577,6 @@ func TestSubscriptionList(t *testing.T) {
 		t.Error(err)
 	}
 
-	customer.Del(cust.ID)
+	customer.Del(cust.ID, nil)
 	plan.Del("test", nil)
 }

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -63,7 +63,7 @@ func createSubItem(t *testing.T) (*stripe.Sub, *stripe.SubItem, func()) {
 	return target, target.Items.Values[0], func() {
 		sub.Cancel(target.ID, nil)
 		plan.Del(p.ID, nil)
-		customer.Del(cust.ID)
+		customer.Del(cust.ID, nil)
 	}
 }
 

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -119,5 +119,5 @@ func TestTransferAllMethods(t *testing.T) {
 		t.Errorf("Expected 4 transfers on %q but got %q\n", acc.ID, nbTransfers)
 	}
 
-	account.Del(acc.ID)
+	account.Del(acc.ID, nil)
 }


### PR DESCRIPTION
This PR fixes https://github.com/stripe/stripe-go/issues/425 and ensures that all Del methods behave the same way.

First, Product/SKU Delete methods were renamed to Del and now return the deleted resource too.

All Del methods now properly take an extra parameter. This lets you pass custom values such as an IdempotencyKey and where relevant the id of the connected account that you're making the request on behalf of.

Also update the Readme to better reflect how Del works.