### PR TITLE
Alphabetize the world

### DIFF
--- a/account.go
+++ b/account.go
@@ -133,37 +133,39 @@ type Account struct {
 	Email                string               `json:"email"`
 	ExternalAccounts     *ExternalAccountList `json:"external_accounts"`
 	ID                   string               `json:"id"`
-	LegalEntity          *LegalEntity         `json:"legal_entity"`
-	Meta                 map[string]string    `json:"metadata"`
-	Name                 string               `json:"display_name"`
-	PayoutSchedule       *PayoutSchedule      `json:"payout_schedule"`
-	PayoutStatement      string               `json:"payout_statement_descriptor"`
-	PayoutsEnabled       bool                 `json:"payouts_enabled"`
-	ProductDesc          string               `json:"product_description"`
-	Statement            string               `json:"statement_descriptor"`
-	SupportAddress       *Address             `json:"support_address"`
-	SupportEmail         string               `json:"support_email"`
-	SupportPhone         string               `json:"support_phone"`
-	SupportUrl           string               `json:"support_url"`
-	Timezone             string               `json:"timezone"`
-	Type                 AccountType
 
 	Keys *struct {
 		Publish string `json:"publishable"`
 		Secret  string `json:"secret"`
 	} `json:"keys"`
 
-	Verification *struct {
-		DisabledReason string   `json:"disabled_reason"`
-		Due            *int64   `json:"due_by"`
-		Fields         []string `json:"fields_needed"`
-	} `json:"verification"`
+	LegalEntity     *LegalEntity      `json:"legal_entity"`
+	Meta            map[string]string `json:"metadata"`
+	Name            string            `json:"display_name"`
+	PayoutSchedule  *PayoutSchedule   `json:"payout_schedule"`
+	PayoutStatement string            `json:"payout_statement_descriptor"`
+	PayoutsEnabled  bool              `json:"payouts_enabled"`
+	ProductDesc     string            `json:"product_description"`
+	Statement       string            `json:"statement_descriptor"`
+	SupportAddress  *Address          `json:"support_address"`
+	SupportEmail    string            `json:"support_email"`
+	SupportPhone    string            `json:"support_phone"`
+	SupportUrl      string            `json:"support_url"`
+	Timezone        string            `json:"timezone"`
 
 	TOSAcceptance *struct {
 		Date      int64  `json:"date"`
 		IP        string `json:"ip"`
 		UserAgent string `json:"user_agent"`
 	} `json:"tos_acceptance"`
+
+	Type AccountType
+
+	Verification *struct {
+		DisabledReason string   `json:"disabled_reason"`
+		Due            *int64   `json:"due_by"`
+		Fields         []string `json:"fields_needed"`
+	} `json:"verification"`
 }
 
 // UnmarshalJSON handles deserialization of an account.

--- a/account.go
+++ b/account.go
@@ -27,58 +27,58 @@ type IdentityVerificationStatus string
 type Interval string
 
 const (
+	// Company is a constant value representing a company legal entity type.
+	Company LegalEntityType = "company"
+
+	// Day is a constant value representing a daily payout interval.
+	Day Interval = "daily"
+
 	// Individual is a constant value representing an individual legal entity
 	// type.
 	Individual LegalEntityType = "individual"
-
-	// Company is a constant value representing a company legal entity type.
-	Company LegalEntityType = "company"
 
 	// IdentityVerificationPending is a constant value indicating that identity
 	// verification status is pending.
 	IdentityVerificationPending IdentityVerificationStatus = "pending"
 
-	// IdentityVerificationVerified is a constant value indicating that
-	// identity verification status is verified.
-	IdentityVerificationVerified IdentityVerificationStatus = "verified"
-
 	// IdentityVerificationUnverified is a constant value indicating that
 	// identity verification status is unverified.
 	IdentityVerificationUnverified IdentityVerificationStatus = "unverified"
 
+	// IdentityVerificationVerified is a constant value indicating that
+	// identity verification status is verified.
+	IdentityVerificationVerified IdentityVerificationStatus = "verified"
+
 	// Manual is a constant value representing a manual payout interval.
 	Manual Interval = "manual"
 
-	// Day is a constant value representing a daily payout interval.
-	Day Interval = "daily"
+	// Month is a constant value representing a monthly payout interval.
+	Month Interval = "monthly"
 
 	// Week is a constant value representing a weekly payout interval.
 	Week Interval = "weekly"
-
-	// Month is a constant value representing a monthly payout interval.
-	Month Interval = "monthly"
 )
 
 // AccountParams are the parameters allowed during account creation/updates.
 type AccountParams struct {
 	Params               `form:"*"`
-	Country              string                        `form:"country"`
-	Email                string                        `form:"email"`
-	DefaultCurrency      string                        `form:"default_currency"`
-	Statement            string                        `form:"statement_descriptor"`
 	BusinessName         string                        `form:"business_name"`
-	BusinessUrl          string                        `form:"business_url"`
 	BusinessPrimaryColor string                        `form:"business_primary_color"`
-	SupportPhone         string                        `form:"support_phone"`
-	SupportEmail         string                        `form:"support_email"`
-	SupportUrl           string                        `form:"support_url"`
-	FromRecipient        string                        `form:"from_recipient"`
-	PayoutStatement      string                        `form:"payout_statement_descriptor"`
-	ExternalAccount      *AccountExternalAccountParams `form:"external_account"`
-	LegalEntity          *LegalEntity                  `form:"legal_entity"`
-	PayoutSchedule       *PayoutScheduleParams         `form:"payout_schedule"`
+	BusinessUrl          string                        `form:"business_url"`
+	Country              string                        `form:"country"`
 	DebitNegativeBal     bool                          `form:"debit_negative_balances"`
+	DefaultCurrency      string                        `form:"default_currency"`
+	Email                string                        `form:"email"`
+	ExternalAccount      *AccountExternalAccountParams `form:"external_account"`
+	FromRecipient        string                        `form:"from_recipient"`
+	LegalEntity          *LegalEntity                  `form:"legal_entity"`
 	NoDebitNegativeBal   bool                          `form:"debit_negative_balances,invert"`
+	PayoutSchedule       *PayoutScheduleParams         `form:"payout_schedule"`
+	PayoutStatement      string                        `form:"payout_statement_descriptor"`
+	Statement            string                        `form:"statement_descriptor"`
+	SupportEmail         string                        `form:"support_email"`
+	SupportPhone         string                        `form:"support_phone"`
+	SupportUrl           string                        `form:"support_url"`
 	TOSAcceptance        *TOSAcceptanceParams          `form:"tos_acceptance"`
 	Type                 AccountType                   `form:"type"`
 }
@@ -105,10 +105,10 @@ type AccountExternalAccountParams struct {
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
 	Delay        uint64   `form:"delay_days"`
-	MonthAnchor  uint64   `form:"monthly_anchor"`
-	WeekAnchor   string   `form:"weekly_anchor"`
 	Interval     Interval `form:"interval"`
 	MinimumDelay bool     `form:"-"` // See custom AppendTo
+	MonthAnchor  uint64   `form:"monthly_anchor"`
+	WeekAnchor   string   `form:"weekly_anchor"`
 }
 
 func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
@@ -120,47 +120,50 @@ func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
 // Account is the resource representing your Stripe account.
 // For more details see https://stripe.com/docs/api/#account.
 type Account struct {
-	ID                   string               `json:"id"`
-	ChargesEnabled       bool                 `json:"charges_enabled"`
-	Country              string               `json:"country"`
-	DefaultCurrency      string               `json:"default_currency"`
-	DetailsSubmitted     bool                 `json:"details_submitted"`
-	PayoutsEnabled       bool                 `json:"payouts_enabled"`
-	Name                 string               `json:"display_name"`
-	Email                string               `json:"email"`
-	ExternalAccounts     *ExternalAccountList `json:"external_accounts"`
-	Statement            string               `json:"statement_descriptor"`
-	PayoutStatement      string               `json:"payout_statement_descriptor"`
-	Timezone             string               `json:"timezone"`
+	BusinessLogo         string               `json:"business_logo"`
 	BusinessName         string               `json:"business_name"`
 	BusinessPrimaryColor string               `json:"business_primary_color"`
 	BusinessUrl          string               `json:"business_url"`
-	BusinessLogo         string               `json:"business_logo"`
-	SupportPhone         string               `json:"support_phone"`
-	SupportEmail         string               `json:"support_email"`
-	SupportUrl           string               `json:"support_url"`
-	ProductDesc          string               `json:"product_description"`
+	ChargesEnabled       bool                 `json:"charges_enabled"`
+	Country              string               `json:"country"`
 	DebitNegativeBal     bool                 `json:"debit_negative_balances"`
+	DefaultCurrency      string               `json:"default_currency"`
+	Deleted              bool                 `json:"deleted"`
+	DetailsSubmitted     bool                 `json:"details_submitted"`
+	Email                string               `json:"email"`
+	ExternalAccounts     *ExternalAccountList `json:"external_accounts"`
+	ID                   string               `json:"id"`
+	LegalEntity          *LegalEntity         `json:"legal_entity"`
+	Meta                 map[string]string    `json:"metadata"`
+	Name                 string               `json:"display_name"`
+	PayoutSchedule       *PayoutSchedule      `json:"payout_schedule"`
+	PayoutStatement      string               `json:"payout_statement_descriptor"`
+	PayoutsEnabled       bool                 `json:"payouts_enabled"`
+	ProductDesc          string               `json:"product_description"`
+	Statement            string               `json:"statement_descriptor"`
+	SupportAddress       *Address             `json:"support_address"`
+	SupportEmail         string               `json:"support_email"`
+	SupportPhone         string               `json:"support_phone"`
+	SupportUrl           string               `json:"support_url"`
+	Timezone             string               `json:"timezone"`
 	Type                 AccountType
-	Keys                 *struct {
-		Secret  string `json:"secret"`
+
+	Keys *struct {
 		Publish string `json:"publishable"`
+		Secret  string `json:"secret"`
 	} `json:"keys"`
+
 	Verification *struct {
-		Fields         []string `json:"fields_needed"`
-		Due            *int64   `json:"due_by"`
 		DisabledReason string   `json:"disabled_reason"`
+		Due            *int64   `json:"due_by"`
+		Fields         []string `json:"fields_needed"`
 	} `json:"verification"`
-	LegalEntity    *LegalEntity    `json:"legal_entity"`
-	PayoutSchedule *PayoutSchedule `json:"payout_schedule"`
-	TOSAcceptance  *struct {
+
+	TOSAcceptance *struct {
 		Date      int64  `json:"date"`
 		IP        string `json:"ip"`
 		UserAgent string `json:"user_agent"`
 	} `json:"tos_acceptance"`
-	SupportAddress *Address          `json:"support_address"`
-	Deleted        bool              `json:"deleted"`
-	Meta           map[string]string `json:"metadata"`
 }
 
 // UnmarshalJSON handles deserialization of an account.
@@ -226,16 +229,16 @@ type ExternalAccountList struct {
 // attached to an account. It contains fields that will be conditionally
 // populated depending on its type.
 type ExternalAccount struct {
-	Type ExternalAccountType `json:"object"`
-	ID   string              `json:"id"`
-
-	// A bank account attached to an account. Populated only if the external
-	// account is a bank account.
+	// BankAccount is a bank account attached to an account. Populated only if
+	// the external account is a bank account.
 	BankAccount *BankAccount
 
-	// A card attached to an account. Populated only if the external account is
-	// a card.
+	// Card is a card attached to an account. Populated only if the external
+	// account is a card.
 	Card *Card
+
+	ID   string              `json:"id"`
+	Type ExternalAccountType `json:"object"`
 }
 
 // UnmarshalJSON implements Unmarshaler.UnmarshalJSON.
@@ -267,12 +270,17 @@ type LegalEntity struct {
 	// owners.
 	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
 
-	BusinessName          string               `json:"business_name" form:"business_name"`
-	BusinessNameKana      string               `json:"business_name_kana" form:"business_name_kana"`
-	BusinessNameKanji     string               `json:"business_name_kanji" form:"business_name_kanji"`
 	Address               Address              `json:"address" form:"address"`
 	AddressKana           Address              `json:"address_kana" form:"address_kana"`
 	AddressKanji          Address              `json:"address_kanji" form:"address_kanji"`
+	BusinessName          string               `json:"business_name" form:"business_name"`
+	BusinessNameKana      string               `json:"business_name_kana" form:"business_name_kana"`
+	BusinessNameKanji     string               `json:"business_name_kanji" form:"business_name_kanji"`
+	BusinessTaxID         string               `json:"-" form:"business_tax_id"`
+	BusinessTaxIDProvided bool                 `json:"business_tax_id_provided" form:"-"`
+	BusinessVatID         string               `json:"-" form:"business_vat_id"`
+	BusinessVatIDProvided bool                 `json:"business_vat_id_provided" form:"-"`
+	DOB                   DOB                  `json:"dob" form:"dob"`
 	First                 string               `json:"first_name" form:"first_name"`
 	FirstKana             string               `json:"first_name_kana" form:"first_name_kana"`
 	FirstKanji            string               `json:"first_name_kanji" form:"first_name_kanji"`
@@ -284,32 +292,28 @@ type LegalEntity struct {
 	PersonalAddress       Address              `json:"personal_address" form:"personal_address"`
 	PersonalAddressKana   Address              `json:"personal_address_kana" form:"personal_address_kana"`
 	PersonalAddressKanji  Address              `json:"personal_address_kanji" form:"personal_address_kanji"`
-	PhoneNumber           string               `json:"phone_number" form:"phone_number"`
-	DOB                   DOB                  `json:"dob" form:"dob"`
-	Verification          IdentityVerification `json:"verification" form:"verification"`
-	SSN                   string               `json:"-" form:"ssn_last_4"`
-	SSNProvided           bool                 `json:"ssn_last_4_provided" form:"-"`
 	PersonalID            string               `json:"-" form:"personal_id_number"`
 	PersonalIDProvided    bool                 `json:"personal_id_number_provided" form:"-"`
-	BusinessTaxID         string               `json:"-" form:"business_tax_id"`
-	BusinessTaxIDProvided bool                 `json:"business_tax_id_provided" form:"-"`
-	BusinessVatID         string               `json:"-" form:"business_vat_id"`
-	BusinessVatIDProvided bool                 `json:"business_vat_id_provided" form:"-"`
+	PhoneNumber           string               `json:"phone_number" form:"phone_number"`
+	SSN                   string               `json:"-" form:"ssn_last_4"`
+	SSNProvided           bool                 `json:"ssn_last_4_provided" form:"-"`
 	Type                  LegalEntityType      `json:"type" form:"type"`
+	Verification          IdentityVerification `json:"verification" form:"verification"`
 }
 
 // Address is the structure for an account address.
 type Address struct {
+	City    string `json:"city" form:"city"`
+	Country string `json:"country" form:"country"`
 	Line1   string `json:"line1" form:"line1"`
 	Line2   string `json:"line2" form:"line2"`
-	City    string `json:"city" form:"city"`
 	State   string `json:"state" form:"state"`
-	Zip     string `json:"postal_code" form:"postal_code"`
-	Country string `json:"country" form:"country"`
 
 	// Town/cho-me. Note that this is only used for Kana/Kanji representations
 	// of an address.
 	Town string `json:"town" form:"town"`
+
+	Zip string `json:"postal_code" form:"postal_code"`
 }
 
 // DOB is a structure for an account owner's date of birth.
@@ -325,25 +329,25 @@ type Gender string
 
 // Owner is the structure for an account owner.
 type Owner struct {
+	Address      Address              `json:"address" form:"address"`
+	DOB          DOB                  `json:"dob" form:"dob"`
 	First        string               `json:"first_name" form:"first_name"`
 	Last         string               `json:"last_name" form:"last_name"`
-	DOB          DOB                  `json:"dob" form:"dob"`
-	Address      Address              `json:"address" form:"address"`
 	Verification IdentityVerification `json:"verification" form:"verification"`
 }
 
 // IdentityVerification is the structure for an account's verification.
 type IdentityVerification struct {
-	DetailsCode IdentityVerificationDetailsCode `json:"details_code"`
-	Status      IdentityVerificationStatus      `json:"status"`
-	Document    *IdentityDocument               `json:"document" form:"document"`
 	Details     *string                         `json:"details"`
+	DetailsCode IdentityVerificationDetailsCode `json:"details_code"`
+	Document    *IdentityDocument               `json:"document" form:"document"`
+	Status      IdentityVerificationStatus      `json:"status"`
 }
 
 // IdentityDocument is the structure for an identity document.
 type IdentityDocument struct {
-	ID      string `json:"id" form:"-"` // See custom AppendTo implementation
 	Created int64  `json:"created" form:"-"`
+	ID      string `json:"id" form:"-"` // See custom AppendTo implementation
 	Size    int64  `json:"size" form:"-"`
 }
 
@@ -368,8 +372,8 @@ func (d *IdentityDocument) AppendTo(body *form.Values, keyParts []string) {
 type PayoutSchedule struct {
 	Delay       uint64   `json:"delay_days" form:"delay_days"`
 	Interval    Interval `json:"interval" form:"interval"`
-	WeekAnchor  string   `json:"weekly_anchor" form:"weekly_anchor"`
 	MonthAnchor uint64   `json:"monthly_anchor" form:"monthly_anchor"`
+	WeekAnchor  string   `json:"weekly_anchor" form:"weekly_anchor"`
 }
 
 // TOSAcceptanceParams is the structure for TOS acceptance.

--- a/address.go
+++ b/address.go
@@ -2,10 +2,10 @@ package stripe
 
 // Standard address parameters.
 type AddressParams struct {
+	City       string `form:"city"`
+	Country    string `form:"country"`
 	Line1      string `form:"line1"`
 	Line2      string `form:"line2"`
-	City       string `form:"city"`
-	State      string `form:"state"`
 	PostalCode string `form:"postal_code"`
-	Country    string `form:"country"`
+	State      string `form:"state"`
 }

--- a/balance.go
+++ b/balance.go
@@ -15,23 +15,23 @@ type TransactionType string
 type TransactionSourceType string
 
 const (
-	// TransactionSourceFee is a constant representing a transaction source of application_fee
-	TransactionSourceFee TransactionSourceType = "application_fee"
-
 	// TransactionSourceCharge is a constant representing a transaction source of charge
 	TransactionSourceCharge TransactionSourceType = "charge"
 
 	// TransactionSourceDispute is a constant representing a transaction source of dispute
 	TransactionSourceDispute TransactionSourceType = "dispute"
 
+	// TransactionSourceFee is a constant representing a transaction source of application_fee
+	TransactionSourceFee TransactionSourceType = "application_fee"
+
 	// TransactionSourcePayout is a constant representing a transaction source of payout
 	TransactionSourcePayout TransactionSourceType = "payout"
 
-	// TransactionSourceRefund is a constant representing a transaction source of refund
-	TransactionSourceRefund TransactionSourceType = "refund"
-
 	// TransactionSourceRecipientTransfer is a constant representing a transaction source of recipient_transfer
 	TransactionSourceRecipientTransfer TransactionSourceType = "recipient_transfer"
+
+	// TransactionSourceRefund is a constant representing a transaction source of refund
+	TransactionSourceRefund TransactionSourceType = "refund"
 
 	// TransactionSourceReversal is a constant representing a transaction source of reversal
 	TransactionSourceReversal TransactionSourceType = "reversal"
@@ -44,16 +44,16 @@ const (
 // The Type should indicate which object is fleshed out.
 // For more details see https://stripe.com/docs/api#retrieve_balance_transaction
 type TransactionSource struct {
-	Type              TransactionSourceType `json:"object"`
-	ID                string                `json:"id"`
 	Charge            *Charge               `json:"-"`
 	Dispute           *Dispute              `json:"-"`
 	Fee               *Fee                  `json:"-"`
+	ID                string                `json:"id"`
 	Payout            *Payout               `json:"-"`
 	RecipientTransfer *RecipientTransfer    `json:"-"`
 	Refund            *Refund               `json:"-"`
 	Reversal          *Reversal             `json:"-"`
 	Transfer          *Transfer             `json:"-"`
+	Type              TransactionSourceType `json:"object"`
 }
 
 // BalanceParams is the set of parameters that can be used when retrieving a balance.
@@ -72,41 +72,40 @@ type TxParams struct {
 // For more details see https://stripe.com/docs/api/#balance_history.
 type TxListParams struct {
 	ListParams     `form:"*"`
-	Created        int64             `form:"created"`
-	CreatedRange   *RangeQueryParams `form:"created"`
 	Available      int64             `form:"available_on"`
 	AvailableRange *RangeQueryParams `form:"available_on"`
+	Created        int64             `form:"created"`
+	CreatedRange   *RangeQueryParams `form:"created"`
 	Currency       string            `form:"currency"`
-	Src            string            `form:"source"`
 	Payout         string            `form:"payout"`
+	Src            string            `form:"source"`
 	Type           TransactionType   `form:"type"`
 }
 
 // Balance is the resource representing your Stripe balance.
 // For more details see https://stripe.com/docs/api/#balance.
 type Balance struct {
-	// Live indicates the live mode.
-	Live      bool     `json:"livemode"`
 	Available []Amount `json:"available"`
+	Live      bool     `json:"livemode"`
 	Pending   []Amount `json:"pending"`
 }
 
 // Transaction is the resource representing the balance transaction.
 // For more details see https://stripe.com/docs/api/#balance.
 type Transaction struct {
-	ID         string            `json:"id"`
 	Amount     int64             `json:"amount"`
-	Currency   Currency          `json:"currency"`
 	Available  int64             `json:"available_on"`
 	Created    int64             `json:"created"`
+	Currency   Currency          `json:"currency"`
+	Desc       string            `json:"description"`
+	ID         string            `json:"id"`
 	Fee        int64             `json:"fee"`
 	FeeDetails []TxFee           `json:"fee_details"`
 	Net        int64             `json:"net"`
+	Recipient  string            `json:"recipient"`
+	Src        TransactionSource `json:"source"`
 	Status     TransactionStatus `json:"status"`
 	Type       TransactionType   `json:"type"`
-	Desc       string            `json:"description"`
-	Src        TransactionSource `json:"source"`
-	Recipient  string            `json:"recipient"`
 }
 
 // TransactionList is a list of transactions as returned from a list endpoint.
@@ -123,11 +122,11 @@ type Amount struct {
 
 // TxFee is a structure that breaks down the fees in a transaction.
 type TxFee struct {
+	Application string   `json:"application"`
 	Amount      int64    `json:"amount"`
 	Currency    Currency `json:"currency"`
-	Type        string   `json:"type"`
 	Desc        string   `json:"description"`
-	Application string   `json:"application"`
+	Type        string   `json:"type"`
 }
 
 // UnmarshalJSON handles deserialization of a Transaction.

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -20,25 +20,23 @@ type BankAccountStatus string
 type BankAccountParams struct {
 	Params `form:"*"`
 
-	// The identifier of the parent account under which bank accounts are
-	// nested.
+	Account string `form:"account_number"`
+
+	// AccountID is the identifier of the parent account under which bank
+	// accounts are nested.
 	AccountID string `form:"-"`
 
-	Customer string `form:"-"`
-
-	// A token referencing an external account like one returned from
-	// Stripe.js.
-	Token string `form:"-"`
-
-	// Information on an external account to reference. Only used if `Token`
-	// is not provided.
-	Account           string `form:"account_number"`
 	AccountHolderName string `form:"account_holder_name"`
 	AccountHolderType string `form:"account_holder_type"`
 	Country           string `form:"country"`
 	Currency          string `form:"currency"`
+	Customer          string `form:"-"`
 	Default           bool   `form:"default_for_currency"`
 	Routing           string `form:"routing_number"`
+
+	// Token is a token referencing an external account like one returned from
+	// Stripe.js.
+	Token string `form:"-"`
 }
 
 // AppendToAsSourceOrExternalAccount appends the given BankAccountParams as
@@ -103,20 +101,20 @@ type BankAccountListParams struct {
 
 // BankAccount represents a Stripe bank account.
 type BankAccount struct {
-	ID                string            `json:"id"`
-	Name              string            `json:"bank_name"`
 	AccountHolderName string            `json:"account_holder_name"`
 	AccountHolderType string            `json:"account_holder_type"`
 	Country           string            `json:"country"`
 	Currency          Currency          `json:"currency"`
-	Default           bool              `json:"default_for_currency"`
-	LastFour          string            `json:"last4"`
-	Fingerprint       string            `json:"fingerprint"`
-	Status            BankAccountStatus `json:"status"`
-	Routing           string            `json:"routing_number"`
-	Deleted           bool              `json:"deleted"`
 	Customer          *Customer         `json:"customer"`
+	Default           bool              `json:"default_for_currency"`
+	Deleted           bool              `json:"deleted"`
+	Fingerprint       string            `json:"fingerprint"`
+	ID                string            `json:"id"`
+	LastFour          string            `json:"last4"`
 	Meta              map[string]string `json:"metadata"`
+	Name              string            `json:"bank_name"`
+	Routing           string            `json:"routing_number"`
+	Status            BankAccountStatus `json:"status"`
 }
 
 // BankAccountList is a list object for bank accounts.

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -52,8 +52,8 @@ type BitcoinReceiver struct {
 	InboundAddress        string                  `json:"inbound_address"`
 	Meta                  map[string]string       `json:"metadata"`
 	Payment               string                  `json:"payment"`
-	RejectTransactions    bool                    `json:"reject_transactions"`
 	RefundAddress         string                  `json:"refund_address"`
+	RejectTransactions    bool                    `json:"reject_transactions"`
 	Transactions          *BitcoinTransactionList `json:"transactions"`
 }
 

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -8,8 +8,8 @@ import (
 // For more details see https://stripe.com/docs/api/#list_bitcoin_receivers.
 type BitcoinReceiverListParams struct {
 	ListParams `form:"*"`
-	NotFilled  bool `form:"filled,invert"`
 	NotActive  bool `form:"active,invert"`
+	NotFilled  bool `form:"filled,invert"`
 	Uncaptured bool `form:"uncaptured_funds"`
 }
 
@@ -36,24 +36,24 @@ type BitcoinReceiverUpdateParams struct {
 // BitcoinReceiver is the resource representing a Stripe bitcoin receiver.
 // For more details see https://stripe.com/docs/api/#bitcoin_receivers
 type BitcoinReceiver struct {
-	ID                    string                  `json:"id"`
-	Created               int64                   `json:"created"`
-	Currency              Currency                `json:"currency"`
+	Active                bool                    `json:"active"`
 	Amount                uint64                  `json:"amount"`
 	AmountReceived        uint64                  `json:"amount_received"`
 	BitcoinAmount         uint64                  `json:"bitcoin_amount"`
 	BitcoinAmountReceived uint64                  `json:"bitcoin_amount_received"`
-	Filled                bool                    `json:"filled"`
-	Active                bool                    `json:"active"`
-	RejectTransactions    bool                    `json:"reject_transactions"`
-	Desc                  string                  `json:"description"`
-	InboundAddress        string                  `json:"inbound_address"`
-	RefundAddress         string                  `json:"refund_address"`
 	BitcoinUri            string                  `json:"bitcoin_uri"`
-	Meta                  map[string]string       `json:"metadata"`
-	Email                 string                  `json:"email"`
-	Payment               string                  `json:"payment"`
+	Created               int64                   `json:"created"`
+	Currency              Currency                `json:"currency"`
 	Customer              string                  `json:"customer"`
+	Desc                  string                  `json:"description"`
+	Email                 string                  `json:"email"`
+	Filled                bool                    `json:"filled"`
+	ID                    string                  `json:"id"`
+	InboundAddress        string                  `json:"inbound_address"`
+	Meta                  map[string]string       `json:"metadata"`
+	Payment               string                  `json:"payment"`
+	RejectTransactions    bool                    `json:"reject_transactions"`
+	RefundAddress         string                  `json:"refund_address"`
 	Transactions          *BitcoinTransactionList `json:"transactions"`
 }
 

--- a/bitcointransaction.go
+++ b/bitcointransaction.go
@@ -5,8 +5,8 @@ import "encoding/json"
 // BitcoinTransactionListParams is the set of parameters that can be used when listing BitcoinTransactions.
 type BitcoinTransactionListParams struct {
 	ListParams `form:"*"`
-	Receiver   string `form:"-"` // Sent in with the URL
 	Customer   string `form:"customer"`
+	Receiver   string `form:"-"` // Sent in with the URL
 }
 
 // BitcoinTransactionList is a list object for BitcoinTransactions.
@@ -20,13 +20,13 @@ type BitcoinTransactionList struct {
 // BitcoinTransaction is the resource representing a Stripe bitcoin transaction.
 // For more details see https://stripe.com/docs/api/#bitcoin_receivers
 type BitcoinTransaction struct {
-	ID            string   `json:"id"`
-	Created       int64    `json:"created"`
 	Amount        uint64   `json:"amount"`
-	Currency      Currency `json:"currency"`
 	BitcoinAmount uint64   `json:"bitcoin_amount"`
-	Receiver      string   `json:"receiver"`
+	Created       int64    `json:"created"`
+	Currency      Currency `json:"currency"`
 	Customer      string   `json:"customer"`
+	ID            string   `json:"id"`
+	Receiver      string   `json:"receiver"`
 }
 
 // UnmarshalJSON handles deserialization of a BitcoinTransaction.

--- a/card.go
+++ b/card.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
+// cardSource is a string that's used to build card form parameters. It's a
+// constant just to make mistakes less likely.
+const cardSource = "source"
+
 // CardBrand is the list of allowed values for the card's brand.
 // Allowed values are "Unknown", "Visa", "American Express", "MasterCard", "Discover"
 // "JCB", "Diners Club".
 type CardBrand string
-
-// Verification is the list of allowed verification responses.
-// Allowed values are "pass", "fail", "unchecked", "unavailable".
-type Verification string
 
 // CardFunding is the list of allowed values for the card's funding.
 // Allowed values are "credit", "debit", "prepaid", "unknown".
@@ -24,6 +24,10 @@ type CardFunding string
 // Allowed values are "apple_pay", "android_pay".
 type TokenizationMethod string
 
+// Verification is the list of allowed verification responses.
+// Allowed values are "pass", "fail", "unchecked", "unavailable".
+type Verification string
+
 // CardParams is the set of parameters that can be used when creating or updating a card.
 // For more details see https://stripe.com/docs/api#create_card and https://stripe.com/docs/api#update_card.
 //
@@ -32,28 +36,24 @@ type TokenizationMethod string
 // of all parameters. See AppendToAsCardSourceOrExternalAccount.
 type CardParams struct {
 	Params    `form:"*"`
-	Token     string `form:"-"`
-	Default   bool   `form:"default_for_currency"`
 	Account   string `form:"-"`
-	Customer  string `form:"-"`
-	Recipient string `form:"-"`
-	Name      string `form:"name"`
-	Number    string `form:"number"`
-	Month     string `form:"exp_month"`
-	Year      string `form:"exp_year"`
-	CVC       string `form:"-"`
-	Currency  string `form:"currency"`
 	Address1  string `form:"address_line1"`
 	Address2  string `form:"address_line2"`
+	CVC       string `form:"-"`
 	City      string `form:"address_city"`
-	State     string `form:"address_state"`
-	Zip       string `form:"address_zip"`
 	Country   string `form:"address_country"`
+	Currency  string `form:"currency"`
+	Customer  string `form:"-"`
+	Default   bool   `form:"default_for_currency"`
+	Month     string `form:"exp_month"`
+	Name      string `form:"name"`
+	Number    string `form:"number"`
+	Recipient string `form:"-"`
+	State     string `form:"address_state"`
+	Token     string `form:"-"`
+	Year      string `form:"exp_year"`
+	Zip       string `form:"address_zip"`
 }
-
-// cardSource is a string that's used to build card form parameters. It's a
-// constant just to make mistakes less likely.
-const cardSource = "source"
 
 // AppendToAsCardSourceOrExternalAccount appends the given CardParams as either a
 // card or external account.
@@ -147,39 +147,29 @@ type CardListParams struct {
 // Card is the resource representing a Stripe credit/debit card.
 // For more details see https://stripe.com/docs/api#cards.
 type Card struct {
-	ID                 string             `json:"id"`
-	Month              uint8              `json:"exp_month"`
-	Year               uint16             `json:"exp_year"`
-	Fingerprint        string             `json:"fingerprint"`
-	Funding            CardFunding        `json:"funding"`
-	LastFour           string             `json:"last4"`
-	Brand              CardBrand          `json:"brand"`
-	Currency           Currency           `json:"currency"`
-	Default            bool               `json:"default_for_currency"`
-	City               string             `json:"address_city"`
-	Country            string             `json:"address_country"`
-	Address1           string             `json:"address_line1"`
-	Address1Check      Verification       `json:"address_line1_check"`
-	Address2           string             `json:"address_line2"`
-	State              string             `json:"address_state"`
-	Zip                string             `json:"address_zip"`
-	ZipCheck           Verification       `json:"address_zip_check"`
-	CardCountry        string             `json:"country"`
-	Customer           *Customer          `json:"customer"`
-	CVCCheck           Verification       `json:"cvc_check"`
-	Meta               map[string]string  `json:"metadata"`
-	Name               string             `json:"name"`
-	Recipient          *Recipient         `json:"recipient"`
-	DynLastFour        string             `json:"dynamic_last4"`
-	Deleted            bool               `json:"deleted"`
-	ThreeDSecure       *ThreeDSecure      `json:"three_d_secure"`
-	TokenizationMethod TokenizationMethod `json:"tokenization_method"`
+	Address1      string       `json:"address_line1"`
+	Address1Check Verification `json:"address_line1_check"`
+	Address2      string       `json:"address_line2"`
+	Brand         CardBrand    `json:"brand"`
+	CVCCheck      Verification `json:"cvc_check"`
+	CardCountry   string       `json:"country"`
+	City          string       `json:"address_city"`
+	Country       string       `json:"address_country"`
+	Currency      Currency     `json:"currency"`
+	Customer      *Customer    `json:"customer"`
+	Default       bool         `json:"default_for_currency"`
+	Deleted       bool         `json:"deleted"`
 
 	// Description is a succinct summary of the card's information.
 	//
 	// Please note that this field is for internal use only and is not returned
 	// as part of standard API requests.
 	Description string `json:"description"`
+
+	DynLastFour string      `json:"dynamic_last4"`
+	Fingerprint string      `json:"fingerprint"`
+	Funding     CardFunding `json:"funding"`
+	ID          string      `json:"id"`
 
 	// IIN is the card's "Issuer Identification Number".
 	//
@@ -192,6 +182,18 @@ type Card struct {
 	// Please note that this field is for internal use only and is not returned
 	// as part of standard API requests.
 	Issuer string `json:"issuer"`
+
+	LastFour           string             `json:"last4"`
+	Meta               map[string]string  `json:"metadata"`
+	Month              uint8              `json:"exp_month"`
+	Name               string             `json:"name"`
+	Recipient          *Recipient         `json:"recipient"`
+	State              string             `json:"address_state"`
+	ThreeDSecure       *ThreeDSecure      `json:"three_d_secure"`
+	TokenizationMethod TokenizationMethod `json:"tokenization_method"`
+	Year               uint16             `json:"exp_year"`
+	Zip                string             `json:"address_zip"`
+	ZipCheck           Verification       `json:"address_zip_check"`
 }
 
 // CardList is a list object for cards.

--- a/charge.go
+++ b/charge.go
@@ -21,19 +21,19 @@ type ChargeParams struct {
 	Amount        uint64             `form:"amount"`
 	Currency      Currency           `form:"currency"`
 	Customer      string             `form:"customer"`
-	Token         string             `form:"-"` // Does not appear to be used?
 	Desc          string             `form:"description"`
-	Statement     string             `form:"statement_descriptor"`
-	Email         string             `form:"receipt_email"`
 	Dest          string             `form:"-"` // Handled in custom AppendTo below
 	Destination   *DestinationParams `form:"destination"`
-	NoCapture     bool               `form:"capture,invert"`
+	Email         string             `form:"receipt_email"`
 	Fee           uint64             `form:"application_fee"`
 	Fraud         FraudReport        `form:"-"` // Handled in custom AppendTo below
-	Source        *SourceParams      `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	Shipping      *ShippingDetails   `form:"shipping"`
-	TransferGroup string             `form:"transfer_group"`
+	NoCapture     bool               `form:"capture,invert"`
 	OnBehalfOf    string             `form:"on_behalf_of"`
+	Shipping      *ShippingDetails   `form:"shipping"`
+	Source        *SourceParams      `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	Statement     string             `form:"statement_descriptor"`
+	Token         string             `form:"-"` // Does not appear to be used?
+	TransferGroup string             `form:"transfer_group"`
 }
 
 // AppendTo implements some custom encoding logic for ChargeParams to support
@@ -82,8 +82,8 @@ type ChargeListParams struct {
 type CaptureParams struct {
 	Params    `form:"*"`
 	Amount    uint64 `form:"amount"`
-	Fee       uint64 `form:"application_fee"`
 	Email     string `form:"receipt_email"`
+	Fee       uint64 `form:"application_fee"`
 	Statement string `form:"statement_descriptor"`
 }
 
@@ -101,7 +101,6 @@ type Charge struct {
 	Dest           *Account          `json:"destination"`
 	Dispute        *Dispute          `json:"dispute"`
 	Email          string            `json:"receipt_email"`
-	ReceiptNumber  string            `json:"receipt_number"`
 	FailCode       string            `json:"failure_code"`
 	FailMsg        string            `json:"failure_message"`
 	Fee            *Fee              `json:"application_fee"`
@@ -112,6 +111,7 @@ type Charge struct {
 	Meta           map[string]string `json:"metadata"`
 	Outcome        *ChargeOutcome    `json:"outcome"`
 	Paid           bool              `json:"paid"`
+	ReceiptNumber  string            `json:"receipt_number"`
 	Refunded       bool              `json:"refunded"`
 	Refunds        *RefundList       `json:"refunds"`
 	Review         *Review           `json:"review"`
@@ -173,11 +173,11 @@ type ChargeOutcome struct {
 
 // ShippingDetails is the structure containing shipping information.
 type ShippingDetails struct {
-	Name     string  `json:"name" form:"name"`
 	Address  Address `json:"address" form:"address"`
+	Carrier  string  `json:"carrier" form:"carrier"`
+	Name     string  `json:"name" form:"name"`
 	Phone    string  `json:"phone" form:"phone"`
 	Tracking string  `json:"tracking_number" form:"tracking_number"`
-	Carrier  string  `json:"carrier" form:"carrier"`
 }
 
 var depth int = -1

--- a/countryspec.go
+++ b/countryspec.go
@@ -13,8 +13,8 @@ type VerificationFieldsList struct {
 // CountrySpec is the resource representing the rules required for a Stripe account.
 // For more details see https://stripe.com/docs/api/#country_specs.
 type CountrySpec struct {
-	ID                             string                                     `json:"id"`
 	DefaultCurrency                Currency                                   `json:"default_currency"`
+	ID                             string                                     `json:"id"`
 	SupportedBankAccountCurrencies map[Country][]Currency                     `json:"supported_bank_account_currencies"`
 	SupportedPaymentCurrencies     []Currency                                 `json:"supported_payment_currencies"`
 	SupportedPaymentMethods        []string                                   `json:"supported_payment_methods"`

--- a/coupon.go
+++ b/coupon.go
@@ -10,14 +10,14 @@ type CouponDuration string
 // For more details see https://stripe.com/docs/api#create_coupon.
 type CouponParams struct {
 	Params         `form:"*"`
-	Duration       CouponDuration `form:"duration"`
-	ID             string         `form:"id"`
-	Currency       Currency       `form:"currency"`
 	Amount         uint64         `form:"amount_off"`
-	Percent        uint64         `form:"percent_off"`
+	Currency       Currency       `form:"currency"`
+	Duration       CouponDuration `form:"duration"`
 	DurationPeriod uint64         `form:"duration_in_months"`
-	Redemptions    uint64         `form:"max_redemptions"`
+	ID             string         `form:"id"`
+	Percent        uint64         `form:"percent_off"`
 	RedeemBy       int64          `form:"redeem_by"`
+	Redemptions    uint64         `form:"max_redemptions"`
 }
 
 // CouponListParams is the set of parameters that can be used when listing coupons.
@@ -31,20 +31,20 @@ type CouponListParams struct {
 // Coupon is the resource representing a Stripe coupon.
 // For more details see https://stripe.com/docs/api#coupons.
 type Coupon struct {
+	Amount         uint64            `json:"amount_off"`
+	Created        int64             `json:"created"`
+	Currency       Currency          `json:"currency"`
+	Deleted        bool              `json:"deleted"`
+	Duration       CouponDuration    `json:"duration"`
+	DurationPeriod uint64            `json:"duration_in_months"`
 	ID             string            `json:"id"`
 	Live           bool              `json:"livemode"`
-	Created        int64             `json:"created"`
-	Duration       CouponDuration    `json:"duration"`
-	Amount         uint64            `json:"amount_off"`
-	Currency       Currency          `json:"currency"`
-	DurationPeriod uint64            `json:"duration_in_months"`
-	Redemptions    uint64            `json:"max_redemptions"`
 	Meta           map[string]string `json:"metadata"`
 	Percent        uint64            `json:"percent_off"`
 	RedeemBy       int64             `json:"redeem_by"`
 	Redeemed       uint64            `json:"times_redeemed"`
+	Redemptions    uint64            `json:"max_redemptions"`
 	Valid          bool              `json:"valid"`
-	Deleted        bool              `json:"deleted"`
 }
 
 // CouponList is a list of coupons as retrieved from a list endpoint.

--- a/customer.go
+++ b/customer.go
@@ -10,20 +10,20 @@ type CustomerParams struct {
 	Params         `form:"*"`
 	Balance        int64                    `form:"account_balance"`
 	BalanceZero    bool                     `form:"account_balance,zero"`
-	Token          string                   `form:"-"` // This doesn't seem to be used?
+	BusinessVatID  string                   `form:"business_vat_id"`
 	Coupon         string                   `form:"coupon"`
 	CouponEmpty    bool                     `form:"coupon,empty"`
-	Source         *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	DefaultSource  string                   `form:"default_source"`
 	Desc           string                   `form:"description"`
 	Email          string                   `form:"email"`
 	Plan           string                   `form:"plan"`
 	Quantity       uint64                   `form:"quantity"`
-	TrialEnd       int64                    `form:"trial_end"`
-	DefaultSource  string                   `form:"default_source"`
 	Shipping       *CustomerShippingDetails `form:"shipping"`
-	BusinessVatID  string                   `form:"business_vat_id"`
+	Source         *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 	TaxPercent     float64                  `form:"tax_percent"`
 	TaxPercentZero bool                     `form:"tax_percent,zero"`
+	Token          string                   `form:"-"` // This doesn't seem to be used?
+	TrialEnd       int64                    `form:"trial_end"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,
@@ -45,22 +45,22 @@ type CustomerListParams struct {
 // Customer is the resource representing a Stripe customer.
 // For more details see https://stripe.com/docs/api#customers.
 type Customer struct {
-	ID            string                   `json:"id"`
-	Live          bool                     `json:"livemode"`
-	Sources       *SourceList              `json:"sources"`
-	Created       int64                    `json:"created"`
 	Balance       int64                    `json:"account_balance"`
+	BusinessVatID string                   `json:"business_vat_id"`
 	Currency      Currency                 `json:"currency"`
+	Created       int64                    `json:"created"`
 	DefaultSource *PaymentSource           `json:"default_source"`
+	Deleted       bool                     `json:"deleted"`
 	Delinquent    bool                     `json:"delinquent"`
 	Desc          string                   `json:"description"`
 	Discount      *Discount                `json:"discount"`
 	Email         string                   `json:"email"`
+	ID            string                   `json:"id"`
+	Live          bool                     `json:"livemode"`
 	Meta          map[string]string        `json:"metadata"`
-	Subs          *SubList                 `json:"subscriptions"`
-	Deleted       bool                     `json:"deleted"`
 	Shipping      *CustomerShippingDetails `json:"shipping"`
-	BusinessVatID string                   `json:"business_vat_id"`
+	Sources       *SourceList              `json:"sources"`
+	Subs          *SubList                 `json:"subscriptions"`
 }
 
 // CustomerList is a list of customers as retrieved from a list endpoint.
@@ -71,8 +71,8 @@ type CustomerList struct {
 
 // CustomerShippingDetails is the structure containing shipping information.
 type CustomerShippingDetails struct {
-	Name    string  `json:"name" form:"name"`
 	Address Address `json:"address" form:"address"`
+	Name    string  `json:"name" form:"name"`
 	Phone   string  `json:"phone" form:"phone"`
 }
 

--- a/discount.go
+++ b/discount.go
@@ -10,8 +10,8 @@ type DiscountParams struct {
 type Discount struct {
 	Coupon   *Coupon `json:"coupon"`
 	Customer string  `json:"customer"`
-	Start    int64   `json:"start"`
-	End      int64   `json:"end"`
-	Sub      string  `json:"subscription"`
 	Deleted  bool    `json:"deleted"`
+	End      int64   `json:"end"`
+	Start    int64   `json:"start"`
+	Sub      string  `json:"subscription"`
 }

--- a/dispute.go
+++ b/dispute.go
@@ -27,43 +27,33 @@ type DisputeParams struct {
 // DisputeEvidenceParams is the set of parameters that can be used when submitting
 // evidence for disputes.
 type DisputeEvidenceParams struct {
-	ActivityLog string `form:"access_activity_log"`
-
-	BillingAddress string `form:"billing_address"`
-
+	ActivityLog                  string `form:"access_activity_log"`
+	BillingAddress               string `form:"billing_address"`
 	CancellationPolicy           string `form:"cancellation_policy"`
 	CancellationPolicyDisclsoure string `form:"cancellation_policy_disclosure"`
 	CancellationRebuttal         string `form:"cancellation_rebuttal"`
-
-	CustomerName  string `form:"customer_name"`
-	CustomerEmail string `form:"customer_email_address"`
-	CustomerIP    string `form:"customer_purchase_ip"`
-	CustomerSig   string `form:"customer_signature"`
-	CustomerComm  string `form:"customer_communication"`
-
-	DuplicateCharge       string `form:"duplicate_charge_id"`
-	DuplicateChargeReason string `form:"duplicate_charge_explanation"`
-	DuplicateChargeDoc    string `form:"duplicate_charge_documentation"`
-
-	ProductDesc string `form:"product_description"`
-
-	Receipt string `form:"receipt"`
-
-	RefundPolicy           string `form:"refund_policy"`
-	RefundPolicyDisclosure string `form:"refund_policy_disclosure"`
-	RefundRefusalReason    string `form:"refund_refusal_explanation"`
-
-	ServiceDate string `form:"service_date"`
-	ServiceDoc  string `form:"service_documentation"`
-
-	ShippingAddress  string `form:"shipping_address"`
-	ShippingCarrier  string `form:"shipping_carrier"`
-	ShippingDate     string `form:"shipping_date"`
-	ShippingTracking string `form:"shipping_tracking_number"`
-	ShippingDoc      string `form:"shipping_documentation"`
-
-	UncategorizedText string `form:"uncategorized_text"`
-	UncategorizedFile string `form:"uncategorized_file"`
+	CustomerComm                 string `form:"customer_communication"`
+	CustomerEmail                string `form:"customer_email_address"`
+	CustomerIP                   string `form:"customer_purchase_ip"`
+	CustomerName                 string `form:"customer_name"`
+	CustomerSig                  string `form:"customer_signature"`
+	DuplicateCharge              string `form:"duplicate_charge_id"`
+	DuplicateChargeDoc           string `form:"duplicate_charge_documentation"`
+	DuplicateChargeReason        string `form:"duplicate_charge_explanation"`
+	ProductDesc                  string `form:"product_description"`
+	Receipt                      string `form:"receipt"`
+	RefundPolicy                 string `form:"refund_policy"`
+	RefundPolicyDisclosure       string `form:"refund_policy_disclosure"`
+	RefundRefusalReason          string `form:"refund_refusal_explanation"`
+	ServiceDate                  string `form:"service_date"`
+	ServiceDoc                   string `form:"service_documentation"`
+	ShippingAddress              string `form:"shipping_address"`
+	ShippingCarrier              string `form:"shipping_carrier"`
+	ShippingDate                 string `form:"shipping_date"`
+	ShippingDoc                  string `form:"shipping_documentation"`
+	ShippingTracking             string `form:"shipping_tracking_number"`
+	UncategorizedFile            string `form:"uncategorized_file"`
+	UncategorizedText            string `form:"uncategorized_text"`
 }
 
 // DisputeListParams is the set of parameters that can be used when listing disputes.
@@ -77,19 +67,19 @@ type DisputeListParams struct {
 // Dispute is the resource representing a Stripe dispute.
 // For more details see https://stripe.com/docs/api#disputes.
 type Dispute struct {
-	ID              string            `json:"id"`
-	Live            bool              `json:"livemode"`
 	Amount          uint64            `json:"amount"`
-	Currency        Currency          `json:"currency"`
 	Charge          string            `json:"charge"`
 	Created         int64             `json:"created"`
-	Refundable      bool              `json:"is_charge_refundable"`
-	Reason          DisputeReason     `json:"reason"`
-	Status          DisputeStatus     `json:"status"`
-	Transactions    []*Transaction    `json:"balance_transactions"`
+	Currency        Currency          `json:"currency"`
 	Evidence        *DisputeEvidence  `json:"evidence"`
 	EvidenceDetails *EvidenceDetails  `json:"evidence_details"`
+	ID              string            `json:"id"`
+	Live            bool              `json:"livemode"`
 	Meta            map[string]string `json:"metadata"`
+	Reason          DisputeReason     `json:"reason"`
+	Refundable      bool              `json:"is_charge_refundable"`
+	Status          DisputeStatus     `json:"status"`
+	Transactions    []*Transaction    `json:"balance_transactions"`
 }
 
 // DisputeList is a list of disputes as retrieved from a list endpoint.
@@ -112,43 +102,43 @@ type EvidenceDetails struct {
 // Almost all fields are strings since there structures (i.e. address)
 // do not typically get parsed by anyone and are thus presented as-received.
 type DisputeEvidence struct {
-	ProductDesc                  string `json:"product_description"`
-	CustomerName                 string `json:"customer_name"`
-	CustomerEmail                string `json:"customer_email_address"`
-	CustomerIP                   string `json:"customer_purchase_ip"`
-	CustomerSig                  *File  `json:"customer_signature"`
+	ActivityLog                  string `json:"access_activity_log"`
 	BillingAddress               string `json:"billing_address"`
-	Receipt                      *File  `json:"receipt"`
-	ShippingAddress              string `json:"shipping_address"`
-	ShippingDate                 string `json:"shipping_date"`
-	ShippingTracking             string `json:"shipping_tracking_number"`
-	ShippingCarrier              string `json:"shipping_carrier"`
-	ShippingDoc                  *File  `json:"shipping_documentation"`
-	RefundPolicy                 *File  `json:"refund_policy"`
-	RefundPolicyDisclosure       string `json:"refund_policy_disclosure"`
-	RefundRefusalReason          string `json:"refund_refusal_explanation"`
 	CancellationPolicy           *File  `json:"cancellation_policy"`
 	CancellationPolicyDisclosure string `json:"cancellation_policy_disclosure"`
 	CancellationRebuttal         string `json:"cancellation_rebuttal"`
-	ActivityLog                  string `json:"access_activity_log"`
+	CustomerComm                 *File  `json:"customer_communication"`
+	CustomerEmail                string `json:"customer_email_address"`
+	CustomerIP                   string `json:"customer_purchase_ip"`
+	CustomerName                 string `json:"customer_name"`
+	CustomerSig                  *File  `json:"customer_signature"`
+	DuplicateCharge              string `json:"duplicate_charge_id"`
+	DuplicateChargeDoc           *File  `json:"duplicate_charge_documentation"`
+	DuplicateChargeReason        string `json:"duplicate_charge_explanation"`
+	ProductDesc                  string `json:"product_description"`
+	Receipt                      *File  `json:"receipt"`
+	RefundPolicy                 *File  `json:"refund_policy"`
+	RefundPolicyDisclosure       string `json:"refund_policy_disclosure"`
+	RefundRefusalReason          string `json:"refund_refusal_explanation"`
 	ServiceDate                  string `json:"service_date"`
 	ServiceDoc                   *File  `json:"service_documentation"`
-	DuplicateCharge              string `json:"duplicate_charge_id"`
-	DuplicateChargeReason        string `json:"duplicate_charge_explanation"`
-	DuplicateChargeDoc           *File  `json:"duplicate_charge_documentation"`
-	CustomerComm                 *File  `json:"customer_communication"`
-	UncategorizedText            string `json:"uncategorized_text"`
+	ShippingAddress              string `json:"shipping_address"`
+	ShippingCarrier              string `json:"shipping_carrier"`
+	ShippingDate                 string `json:"shipping_date"`
+	ShippingDoc                  *File  `json:"shipping_documentation"`
+	ShippingTracking             string `json:"shipping_tracking_number"`
 	UncategorizedFile            *File  `json:"uncategorized_file"`
+	UncategorizedText            string `json:"uncategorized_text"`
 }
 
 // File represents a link to downloadable content.
 type File struct {
-	ID      string `json:"id"`
 	Created int64  `json:"created"`
-	Size    int    `json:"size"`
-	Purpose string `json:"purpose"`
-	URL     string `json:"url"`
+	ID      string `json:"id"`
 	Mime    string `json:"mime_type"`
+	Purpose string `json:"purpose"`
+	Size    int    `json:"size"`
+	URL     string `json:"url"`
 }
 
 // UnmarshalJSON handles deserialization of a Dispute.

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -14,14 +14,10 @@ type EphemeralKeyParams struct {
 // EphemeralKey is the resource representing a Stripe ephemeral key.
 // For more details see https://stripe.com/docs/api#ephemeral_keys.
 type EphemeralKey struct {
-	ID                string `json:"id"`
-	Created           int64  `json:"created"`
-	Expires           int64  `json:"expires"`
-	Live              bool   `json:"livemode"`
-	AssociatedObjects []struct {
-		ID   string `json:"id"`
-		Type string `json:"type"`
-	} `json:"associated_objects"`
+	Created int64  `json:"created"`
+	Expires int64  `json:"expires"`
+	ID      string `json:"id"`
+	Live    bool   `json:"livemode"`
 
 	// RawJSON is provided so that it may be passed back to the frontend
 	// unchanged.  Ephemeral keys are issued on behalf of another client which
@@ -30,6 +26,11 @@ type EphemeralKey struct {
 	// from the version of these bindings, we can still pass back a compatible
 	// key.
 	RawJSON []byte `json:"-"`
+
+	AssociatedObjects []struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	} `json:"associated_objects"`
 }
 
 // UnmarshalJSON handles deserialization of an EphemeralKey.

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -14,6 +14,11 @@ type EphemeralKeyParams struct {
 // EphemeralKey is the resource representing a Stripe ephemeral key.
 // For more details see https://stripe.com/docs/api#ephemeral_keys.
 type EphemeralKey struct {
+	AssociatedObjects []struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	} `json:"associated_objects"`
+
 	Created int64  `json:"created"`
 	Expires int64  `json:"expires"`
 	ID      string `json:"id"`
@@ -26,11 +31,6 @@ type EphemeralKey struct {
 	// from the version of these bindings, we can still pass back a compatible
 	// key.
 	RawJSON []byte `json:"-"`
-
-	AssociatedObjects []struct {
-		ID   string `json:"id"`
-		Type string `json:"type"`
-	} `json:"associated_objects"`
 }
 
 // UnmarshalJSON handles deserialization of an EphemeralKey.

--- a/error.go
+++ b/error.go
@@ -17,15 +17,15 @@ const (
 	ErrorTypePermission     ErrorType = "more_permissions_required"
 	ErrorTypeRateLimit      ErrorType = "rate_limit_error"
 
+	CardDeclined  ErrorCode = "card_declined"
+	ExpiredCard   ErrorCode = "expired_card"
 	IncorrectNum  ErrorCode = "incorrect_number"
-	InvalidNum    ErrorCode = "invalid_number"
+	InvalidCvc    ErrorCode = "invalid_cvc"
 	InvalidExpM   ErrorCode = "invalid_expiry_month"
 	InvalidExpY   ErrorCode = "invalid_expiry_year"
-	InvalidCvc    ErrorCode = "invalid_cvc"
-	ExpiredCard   ErrorCode = "expired_card"
+	InvalidNum    ErrorCode = "invalid_number"
 	IncorrectCvc  ErrorCode = "incorrect_cvc"
 	IncorrectZip  ErrorCode = "incorrect_zip"
-	CardDeclined  ErrorCode = "card_declined"
 	Missing       ErrorCode = "missing"
 	ProcessingErr ErrorCode = "processing_error"
 	RateLimit     ErrorCode = "rate_limit"
@@ -42,19 +42,20 @@ const (
 // Error is the response returned when a call is unsuccessful.
 // For more details see  https://stripe.com/docs/api#errors.
 type Error struct {
-	Type           ErrorType `json:"type"`
-	Msg            string    `json:"message"`
-	Code           ErrorCode `json:"code,omitempty"`
-	Param          string    `json:"param,omitempty"`
-	RequestID      string    `json:"request_id,omitempty"`
-	HTTPStatusCode int       `json:"status,omitempty"`
-	ChargeID       string    `json:"charge,omitempty"`
+	ChargeID string    `json:"charge,omitempty"`
+	Code     ErrorCode `json:"code,omitempty"`
 
 	// Err contains an internal error with an additional level of granularity
 	// that can be used in some cases to get more detailed information about
 	// what went wrong. For example, Err may hold a ChargeError that indicates
 	// exactly what went wrong during a charge.
 	Err error `json:"-"`
+
+	HTTPStatusCode int       `json:"status,omitempty"`
+	Msg            string    `json:"message"`
+	Param          string    `json:"param,omitempty"`
+	RequestID      string    `json:"request_id,omitempty"`
+	Type           ErrorType `json:"type"`
 }
 
 // Error serializes the error object to JSON and returns it as a string.

--- a/error_test.go
+++ b/error_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestErrorError(t *testing.T) {
 	err := &Error{Type: "foo", Msg: "bar"}
-	assert.Equal(t, `{"type":"foo","message":"bar"}`, err.Error())
+	assert.Equal(t, `{"message":"bar","type":"foo"}`, err.Error())
 }
 
 func TestErrorResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Request-Id", "req_123")
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, `{"error":{"type":"`+InvalidRequest+`","message":"bar"}}`)
+		fmt.Fprintln(w, `{"error":{"message":"bar","type":"`+InvalidRequest+`"}}`)
 	}))
 	defer ts.Close()
 

--- a/event.go
+++ b/event.go
@@ -8,14 +8,14 @@ import (
 // Event is the resource representing a Stripe event.
 // For more details see https://stripe.com/docs/api#events.
 type Event struct {
-	ID       string        `json:"id"`
 	Account  string        `json:"account"`
-	Live     bool          `json:"livemode"`
 	Created  int64         `json:"created"`
 	Data     *EventData    `json:"data"`
-	Webhooks uint64        `json:"pending_webhooks"`
-	Type     string        `json:"type"`
+	ID       string        `json:"id"`
+	Live     bool          `json:"livemode"`
 	Request  *EventRequest `json:"request"`
+	Type     string        `json:"type"`
+	Webhooks uint64        `json:"pending_webhooks"`
 }
 
 // EventRequest contains information on a request that created an event.
@@ -32,9 +32,9 @@ type EventRequest struct {
 
 // EventData is the unmarshalled object as a map.
 type EventData struct {
-	Raw  json.RawMessage        `json:"object"`
-	Prev map[string]interface{} `json:"previous_attributes"`
 	Obj  map[string]interface{}
+	Prev map[string]interface{} `json:"previous_attributes"`
+	Raw  json.RawMessage        `json:"object"`
 }
 
 // EventList is a list of events as retrieved from a list endpoint.

--- a/fee.go
+++ b/fee.go
@@ -13,27 +13,27 @@ type FeeParams struct {
 // For more details see https://stripe.com/docs/api#list_application_fees.
 type FeeListParams struct {
 	ListParams   `form:"*"`
+	Charge       string            `form:"charge"`
 	Created      int64             `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Charge       string            `form:"charge"`
 }
 
 // Fee is the resource representing a Stripe application fee.
 // For more details see https://stripe.com/docs/api#application_fees.
 type Fee struct {
-	ID                     string         `json:"id"`
-	Live                   bool           `json:"livemode"`
 	Account                *Account       `json:"account"`
 	Amount                 uint64         `json:"amount"`
+	AmountRefunded         uint64         `json:"amount_refunded"`
 	App                    string         `json:"application"`
-	Tx                     *Transaction   `json:"balance_transaction"`
 	Charge                 *Charge        `json:"charge"`
-	OriginatingTransaction *Charge        `json:"originating_transaction"`
 	Created                int64          `json:"created"`
 	Currency               Currency       `json:"currency"`
+	ID                     string         `json:"id"`
+	Live                   bool           `json:"livemode"`
+	OriginatingTransaction *Charge        `json:"originating_transaction"`
 	Refunded               bool           `json:"refunded"`
 	Refunds                *FeeRefundList `json:"refunds"`
-	AmountRefunded         uint64         `json:"amount_refunded"`
+	Tx                     *Transaction   `json:"balance_transaction"`
 }
 
 // FeeList is a list of fees as retrieved from a list endpoint.

--- a/feerefund.go
+++ b/feerefund.go
@@ -8,8 +8,8 @@ import (
 // For more details see https://stripe.com/docs/api#fee_refund.
 type FeeRefundParams struct {
 	Params `form:"*"`
-	Fee    string `form:"-"` // Included in the URL
 	Amount uint64 `form:"amount"`
+	Fee    string `form:"-"` // Included in the URL
 }
 
 // FeeRefundListParams is the set of parameters that can be used when listing fee refunds.
@@ -22,13 +22,13 @@ type FeeRefundListParams struct {
 // FeeRefund is the resource representing a Stripe fee refund.
 // For more details see https://stripe.com/docs/api#fee_refunds.
 type FeeRefund struct {
-	ID       string            `json:"id"`
 	Amount   uint64            `json:"amount"`
+	ID       string            `json:"id"`
 	Created  int64             `json:"created"`
 	Currency Currency          `json:"currency"`
-	Tx       *Transaction      `json:"balance_transaction"`
 	Fee      string            `json:"fee"`
 	Meta     map[string]string `json:"metadata"`
+	Tx       *Transaction      `json:"balance_transaction"`
 }
 
 // FeeRefundList is a list object for fee refunds.

--- a/feerefund.go
+++ b/feerefund.go
@@ -23,10 +23,10 @@ type FeeRefundListParams struct {
 // For more details see https://stripe.com/docs/api#fee_refunds.
 type FeeRefund struct {
 	Amount   uint64            `json:"amount"`
-	ID       string            `json:"id"`
 	Created  int64             `json:"created"`
 	Currency Currency          `json:"currency"`
 	Fee      string            `json:"fee"`
+	ID       string            `json:"id"`
 	Meta     map[string]string `json:"metadata"`
 	Tx       *Transaction      `json:"balance_transaction"`
 }

--- a/fileupload.go
+++ b/fileupload.go
@@ -12,6 +12,8 @@ import (
 // file upload.
 // For more details see https://stripe.com/docs/api#create_file_upload.
 type FileUploadParams struct {
+	Params `form:"*"`
+
 	// File is a deprecated form of FileReader and Filename that will do the same thing, but
 	// allows referencing a file directly. Please prefer the use of FileReader and Filename instead.
 	File *os.File
@@ -22,7 +24,6 @@ type FileUploadParams struct {
 	// Filename is just the name of the file without path information.
 	Filename string
 
-	Params  `form:"*"`
 	Purpose FileUploadPurpose
 }
 

--- a/fileupload.go
+++ b/fileupload.go
@@ -12,18 +12,18 @@ import (
 // file upload.
 // For more details see https://stripe.com/docs/api#create_file_upload.
 type FileUploadParams struct {
-	Params  `form:"*"`
-	Purpose FileUploadPurpose
-
-	// Filename is just the name of the file without path information.
-	Filename string
+	// File is a deprecated form of FileReader and Filename that will do the same thing, but
+	// allows referencing a file directly. Please prefer the use of FileReader and Filename instead.
+	File *os.File
 
 	// FileReader is a reader with the contents of the file that should be uploaded.
 	FileReader io.Reader
 
-	// File is a deprecated form of FileReader and Filename that will do the same thing, but
-	// allows referencing a file directly. Please prefer the use of FileReader and Filename instead.
-	File *os.File
+	// Filename is just the name of the file without path information.
+	Filename string
+
+	Params  `form:"*"`
+	Purpose FileUploadPurpose
 }
 
 // FileUploadListParams is the set of parameters that can be used when listing
@@ -42,12 +42,12 @@ type FileUploadPurpose string
 // FileUpload is the resource representing a Stripe file upload.
 // For more details see https://stripe.com/docs/api#file_uploads.
 type FileUpload struct {
-	ID      string            `json:"id"`
 	Created int64             `json:"created"`
-	Size    int64             `json:"size"`
+	ID      string            `json:"id"`
 	Purpose FileUploadPurpose `json:"purpose"`
-	URL     string            `json:"url"`
+	Size    int64             `json:"size"`
 	Type    string            `json:"type"`
+	URL     string            `json:"url"`
 }
 
 // FileUploadList is a list of file uploads as retrieved from a list endpoint.

--- a/invoice.go
+++ b/invoice.go
@@ -15,8 +15,8 @@ type InvoiceBilling string
 type InvoiceParams struct {
 	Params         `form:"*"`
 	Billing        InvoiceBilling `form:"billing"`
-	Customer       string         `form:"customer"`
 	Closed         bool           `form:"closed"`
+	Customer       string         `form:"customer"`
 	DaysUntilDue   uint64         `form:"days_until_due"`
 	Desc           string         `form:"description"`
 	DueDate        int64          `form:"due_date"`
@@ -32,12 +32,12 @@ type InvoiceParams struct {
 
 	// These are all for exclusive use by GetNext.
 
+	SubItems         []*SubItemsParams `form:"subscription_items,indexed"`
 	SubNoProrate     bool              `form:"subscription_prorate,invert"`
 	SubPlan          string            `form:"subscription_plan"`
 	SubProrationDate int64             `form:"subscription_proration_date"`
 	SubQuantity      uint64            `form:"subscription_quantity"`
 	SubQuantityZero  bool              `form:"subscription_quantity,zero"`
-	SubItems         []*SubItemsParams `form:"subscription_items,indexed"`
 	SubTrialEnd      int64             `form:"subscription_trial_end"`
 }
 
@@ -95,12 +95,12 @@ type Invoice struct {
 	ReceiptNumber string            `json:"receipt_number"`
 	Start         int64             `json:"period_start"`
 	StartBalance  int64             `json:"starting_balance"`
+	Statement     string            `json:"statement_descriptor"`
+	Sub           string            `json:"subscription"`
 	Subtotal      int64             `json:"subtotal"`
 	Tax           int64             `json:"tax"`
 	TaxPercent    float64           `json:"tax_percent"`
 	Total         int64             `json:"total"`
-	Statement     string            `json:"statement_descriptor"`
-	Sub           string            `json:"subscription"`
 	Webhook       int64             `json:"webhooks_delivered_at"`
 }
 

--- a/invoice.go
+++ b/invoice.go
@@ -14,43 +14,43 @@ type InvoiceBilling string
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
 	Params         `form:"*"`
+	Billing        InvoiceBilling `form:"billing"`
 	Customer       string         `form:"customer"`
+	Closed         bool           `form:"closed"`
+	DaysUntilDue   uint64         `form:"days_until_due"`
 	Desc           string         `form:"description"`
-	Statement      string         `form:"statement_descriptor"`
-	Sub            string         `form:"subscription"`
+	DueDate        int64          `form:"due_date"`
 	Fee            uint64         `form:"application_fee"`
 	FeeZero        bool           `form:"application_fee,zero"`
-	Closed         bool           `form:"closed"`
-	NoClosed       bool           `form:"closed,invert"`
 	Forgive        bool           `form:"forgiven"`
+	NoClosed       bool           `form:"closed,invert"`
+	Paid           bool           `form:"paid"`
+	Statement      string         `form:"statement_descriptor"`
+	Sub            string         `form:"subscription"`
 	TaxPercent     float64        `form:"tax_percent"`
 	TaxPercentZero bool           `form:"tax_percent,zero"`
-	Billing        InvoiceBilling `form:"billing"`
-	DueDate        int64          `form:"due_date"`
-	DaysUntilDue   uint64         `form:"days_until_due"`
-	Paid           bool           `form:"paid"`
 
 	// These are all for exclusive use by GetNext.
 
-	SubPlan          string            `form:"subscription_plan"`
 	SubNoProrate     bool              `form:"subscription_prorate,invert"`
+	SubPlan          string            `form:"subscription_plan"`
 	SubProrationDate int64             `form:"subscription_proration_date"`
 	SubQuantity      uint64            `form:"subscription_quantity"`
 	SubQuantityZero  bool              `form:"subscription_quantity,zero"`
-	SubTrialEnd      int64             `form:"subscription_trial_end"`
 	SubItems         []*SubItemsParams `form:"subscription_items,indexed"`
+	SubTrialEnd      int64             `form:"subscription_trial_end"`
 }
 
 // InvoiceListParams is the set of parameters that can be used when listing invoices.
 // For more details see https://stripe.com/docs/api#list_customer_invoices.
 type InvoiceListParams struct {
 	ListParams `form:"*"`
+	Billing    InvoiceBilling    `form:"billing"`
+	Customer   string            `form:"customer"`
 	Date       int64             `form:"date"`
 	DateRange  *RangeQueryParams `form:"date"`
-	Customer   string            `form:"customer"`
-	Sub        string            `form:"subscription"`
-	Billing    InvoiceBilling    `form:"billing"`
 	DueDate    int64             `form:"due_date"`
+	Sub        string            `form:"subscription"`
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.
@@ -58,49 +58,50 @@ type InvoiceListParams struct {
 type InvoiceLineListParams struct {
 	ListParams `form:"*"`
 
+	Customer string `form:"customer"`
+
 	// ID is the invoice ID to list invoice lines for.
 	ID string `form:"-"` // Goes in the URL
 
-	Customer string `form:"customer"`
-	Sub      string `form:"subscription"`
+	Sub string `form:"subscription"`
 }
 
 // Invoice is the resource representing a Stripe invoice.
 // For more details see https://stripe.com/docs/api#invoice_object.
 type Invoice struct {
-	ID            string            `json:"id"`
-	Live          bool              `json:"livemode"`
 	Amount        int64             `json:"amount_due"`
-	Attempts      uint64            `json:"attempt_count"`
 	Attempted     bool              `json:"attempted"`
+	Attempts      uint64            `json:"attempt_count"`
+	Billing       InvoiceBilling    `json:"billing"`
+	Charge        *Charge           `json:"charge"`
 	Closed        bool              `json:"closed"`
 	Currency      Currency          `json:"currency"`
 	Customer      *Customer         `json:"customer"`
 	Date          int64             `json:"date"`
-	Forgive       bool              `json:"forgiven"`
-	Lines         *InvoiceLineList  `json:"lines"`
-	Paid          bool              `json:"paid"`
+	Desc          string            `json:"description"`
+	Discount      *Discount         `json:"discount"`
+	DueDate       int64             `json:"due_date"`
 	End           int64             `json:"period_end"`
+	EndBalance    int64             `json:"ending_balance"`
+	Fee           uint64            `json:"application_fee"`
+	Forgive       bool              `json:"forgiven"`
+	ID            string            `json:"id"`
+	Lines         *InvoiceLineList  `json:"lines"`
+	Live          bool              `json:"livemode"`
+	Meta          map[string]string `json:"metadata"`
+	NextAttempt   int64             `json:"next_payment_attempt"`
+	Number        string            `json:"number"`
+	Paid          bool              `json:"paid"`
+	ReceiptNumber string            `json:"receipt_number"`
 	Start         int64             `json:"period_start"`
 	StartBalance  int64             `json:"starting_balance"`
 	Subtotal      int64             `json:"subtotal"`
-	Total         int64             `json:"total"`
 	Tax           int64             `json:"tax"`
 	TaxPercent    float64           `json:"tax_percent"`
-	Fee           uint64            `json:"application_fee"`
-	Charge        *Charge           `json:"charge"`
-	Desc          string            `json:"description"`
-	Discount      *Discount         `json:"discount"`
-	ReceiptNumber string            `json:"receipt_number"`
-	EndBalance    int64             `json:"ending_balance"`
-	NextAttempt   int64             `json:"next_payment_attempt"`
+	Total         int64             `json:"total"`
 	Statement     string            `json:"statement_descriptor"`
 	Sub           string            `json:"subscription"`
 	Webhook       int64             `json:"webhooks_delivered_at"`
-	Meta          map[string]string `json:"metadata"`
-	Billing       InvoiceBilling    `json:"billing"`
-	DueDate       int64             `json:"due_date"`
-	Number        string            `json:"number"`
 }
 
 // InvoiceList is a list of invoices as retrieved from a list endpoint.
@@ -112,25 +113,25 @@ type InvoiceList struct {
 // InvoiceLine is the resource representing a Stripe invoice line item.
 // For more details see https://stripe.com/docs/api#invoice_line_item_object.
 type InvoiceLine struct {
-	ID           string            `json:"id"`
-	Live         bool              `json:"live_mode"`
 	Amount       int64             `json:"amount"`
 	Currency     Currency          `json:"currency"`
-	Period       *Period           `json:"period"`
-	Proration    bool              `json:"proration"`
-	Type         InvoiceLineType   `json:"type"`
 	Desc         string            `json:"description"`
+	Discountable bool              `json:"discountable"`
+	ID           string            `json:"id"`
+	Live         bool              `json:"live_mode"`
 	Meta         map[string]string `json:"metadata"`
+	Period       *Period           `json:"period"`
 	Plan         *Plan             `json:"plan"`
+	Proration    bool              `json:"proration"`
 	Quantity     int64             `json:"quantity"`
 	Sub          string            `json:"subscription"`
-	Discountable bool              `json:"discountable"`
+	Type         InvoiceLineType   `json:"type"`
 }
 
 // Period is a structure representing a start and end dates.
 type Period struct {
-	Start int64 `json:"start"`
 	End   int64 `json:"end"`
+	Start int64 `json:"start"`
 }
 
 // InvoiceLineList is a list object for invoice line items.

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -6,14 +6,14 @@ import "encoding/json"
 // For more details see https://stripe.com/docs/api#create_invoiceitem and https://stripe.com/docs/api#update_invoiceitem.
 type InvoiceItemParams struct {
 	Params         `form:"*"`
-	Customer       string   `form:"customer"`
 	Amount         int64    `form:"amount"`
 	Currency       Currency `form:"currency"`
-	Invoice        string   `form:"invoice"`
+	Customer       string   `form:"customer"`
 	Desc           string   `form:"description"`
-	Sub            string   `form:"subscription"`
 	Discountable   bool     `form:"discountable"`
+	Invoice        string   `form:"invoice"`
 	NoDiscountable bool     `form:"discountable,invert"`
+	Sub            string   `form:"subscription"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.
@@ -28,22 +28,22 @@ type InvoiceItemListParams struct {
 // InvoiceItem is the resource represneting a Stripe invoice item.
 // For more details see https://stripe.com/docs/api#invoiceitems.
 type InvoiceItem struct {
-	ID           string            `json:"id"`
-	Live         bool              `json:"livemode"`
 	Amount       int64             `json:"amount"`
 	Currency     Currency          `json:"currency"`
 	Customer     *Customer         `json:"customer"`
 	Date         int64             `json:"date"`
+	Deleted      bool              `json:"deleted"`
+	Desc         string            `json:"description"`
+	Discountable bool              `json:"discountable"`
+	ID           string            `json:"id"`
+	Invoice      *Invoice          `json:"invoice"`
+	Live         bool              `json:"livemode"`
+	Meta         map[string]string `json:"metadata"`
 	Period       *Period           `json:"period"`
 	Plan         *Plan             `json:"plan"`
 	Proration    bool              `json:"proration"`
-	Desc         string            `json:"description"`
-	Invoice      *Invoice          `json:"invoice"`
-	Meta         map[string]string `json:"metadata"`
-	Sub          string            `json:"subscription"`
-	Discountable bool              `json:"discountable"`
-	Deleted      bool              `json:"deleted"`
 	Quantity     int64             `json:"quantity"`
+	Sub          string            `json:"subscription"`
 }
 
 // InvoiceItemList is a list of invoice items as retrieved from a list endpoint.

--- a/iter.go
+++ b/iter.go
@@ -18,13 +18,13 @@ type Query func(*form.Values) ([]interface{}, ListMeta, error)
 // Iterators are not thread-safe, so they should not be consumed
 // across multiple goroutines.
 type Iter struct {
-	query  Query
-	qs     *form.Values
-	values []interface{}
+	cur    interface{}
+	err    error
 	meta   ListMeta
 	params ListParams
-	err    error
-	cur    interface{}
+	qs     *form.Values
+	query  Query
+	values []interface{}
 }
 
 // GetIter returns a new Iter for a given query and its options.

--- a/order.go
+++ b/order.go
@@ -8,10 +8,10 @@ import (
 type OrderStatus string
 
 const (
-	StatusCreated   OrderStatus = "created"
-	StatusPaid      OrderStatus = "paid"
 	StatusCanceled  OrderStatus = "canceled"
+	StatusCreated   OrderStatus = "created"
 	StatusFulfilled OrderStatus = "fulfilled"
+	StatusPaid      OrderStatus = "paid"
 	StatusReturned  OrderStatus = "returned"
 )
 
@@ -26,8 +26,8 @@ type OrderParams struct {
 }
 
 type ShippingParams struct {
-	Name    string         `form:"name"`
 	Address *AddressParams `form:"address"`
+	Name    string         `form:"name"`
 	Phone   string         `form:"phone"`
 }
 
@@ -46,17 +46,17 @@ type OrderReturnParams struct {
 }
 
 type Shipping struct {
-	Name    string  `json:"name"`
 	Address Address `json:"address"`
+	Name    string  `json:"name"`
 	Phone   string  `json:"phone"`
 }
 
 type ShippingMethod struct {
-	ID               string            `json:"id"`
 	Amount           int64             `json:"amount"`
+	ID               string            `json:"id"`
 	Currency         Currency          `json:"currency"`
-	Description      string            `json:"description"`
 	DeliveryEstimate *DeliveryEstimate `json:"delivery_estimate"`
+	Description      string            `json:"description"`
 }
 
 type EstimateType string
@@ -76,7 +76,6 @@ type DeliveryEstimate struct {
 }
 
 type Order struct {
-	ID                     string            `json:"id"`
 	Amount                 int64             `json:"amount"`
 	AmountReturned         int64             `json:"amount_returned"`
 	Application            string            `json:"application"`
@@ -86,6 +85,7 @@ type Order struct {
 	Currency               Currency          `json:"currency"`
 	Customer               Customer          `json:"customer"`
 	Email                  string            `json:"email"`
+	ID                     string            `json:"id"`
 	Items                  []OrderItem       `json:"items"`
 	Live                   bool              `json:"livemode"`
 	Meta                   map[string]string `json:"metadata"`
@@ -93,8 +93,8 @@ type Order struct {
 	SelectedShippingMethod *string           `json:"selected_shipping_method"`
 	Shipping               Shipping          `json:"shipping"`
 	ShippingMethods        []ShippingMethod  `json:"shipping_methods"`
-	StatusTransitions      StatusTransitions `json:"status_transitions"`
 	Status                 OrderStatus       `json:"status"`
+	StatusTransitions      StatusTransitions `json:"status_transitions"`
 	Updated                int64             `json:"updated"`
 }
 
@@ -129,10 +129,10 @@ type StatusTransitions struct {
 // https://stripe.com/docs/api#pay_order.
 type OrderPayParams struct {
 	Params         `form:"*"`
-	Source         *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	Customer       string        `form:"customer"`
 	ApplicationFee int64         `form:"application_fee"`
+	Customer       string        `form:"customer"`
 	Email          string        `form:"email"`
+	Source         *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 
 // SetSource adds valid sources to a OrderParams object,

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -8,8 +8,8 @@ type OrderReturn struct {
 	Currency Currency    `json:"currency"`
 	ID       string      `json:"id"`
 	Items    []OrderItem `json:"items"`
-	Order    Order       `json:"order"`
 	Live     bool        `json:"livemode"`
+	Order    Order       `json:"order"`
 	Refund   *Refund     `json:"refund"`
 }
 

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -3,13 +3,13 @@ package stripe
 import "encoding/json"
 
 type OrderReturn struct {
-	ID       string      `json:"id"`
 	Amount   int64       `json:"amount"`
 	Created  int64       `json:"created"`
 	Currency Currency    `json:"currency"`
+	ID       string      `json:"id"`
 	Items    []OrderItem `json:"items"`
-	Live     bool        `json:"livemode"`
 	Order    Order       `json:"order"`
+	Live     bool        `json:"livemode"`
 	Refund   *Refund     `json:"refund"`
 }
 

--- a/params.go
+++ b/params.go
@@ -12,30 +12,31 @@ import (
 )
 
 const (
-	startafter = "starting_after"
 	endbefore  = "ending_before"
+	startafter = "starting_after"
 )
 
 // Params is the structure that contains the common properties
 // of any *Params structure.
 type Params struct {
-	Exp            []string          `form:"expand"`
-	Meta           map[string]string `form:"metadata"`
-	Extra          url.Values        `form:"-"` // See custom encoding in AppendTo
+	// Account is deprecated form of StripeAccount that will do the same thing.
+	// Please use StripeAccount instead.
+	Account string `form:"-"` // Passed as header
+
+	Exp   []string   `form:"expand"`
+	Extra url.Values `form:"-"` // See custom encoding in AppendTo
+
+	// Headers may be used to provide extra header lines on the HTTP request.
+	Headers http.Header `form:"-"`
+
 	IdempotencyKey string            `form:"-"` // Passed as header
+	Meta           map[string]string `form:"metadata"`
 
 	// StripeAccount may contain the ID of a connected account. By including
 	// this field, the request is made as if it originated from the connected
 	// account instead of under the account of the owner of the configured
 	// Stripe key.
 	StripeAccount string `form:"-"` // Passed as header
-
-	// Account is deprecated form of StripeAccount that will do the same thing.
-	// Please use StripeAccount instead.
-	Account string `form:"-"` // Passed as header
-
-	// Headers may be used to provide extra header lines on the HTTP request.
-	Headers http.Header `form:"-"`
 }
 
 // AppendTo implements custom form encoding for Params.
@@ -55,16 +56,18 @@ func (p *Params) AppendTo(body *form.Values, keyParts []string) {
 // ListParams is the structure that contains the common properties
 // of any *ListParams structure.
 type ListParams struct {
-	Exp     []string `form:"expand"`
-	Start   string   `form:"starting_after"`
 	End     string   `form:"ending_before"`
-	Limit   int      `form:"limit"`
+	Exp     []string `form:"expand"`
 	Filters Filters  `form:"-"` // See custom encoding in AppendTo
+	Limit   int      `form:"limit"`
 
-	// By default, listing through an iterator will automatically grab
-	// additional pages as the query progresses. To change this behavior
-	// and just load a single page, set this to true.
+	// Single specifies whether this is a single page iterator. By default,
+	// listing through an iterator will automatically grab additional pages as
+	// the query progresses. To change this behavior and just load a single
+	// page, set this to true.
 	Single bool `form:"-"` // Not an API parameter
+
+	Start string `form:"starting_after"`
 
 	// StripeAccount may contain the ID of a connected account. By including
 	// this field, the request is made as if it originated from the connected

--- a/params_test.go
+++ b/params_test.go
@@ -76,8 +76,8 @@ func TestListParams_Nested(t *testing.T) {
 		Field: "field_value",
 		ListParams: stripe.ListParams{
 			End:   "acct_123",
-			Start: "acct_123",
 			Limit: 100,
+			Start: "acct_123",
 		},
 	}
 
@@ -85,9 +85,9 @@ func TestListParams_Nested(t *testing.T) {
 	form.AppendTo(body, params)
 
 	assert.Equal(t, valuesFromArray([][2]string{
-		{"starting_after", "acct_123"},
 		{"ending_before", "acct_123"},
 		{"limit", "100"},
+		{"starting_after", "acct_123"},
 		{"field", "field_value"},
 	}), body)
 }

--- a/payout.go
+++ b/payout.go
@@ -2,17 +2,8 @@ package stripe
 
 import "encoding/json"
 
-// PayoutStatus is the list of allowed values for the payout's status.
-// Allowed values are "paid", "pending", "in_transit",  "failed", "canceled".
-type PayoutStatus string
-
-// PayoutType is the list of allowed values for the payout's type.
-// Allowed values are "bank_account" or "card".
-type PayoutType string
-
-// PayoutSourceType is the list of allowed values for the payout's source_type field.
-// Allowed values are "alipay_account", bank_account", "bitcoin_receiver", "card".
-type PayoutSourceType string
+// PayoutDestinationType consts represent valid payout destinations.
+type PayoutDestinationType string
 
 // PayoutFailureCode is the list of allowed values for the payout's failure code.
 // Allowed values are "insufficient_funds", "account_closed", "no_account",
@@ -20,8 +11,17 @@ type PayoutSourceType string
 // "account_frozen", "could_not_process", "bank_account_restricted", "invalid_currency".
 type PayoutFailureCode string
 
-// PayoutDestinationType consts represent valid payout destinations.
-type PayoutDestinationType string
+// PayoutSourceType is the list of allowed values for the payout's source_type field.
+// Allowed values are "alipay_account", bank_account", "bitcoin_receiver", "card".
+type PayoutSourceType string
+
+// PayoutStatus is the list of allowed values for the payout's status.
+// Allowed values are "paid", "pending", "in_transit",  "failed", "canceled".
+type PayoutStatus string
+
+// PayoutType is the list of allowed values for the payout's type.
+// Allowed values are "bank_account" or "card".
+type PayoutType string
 
 const (
 	// PayoutDestinationBankAccount is a constant representing a payout destination
@@ -48,10 +48,10 @@ const (
 // The Type should indicate which object is fleshed out
 // For more details see https://stripe.com/docs/api/go#payout_object
 type PayoutDestination struct {
-	Type        PayoutDestinationType `json:"object"`
-	ID          string                `json:"id"`
 	BankAccount *BankAccount          `json:"-"`
 	Card        *Card                 `json:"-"`
+	ID          string                `json:"id"`
+	Type        PayoutDestinationType `json:"object"`
 }
 
 // PayoutParams is the set of parameters that can be used when creating or updating a payout.
@@ -81,8 +81,6 @@ type PayoutListParams struct {
 // Payout is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payouts.
 type Payout struct {
-	ID                        string            `json:"id"`
-	Live                      bool              `json:"livemode"`
 	Amount                    int64             `json:"amount"`
 	ArrivalDate               int64             `json:"arrival_date"`
 	BalanceTransaction        *Transaction      `json:"balance_transaction"`
@@ -91,9 +89,11 @@ type Payout struct {
 	Created                   int64             `json:"created"`
 	Currency                  Currency          `json:"currency"`
 	Destination               PayoutDestination `json:"destination"`
-	FailureBalanceTransaction *Transaction      `json:"failure_balance_transaction"`
 	FailCode                  PayoutFailureCode `json:"failure_code"`
 	FailMessage               string            `json:"failure_message"`
+	FailureBalanceTransaction *Transaction      `json:"failure_balance_transaction"`
+	ID                        string            `json:"id"`
+	Live                      bool              `json:"livemode"`
 	Meta                      map[string]string `json:"metadata"`
 	Method                    PayoutMethodType  `json:"method"`
 	SourceType                PayoutSourceType  `json:"source_type"`

--- a/plan.go
+++ b/plan.go
@@ -7,18 +7,18 @@ type PlanInterval string
 // Plan is the resource representing a Stripe plan.
 // For more details see https://stripe.com/docs/api#plans.
 type Plan struct {
-	ID            string            `json:"id"`
-	Live          bool              `json:"livemode"`
 	Amount        uint64            `json:"amount"`
 	Created       int64             `json:"created"`
 	Currency      Currency          `json:"currency"`
+	Deleted       bool              `json:"deleted"`
+	ID            string            `json:"id"`
 	Interval      PlanInterval      `json:"interval"`
 	IntervalCount uint64            `json:"interval_count"`
-	Name          string            `json:"name"`
+	Live          bool              `json:"livemode"`
 	Meta          map[string]string `json:"metadata"`
-	TrialPeriod   uint64            `json:"trial_period_days"`
+	Name          string            `json:"name"`
 	Statement     string            `json:"statement_descriptor"`
-	Deleted       bool              `json:"deleted"`
+	TrialPeriod   uint64            `json:"trial_period_days"`
 }
 
 // PlanList is a list of plans as returned from a list endpoint.
@@ -39,12 +39,12 @@ type PlanListParams struct {
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
 	Params        `form:"*"`
-	ID            string       `form:"id"`
-	Name          string       `form:"name"`
-	Currency      Currency     `form:"currency"`
 	Amount        uint64       `form:"amount"`
+	Currency      Currency     `form:"currency"`
+	ID            string       `form:"id"`
 	Interval      PlanInterval `form:"interval"`
 	IntervalCount uint64       `form:"interval_count"`
-	TrialPeriod   uint64       `form:"trial_period_days"`
+	Name          string       `form:"name"`
 	Statement     string       `form:"statement_descriptor"`
+	TrialPeriod   uint64       `form:"trial_period_days"`
 }

--- a/product.go
+++ b/product.go
@@ -7,8 +7,8 @@ import "encoding/json"
 type PackageDimensions struct {
 	Height float64 `json:"height" form:"height"`
 	Length float64 `json:"length" form:"length"`
-	Width  float64 `json:"width" form:"width"`
 	Weight float64 `json:"weight" form:"weight"`
+	Width  float64 `json:"width" form:"width"`
 }
 
 // ProductParams is the set of parameters that can be used
@@ -17,38 +17,38 @@ type PackageDimensions struct {
 // and https://stripe.com/docs/api#update_product.
 type ProductParams struct {
 	Params            `form:"*"`
-	ID                string             `form:"id"`
 	Active            *bool              `form:"active"`
-	Name              string             `form:"name"`
-	Caption           string             `form:"caption"`
-	Desc              string             `form:"description"`
 	Attrs             []string           `form:"attributes"`
-	Images            []string           `form:"images"`
-	URL               string             `form:"url"`
-	Shippable         *bool              `form:"shippable"`
-	PackageDimensions *PackageDimensions `form:"package_dimensions"`
+	Caption           string             `form:"caption"`
 	DeactivateOn      []string           `form:"deactivate_on"`
+	Desc              string             `form:"description"`
+	ID                string             `form:"id"`
+	Images            []string           `form:"images"`
+	Name              string             `form:"name"`
+	PackageDimensions *PackageDimensions `form:"package_dimensions"`
+	Shippable         *bool              `form:"shippable"`
+	URL               string             `form:"url"`
 }
 
 // Product is the resource representing a Stripe product.
 // For more details see https://stripe.com/docs/api#products.
 type Product struct {
-	ID                string             `json:"id"`
-	Created           int64              `json:"created"`
-	Updated           int64              `json:"updated"`
-	Live              bool               `json:"livemode"`
 	Active            bool               `json:"active"`
-	Name              string             `json:"name"`
-	Caption           string             `json:"caption"`
-	Desc              string             `json:"description"`
 	Attrs             []string           `json:"attributes"`
-	Shippable         bool               `json:"shippable"`
-	PackageDimensions *PackageDimensions `json:"package_dimensions"`
-	Images            []string           `json:"images"`
-	Meta              map[string]string  `json:"metadata"`
-	URL               string             `json:"url"`
+	Caption           string             `json:"caption"`
+	Created           int64              `json:"created"`
 	DeactivateOn      []string           `json:"deactivate_on"`
+	Desc              string             `json:"description"`
+	ID                string             `json:"id"`
+	Images            []string           `json:"images"`
+	Live              bool               `json:"livemode"`
+	Meta              map[string]string  `json:"metadata"`
+	Name              string             `json:"name"`
+	PackageDimensions *PackageDimensions `json:"package_dimensions"`
+	Shippable         bool               `json:"shippable"`
 	Skus              *SKUList           `json:"skus"`
+	URL               string             `json:"url"`
+	Updated           int64              `json:"updated"`
 }
 
 // ProductList is a list of products as retrieved from a list endpoint.

--- a/recipient.go
+++ b/recipient.go
@@ -13,18 +13,17 @@ type RecipientType string
 // RecipientParams is the set of parameters that can be used when creating or updating recipients.
 // For more details see https://stripe.com/docs/api#create_recipient and https://stripe.com/docs/api#update_recipient.
 type RecipientParams struct {
-	Params      `form:"*"`
-	Name        string      `form:"name"`
-	TaxID       string      `form:"tax_id"`
-	Token       string      `form:"card"`
-	Email       string      `form:"email"`
-	Desc        string      `form:"description"`
-	Card        *CardParams `form:"card"`
-	DefaultCard string      `form:"default_card"`
+	Params `form:"*"`
 
-	Bank *BankAccountParams `form:"-"` // Kind of an abberation because a bank account's token will be replace the rest of its data. Keep this in a custom AppendTo for now.
-
-	Type RecipientType `form:"-"` // Doesn't seem to be used anywhere
+	Bank        *BankAccountParams `form:"-"` // Kind of an abberation because a bank account's token will be replace the rest of its data. Keep this in a custom AppendTo for now.
+	Card        *CardParams        `form:"card"`
+	DefaultCard string             `form:"default_card"`
+	Desc        string             `form:"description"`
+	Email       string             `form:"email"`
+	Name        string             `form:"name"`
+	TaxID       string             `form:"tax_id"`
+	Token       string             `form:"card"`
+	Type        RecipientType      `form:"-"` // Doesn't seem to be used anywhere
 }
 
 // AppendTo implements some custom behavior around a recipient's bank account.
@@ -50,19 +49,19 @@ type RecipientListParams struct {
 // Recipient is the resource representing a Stripe recipient.
 // For more details see https://stripe.com/docs/api#recipients.
 type Recipient struct {
-	ID          string            `json:"id"`
-	Live        bool              `json:"livemode"`
-	Created     int64             `json:"created"`
-	Type        RecipientType     `json:"type"`
 	Bank        *BankAccount      `json:"active_account"`
+	Cards       *CardList         `json:"cards"`
+	Created     int64             `json:"created"`
+	DefaultCard *Card             `json:"default_card"`
+	Deleted     bool              `json:"deleted"`
 	Desc        string            `json:"description"`
 	Email       string            `json:"email"`
+	ID          string            `json:"id"`
+	Live        bool              `json:"livemode"`
 	Meta        map[string]string `json:"metadata"`
 	MigratedTo  *Account          `json:"migrated_to"`
 	Name        string            `json:"name"`
-	Cards       *CardList         `json:"cards"`
-	DefaultCard *Card             `json:"default_card"`
-	Deleted     bool              `json:"deleted"`
+	Type        RecipientType     `json:"type"`
 }
 
 // RecipientList is a list of recipients as retrieved from a list endpoint.

--- a/recipienttransfer.go
+++ b/recipienttransfer.go
@@ -2,17 +2,8 @@ package stripe
 
 import "encoding/json"
 
-// RecipientTransferStatus is the list of allowed values for the recipient_transfer's status.
-// Allowed values are "paid", "pending", "in_transit",  "failed".
-type RecipientTransferStatus string
-
-// RecipientTransferType is the list of allowed values for the recipient_transfer's type.
-// Allowed values are "bank_account" or "card".
-type RecipientTransferType string
-
-// RecipientTransferSourceType is the list of allowed values for the recipient_transfer's source_type field.
-// Allowed values are "alipay_account", bank_account", "bitcoin_receiver", "card".
-type RecipientTransferSourceType string
+// RecipientTransferDestinationType consts represent valid recipient_transfer destinations.
+type RecipientTransferDestinationType string
 
 // RecipientTransferFailCode is the list of allowed values for the recipient_transfer's failure code.
 // Allowed values are "insufficient_funds", "account_closed", "no_account",
@@ -20,8 +11,17 @@ type RecipientTransferSourceType string
 // "account_frozen", "could_not_process", "bank_account_restricted", "invalid_currency".
 type RecipientTransferFailCode string
 
-// RecipientTransferDestinationType consts represent valid recipient_transfer destinations.
-type RecipientTransferDestinationType string
+// RecipientTransferSourceType is the list of allowed values for the recipient_transfer's source_type field.
+// Allowed values are "alipay_account", bank_account", "bitcoin_receiver", "card".
+type RecipientTransferSourceType string
+
+// RecipientTransferStatus is the list of allowed values for the recipient_transfer's status.
+// Allowed values are "paid", "pending", "in_transit",  "failed".
+type RecipientTransferStatus string
+
+// RecipientTransferType is the list of allowed values for the recipient_transfer's type.
+// Allowed values are "bank_account" or "card".
+type RecipientTransferType string
 
 const (
 	// RecipientTransferDestinationBankAccount is a constant representing a recipient_transfer destination
@@ -48,17 +48,15 @@ const (
 // The Type should indicate which object is fleshed out
 // For more details see https://stripe.com/docs/api/go#recipient_transfer_object
 type RecipientTransferDestination struct {
-	Type        RecipientTransferDestinationType `json:"object"`
-	ID          string                           `json:"id"`
-	BankAccount *BankAccount                     `json:"-"`
 	Card        *Card                            `json:"-"`
+	BankAccount *BankAccount                     `json:"-"`
+	ID          string                           `json:"id"`
+	Type        RecipientTransferDestinationType `json:"object"`
 }
 
 // RecipientTransfer is the resource representing a Stripe recipient_transfer.
 // For more details see https://stripe.com/docs/api#recipient_transfers.
 type RecipientTransfer struct {
-	ID                 string                       `json:"id"`
-	Live               bool                         `json:"livemode"`
 	Amount             int64                        `json:"amount"`
 	AmountReversed     int64                        `json:"amount_reversed"`
 	BalanceTransaction *Transaction                 `json:"balance_transaction"`
@@ -71,6 +69,8 @@ type RecipientTransfer struct {
 	Dest               RecipientTransferDestination `json:"destination"`
 	FailCode           RecipientTransferFailCode    `json:"failure_code"`
 	FailMsg            string                       `json:"failure_message"`
+	ID                 string                       `json:"id"`
+	Live               bool                         `json:"livemode"`
 	Meta               map[string]string            `json:"metadata"`
 	Method             RecipientTransferMethodType  `json:"method"`
 	Recipient          *Recipient                   `json:"recipient"`

--- a/recipienttransfer.go
+++ b/recipienttransfer.go
@@ -48,8 +48,8 @@ const (
 // The Type should indicate which object is fleshed out
 // For more details see https://stripe.com/docs/api/go#recipient_transfer_object
 type RecipientTransferDestination struct {
-	Card        *Card                            `json:"-"`
 	BankAccount *BankAccount                     `json:"-"`
+	Card        *Card                            `json:"-"`
 	ID          string                           `json:"id"`
 	Type        RecipientTransferDestinationType `json:"object"`
 }

--- a/refund.go
+++ b/refund.go
@@ -15,8 +15,8 @@ type RefundStatus string
 // For more details see https://stripe.com/docs/api#refund.
 type RefundParams struct {
 	Params   `form:"*"`
-	Charge   string       `form:"charge"`
 	Amount   uint64       `form:"amount"`
+	Charge   string       `form:"charge"`
 	Fee      bool         `form:"refund_application_fee"`
 	Reason   RefundReason `form:"reason"`
 	Transfer bool         `form:"reverse_transfer"`
@@ -31,16 +31,16 @@ type RefundListParams struct {
 // Refund is the resource representing a Stripe refund.
 // For more details see https://stripe.com/docs/api#refunds.
 type Refund struct {
-	ID            string            `json:"id"`
 	Amount        uint64            `json:"amount"`
+	Charge        *Charge           `json:"charge"`
 	Created       int64             `json:"created"`
 	Currency      Currency          `json:"currency"`
-	Tx            *Transaction      `json:"balance_transaction"`
-	Charge        *Charge           `json:"charge"`
+	ID            string            `json:"id"`
 	Meta          map[string]string `json:"metadata"`
 	Reason        RefundReason      `json:"reason"`
 	ReceiptNumber string            `json:"receipt_number"`
 	Status        RefundStatus      `json:"status"`
+	Tx            *Transaction      `json:"balance_transaction"`
 }
 
 // RefundList is a list object for refunds.

--- a/reversal.go
+++ b/reversal.go
@@ -18,12 +18,12 @@ type ReversalListParams struct {
 
 // Reversal represents a transfer reversal.
 type Reversal struct {
-	ID       string            `json:"id"`
 	Amount   uint64            `json:"amount"`
 	Created  int64             `json:"created"`
 	Currency Currency          `json:"currency"`
-	Transfer string            `json:"transfer"`
+	ID       string            `json:"id"`
 	Meta     map[string]string `json:"metadata"`
+	Transfer string            `json:"transfer"`
 	Tx       *Transaction      `json:"balance_transaction"`
 }
 

--- a/review.go
+++ b/review.go
@@ -8,12 +8,12 @@ import "encoding/json"
 type ReasonType string
 
 const (
-	ReasonRule            ReasonType = "rule"
-	ReasonManual          ReasonType = "manual"
 	ReasonApproved        ReasonType = "approved"
+	ReasonDisputed        ReasonType = "disputed"
+	ReasonManual          ReasonType = "manual"
 	ReasonRefunded        ReasonType = "refunded"
 	ReasonRefundedAsFraud ReasonType = "refunded_as_fraud"
-	ReasonDisputed        ReasonType = "disputed"
+	ReasonRule            ReasonType = "rule"
 )
 
 type Review struct {

--- a/sku.go
+++ b/sku.go
@@ -4,39 +4,39 @@ import "encoding/json"
 
 type SKUParams struct {
 	Params            `form:"*"`
-	ID                string             `form:"id"`
 	Active            *bool              `form:"active"`
-	Desc              string             `form:"description"`
 	Attrs             map[string]string  `form:"attributes"`
-	Price             int64              `form:"price"`
 	Currency          string             `form:"currency"`
+	Desc              string             `form:"description"`
+	ID                string             `form:"id"`
 	Image             string             `form:"image"`
 	Inventory         Inventory          `form:"inventory"`
-	Product           string             `form:"product"`
 	PackageDimensions *PackageDimensions `form:"package_dimensions"`
+	Price             int64              `form:"price"`
+	Product           string             `form:"product"`
 }
 
 type Inventory struct {
-	Type     string `json:"type" form:"type"`
 	Quantity int64  `json:"quantity" form:"quantity"`
+	Type     string `json:"type" form:"type"`
 	Value    string `json:"value" form:"value"`
 }
 
 type SKU struct {
-	ID                string             `json:"id"`
-	Created           int64              `json:"created"`
-	Updated           int64              `json:"updated"`
-	Live              bool               `json:"livemode"`
 	Active            bool               `json:"active"`
-	Desc              string             `json:"description"`
 	Attrs             map[string]string  `json:"attributes"`
-	Price             int64              `json:"price"`
+	Created           int64              `json:"created"`
 	Currency          string             `json:"currency"`
-	PackageDimensions *PackageDimensions `json:"package_dimensions"`
+	Desc              string             `json:"description"`
+	ID                string             `json:"id"`
 	Image             string             `json:"image"`
 	Inventory         Inventory          `json:"inventory"`
-	Product           Product            `json:"product"`
+	Live              bool               `json:"livemode"`
 	Meta              map[string]string  `json:"metadata"`
+	PackageDimensions *PackageDimensions `json:"package_dimensions"`
+	Price             int64              `json:"price"`
+	Product           Product            `json:"product"`
+	Updated           int64              `json:"updated"`
 }
 
 type SKUList struct {
@@ -47,10 +47,10 @@ type SKUList struct {
 type SKUListParams struct {
 	ListParams `form:"*"`
 	Active     *bool             `form:"active"`
-	Product    string            `form:"product"`
 	Attributes map[string]string `form:"attributes"`
 	IDs        []string          `form:"ids"`
 	InStock    *bool             `form:"in_stock"`
+	Product    string            `form:"product"`
 }
 
 func (s *SKU) UnmarshalJSON(data []byte) error {

--- a/source.go
+++ b/source.go
@@ -8,50 +8,58 @@ import (
 type SourceStatus string
 
 const (
+	// SourceStatusCanceled we canceled the source along with any side-effect
+	// it had (returned funds to customers if any were sent).
+	SourceStatusCanceled SourceStatus = "canceled"
+
+	// SourceStatusChargeable the source is ready to be charged (once if usage
+	// is `single_use`, repeatidly otherwise).
+	SourceStatusChargeable SourceStatus = "chargeable"
+
+	// SourceStatusConsumed the source is `single_use` usage and has been
+	// charged already.
+	SourceStatusConsumed SourceStatus = "consumed"
+
+	// SourceStatusFailed the source is no longer usable.
+	SourceStatusFailed SourceStatus = "failed"
+
 	// SourceStatusPending the source is freshly created and not yet
 	// chargeable. The flow should indicate how to authenticate it with your
 	// customer.
 	SourceStatusPending SourceStatus = "pending"
-	// SourceStatusChargeable the source is ready to be charged (once if usage
-	// is `single_use`, repeatidly otherwise).
-	SourceStatusChargeable SourceStatus = "chargeable"
-	// SourceStatusConsumed the source is `single_use` usage and has been
-	// charged already.
-	SourceStatusConsumed SourceStatus = "consumed"
-	// SourceStatusFailed the source is no longer usable.
-	SourceStatusFailed SourceStatus = "failed"
-	// SourceStatusCanceled we canceled the source along with any side-effect
-	// it had (returned funds to customers if any were sent).
-	SourceStatusCanceled SourceStatus = "canceled"
 )
 
 // SourceFlow represents the possible flows of a source object.
 type SourceFlow string
 
 const (
-	// FlowRedirect a redirect is required to authenticate the source.
-	FlowRedirect SourceFlow = "redirect"
-	// FlowReceiver a receiver address should be communicated to the customer
-	// to push funds to it.
-	FlowReceiver SourceFlow = "receiver"
-	// FlowVerification a verification code should be communicated by the
-	// customer to authenticate the source.
-	FlowVerification SourceFlow = "verification"
 	// FlowNone no particular authentication is involved the source should
 	// become chargeable directly or asyncrhonously.
 	FlowNone SourceFlow = "none"
+
+	// FlowReceiver a receiver address should be communicated to the customer
+	// to push funds to it.
+	FlowReceiver SourceFlow = "receiver"
+
+	// FlowRedirect a redirect is required to authenticate the source.
+	FlowRedirect SourceFlow = "redirect"
+
+	// FlowVerification a verification code should be communicated by the
+	// customer to authenticate the source.
+	FlowVerification SourceFlow = "verification"
 )
 
 // SourceUsage represents the possible usages of a source object.
 type SourceUsage string
 
 const (
-	// UsageSingleUse the source can only be charged once for the specified
-	// amount and currency.
-	UsageSingleUse SourceUsage = "single_use"
 	// UsageReusable the source can be charged multiple times for arbitrary
 	// amounts.
 	UsageReusable SourceUsage = "reusable"
+
+	// UsageSingleUse the source can only be charged once for the specified
+	// amount and currency.
+	UsageSingleUse SourceUsage = "single_use"
 )
 
 type SourceOwnerParams struct {
@@ -67,16 +75,16 @@ type RedirectParams struct {
 
 type SourceObjectParams struct {
 	Params   `form:"*"`
-	Type     string             `form:"type"`
-	Usage    SourceUsage        `form:"usage"`
-	Customer string             `form:"customer"`
 	Amount   uint64             `form:"amount"`
 	Currency Currency           `form:"currency"`
+	Customer string             `form:"customer"`
 	Flow     SourceFlow         `form:"flow"`
 	Owner    *SourceOwnerParams `form:"owner"`
 	Redirect *RedirectParams    `form:"redirect"`
 	Token    string             `form:"token"`
+	Type     string             `form:"type"`
 	TypeData map[string]string  `form:"*"`
+	Usage    SourceUsage        `form:"usage"`
 }
 
 type SourceOwner struct {
@@ -94,16 +102,16 @@ type SourceOwner struct {
 type RedirectFlowStatus string
 
 const (
+	RedirectFlowStatusFailed    RedirectFlowStatus = "failed"
 	RedirectFlowStatusPending   RedirectFlowStatus = "pending"
 	RedirectFlowStatusSucceeded RedirectFlowStatus = "succeeded"
-	RedirectFlowStatusFailed    RedirectFlowStatus = "failed"
 )
 
 // ReceiverFlow informs of the state of a redirect authentication flow.
 type RedirectFlow struct {
-	URL       string             `json:"url"`
 	ReturnURL string             `json:"return_url"`
 	Status    RedirectFlowStatus `json:"status"`
+	URL       string             `json:"url"`
 }
 
 // RefundAttributesStatus are the possible status of a receiver's refund
@@ -113,10 +121,12 @@ type RefundAttributesStatus string
 const (
 	// RefundAttributesAvailable the refund attributes are available
 	RefundAttributesAvailable RefundAttributesStatus = "available"
-	// RefundAttributesRequested the refund attributes have been requested
-	RefundAttributesRequested RefundAttributesStatus = "requested"
+
 	// RefundAttributesMissing the refund attributes are missing
 	RefundAttributesMissing RefundAttributesStatus = "missing"
+
+	// RefundAttributesRequested the refund attributes have been requested
+	RefundAttributesRequested RefundAttributesStatus = "requested"
 )
 
 // RefundAttributesMethod are the possible method to retrieve a receiver's
@@ -126,18 +136,19 @@ type RefundAttributesMethod string
 const (
 	// RefundAttributesEmail the refund attributes are automatically collected over email
 	RefundAttributesEmail RefundAttributesMethod = "email"
+
 	// RefundAttributesManual the refund attributes should be collected by the user
 	RefundAttributesManual RefundAttributesMethod = "manual"
 )
 
 // ReceiverFlow informs of the state of a receiver authentication flow.
 type ReceiverFlow struct {
-	RefundAttributesStatus RefundAttributesStatus `json:"refund_attributes_status"`
-	RefundAttributesMethod RefundAttributesMethod `json:"refund_attributes_method"`
 	Address                string                 `json:"address"`
+	AmountCharged          int64                  `json:"amount_charged"`
 	AmountReceived         int64                  `json:"amount_received"`
 	AmountReturned         int64                  `json:"amount_returned"`
-	AmountCharged          int64                  `json:"amount_charged"`
+	RefundAttributesMethod RefundAttributesMethod `json:"refund_attributes_method"`
+	RefundAttributesStatus RefundAttributesStatus `json:"refund_attributes_status"`
 }
 
 // VerificationFlowStatus represents the possible statuses of a verification
@@ -145,9 +156,9 @@ type ReceiverFlow struct {
 type VerificationFlowStatus string
 
 const (
+	VerificationFlowStatusFailed    VerificationFlowStatus = "failed"
 	VerificationFlowStatusPending   VerificationFlowStatus = "pending"
 	VerificationFlowStatusSucceeded VerificationFlowStatus = "succeeded"
-	VerificationFlowStatusFailed    VerificationFlowStatus = "failed"
 )
 
 // ReceiverFlow informs of the state of a verification authentication flow.
@@ -157,25 +168,22 @@ type VerificationFlow struct {
 }
 
 type Source struct {
-	ID           string       `json:"id"`
-	Amount       int64        `json:"amount"`
-	ClientSecret string       `json:"client_secret"`
-	Created      int64        `json:"created"`
-	Currency     Currency     `json:"currency"`
-	Flow         SourceFlow   `json:"flow"`
-	Status       SourceStatus `json:"status"`
-	Type         string       `json:"type"`
-	Usage        SourceUsage  `json:"usage"`
-
-	Live bool              `json:"livemode"`
-	Meta map[string]string `json:"metadata"`
-
+	Amount       int64             `json:"amount"`
+	ClientSecret string            `json:"client_secret"`
+	Created      int64             `json:"created"`
+	Currency     Currency          `json:"currency"`
+	Flow         SourceFlow        `json:"flow"`
+	ID           string            `json:"id"`
+	Live         bool              `json:"livemode"`
+	Meta         map[string]string `json:"metadata"`
 	Owner        SourceOwner       `json:"owner"`
-	Redirect     *RedirectFlow     `json:"redirect,omitempty"`
 	Receiver     *ReceiverFlow     `json:"receiver,omitempty"`
+	Redirect     *RedirectFlow     `json:"redirect,omitempty"`
+	Status       SourceStatus      `json:"status"`
+	Type         string            `json:"type"`
+	TypeData     map[string]interface{}
+	Usage        SourceUsage       `json:"usage"`
 	Verification *VerificationFlow `json:"verification,omitempty"`
-
-	TypeData map[string]interface{}
 }
 
 // UnmarshalJSON handles deserialization of an Source. This custom unmarshaling

--- a/sub.go
+++ b/sub.go
@@ -35,9 +35,9 @@ type SubParams struct {
 	ProrationDate         int64             `form:"proration_date"`
 	Quantity              uint64            `form:"quantity"`
 	QuantityZero          bool              `form:"quantity,zero"`
-	Token                 string            `form:"card"`
 	TaxPercent            float64           `form:"tax_percent"`
 	TaxPercentZero        bool              `form:"tax_percent,zero"`
+	Token                 string            `form:"card"`
 	TrialEnd              int64             `form:"trial_end"`
 	TrialEndNow           bool              `form:"-"` // See custom AppendTo
 	TrialPeriod           int64             `form:"trial_period_days"`
@@ -102,8 +102,8 @@ type Sub struct {
 	PeriodStart  int64             `json:"current_period_start"`
 	Plan         *Plan             `json:"plan"`
 	Quantity     uint64            `json:"quantity"`
-	Status       SubStatus         `json:"status"`
 	Start        int64             `json:"start"`
+	Status       SubStatus         `json:"status"`
 	TaxPercent   float64           `json:"tax_percent"`
 	TrialEnd     int64             `json:"trial_end"`
 	TrialStart   int64             `json:"trial_start"`

--- a/sub.go
+++ b/sub.go
@@ -18,29 +18,29 @@ type SubBilling string
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubParams struct {
 	Params                `form:"*"`
-	Customer              string            `form:"customer"`
-	Plan                  string            `form:"plan"`
-	Token                 string            `form:"card"`
+	Billing               SubBilling        `form:"billing"`
+	BillingCycleAnchor    int64             `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow bool              `form:"-"` // See custom AppendTo
+	Card                  *CardParams       `form:"card"`
 	Coupon                string            `form:"coupon"`
 	CouponEmpty           bool              `form:"coupon,empty"`
+	Customer              string            `form:"customer"`
+	DaysUntilDue          uint64            `form:"days_until_due"`
+	FeePercent            float64           `form:"application_fee_percent"`
+	FeePercentZero        bool              `form:"application_fee_percent,zero"`
+	Items                 []*SubItemsParams `form:"items,indexed"`
+	NoProrate             bool              `form:"prorate,invert"`
+	OnBehalfOf            string            `form:"on_behalf_of"`
+	Plan                  string            `form:"plan"`
+	ProrationDate         int64             `form:"proration_date"`
+	Quantity              uint64            `form:"quantity"`
+	QuantityZero          bool              `form:"quantity,zero"`
+	Token                 string            `form:"card"`
+	TaxPercent            float64           `form:"tax_percent"`
+	TaxPercentZero        bool              `form:"tax_percent,zero"`
 	TrialEnd              int64             `form:"trial_end"`
 	TrialEndNow           bool              `form:"-"` // See custom AppendTo
 	TrialPeriod           int64             `form:"trial_period_days"`
-	Card                  *CardParams       `form:"card"`
-	Quantity              uint64            `form:"quantity"`
-	QuantityZero          bool              `form:"quantity,zero"`
-	ProrationDate         int64             `form:"proration_date"`
-	NoProrate             bool              `form:"prorate,invert"`
-	FeePercent            float64           `form:"application_fee_percent"`
-	FeePercentZero        bool              `form:"application_fee_percent,zero"`
-	TaxPercent            float64           `form:"tax_percent"`
-	TaxPercentZero        bool              `form:"tax_percent,zero"`
-	BillingCycleAnchor    int64             `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow bool              `form:"-"` // See custom AppendTo
-	Items                 []*SubItemsParams `form:"items,indexed"`
-	Billing               SubBilling        `form:"billing"`
-	DaysUntilDue          uint64            `form:"days_until_due"`
-	OnBehalfOf            string            `form:"on_behalf_of"`
 
 	// Used for Cancel
 
@@ -64,49 +64,49 @@ func (p *SubParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubItemsParams struct {
 	Params       `form:"*"`
+	Deleted      bool   `form:"deleted"`
 	ID           string `form:"id"`
+	Plan         string `form:"plan"`
 	Quantity     uint64 `form:"quantity"`
 	QuantityZero bool   `form:"quantity,zero"`
-	Plan         string `form:"plan"`
-	Deleted      bool   `form:"deleted"`
 }
 
 // SubListParams is the set of parameters that can be used when listing active subscriptions.
 // For more details see https://stripe.com/docs/api#list_subscriptions.
 type SubListParams struct {
 	ListParams   `form:"*"`
+	Billing      SubBilling        `form:"billing"`
 	Created      int64             `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 	Customer     string            `form:"customer"`
 	Plan         string            `form:"plan"`
 	Status       SubStatus         `form:"status"`
-	Billing      SubBilling        `form:"billing"`
 }
 
 // Sub is the resource representing a Stripe subscription.
 // For more details see https://stripe.com/docs/api#subscriptions.
 type Sub struct {
-	ID           string            `json:"id"`
-	EndCancel    bool              `json:"cancel_at_period_end"`
+	Billing      SubBilling        `json:"billing"`
+	Canceled     int64             `json:"canceled_at"`
+	Created      int64             `json:"created"`
 	Customer     *Customer         `json:"customer"`
+	DaysUntilDue uint64            `json:"days_until_due"`
+	Discount     *Discount         `json:"discount"`
+	EndCancel    bool              `json:"cancel_at_period_end"`
+	Ended        int64             `json:"ended_at"`
+	FeePercent   float64           `json:"application_fee_percent"`
+	ID           string            `json:"id"`
+	Items        *SubItemList      `json:"items"`
+	Meta         map[string]string `json:"metadata"`
+	PeriodEnd    int64             `json:"current_period_end"`
+	PeriodStart  int64             `json:"current_period_start"`
 	Plan         *Plan             `json:"plan"`
 	Quantity     uint64            `json:"quantity"`
 	Status       SubStatus         `json:"status"`
-	FeePercent   float64           `json:"application_fee_percent"`
-	Canceled     int64             `json:"canceled_at"`
-	Created      int64             `json:"created"`
 	Start        int64             `json:"start"`
-	PeriodEnd    int64             `json:"current_period_end"`
-	PeriodStart  int64             `json:"current_period_start"`
-	Discount     *Discount         `json:"discount"`
-	Ended        int64             `json:"ended_at"`
-	Meta         map[string]string `json:"metadata"`
 	TaxPercent   float64           `json:"tax_percent"`
 	TrialEnd     int64             `json:"trial_end"`
 	TrialStart   int64             `json:"trial_start"`
-	Items        *SubItemList      `json:"items"`
-	Billing      SubBilling        `json:"billing"`
-	DaysUntilDue uint64            `json:"days_until_due"`
 }
 
 // SubList is a list object for subscriptions.

--- a/subitem.go
+++ b/subitem.go
@@ -4,13 +4,13 @@ package stripe
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
 type SubItemParams struct {
 	Params        `form:"*"`
-	Sub           string `form:"subscription"`
 	ID            string `form:"-"` // Handled in URL
-	Quantity      uint64 `form:"quantity"`
-	QuantityZero  bool   `form:"quantity,zero"`
+	NoProrate     bool   `form:"prorate,invert"`
 	Plan          string `form:"plan"`
 	ProrationDate int64  `form:"proration_date"`
-	NoProrate     bool   `form:"prorate,invert"`
+	Quantity      uint64 `form:"quantity"`
+	QuantityZero  bool   `form:"quantity,zero"`
+	Sub           string `form:"subscription"`
 }
 
 // SubItemListParams is the set of parameters that can be used when listing invoice items.
@@ -23,12 +23,12 @@ type SubItemListParams struct {
 // SubItem is the resource representing a Stripe subscription item.
 // For more details see https://stripe.com/docs/api#subscription_items.
 type SubItem struct {
-	ID       string            `json:"id"`
-	Plan     *Plan             `json:"plan"`
-	Quantity uint64            `json:"quantity"`
 	Created  int64             `json:"created"`
 	Deleted  bool              `json:"deleted"`
+	ID       string            `json:"id"`
 	Meta     map[string]string `json:"metadata"`
+	Plan     *Plan             `json:"plan"`
+	Quantity uint64            `json:"quantity"`
 }
 
 // SubItemList is a list of invoice items as retrieved from a list endpoint.

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -19,11 +19,11 @@ type ThreeDSecure struct {
 	Amount        uint64             `json:"amount"`
 	Authenticated bool               `json:"authenticated"`
 	Card          *Card              `json:"card"`
-	Currency      Currency           `json:"currency"`
 	Created       int64              `json:"created"`
+	Currency      Currency           `json:"currency"`
 	ID            string             `json:"id"`
 	Live          bool               `json:"livemode"`
 	RedirectURL   string             `json:"redirect_url"`
-	Supported     string             `json:"supported"`
 	Status        ThreeDSecureStatus `json:"status"`
+	Supported     string             `json:"supported"`
 }

--- a/token.go
+++ b/token.go
@@ -8,30 +8,33 @@ type TokenType string
 // For more details see https://stripe.com/docs/api#create_card_token and https://stripe.com/docs/api#create_bank_account_token.
 type TokenParams struct {
 	Params   `form:"*"`
-	Card     *CardParams        `form:"card"`
 	Bank     *BankAccountParams `form:"bank_account"`
-	PII      *PIIParams         `form:"pii"`
+	Card     *CardParams        `form:"card"`
 	Customer string             `form:"customer"`
 
 	// Email is an undocumented parameter used by Stripe Checkout
 	// It may be removed from the API without notice.
 	Email string `form:"email"`
+
+	PII *PIIParams `form:"pii"`
 }
 
 // Token is the resource representing a Stripe token.
 // For more details see https://stripe.com/docs/api#tokens.
 type Token struct {
-	ID       string       `json:"id"`
-	Live     bool         `json:"livemode"`
-	Created  int64        `json:"created"`
-	Type     TokenType    `json:"type"`
-	Used     bool         `json:"used"`
 	Bank     *BankAccount `json:"bank_account"`
 	Card     *Card        `json:"card"`
 	ClientIP string       `json:"client_ip"`
+	Created  int64        `json:"created"`
+
 	// Email is an undocumented field but included for all tokens created
 	// with Stripe Checkout.
 	Email string `json:"email"`
+
+	ID   string    `json:"id"`
+	Live bool      `json:"livemode"`
+	Type TokenType `json:"type"`
+	Used bool      `json:"used"`
 }
 
 // PIIParams are parameters for personal identifiable information (PII).

--- a/transfer.go
+++ b/transfer.go
@@ -10,8 +10,8 @@ type TransferSourceType string
 // The Type should indicate which object is fleshed out
 // For more details see https://stripe.com/docs/api/go#transfer_object
 type TransferDestination struct {
-	ID      string   `json:"id"`
 	Account *Account `json:"-"`
+	ID      string   `json:"id"`
 }
 
 // TransferParams is the set of parameters that can be used when creating or updating a transfer.
@@ -40,21 +40,21 @@ type TransferListParams struct {
 // Transfer is the resource representing a Stripe transfer.
 // For more details see https://stripe.com/docs/api#transfers.
 type Transfer struct {
-	ID             string              `json:"id"`
-	Live           bool                `json:"livemode"`
 	Amount         int64               `json:"amount"`
 	AmountReversed int64               `json:"amount_reversed"`
-	Currency       Currency            `json:"currency"`
 	Created        int64               `json:"created"`
+	Currency       Currency            `json:"currency"`
 	Dest           TransferDestination `json:"destination"`
-	Tx             *Transaction        `json:"balance_transaction"`
+	DestPayment    string              `json:"destination_payment"`
+	ID             string              `json:"id"`
+	Live           bool                `json:"livemode"`
 	Meta           map[string]string   `json:"metadata"`
-	Statement      string              `json:"statement_descriptor"`
 	Reversals      *ReversalList       `json:"reversals"`
 	Reversed       bool                `json:"reversed"`
 	SourceTx       *TransactionSource  `json:"source_transaction"`
-	DestPayment    string              `json:"destination_payment"`
+	Statement      string              `json:"statement_descriptor"`
 	TransferGroup  string              `json:"transfer_group"`
+	Tx             *Transaction        `json:"balance_transaction"`
 }
 
 // TransferList is a list of transfers as retrieved from a list endpoint.


### PR DESCRIPTION
Alphabetizes all API parameter and resource structs. I'm not going to pretend like this was a great use of time, but at least it will allow us to have some kind of convention to point to so that we can help control consistency in the project.

This is technically breaking because you can initialize structs with positional order in Go (e.g. `MyStruct{1, 2}`), but I doubt it'll break almost anyone because (1) most people won't use the positional initialization for these sorts of big structs, and (2) even if they were, type mismatches in the new order will let the compiler tell them about the problem. That said, there are a few potential danger spots that I noticed like `PackageDimemsions` for Relay which is four fields with all exactly the same type.

Let's put a note in the changelog but ship it as a major version. I haven't released #446 yet, so I'd like to group it in with that.

Fixes part of #449.

r? @remi-stripe Sorry for another huge diff, but I think this one is relatively benign. Are you okay with it?