### PR TITLE
Remove Charge.Token

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -29,7 +29,6 @@ type ChargeParams struct {
 	Shipping      *ShippingDetails    `form:"shipping"`
 	Source        *SourceParams       `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 	Statement     string              `form:"statement_descriptor"`
-	Token         string              `form:"-"` // Does not appear to be used?
 	TransferGroup string              `form:"transfer_group"`
 }
 


### PR DESCRIPTION
Unfortunately I forgot about this one before releasing, but it doesn't
appear that `Token` on `ChargeParams` is used anywhere and I can't find
it in any of the charge-related documentation on the API reference.

@remi-stripe Thoughts?