### PR TITLE
Build a type encoder caching system for the `form` package

### DIFF
--- a/account.go
+++ b/account.go
@@ -340,10 +340,10 @@ type Owner struct {
 
 // IdentityVerification is the structure for an account's verification.
 type IdentityVerification struct {
-	Details     *string                         `json:"details"`
-	DetailsCode IdentityVerificationDetailsCode `json:"details_code"`
+	Details     *string                         `json:"details" form:"-"`
+	DetailsCode IdentityVerificationDetailsCode `json:"details_code" form:"-"`
 	Document    *IdentityDocument               `json:"document" form:"document"`
-	Status      IdentityVerificationStatus      `json:"status"`
+	Status      IdentityVerificationStatus      `json:"status" form:"-"`
 }
 
 // IdentityDocument is the structure for an identity document.

--- a/form/form.go
+++ b/form/form.go
@@ -7,9 +7,37 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 )
 
 const tagName = "form"
+
+// Appender is the interface implemented by types that can append themselves to
+// a collection of form values.
+//
+// This is usually something that shouldn't be used, but is needed in a few
+// places where authors deviated from norms while implementing various
+// parameters.
+type Appender interface {
+	// AppendTo is invoked by the form package on any types found to implement
+	// Appender so that they have a chance to encode themselves. Note that
+	// AppendTo is called in addition to normal encoding, so other form tags on
+	// the struct are still fair game.
+	AppendTo(values *Values, keyParts []string)
+}
+
+type encoderFunc func(values *Values, v reflect.Value, keyParts []string, options *formOptions)
+
+// field represents a single field found in a struct. It caches information
+// about that field so that we can make encoding faster.
+type field struct {
+	formName   string
+	index      int
+	isAppender bool
+	isPtr      bool
+	options    *formOptions
+}
 
 type formOptions struct {
 	// IndexedArray indicates that contrary to standard "Rack-style" form
@@ -35,30 +63,54 @@ type formOptions struct {
 	Zero bool
 }
 
-// Appender is the interface implemented by types that can append themselves to
-// a collection of form values.
-//
-// This is usually something that shouldn't be used, but is needed in a few
-// places where authors deviated from norms while implementing various
-// parameters.
-type Appender interface {
-	// AppendTo is invoked by the form package on any types found to implement
-	// Appender so that they have a chance to encode themselves. Note that
-	// AppendTo is called in addition to normal encoding, so other form tags on
-	// the struct are still fair game.
-	AppendTo(values *Values, keyParts []string)
+type structEncoder struct {
+	fields    []*field
+	fieldEncs []encoderFunc
 }
 
-var (
-	// Strict enables strict mode wherein the package will panic on an AppendTo
-	// function if it finds that a tag string was malformed.
-	Strict = false
-)
+func (se *structEncoder) encode(values *Values, v reflect.Value, keyParts []string, _ *formOptions) {
+	for i, f := range se.fields {
+		var fieldKeyParts []string
+		fieldV := v.Field(f.index)
+
+		// The wildcard on a form tag is a "special" value: it indicates a
+		// struct field that we should recurse into, but for which no part
+		// should be added to the key parts, meaning that its own subfields
+		// will be named at the same level as with the fields of the
+		// current structure.
+		if f.formName == "*" {
+			fieldKeyParts = keyParts
+		} else {
+			fieldKeyParts = append(keyParts, f.formName)
+		}
+
+		se.fieldEncs[i](values, fieldV, fieldKeyParts, f.options)
+		if f.isAppender && (!f.isPtr || !fieldV.IsNil()) {
+			fieldV.Interface().(Appender).AppendTo(values, fieldKeyParts)
+		}
+	}
+}
+
+// ---
+
+// Strict enables strict mode wherein the package will panic on an AppendTo
+// function if it finds that a tag string was malformed.
+var Strict = false
+
+var encoderCache struct {
+	mu    sync.Mutex   // used only by writers
+	value atomic.Value // map[reflect.Type]encoderFunc
+}
+
+var structCache struct {
+	mu    sync.Mutex   // used only by writers
+	value atomic.Value // map[reflect.Type]*structEncoder
+}
 
 // AppendTo uses reflection to form encode into the given values collection
 // based off the form tags that it defines.
 func AppendTo(values *Values, i interface{}) {
-	reflectValue(values, reflect.ValueOf(i), nil, nil)
+	reflectValue(values, reflect.ValueOf(i), nil)
 }
 
 // AppendToPrefixed is the same as AppendTo, but it allows a slice of key parts
@@ -68,7 +120,7 @@ func AppendTo(values *Values, i interface{}) {
 // for recipients. Recipients is going away, and when it does, we can probably
 // remove it again.
 func AppendToPrefixed(values *Values, i interface{}, keyParts []string) {
-	reflectValue(values, reflect.ValueOf(i), keyParts, nil)
+	reflectValue(values, reflect.ValueOf(i), keyParts)
 }
 
 // FormatKey takes a series of key parts that may be parameter keyParts, map keys,
@@ -86,27 +138,39 @@ func FormatKey(parts []string) string {
 	return key
 }
 
-func reflectValue(values *Values, val reflect.Value, keyParts []string, options *formOptions) {
-	t := val.Type()
+// ---
 
-	// Also do nothing if this is the type's zero value
-	if t.Comparable() && val.Interface() == reflect.Zero(t).Interface() {
+func boolEncoder(values *Values, v reflect.Value, keyParts []string, options *formOptions) {
+	if !v.Bool() {
 		return
 	}
 
-	// Special case for when a type has implemented special logic to append
-	// itself to a form.
-	if t.Implements(reflect.TypeOf((*Appender)(nil)).Elem()) {
-		val.Interface().(Appender).AppendTo(values, keyParts)
+	if options != nil {
+		if v.Bool() {
+			switch {
+			case options.Empty:
+				values.Add(FormatKey(keyParts), "")
+			case options.Invert:
+				values.Add(FormatKey(keyParts), strconv.FormatBool(false))
+			case options.Zero:
+				values.Add(FormatKey(keyParts), "0")
+			}
+		}
+	} else {
+		values.Add(FormatKey(keyParts), strconv.FormatBool(v.Bool()))
 	}
+}
 
-	switch val.Kind() {
-	case reflect.Array, reflect.Slice:
+func buildArrayOrSliceEncoder(t reflect.Type) encoderFunc {
+	// Gets an encoder for the type that the array or slice will hold
+	elemF := getCachedOrBuildTypeEncoder(t.Elem())
+
+	return func(values *Values, v reflect.Value, keyParts []string, options *formOptions) {
 		// FormatKey automatically adds square brackets, so just pass an empty
 		// string into the breadcrumb trail
 		arrNames := append(keyParts, "")
 
-		for i := 0; i < val.Len(); i++ {
+		for i := 0; i < v.Len(); i++ {
 			// The one exception to the above is when options have requested
 			// that this array/slice be indexed. In that case we produce a hash
 			// keyed with integers which the Stripe API knows how to interpret.
@@ -114,103 +178,251 @@ func reflectValue(values *Values, val reflect.Value, keyParts []string, options 
 				arrNames = append(keyParts, strconv.Itoa(i))
 			}
 
-			reflectValue(values, val.Index(i), arrNames, nil)
+			indexV := v.Index(i)
+			elemF(values, indexV, arrNames, nil)
+
+			if isAppender(indexV.Type()) && !indexV.IsNil() {
+				v.Interface().(Appender).AppendTo(values, arrNames)
+			}
 		}
+	}
+}
+
+func buildPtrEncoder(t reflect.Type) encoderFunc {
+	// Gets an encoder for the type that the pointer wraps
+	elemF := getCachedOrBuildTypeEncoder(t.Elem())
+
+	return func(values *Values, v reflect.Value, keyParts []string, options *formOptions) {
+		if v.IsNil() {
+			return
+		}
+		elemF(values, v.Elem(), keyParts, options)
+	}
+}
+
+func buildStructEncoder(t reflect.Type) encoderFunc {
+	se := getCachedOrBuildStructEncoder(t)
+	return se.encode
+}
+
+func float32Encoder(values *Values, v reflect.Value, keyParts []string, _ *formOptions) {
+	if v.Float() == 0.0 {
+		return
+	}
+	values.Add(FormatKey(keyParts), strconv.FormatFloat(v.Float(), 'f', 4, 32))
+}
+
+func float64Encoder(values *Values, v reflect.Value, keyParts []string, _ *formOptions) {
+	if v.Float() == 0.0 {
+		return
+	}
+	values.Add(FormatKey(keyParts), strconv.FormatFloat(v.Float(), 'f', 4, 64))
+}
+
+func getCachedOrBuildStructEncoder(t reflect.Type) *structEncoder {
+	m, _ := structCache.value.Load().(map[reflect.Type]*structEncoder)
+	f := m[t]
+	if f != nil {
+		return f
+	}
+
+	// We do the work to get the encoder without holding a lock. This could
+	// result in duplicate work, but it will help us avoid a deadlock. Encoders
+	// may be built and stored recursively in the cases of something like an
+	// array or slice, so we need to make sure that this function is properly
+	// re-entrant.
+	f = makeStructEncoder(t)
+
+	structCache.mu.Lock()
+	defer structCache.mu.Unlock()
+
+	m, _ = structCache.value.Load().(map[reflect.Type]*structEncoder)
+	newM := m
+	if newM == nil {
+		newM = make(map[reflect.Type]*structEncoder)
+		structCache.value.Store(newM)
+	}
+	newM[t] = f
+
+	return f
+}
+
+// getCachedOrBuildTypeEncoder tries to get an encoderFunc for the type from
+// the cache, and falls back to building one if there wasn't a cached one
+// available. If an encoder is built, it's stored back to the cache.
+func getCachedOrBuildTypeEncoder(t reflect.Type) encoderFunc {
+	m, _ := encoderCache.value.Load().(map[reflect.Type]encoderFunc)
+	f := m[t]
+	if f != nil {
+		return f
+	}
+
+	// We do the work to get the encoder without holding a lock. This could
+	// result in duplicate work, but it will help us avoid a deadlock. Encoders
+	// may be built and stored recursively in the cases of something like an
+	// array or slice, so we need to make sure that this function is properly
+	// re-entrant.
+	f = makeTypeEncoder(t)
+
+	encoderCache.mu.Lock()
+	defer encoderCache.mu.Unlock()
+
+	m, _ = encoderCache.value.Load().(map[reflect.Type]encoderFunc)
+	newM := m
+	if newM == nil {
+		newM = make(map[reflect.Type]encoderFunc)
+		encoderCache.value.Store(newM)
+	}
+	newM[t] = f
+
+	return f
+}
+
+func intEncoder(values *Values, v reflect.Value, keyParts []string, _ *formOptions) {
+	if v.Int() == 0 {
+		return
+	}
+	values.Add(FormatKey(keyParts), strconv.FormatInt(v.Int(), 10))
+}
+
+func interfaceEncoder(values *Values, v reflect.Value, keyParts []string, _ *formOptions) {
+	if v.IsNil() {
+		return
+	}
+	reflectValue(values, v.Elem(), keyParts)
+}
+
+func isAppender(t reflect.Type) bool {
+	return t.Implements(reflect.TypeOf((*Appender)(nil)).Elem())
+}
+
+func mapEncoder(values *Values, v reflect.Value, keyParts []string, _ *formOptions) {
+	for _, keyVal := range v.MapKeys() {
+		if Strict && keyVal.Kind() != reflect.String {
+			panic("Don't support serializing maps with non-string keys")
+		}
+
+		reflectValue(values, v.MapIndex(keyVal), append(keyParts, keyVal.String()))
+	}
+}
+
+func stringEncoder(values *Values, v reflect.Value, keyParts []string, _ *formOptions) {
+	if v.String() == "" {
+		return
+	}
+	values.Add(FormatKey(keyParts), v.String())
+}
+
+func uintEncoder(values *Values, v reflect.Value, keyParts []string, _ *formOptions) {
+	if v.Uint() == 0 {
+		return
+	}
+	values.Add(FormatKey(keyParts), strconv.FormatUint(v.Uint(), 10))
+}
+
+func reflectValue(values *Values, v reflect.Value, keyParts []string) {
+	t := v.Type()
+
+	f := getCachedOrBuildTypeEncoder(t)
+	if f != nil {
+		f(values, v, keyParts, nil)
+	}
+
+	if isAppender(t) {
+		v.Interface().(Appender).AppendTo(values, keyParts)
+	}
+}
+
+func makeStructEncoder(t reflect.Type) *structEncoder {
+	// Don't specify capacity because we don't know how many fields are tagged with
+	// `form`
+	se := &structEncoder{}
+
+	for i := 0; i < t.NumField(); i++ {
+		reflectField := t.Field(i)
+		tag := reflectField.Tag.Get(tagName)
+		if Strict && tag == "" {
+			panic(fmt.Sprintf(
+				"All fields in structs to be form-encoded must have `form` tag; on: %s/%s "+
+					"(hint: use an explicit `form:\"-\"` if the field should not be encoded",
+				t.Name(), reflectField.Name,
+			))
+		}
+
+		formName, options := parseTag(tag)
+
+		// Like with encoding/json, a hyphen is an explicit way of saying
+		// that this field should not be encoded
+		if formName == "-" {
+			continue
+		}
+
+		if Strict && options != nil &&
+			(options.Empty || options.Invert || options.Zero) &&
+			reflectField.Type.Kind() != reflect.Bool {
+
+			panic(fmt.Sprintf(
+				"Cannot specify `empty`, `invert`, or `zero` for non-boolean field; on: %s/%s",
+				t.Name(), reflectField.Name,
+			))
+		}
+
+		var isPtr bool
+		if reflectField.Type.Kind() == reflect.Ptr {
+			isPtr = true
+		}
+
+		se.fields = append(se.fields, &field{
+			formName:   formName,
+			index:      i,
+			isAppender: isAppender(reflectField.Type),
+			isPtr:      isPtr,
+			options:    options,
+		})
+		se.fieldEncs = append(se.fieldEncs,
+			getCachedOrBuildTypeEncoder(reflectField.Type))
+	}
+
+	return se
+}
+
+func makeTypeEncoder(t reflect.Type) encoderFunc {
+	switch t.Kind() {
+	case reflect.Array, reflect.Slice:
+		return buildArrayOrSliceEncoder(t)
 
 	case reflect.Bool:
-		if options != nil {
-			if val.Bool() {
-				switch {
-				case options.Empty:
-					values.Add(FormatKey(keyParts), "")
-				case options.Invert:
-					values.Add(FormatKey(keyParts), strconv.FormatBool(false))
-				case options.Zero:
-					values.Add(FormatKey(keyParts), "0")
-				}
-			}
-		} else {
-			values.Add(FormatKey(keyParts), strconv.FormatBool(val.Bool()))
-		}
+		return boolEncoder
 
 	case reflect.Float32:
-		values.Add(FormatKey(keyParts), strconv.FormatFloat(val.Float(), 'f', 4, 32))
+		return float32Encoder
 
 	case reflect.Float64:
-		values.Add(FormatKey(keyParts), strconv.FormatFloat(val.Float(), 'f', 4, 64))
+		return float64Encoder
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		values.Add(FormatKey(keyParts), strconv.FormatInt(val.Int(), 10))
+		return intEncoder
 
 	case reflect.Interface:
-		if val.IsNil() {
-			return
-		}
-		reflectValue(values, val.Elem(), keyParts, nil)
+		return interfaceEncoder
 
 	case reflect.Map:
-		for _, keyVal := range val.MapKeys() {
-			if Strict && keyVal.Kind() != reflect.String {
-				panic("Don't support serializing maps with non-string keys")
-			}
-
-			reflectValue(values, val.MapIndex(keyVal), append(keyParts, keyVal.String()), nil)
-		}
+		return mapEncoder
 
 	case reflect.Ptr:
-		if val.IsNil() {
-			return
-		}
-		reflectValue(values, val.Elem(), keyParts, options)
+		return buildPtrEncoder(t)
 
 	case reflect.String:
-		values.Add(FormatKey(keyParts), val.String())
+		return stringEncoder
 
 	case reflect.Struct:
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
-			tag := field.Tag.Get(tagName)
-			if Strict && tag == "" {
-				panic(fmt.Sprintf(
-					"All fields in structs to be form-encoded must have `form` tag; on: %s/%s "+
-						"(hint: use an explicit `form:\"-\"` if the field should not be encoded",
-					t.Name(), field.Name,
-				))
-			}
-
-			formName, options := parseTag(tag)
-
-			// Like with encoding/json, a hyphen is an explicit way of saying
-			// that this field should not be encoded
-			if formName == "-" {
-				continue
-			}
-
-			if Strict && options != nil &&
-				(options.Empty || options.Invert || options.Zero) &&
-				val.Field(i).Type().Kind() != reflect.Bool {
-
-				panic(fmt.Sprintf(
-					"Cannot specify `empty`, `invert`, or `zero` for non-boolean field; on: %s/%s",
-					t.Name(), field.Name,
-				))
-			}
-
-			// The wildcard on a form tag is a "special" value: it indicates a
-			// struct field that we should recurse into, but for which no part
-			// should be added to the key parts, meaning that its own subfields
-			// will be named at the same level as with the fields of the
-			// current structure.
-			if formName == "*" {
-				reflectValue(values, val.Field(i), keyParts, options)
-			} else {
-				reflectValue(values, val.Field(i), append(keyParts, formName), options)
-			}
-		}
+		return buildStructEncoder(t)
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		values.Add(FormatKey(keyParts), strconv.FormatUint(val.Uint(), 10))
+		return uintEncoder
 	}
+
+	return nil
 }
 
 func parseTag(tag string) (string, *formOptions) {


### PR DESCRIPTION
Here we optimize the `AppendTo` function of the form package and its
associated helpers. As #446 came in, there was some concerns expressed
around its performance. This implementation might not be as quick as a
bunch of `if` statements, but it's pretty fast.

Before:

    $ make bench
    go test -bench . -run "Benchmark" ./form
    goos: darwin
    goarch: amd64
    pkg: github.com/stripe/stripe-go/form
    BenchmarkAppendTo-4       500000              2767 ns/op
    PASS
    ok      github.com/stripe/stripe-go/form        1.480s

After:

    $ make bench
    go test -bench . -run "Benchmark" ./form
    goos: darwin
    goarch: amd64
    pkg: github.com/stripe/stripe-go/form
    BenchmarkAppendTo-4      2000000               922 ns/op
    PASS
    ok      github.com/stripe/stripe-go/form        2.867s

Which shows roughly a 3x speedup. Encoding a fairly normal struct 
takes < 1 ms on my commodity PC.

The implementation here looks pretty exotic, but it's very inspired by
Go's own `encoding/json` which is where the ideas of type and struct 
encoding caches comes from.

Testing is pretty extensive, so I have pretty good confidence that this
works as expected based off of the passing suite.

Fixes part of #449.

r? @remi-stripe 

---

~~Currently targets #454 because we want this params-related bug fix.~~