### PR TITLE
Remove Displayer and Display

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/stripe/stripe-go/form"
@@ -124,11 +123,6 @@ type BankAccount struct {
 type BankAccountList struct {
 	ListMeta
 	Values []*BankAccount `json:"data"`
-}
-
-// Display implements Displayer.Display.
-func (b *BankAccount) Display() string {
-	return fmt.Sprintf("Bank account ending in %s", b.LastFour)
 }
 
 // UnmarshalJSON handles deserialization of a BankAccount.

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // BitcoinReceiverListParams is the set of parameters that can be used when listing BitcoinReceivers.
@@ -62,19 +61,6 @@ type BitcoinReceiver struct {
 type BitcoinReceiverList struct {
 	ListMeta
 	Values []*BitcoinReceiver `json:"data"`
-}
-
-// Display human readable representation of a BitcoinReceiver.
-func (br *BitcoinReceiver) Display() string {
-	var filled string
-	if br.Filled {
-		filled = "Filled"
-	} else if br.BitcoinAmountReceived > 0 {
-		filled = "Partially filled"
-	} else {
-		filled = "Unfilled"
-	}
-	return fmt.Sprintf("%s bitcoin receiver (%d/%d %s)", filled, br.AmountReceived, br.Amount, br.Currency)
 }
 
 // UnmarshalJSON handles deserialization of a BitcoinReceiver.

--- a/card.go
+++ b/card.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/stripe/stripe-go/form"
@@ -199,11 +198,6 @@ type Card struct {
 type CardList struct {
 	ListMeta
 	Values []*Card `json:"data"`
-}
-
-// Display human readable representation of a Card.
-func (c *Card) Display() string {
-	return fmt.Sprintf("%s ending in %s", c.Brand, c.LastFour)
 }
 
 // UnmarshalJSON handles deserialization of a Card.

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -69,11 +69,6 @@ func SourceParamsFor(obj interface{}) (*SourceParams, error) {
 	return sp, err
 }
 
-// Displayer provides a human readable representation of a struct
-type Displayer interface {
-	Display() string
-}
-
 // PaymentSourceType consts represent valid payment sources.
 type PaymentSourceType string
 
@@ -123,22 +118,6 @@ type SourceList struct {
 type SourceListParams struct {
 	ListParams `form:"*"`
 	Customer   string `form:"-"` // Handled in URL
-}
-
-// Display human readable representation of source.
-func (s *PaymentSource) Display() string {
-	switch s.Type {
-	case PaymentSourceBankAccount:
-		return s.BankAccount.Display()
-	case PaymentSourceBitcoinReceiver:
-		return s.BitcoinReceiver.Display()
-	case PaymentSourceCard:
-		return s.Card.Display()
-	case PaymentSourceObject:
-		return s.SourceObject.Display()
-	}
-
-	return ""
 }
 
 // UnmarshalJSON handles deserialization of a PaymentSource.

--- a/source.go
+++ b/source.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // SourceStatus represents the possible statuses of a source object.
@@ -177,29 +176,6 @@ type Source struct {
 	Verification *VerificationFlow `json:"verification,omitempty"`
 
 	TypeData map[string]interface{}
-}
-
-// Display human readable representation of a Source.
-func (s *Source) Display() string {
-	var status string
-	switch s.Status {
-	case SourceStatusPending:
-		status = "Pending"
-	case SourceStatusChargeable:
-		status = "Chargeable"
-	case SourceStatusConsumed:
-		status = "Consumed"
-	case SourceStatusFailed:
-		status = "Failed"
-	case SourceStatusCanceled:
-		status = "Canceled"
-	}
-
-	desc := fmt.Sprintf("%s %s source", status, s.Type)
-	if s.Amount > 0 {
-		desc += fmt.Sprintf(" (%d %s)", s.Amount, s.Currency)
-	}
-	return desc
 }
 
 // UnmarshalJSON handles deserialization of an Source. This custom unmarshaling


### PR DESCRIPTION
At some point we added a `Displayer` interface that worked with certain
payment sources to display a short human readable string.

This hasn't turned out to be maintained very well, and is a convention
that's so localized to one small part of the library that it's not very
useful in practice. Here we drop `Displayer` and its associated
implementations.

I doubt this has wide use, but it's a breaking change nonetheless.

Fixes part of #449.

r? @remi-stripe