### PR TITLE
Use Bearer auth

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -249,8 +249,9 @@ func (s *BackendConfiguration) NewRequest(method, path, key, contentType string,
 		return nil, err
 	}
 
-	req.SetBasicAuth(key, "")
+	authorization := "Bearer " + key
 
+	req.Header.Add("Authorization", authorization)
 	req.Header.Add("Stripe-Version", apiversion)
 	req.Header.Add("User-Agent", encodedUserAgent)
 	req.Header.Add("Content-Type", contentType)

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -11,6 +11,22 @@ import (
 	. "github.com/stripe/stripe-go/testing"
 )
 
+func TestCheckinUseBearerAuth(t *testing.T) {
+	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	key := "apiKey"
+
+	req, err := c.NewRequest("", "", key, "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedAuthorizationHeader := "Bearer " + key
+	if req.Header.Get("Authorization") != expectedAuthorizationHeader {
+		t.Fatalf("Expected Authorization %v but got %v.",
+			expectedAuthorizationHeader, req.Header.Get("Authorization"))
+	}
+}
+
 func TestCheckinBackendConfigurationNewRequestWithStripeAccount(t *testing.T) {
 	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
 	p := &stripe.Params{StripeAccount: TestMerchantID}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Use Bearer auth instead of Basic auth for API requests. Similar to https://github.com/stripe/stripe-node/pull/379.