### PR TITLE
Drop ChargeParams.Dest

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -2,8 +2,6 @@ package stripe
 
 import (
 	"encoding/json"
-
-	"github.com/stripe/stripe-go/form"
 )
 
 // Currency is the list of supported currencies.
@@ -22,7 +20,6 @@ type ChargeParams struct {
 	Currency      Currency            `form:"currency"`
 	Customer      string              `form:"customer"`
 	Desc          string              `form:"description"`
-	Dest          string              `form:"-"` // Handled in custom AppendTo below
 	Destination   *DestinationParams  `form:"destination"`
 	Email         string              `form:"receipt_email"`
 	Fee           uint64              `form:"application_fee"`
@@ -34,16 +31,6 @@ type ChargeParams struct {
 	Statement     string              `form:"statement_descriptor"`
 	Token         string              `form:"-"` // Does not appear to be used?
 	TransferGroup string              `form:"transfer_group"`
-}
-
-// AppendTo implements some custom encoding logic for ChargeParams to support
-// the deprecated Dest field (please use Destination instead) and the deviant
-// Fraud field.
-func (p *ChargeParams) AppendTo(body *form.Values, keyParts []string) {
-	// TODO: Stop supporting this field.
-	if len(p.Dest) > 0 {
-		body.Add(form.FormatKey(append(keyParts, "destination", "account")), p.Dest)
-	}
 }
 
 // SetSource adds valid sources to a ChargeParams object,

--- a/charge_test.go
+++ b/charge_test.go
@@ -17,14 +17,6 @@ func TestChargeParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &ChargeParams{Dest: "acct_123"}
-		body := &form.Values{}
-		form.AppendTo(body, params)
-		t.Logf("body = %+v", body)
-		assert.Equal(t, []string{"acct_123"}, body.Get("destination[account]"))
-	}
-
-	{
 		params := &ChargeParams{Source: &SourceParams{Card: &CardParams{Number: "4242424242424242"}}}
 		body := &form.Values{}
 		form.AppendTo(body, params)


### PR DESCRIPTION
Drop `ChargeParams.Dest` in favor of `ChargeParams.Destination.Account`,
which is aligned with how the API is designed. This also allows us to
completely drop a custom `AppendTo` implementation on `Charge`.

Fixes part of #449.

r? @remi-stripe Sorry about the boatload of reviews, but I'd previously
discussed this one with you as well.