### PR TITLE
Add missing OnBehalfOf

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -27,6 +27,7 @@ type ChargeParams struct {
 	Source                       *SourceParams
 	Shipping                     *ShippingDetails
 	TransferGroup                string
+	OnBehalfOf                   string
 }
 
 type DestinationParams struct {

--- a/charge/client.go
+++ b/charge/client.go
@@ -88,6 +88,10 @@ func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 		body.Add("application_fee", strconv.FormatUint(params.Fee, 10))
 	}
 
+	if len(params.OnBehalfOf) > 0 {
+		body.Add("on_behalf_of", params.OnBehalfOf)
+	}
+
 	if params.Shipping != nil {
 		params.Shipping.AppendDetails(body)
 	}

--- a/sub.go
+++ b/sub.go
@@ -29,6 +29,7 @@ type SubParams struct {
 	Items                                           []*SubItemsParams
 	Billing                                         SubBilling
 	DaysUntilDue                                    uint64
+	OnBehalfOf                                      string
 }
 
 // SubItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription

--- a/sub/client.go
+++ b/sub/client.go
@@ -108,6 +108,10 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 			body.Add("billing_cycle_anchor", strconv.FormatInt(params.BillingCycleAnchor, 10))
 		}
 
+		if len(params.OnBehalfOf) > 0 {
+			body.Add("on_behalf_of", params.OnBehalfOf)
+		}
+
 		commonParams = &params.Params
 
 		params.AppendTo(body)


### PR DESCRIPTION
Reading the documentation, there is a functionality of adding an OnBehalfOf parameter When creating separate charges:
https://stripe.com/docs/connect/charges-transfers#on-behalf-of

This is also the case for creating subscriptions, however it is not currently documented in the official documentation.