### PR TITLE
Create FraudDetailsParams

### DIFF
--- a/charge/client.go
+++ b/charge/client.go
@@ -141,7 +141,12 @@ func MarkFraudulent(id string) (*stripe.Charge, error) {
 func (c Client) MarkFraudulent(id string) (*stripe.Charge, error) {
 	return c.Update(
 		id,
-		&stripe.ChargeParams{Fraud: ReportFraudulent})
+		&stripe.ChargeParams{
+			FraudDetails: &stripe.FraudDetailsParams{
+				UserReport: ReportFraudulent,
+			},
+		},
+	)
 }
 
 // MarkSafe reports the charge as not-fraudulent.
@@ -152,7 +157,12 @@ func MarkSafe(id string) (*stripe.Charge, error) {
 func (c Client) MarkSafe(id string) (*stripe.Charge, error) {
 	return c.Update(
 		id,
-		&stripe.ChargeParams{Fraud: ReportSafe})
+		&stripe.ChargeParams{
+			FraudDetails: &stripe.FraudDetailsParams{
+				UserReport: ReportSafe,
+			},
+		},
+	)
 }
 
 // Update updates a charge's dispute.

--- a/charge_test.go
+++ b/charge_test.go
@@ -25,14 +25,6 @@ func TestChargeParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &ChargeParams{Fraud: "suspicious"}
-		body := &form.Values{}
-		form.AppendTo(body, params)
-		t.Logf("body = %+v", body)
-		assert.Equal(t, []string{"suspicious"}, body.Get("fraud_details[user_report]"))
-	}
-
-	{
 		params := &ChargeParams{Source: &SourceParams{Card: &CardParams{Number: "4242424242424242"}}}
 		body := &form.Values{}
 		form.AppendTo(body, params)

--- a/feerefund.go
+++ b/feerefund.go
@@ -23,6 +23,7 @@ type FeeRefundListParams struct {
 // For more details see https://stripe.com/docs/api#fee_refunds.
 type FeeRefund struct {
 	Amount   uint64            `json:"amount"`
+	ID       string            `json:"id"`
 	Created  int64             `json:"created"`
 	Currency Currency          `json:"currency"`
 	Fee      string            `json:"fee"`

--- a/feerefund.go
+++ b/feerefund.go
@@ -23,7 +23,6 @@ type FeeRefundListParams struct {
 // For more details see https://stripe.com/docs/api#fee_refunds.
 type FeeRefund struct {
 	Amount   uint64            `json:"amount"`
-	ID       string            `json:"id"`
 	Created  int64             `json:"created"`
 	Currency Currency          `json:"currency"`
 	Fee      string            `json:"fee"`

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -8,8 +8,8 @@ type OrderReturn struct {
 	Currency Currency    `json:"currency"`
 	ID       string      `json:"id"`
 	Items    []OrderItem `json:"items"`
-	Live     bool        `json:"livemode"`
 	Order    Order       `json:"order"`
+	Live     bool        `json:"livemode"`
 	Refund   *Refund     `json:"refund"`
 }
 


### PR DESCRIPTION
Before fraud details were specified as a weird special case where a user
report could be embedded directly into a `ChargeParams`. Here we
normalize that by breaking them out into their own parameters struct
like everything else.

The upside is that we get to remove special-cased `AppendTo` logic and
encoding becomes more normal as a result.

Partially fixes #449.

r? @remi-stripe Implemented as discussed previously.

---

~~Note: Currently targets the branch in #450 to minimize conflicts.~~