### PR TITLE
Renaming all properties, structs and methods to match the API naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ i := event.List(nil)
 for i.Next() {
 	e := i.Event()
 
-	// access event data via e.GetObjValue("resource_name_based_on_type", "resource_property_name")
-	// alternatively you can access values via e.Data.Obj["resource_name_based_on_type"].(map[string]interface{})["resource_property_name"]
+	// access event data via e.GetObjectValue("resource_name_based_on_type", "resource_property_name")
+	// alternatively you can access values via e.Data.Object["resource_name_based_on_type"].(map[string]interface{})["resource_property_name"]
 
-	// access previous attributes via e.GetPrevValue("resource_name_based_on_type", "resource_property_name")
-	// alternatively you can access values via e.Data.Prev["resource_name_based_on_type"].(map[string]interface{})["resource_property_name"]
+	// access previous attributes via e.GetPreviousValue("resource_name_based_on_type", "resource_property_name")
+	// alternatively you can access values via e.Data.PrevPreviousAttributes["resource_name_based_on_type"].(map[string]interface{})["resource_property_name"]
 }
 ```
 

--- a/account.go
+++ b/account.go
@@ -52,35 +52,36 @@ const (
 	// Manual is a constant value representing a manual payout interval.
 	Manual Interval = "manual"
 
-	// Month is a constant value representing a monthly payout interval.
-	Month Interval = "monthly"
+	// Monthly is a constant value representing a monthly payout interval.
+	Monthly Interval = "monthly"
 
-	// Week is a constant value representing a weekly payout interval.
-	Week Interval = "weekly"
+	// Weekly is a constant value representing a weekly payout interval.
+	Weekly Interval = "weekly"
 )
 
 // AccountParams are the parameters allowed during account creation/updates.
 type AccountParams struct {
-	Params               `form:"*"`
-	BusinessName         string                        `form:"business_name"`
-	BusinessPrimaryColor string                        `form:"business_primary_color"`
-	BusinessUrl          string                        `form:"business_url"`
-	Country              string                        `form:"country"`
-	DebitNegativeBal     bool                          `form:"debit_negative_balances"`
-	DefaultCurrency      string                        `form:"default_currency"`
-	Email                string                        `form:"email"`
-	ExternalAccount      *AccountExternalAccountParams `form:"external_account"`
-	FromRecipient        string                        `form:"from_recipient"`
-	LegalEntity          *LegalEntity                  `form:"legal_entity"`
-	NoDebitNegativeBal   bool                          `form:"debit_negative_balances,invert"`
-	PayoutSchedule       *PayoutScheduleParams         `form:"payout_schedule"`
-	PayoutStatement      string                        `form:"payout_statement_descriptor"`
-	Statement            string                        `form:"statement_descriptor"`
-	SupportEmail         string                        `form:"support_email"`
-	SupportPhone         string                        `form:"support_phone"`
-	SupportUrl           string                        `form:"support_url"`
-	TOSAcceptance        *TOSAcceptanceParams          `form:"tos_acceptance"`
-	Type                 AccountType                   `form:"type"`
+	Params                    `form:"*"`
+	BusinessName              string                        `form:"business_name"`
+	BusinessPrimaryColor      string                        `form:"business_primary_color"`
+	BusinessURL               string                        `form:"business_url"`
+	Country                   string                        `form:"country"`
+	DebitNegativeBalances     bool                          `form:"debit_negative_balances"`
+	DefaultCurrency           string                        `form:"default_currency"`
+	Email                     string                        `form:"email"`
+	ExternalAccount           *AccountExternalAccountParams `form:"external_account"`
+	FromRecipient             string                        `form:"from_recipient"`
+	LegalEntity               *LegalEntity                  `form:"legal_entity"`
+	NoDebitNegativeBalances   bool                          `form:"debit_negative_balances,invert"`
+	PayoutSchedule            *PayoutScheduleParams         `form:"payout_schedule"`
+	PayoutStatementDescriptor string                        `form:"payout_statement_descriptor"`
+	ProductDescription        string                        `form:"product_description"`
+	StatementDescriptor       string                        `form:"statement_descriptor"`
+	SupportEmail              string                        `form:"support_email"`
+	SupportPhone              string                        `form:"support_phone"`
+	SupportURL                string                        `form:"support_url"`
+	TOSAcceptance             *TOSAcceptanceParams          `form:"tos_acceptance"`
+	Type                      AccountType                   `form:"type"`
 }
 
 // AccountListParams are the parameters allowed during account listing.
@@ -93,12 +94,12 @@ type AccountListParams struct {
 // or everything else.
 type AccountExternalAccountParams struct {
 	Params            `form:"*"`
-	Account           string `form:"account_number"`
+	AccountNumber     string `form:"account_number"`
 	AccountHolderName string `form:"account_holder_name"`
 	AccountHolderType string `form:"account_holder_type"`
 	Country           string `form:"country"`
 	Currency          string `form:"currency"`
-	Routing           string `form:"routing_number"`
+	RoutingNumber     string `form:"routing_number"`
 	Token             string `form:"token"`
 }
 
@@ -115,11 +116,11 @@ func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []st
 
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
-	Delay        uint64   `form:"delay_days"`
-	Interval     Interval `form:"interval"`
-	MinimumDelay bool     `form:"-"` // See custom AppendTo
-	MonthAnchor  uint64   `form:"monthly_anchor"`
-	WeekAnchor   string   `form:"weekly_anchor"`
+	DelayDays     uint64   `form:"delay_days"`
+	Interval      Interval `form:"interval"`
+	MinimumDelay  bool     `form:"-"` // See custom AppendTo
+	MonthlyAnchor uint64   `form:"monthly_anchor"`
+	WeeklyAnchor  string   `form:"weekly_anchor"`
 }
 
 func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
@@ -131,38 +132,38 @@ func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
 // Account is the resource representing your Stripe account.
 // For more details see https://stripe.com/docs/api/#account.
 type Account struct {
-	BusinessLogo         string               `json:"business_logo"`
-	BusinessName         string               `json:"business_name"`
-	BusinessPrimaryColor string               `json:"business_primary_color"`
-	BusinessUrl          string               `json:"business_url"`
-	ChargesEnabled       bool                 `json:"charges_enabled"`
-	Country              string               `json:"country"`
-	DebitNegativeBal     bool                 `json:"debit_negative_balances"`
-	DefaultCurrency      string               `json:"default_currency"`
-	Deleted              bool                 `json:"deleted"`
-	DetailsSubmitted     bool                 `json:"details_submitted"`
-	Email                string               `json:"email"`
-	ExternalAccounts     *ExternalAccountList `json:"external_accounts"`
-	ID                   string               `json:"id"`
+	BusinessLogo          string               `json:"business_logo"`
+	BusinessName          string               `json:"business_name"`
+	BusinessPrimaryColor  string               `json:"business_primary_color"`
+	BusinessURL           string               `json:"business_url"`
+	ChargesEnabled        bool                 `json:"charges_enabled"`
+	Country               string               `json:"country"`
+	DebitNegativeBalances bool                 `json:"debit_negative_balances"`
+	DefaultCurrency       string               `json:"default_currency"`
+	Deleted               bool                 `json:"deleted"`
+	DetailsSubmitted      bool                 `json:"details_submitted"`
+	Email                 string               `json:"email"`
+	ExternalAccounts      *ExternalAccountList `json:"external_accounts"`
+	ID                    string               `json:"id"`
 
 	Keys *struct {
 		Publish string `json:"publishable"`
 		Secret  string `json:"secret"`
 	} `json:"keys"`
 
-	LegalEntity     *LegalEntity      `json:"legal_entity"`
-	Meta            map[string]string `json:"metadata"`
-	Name            string            `json:"display_name"`
-	PayoutSchedule  *PayoutSchedule   `json:"payout_schedule"`
-	PayoutStatement string            `json:"payout_statement_descriptor"`
-	PayoutsEnabled  bool              `json:"payouts_enabled"`
-	ProductDesc     string            `json:"product_description"`
-	Statement       string            `json:"statement_descriptor"`
-	SupportAddress  *Address          `json:"support_address"`
-	SupportEmail    string            `json:"support_email"`
-	SupportPhone    string            `json:"support_phone"`
-	SupportUrl      string            `json:"support_url"`
-	Timezone        string            `json:"timezone"`
+	LegalEntity               *LegalEntity      `json:"legal_entity"`
+	Metadata                  map[string]string `json:"metadata"`
+	DisplayName               string            `json:"display_name"`
+	PayoutSchedule            *PayoutSchedule   `json:"payout_schedule"`
+	PayoutStatementDescriptor string            `json:"payout_statement_descriptor"`
+	PayoutsEnabled            bool              `json:"payouts_enabled"`
+	ProductDescription        string            `json:"product_description"`
+	StatementDescriptor       string            `json:"statement_descriptor"`
+	SupportAddress            *Address          `json:"support_address"`
+	SupportEmail              string            `json:"support_email"`
+	SupportPhone              string            `json:"support_phone"`
+	SupportURL                string            `json:"support_url"`
+	Timezone                  string            `json:"timezone"`
 
 	TOSAcceptance *struct {
 		Date      int64  `json:"date"`
@@ -174,8 +175,8 @@ type Account struct {
 
 	Verification *struct {
 		DisabledReason string   `json:"disabled_reason"`
-		Due            *int64   `json:"due_by"`
-		Fields         []string `json:"fields_needed"`
+		DueBy          *int64   `json:"due_by"`
+		FieldsNeeded   []string `json:"fields_needed"`
 	} `json:"verification"`
 }
 
@@ -225,7 +226,7 @@ const (
 // AccountList is a list of accounts as returned from a list endpoint.
 type AccountList struct {
 	ListMeta
-	Values []*Account `json:"data"`
+	Data []*Account `json:"data"`
 }
 
 // ExternalAccountList is a list of external accounts that may be either bank
@@ -235,7 +236,7 @@ type ExternalAccountList struct {
 
 	// Values contains any external accounts (bank accounts and/or cards)
 	// currently attached to this account.
-	Values []*ExternalAccount `json:"data"`
+	Data []*ExternalAccount `json:"data"`
 }
 
 // ExternalAccount is an external account (a bank account or card) that's
@@ -277,56 +278,55 @@ func (ea *ExternalAccount) UnmarshalJSON(b []byte) error {
 
 // LegalEntity is the structure for properties related to an account's legal state.
 type LegalEntity struct {
-	AdditionalOwners []Owner `json:"additional_owners" form:"additional_owners,indexed"`
+	AdditionalOwners []AdditionalOwner `json:"additional_owners" form:"additional_owners,indexed"`
 
 	// AdditionalOwnersEmpty can be set to clear a legal entity's additional
 	// owners.
 	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
 
-	Address               Address              `json:"address" form:"address"`
-	AddressKana           Address              `json:"address_kana" form:"address_kana"`
-	AddressKanji          Address              `json:"address_kanji" form:"address_kanji"`
-	BusinessName          string               `json:"business_name" form:"business_name"`
-	BusinessNameKana      string               `json:"business_name_kana" form:"business_name_kana"`
-	BusinessNameKanji     string               `json:"business_name_kanji" form:"business_name_kanji"`
-	BusinessTaxID         string               `json:"-" form:"business_tax_id"`
-	BusinessTaxIDProvided bool                 `json:"business_tax_id_provided" form:"-"`
-	BusinessVatID         string               `json:"-" form:"business_vat_id"`
-	BusinessVatIDProvided bool                 `json:"business_vat_id_provided" form:"-"`
-	DOB                   DOB                  `json:"dob" form:"dob"`
-	First                 string               `json:"first_name" form:"first_name"`
-	FirstKana             string               `json:"first_name_kana" form:"first_name_kana"`
-	FirstKanji            string               `json:"first_name_kanji" form:"first_name_kanji"`
-	Gender                Gender               `json:"gender" form:"gender"`
-	Last                  string               `json:"last_name" form:"last_name"`
-	LastKana              string               `json:"last_name_kana" form:"last_name_kana"`
-	LastKanji             string               `json:"last_name_kanji" form:"last_name_kanji"`
-	MaidenName            string               `json:"maiden_name" form:"maiden_name"`
-	PersonalAddress       Address              `json:"personal_address" form:"personal_address"`
-	PersonalAddressKana   Address              `json:"personal_address_kana" form:"personal_address_kana"`
-	PersonalAddressKanji  Address              `json:"personal_address_kanji" form:"personal_address_kanji"`
-	PersonalID            string               `json:"-" form:"personal_id_number"`
-	PersonalIDProvided    bool                 `json:"personal_id_number_provided" form:"-"`
-	PhoneNumber           string               `json:"phone_number" form:"phone_number"`
-	SSN                   string               `json:"-" form:"ssn_last_4"`
-	SSNProvided           bool                 `json:"ssn_last_4_provided" form:"-"`
-	Type                  LegalEntityType      `json:"type" form:"type"`
-	Verification          IdentityVerification `json:"verification" form:"verification"`
+	Address                  Address              `json:"address" form:"address"`
+	AddressKana              Address              `json:"address_kana" form:"address_kana"`
+	AddressKanji             Address              `json:"address_kanji" form:"address_kanji"`
+	BusinessName             string               `json:"business_name" form:"business_name"`
+	BusinessNameKana         string               `json:"business_name_kana" form:"business_name_kana"`
+	BusinessNameKanji        string               `json:"business_name_kanji" form:"business_name_kanji"`
+	BusinessTaxID            string               `json:"-" form:"business_tax_id"`
+	BusinessTaxIDProvided    bool                 `json:"business_tax_id_provided" form:"-"`
+	BusinessVatID            string               `json:"-" form:"business_vat_id"`
+	BusinessVatIDProvided    bool                 `json:"business_vat_id_provided" form:"-"`
+	DOB                      DOB                  `json:"dob" form:"dob"`
+	FirstName                string               `json:"first_name" form:"first_name"`
+	FirstNameKana            string               `json:"first_name_kana" form:"first_name_kana"`
+	FirstNameKanji           string               `json:"first_name_kanji" form:"first_name_kanji"`
+	Gender                   Gender               `json:"gender" form:"gender"`
+	LastName                 string               `json:"last_name" form:"last_name"`
+	LastNameKana             string               `json:"last_name_kana" form:"last_name_kana"`
+	LastNameKanji            string               `json:"last_name_kanji" form:"last_name_kanji"`
+	MaidenName               string               `json:"maiden_name" form:"maiden_name"`
+	PersonalAddress          Address              `json:"personal_address" form:"personal_address"`
+	PersonalAddressKana      Address              `json:"personal_address_kana" form:"personal_address_kana"`
+	PersonalAddressKanji     Address              `json:"personal_address_kanji" form:"personal_address_kanji"`
+	PersonalIDNumber         string               `json:"-" form:"personal_id_number"`
+	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided" form:"-"`
+	PhoneNumber              string               `json:"phone_number" form:"phone_number"`
+	SSNLast4                 string               `json:"-" form:"ssn_last_4"`
+	SSNLast4Provided         bool                 `json:"ssn_last_4_provided" form:"-"`
+	Type                     LegalEntityType      `json:"type" form:"type"`
+	Verification             IdentityVerification `json:"verification" form:"verification"`
 }
 
 // Address is the structure for an account address.
 type Address struct {
-	City    string `json:"city" form:"city"`
-	Country string `json:"country" form:"country"`
-	Line1   string `json:"line1" form:"line1"`
-	Line2   string `json:"line2" form:"line2"`
-	State   string `json:"state" form:"state"`
+	City       string `json:"city" form:"city"`
+	Country    string `json:"country" form:"country"`
+	Line1      string `json:"line1" form:"line1"`
+	Line2      string `json:"line2" form:"line2"`
+	PostalCode string `json:"postal_code" form:"postal_code"`
+	State      string `json:"state" form:"state"`
 
 	// Town/cho-me. Note that this is only used for Kana/Kanji representations
 	// of an address.
 	Town string `json:"town" form:"town"`
-
-	Zip string `json:"postal_code" form:"postal_code"`
 }
 
 // DOB is a structure for an account owner's date of birth.
@@ -340,12 +340,13 @@ type DOB struct {
 // either “male” or “female”.
 type Gender string
 
-// Owner is the structure for an account owner.
-type Owner struct {
+// AdditionalOwner is the structure for an account owner.
+type AdditionalOwner struct {
 	Address      Address              `json:"address" form:"address"`
 	DOB          DOB                  `json:"dob" form:"dob"`
-	First        string               `json:"first_name" form:"first_name"`
-	Last         string               `json:"last_name" form:"last_name"`
+	FirstName    string               `json:"first_name" form:"first_name"`
+	LastName     string               `json:"last_name" form:"last_name"`
+	MaidenName   string               `json:"maiden_name" form:"maiden_name"`
 	Verification IdentityVerification `json:"verification" form:"verification"`
 }
 
@@ -383,10 +384,10 @@ func (d *IdentityDocument) AppendTo(body *form.Values, keyParts []string) {
 
 // PayoutSchedule is the structure for an account's payout schedule.
 type PayoutSchedule struct {
-	Delay       uint64   `json:"delay_days" form:"delay_days"`
-	Interval    Interval `json:"interval" form:"interval"`
-	MonthAnchor uint64   `json:"monthly_anchor" form:"monthly_anchor"`
-	WeekAnchor  string   `json:"weekly_anchor" form:"weekly_anchor"`
+	DelayDays     uint64   `json:"delay_days" form:"delay_days"`
+	Interval      Interval `json:"interval" form:"interval"`
+	MonthlyAnchor uint64   `json:"monthly_anchor" form:"monthly_anchor"`
+	WeeklyAnchor  string   `json:"weekly_anchor" form:"weekly_anchor"`
 }
 
 // TOSAcceptanceParams is the structure for TOS acceptance.

--- a/account.go
+++ b/account.go
@@ -66,13 +66,12 @@ type AccountParams struct {
 	BusinessPrimaryColor      string                        `form:"business_primary_color"`
 	BusinessURL               string                        `form:"business_url"`
 	Country                   string                        `form:"country"`
-	DebitNegativeBalances     bool                          `form:"debit_negative_balances"`
+	DebitNegativeBalances     *bool                         `form:"debit_negative_balances"`
 	DefaultCurrency           string                        `form:"default_currency"`
 	Email                     string                        `form:"email"`
 	ExternalAccount           *AccountExternalAccountParams `form:"external_account"`
 	FromRecipient             string                        `form:"from_recipient"`
 	LegalEntity               *LegalEntity                  `form:"legal_entity"`
-	NoDebitNegativeBalances   bool                          `form:"debit_negative_balances,invert"`
 	PayoutSchedule            *PayoutScheduleParams         `form:"payout_schedule"`
 	PayoutStatementDescriptor string                        `form:"payout_statement_descriptor"`
 	ProductDescription        string                        `form:"product_description"`
@@ -116,15 +115,15 @@ func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []st
 
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
-	DelayDays     uint64   `form:"delay_days"`
-	Interval      Interval `form:"interval"`
-	MinimumDelay  bool     `form:"-"` // See custom AppendTo
-	MonthlyAnchor uint64   `form:"monthly_anchor"`
-	WeeklyAnchor  string   `form:"weekly_anchor"`
+	DelayDays        uint64   `form:"delay_days"`
+	DelayDaysMinimum *bool    `form:"-"` // See custom AppendTo
+	Interval         Interval `form:"interval"`
+	MonthlyAnchor    uint64   `form:"monthly_anchor"`
+	WeeklyAnchor     string   `form:"weekly_anchor"`
 }
 
 func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
-	if p.MinimumDelay {
+	if BoolValue(p.DelayDaysMinimum) {
 		body.Add(form.FormatKey(append(keyParts, "delay_days")), "minimum")
 	}
 }

--- a/account/client.go
+++ b/account/client.go
@@ -146,8 +146,8 @@ func (c Client) List(params *stripe.AccountListParams) *Iter {
 		list := &stripe.AccountList{}
 		err := c.B.Call("GET", "/accounts", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -37,20 +37,20 @@ func TestAccountList(t *testing.T) {
 
 func TestAccountNew(t *testing.T) {
 	account, err := New(&stripe.AccountParams{
-		Type:                 stripe.AccountTypeCustom,
-		Country:              "CA",
-		BusinessUrl:          "www.stripe.com",
-		BusinessName:         "Stripe",
-		BusinessPrimaryColor: "#ffffff",
-		DebitNegativeBal:     true,
-		SupportEmail:         "foo@bar.com",
-		SupportUrl:           "www.stripe.com",
-		SupportPhone:         "4151234567",
+		Type:                  stripe.AccountTypeCustom,
+		Country:               "CA",
+		BusinessURL:           "www.stripe.com",
+		BusinessName:          "Stripe",
+		BusinessPrimaryColor:  "#ffffff",
+		DebitNegativeBalances: true,
+		SupportEmail:          "foo@bar.com",
+		SupportURL:            "www.stripe.com",
+		SupportPhone:          "4151234567",
 		LegalEntity: &stripe.LegalEntity{
 			Type:         stripe.Individual,
 			BusinessName: "Stripe Go",
-			AdditionalOwners: []stripe.Owner{
-				{First: "Jane"},
+			AdditionalOwners: []stripe.AdditionalOwner{
+				{FirstName: "Jane"},
 			},
 			DOB: stripe.DOB{
 				Day:   1,
@@ -82,11 +82,11 @@ func TestAccountUpdate(t *testing.T) {
 		Country: "CA",
 		LegalEntity: &stripe.LegalEntity{
 			Address: stripe.Address{
-				Country: "CA",
-				City:    "Montreal",
-				Zip:     "H2Y 1C6",
-				Line1:   "275, rue Notre-Dame Est",
-				State:   "QC",
+				Country:    "CA",
+				City:       "Montreal",
+				PostalCode: "H2Y 1C6",
+				Line1:      "275, rue Notre-Dame Est",
+				State:      "QC",
 			},
 		},
 	})

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -42,7 +42,7 @@ func TestAccountNew(t *testing.T) {
 		BusinessURL:           "www.stripe.com",
 		BusinessName:          "Stripe",
 		BusinessPrimaryColor:  "#ffffff",
-		DebitNegativeBalances: true,
+		DebitNegativeBalances: stripe.Bool(true),
 		SupportEmail:          "foo@bar.com",
 		SupportURL:            "www.stripe.com",
 		SupportPhone:          "4151234567",

--- a/account_test.go
+++ b/account_test.go
@@ -80,7 +80,7 @@ func TestIdentityDocument_Appendto(t *testing.T) {
 
 func TestPayoutScheduleParams_AppendTo(t *testing.T) {
 	{
-		params := &PayoutScheduleParams{MinimumDelay: true}
+		params := &PayoutScheduleParams{DelayDaysMinimum: Bool(true)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/account_test.go
+++ b/account_test.go
@@ -57,11 +57,11 @@ func TestAccountUnmarshal(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "acct_123", account.ID)
-	assert.Equal(t, true, account.ExternalAccounts.More)
+	assert.Equal(t, true, account.ExternalAccounts.HasMore)
 
-	assert.Equal(t, 2, len(account.ExternalAccounts.Values))
-	assert.Equal(t, "ba_123", account.ExternalAccounts.Values[0].ID)
-	assert.Equal(t, "card_123", account.ExternalAccounts.Values[1].ID)
+	assert.Equal(t, 2, len(account.ExternalAccounts.Data))
+	assert.Equal(t, "ba_123", account.ExternalAccounts.Data[0].ID)
+	assert.Equal(t, "card_123", account.ExternalAccounts.Data[1].ID)
 }
 
 func TestIdentityDocument_Appendto(t *testing.T) {

--- a/applepaydomain.go
+++ b/applepaydomain.go
@@ -12,7 +12,7 @@ type ApplePayDomain struct {
 	Deleted    bool   `json:"deleted"`
 	DomainName string `json:"domain_name"`
 	ID         string `json:"id"`
-	Live       bool   `json:"livemode"`
+	Livemode   bool   `json:"livemode"`
 }
 
 // ApplePayDomainListParams are the parameters allowed during ApplePayDomain listing.
@@ -23,5 +23,5 @@ type ApplePayDomainListParams struct {
 // ApplePayDomainList is a list of ApplePayDomains as returned from a list endpoint.
 type ApplePayDomainList struct {
 	ListMeta
-	Values []*ApplePayDomain `json:"data"`
+	Data []*ApplePayDomain `json:"data"`
 }

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -89,8 +89,8 @@ func (c Client) List(params *stripe.ApplePayDomainListParams) *Iter {
 		list := &stripe.ApplePayDomainList{}
 		err := c.B.Call("GET", "/apple_pay/domains", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/balance.go
+++ b/balance.go
@@ -2,58 +2,58 @@ package stripe
 
 import "encoding/json"
 
-// TransactionStatus is the list of allowed values for the transaction's status.
+// BalanceTransactionStatus is the list of allowed values for the balance transaction's status.
 // Allowed values are "available", "pending".
-type TransactionStatus string
+type BalanceTransactionStatus string
 
-// TransactionType is the list of allowed values for the transaction's type.
+// BalanceTransactionType is the list of allowed values for the balance transaction's type.
 // Allowed values are "charge", "refund", "adjustment", "application_fee",
 // "application_fee_refund", "transfer", "transfer_cancel", "transfer_failure".
-type TransactionType string
+type BalanceTransactionType string
 
-// TransactionSourceType consts represent valid balance transaction sources.
-type TransactionSourceType string
+// BalanceTransactionSourceType consts represent valid balance transaction sources.
+type BalanceTransactionSourceType string
 
 const (
-	// TransactionSourceCharge is a constant representing a transaction source of charge
-	TransactionSourceCharge TransactionSourceType = "charge"
+	// BalanceTransactionSourceTypeCharge is a constant representing a transaction source of charge
+	BalanceTransactionSourceTypeCharge BalanceTransactionSourceType = "charge"
 
-	// TransactionSourceDispute is a constant representing a transaction source of dispute
-	TransactionSourceDispute TransactionSourceType = "dispute"
+	// BalanceTransactionSourceTypeDispute is a constant representing a transaction source of dispute
+	BalanceTransactionSourceTypeDispute BalanceTransactionSourceType = "dispute"
 
-	// TransactionSourceFee is a constant representing a transaction source of application_fee
-	TransactionSourceFee TransactionSourceType = "application_fee"
+	// BalanceTransactionSourceTypeApplicationFee is a constant representing a transaction source of application_fee
+	BalanceTransactionSourceTypeApplicationFee BalanceTransactionSourceType = "application_fee"
 
-	// TransactionSourcePayout is a constant representing a transaction source of payout
-	TransactionSourcePayout TransactionSourceType = "payout"
+	// BalanceTransactionSourceTypePayout is a constant representing a transaction source of payout
+	BalanceTransactionSourceTypePayout BalanceTransactionSourceType = "payout"
 
-	// TransactionSourceRecipientTransfer is a constant representing a transaction source of recipient_transfer
-	TransactionSourceRecipientTransfer TransactionSourceType = "recipient_transfer"
+	// BalanceTransactionSourceTypeRecipientTransfer is a constant representing a transaction source of recipient_transfer
+	BalanceTransactionSourceTypeRecipientTransfer BalanceTransactionSourceType = "recipient_transfer"
 
-	// TransactionSourceRefund is a constant representing a transaction source of refund
-	TransactionSourceRefund TransactionSourceType = "refund"
+	// BalanceTransactionSourceTypeRefund is a constant representing a transaction source of refund
+	BalanceTransactionSourceTypeRefund BalanceTransactionSourceType = "refund"
 
-	// TransactionSourceReversal is a constant representing a transaction source of reversal
-	TransactionSourceReversal TransactionSourceType = "reversal"
+	// BalanceTransactionSourceTypeReversal is a constant representing a transaction source of reversal
+	BalanceTransactionSourceTypeReversal BalanceTransactionSourceType = "reversal"
 
-	// TransactionSourceTransfer is a constant representing a transaction source of transfer
-	TransactionSourceTransfer TransactionSourceType = "transfer"
+	// BalanceTransactionSourceTypeTransfer is a constant representing a transaction source of transfer
+	BalanceTransactionSourceTypeTransfer BalanceTransactionSourceType = "transfer"
 )
 
-// TransactionSource describes the source of a balance Transaction.
+// BalanceTransactionSource describes the source of a balance Transaction.
 // The Type should indicate which object is fleshed out.
 // For more details see https://stripe.com/docs/api#retrieve_balance_transaction
-type TransactionSource struct {
-	Charge            *Charge               `json:"-"`
-	Dispute           *Dispute              `json:"-"`
-	Fee               *Fee                  `json:"-"`
-	ID                string                `json:"id"`
-	Payout            *Payout               `json:"-"`
-	RecipientTransfer *RecipientTransfer    `json:"-"`
-	Refund            *Refund               `json:"-"`
-	Reversal          *Reversal             `json:"-"`
-	Transfer          *Transfer             `json:"-"`
-	Type              TransactionSourceType `json:"object"`
+type BalanceTransactionSource struct {
+	ApplicationFee    *ApplicationFee              `json:"-"`
+	Charge            *Charge                      `json:"-"`
+	Dispute           *Dispute                     `json:"-"`
+	ID                string                       `json:"id"`
+	Payout            *Payout                      `json:"-"`
+	RecipientTransfer *RecipientTransfer           `json:"-"`
+	Refund            *Refund                      `json:"-"`
+	Reversal          *Reversal                    `json:"-"`
+	Transfer          *Transfer                    `json:"-"`
+	Type              BalanceTransactionSourceType `json:"object"`
 }
 
 // BalanceParams is the set of parameters that can be used when retrieving a balance.
@@ -62,56 +62,56 @@ type BalanceParams struct {
 	Params `form:"*"`
 }
 
-// TxParams is the set of parameters that can be used when retrieving a transaction.
+// BalanceTransactionParams is the set of parameters that can be used when retrieving a transaction.
 // For more details see https://stripe.com/docs/api#retrieve_balance_transaction.
-type TxParams struct {
+type BalanceTransactionParams struct {
 	Params `form:"*"`
 }
 
-// TxListParams is the set of parameters that can be used when listing balance transactions.
+// BalanceTransactionListParams is the set of parameters that can be used when listing balance transactions.
 // For more details see https://stripe.com/docs/api/#balance_history.
-type TxListParams struct {
-	ListParams     `form:"*"`
-	Available      int64             `form:"available_on"`
-	AvailableRange *RangeQueryParams `form:"available_on"`
-	Created        int64             `form:"created"`
-	CreatedRange   *RangeQueryParams `form:"created"`
-	Currency       string            `form:"currency"`
-	Payout         string            `form:"payout"`
-	Src            string            `form:"source"`
-	Type           TransactionType   `form:"type"`
+type BalanceTransactionListParams struct {
+	ListParams       `form:"*"`
+	AvailableOn      int64                  `form:"available_on"`
+	AvailableOnRange *RangeQueryParams      `form:"available_on"`
+	Created          int64                  `form:"created"`
+	CreatedRange     *RangeQueryParams      `form:"created"`
+	Currency         string                 `form:"currency"`
+	Payout           string                 `form:"payout"`
+	Source           string                 `form:"source"`
+	Type             BalanceTransactionType `form:"type"`
 }
 
 // Balance is the resource representing your Stripe balance.
 // For more details see https://stripe.com/docs/api/#balance.
 type Balance struct {
 	Available []Amount `json:"available"`
-	Live      bool     `json:"livemode"`
+	Livemode  bool     `json:"livemode"`
 	Pending   []Amount `json:"pending"`
 }
 
-// Transaction is the resource representing the balance transaction.
+// BalanceTransaction is the resource representing the balance transaction.
 // For more details see https://stripe.com/docs/api/#balance.
-type Transaction struct {
-	Amount     int64             `json:"amount"`
-	Available  int64             `json:"available_on"`
-	Created    int64             `json:"created"`
-	Currency   Currency          `json:"currency"`
-	Desc       string            `json:"description"`
-	ID         string            `json:"id"`
-	Fee        int64             `json:"fee"`
-	FeeDetails []TxFee           `json:"fee_details"`
-	Net        int64             `json:"net"`
-	Recipient  string            `json:"recipient"`
-	Src        TransactionSource `json:"source"`
-	Status     TransactionStatus `json:"status"`
-	Type       TransactionType   `json:"type"`
+type BalanceTransaction struct {
+	Amount      int64                    `json:"amount"`
+	AvailableOn int64                    `json:"available_on"`
+	Created     int64                    `json:"created"`
+	Currency    Currency                 `json:"currency"`
+	Description string                   `json:"description"`
+	ID          string                   `json:"id"`
+	Fee         int64                    `json:"fee"`
+	FeeDetails  []BalanceTransactionFee  `json:"fee_details"`
+	Net         int64                    `json:"net"`
+	Recipient   string                   `json:"recipient"`
+	Source      BalanceTransactionSource `json:"source"`
+	Status      BalanceTransactionStatus `json:"status"`
+	Type        BalanceTransactionType   `json:"type"`
 }
 
-// TransactionList is a list of transactions as returned from a list endpoint.
-type TransactionList struct {
+// BalanceTransactionList is a list of transactions as returned from a list endpoint.
+type BalanceTransactionList struct {
 	ListMeta
-	Values []*Transaction `json:"data"`
+	Data []*BalanceTransaction `json:"data"`
 }
 
 // Amount is a structure wrapping an amount value and its currency.
@@ -120,24 +120,24 @@ type Amount struct {
 	Currency Currency `json:"currency"`
 }
 
-// TxFee is a structure that breaks down the fees in a transaction.
-type TxFee struct {
-	Application string   `json:"application"`
+// BalanceTransactionFee is a structure that breaks down the fees in a transaction.
+type BalanceTransactionFee struct {
 	Amount      int64    `json:"amount"`
+	Application string   `json:"application"`
 	Currency    Currency `json:"currency"`
-	Desc        string   `json:"description"`
+	Description string   `json:"description"`
 	Type        string   `json:"type"`
 }
 
 // UnmarshalJSON handles deserialization of a Transaction.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (t *Transaction) UnmarshalJSON(data []byte) error {
-	type transaction Transaction
-	var tt transaction
+func (t *BalanceTransaction) UnmarshalJSON(data []byte) error {
+	type bt BalanceTransaction
+	var tt bt
 	err := json.Unmarshal(data, &tt)
 	if err == nil {
-		*t = Transaction(tt)
+		*t = BalanceTransaction(tt)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		t.ID = string(data[1 : len(data)-1])
@@ -146,32 +146,32 @@ func (t *Transaction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// UnmarshalJSON handles deserialization of a TransactionSource.
+// UnmarshalJSON handles deserialization of a BalanceTransactionSource.
 // This custom unmarshaling is needed because the specific
 // type of transaction source it refers to is specified in the JSON
-func (s *TransactionSource) UnmarshalJSON(data []byte) error {
-	type source TransactionSource
+func (s *BalanceTransactionSource) UnmarshalJSON(data []byte) error {
+	type source BalanceTransactionSource
 	var ss source
 	err := json.Unmarshal(data, &ss)
 	if err == nil {
-		*s = TransactionSource(ss)
+		*s = BalanceTransactionSource(ss)
 
 		switch s.Type {
-		case TransactionSourceCharge:
+		case BalanceTransactionSourceTypeApplicationFee:
+			err = json.Unmarshal(data, &s.ApplicationFee)
+		case BalanceTransactionSourceTypeCharge:
 			err = json.Unmarshal(data, &s.Charge)
-		case TransactionSourceDispute:
+		case BalanceTransactionSourceTypeDispute:
 			err = json.Unmarshal(data, &s.Dispute)
-		case TransactionSourceFee:
-			err = json.Unmarshal(data, &s.Fee)
-		case TransactionSourcePayout:
+		case BalanceTransactionSourceTypePayout:
 			err = json.Unmarshal(data, &s.Payout)
-		case TransactionSourceRecipientTransfer:
+		case BalanceTransactionSourceTypeRecipientTransfer:
 			err = json.Unmarshal(data, &s.RecipientTransfer)
-		case TransactionSourceRefund:
+		case BalanceTransactionSourceTypeRefund:
 			err = json.Unmarshal(data, &s.Refund)
-		case TransactionSourceReversal:
+		case BalanceTransactionSourceTypeReversal:
 			err = json.Unmarshal(data, &s.Reversal)
-		case TransactionSourceTransfer:
+		case BalanceTransactionSourceTypeTransfer:
 			err = json.Unmarshal(data, &s.Transfer)
 		}
 
@@ -186,7 +186,7 @@ func (s *TransactionSource) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON handles serialization of a TransactionSource.
-func (s *TransactionSource) MarshalJSON() ([]byte, error) {
+// MarshalJSON handles serialization of a BalanceTransactionSource.
+func (s *BalanceTransactionSource) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.ID)
 }

--- a/balance/client.go
+++ b/balance/client.go
@@ -7,22 +7,22 @@ import (
 )
 
 const (
-	TxAvailable stripe.TransactionStatus = "available"
-	TxPending   stripe.TransactionStatus = "pending"
+	BalanceTransactionAvailable stripe.BalanceTransactionStatus = "available"
+	BalanceTransactionPending   stripe.BalanceTransactionStatus = "pending"
 
-	TxCharge                  stripe.TransactionType = "charge"
-	TxRefund                  stripe.TransactionType = "refund"
-	TxAdjust                  stripe.TransactionType = "adjustment"
-	TxAppFee                  stripe.TransactionType = "application_fee"
-	TxFeeRefund               stripe.TransactionType = "application_fee_refund"
-	TxRecipientTransfer       stripe.TransactionType = "recipient_transfer"
-	TxRecipientTransferCancel stripe.TransactionType = "recipient_transfer_cancel"
-	TxRecipientTransferFail   stripe.TransactionType = "recipient_transfer_failure"
-	TxPayout                  stripe.TransactionType = "payout"
-	TxPayoutCancel            stripe.TransactionType = "payout_cancel"
-	TxPayoutFail              stripe.TransactionType = "payout_failure"
-	TxTransfer                stripe.TransactionType = "transfer"
-	TxTransferCancel          stripe.TransactionType = "transfer_refund"
+	BalanceTransactionCharge                  stripe.BalanceTransactionType = "charge"
+	BalanceTransactionRefund                  stripe.BalanceTransactionType = "refund"
+	BalanceTransactionAdjust                  stripe.BalanceTransactionType = "adjustment"
+	BalanceTransactionAppFee                  stripe.BalanceTransactionType = "application_fee"
+	BalanceTransactionFeeRefund               stripe.BalanceTransactionType = "application_fee_refund"
+	BalanceTransactionRecipientTransfer       stripe.BalanceTransactionType = "recipient_transfer"
+	BalanceTransactionRecipientTransferCancel stripe.BalanceTransactionType = "recipient_transfer_cancel"
+	BalanceTransactionRecipientTransferFail   stripe.BalanceTransactionType = "recipient_transfer_failure"
+	BalanceTransactionPayout                  stripe.BalanceTransactionType = "payout"
+	BalanceTransactionPayoutCancel            stripe.BalanceTransactionType = "payout_cancel"
+	BalanceTransactionPayoutFail              stripe.BalanceTransactionType = "payout_failure"
+	BalanceTransactionTransfer                stripe.BalanceTransactionType = "transfer"
+	BalanceTransactionTransferCancel          stripe.BalanceTransactionType = "transfer_refund"
 )
 
 // Client is used to invoke /balance and transaction-related APIs.
@@ -53,13 +53,13 @@ func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 	return balance, err
 }
 
-// GetTx returns the details of a balance transaction.
+// GetBalanceTransaction returns the details of a balance transaction.
 // For more details see	https://stripe.com/docs/api#retrieve_balance_transaction.
-func GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, error) {
-	return getC().GetTx(id, params)
+func GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
+	return getC().GetBalanceTransaction(id, params)
 }
 
-func (c Client) GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, error) {
+func (c Client) GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -69,7 +69,7 @@ func (c Client) GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, 
 		form.AppendTo(body, params)
 	}
 
-	balance := &stripe.Transaction{}
+	balance := &stripe.BalanceTransaction{}
 	err := c.B.Call("GET", "/balance/history/"+id, c.Key, body, commonParams, balance)
 
 	return balance, err
@@ -77,11 +77,11 @@ func (c Client) GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, 
 
 // List returns a list of balance transactions.
 // For more details see https://stripe.com/docs/api#balance_history.
-func List(params *stripe.TxListParams) *Iter {
+func List(params *stripe.BalanceTransactionListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.TxListParams) *Iter {
+func (c Client) List(params *stripe.BalanceTransactionListParams) *Iter {
 	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -94,11 +94,11 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.TransactionList{}
+		list := &stripe.BalanceTransactionList{}
 		err := c.B.Call("GET", "/balance/history", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -106,17 +106,17 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Transactions.
+// Iter is an iterator for lists of BalanceTransactions.
 // The embedded Iter carries methods with it;
 // see its documentation for details.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Charge returns the most recent Transaction
+// Charge returns the most recent BalanceTransaction
 // visited by a call to Next.
-func (i *Iter) Transaction() *stripe.Transaction {
-	return i.Current().(*stripe.Transaction)
+func (i *Iter) BalanceTransaction() *stripe.BalanceTransaction {
+	return i.Current().(*stripe.BalanceTransaction)
 }
 
 func getC() Client {

--- a/balance/client_test.go
+++ b/balance/client_test.go
@@ -14,17 +14,17 @@ func TestBalanceGet(t *testing.T) {
 	assert.NotNil(t, balance)
 }
 
-func TestBalanceList(t *testing.T) {
-	i := List(&stripe.TxListParams{})
+func TestBalanceTransactionList(t *testing.T) {
+	i := List(&stripe.BalanceTransactionListParams{})
 
 	// Verify that we can get at least one transaction
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.Transaction())
+	assert.NotNil(t, i.BalanceTransaction())
 }
 
-func TestBalanceTxGet(t *testing.T) {
-	transaction, err := GetTx("txn_123", nil)
+func TestBalanceBalanceTransactionGet(t *testing.T) {
+	transaction, err := GetBalanceTransaction("txn_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, transaction)
 }

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -30,7 +30,7 @@ type BankAccountParams struct {
 	Country            string `form:"country"`
 	Currency           string `form:"currency"`
 	Customer           string `form:"-"`
-	DefaultForCurrency bool   `form:"default_for_currency"`
+	DefaultForCurrency *bool  `form:"default_for_currency"`
 	RoutingNumber      string `form:"routing_number"`
 
 	// Token is a token referencing an external account like one returned from
@@ -67,8 +67,8 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 	if len(a.Token) > 0 {
 		body.Add(sourceType, a.Token)
 
-		if a.DefaultForCurrency {
-			body.Add("default_for_currency", strconv.FormatBool(a.DefaultForCurrency))
+		if a.DefaultForCurrency != nil {
+			body.Add("default_for_currency", strconv.FormatBool(BoolValue(a.DefaultForCurrency)))
 		}
 	} else {
 		body.Add(sourceType+"[object]", "bank_account")
@@ -91,8 +91,8 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 			body.Add(sourceType+"[routing_number]", a.RoutingNumber)
 		}
 
-		if a.DefaultForCurrency {
-			body.Add(sourceType+"[default_for_currency]", strconv.FormatBool(a.DefaultForCurrency))
+		if a.DefaultForCurrency != nil {
+			body.Add(sourceType+"[default_for_currency]", strconv.FormatBool(BoolValue(a.DefaultForCurrency)))
 		}
 	}
 }

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -8,7 +8,7 @@ import (
 )
 
 // BankAccountStatus is the list of allowed values for the bank account's status.
-// Allowed values are "new", "verified", "validated", "errored".
+// Allowed values are "new", "validated", "verified", "verification_failed", "errored".
 type BankAccountStatus string
 
 // BankAccountParams is the set of parameters that can be used when updating a
@@ -20,19 +20,18 @@ type BankAccountStatus string
 type BankAccountParams struct {
 	Params `form:"*"`
 
-	Account string `form:"account_number"`
-
-	// AccountID is the identifier of the parent account under which bank
+	// Account is the identifier of the parent account under which bank
 	// accounts are nested.
-	AccountID string `form:"-"`
+	Account string `form:"-"`
 
-	AccountHolderName string `form:"account_holder_name"`
-	AccountHolderType string `form:"account_holder_type"`
-	Country           string `form:"country"`
-	Currency          string `form:"currency"`
-	Customer          string `form:"-"`
-	Default           bool   `form:"default_for_currency"`
-	Routing           string `form:"routing_number"`
+	AccountHolderName  string `form:"account_holder_name"`
+	AccountHolderType  string `form:"account_holder_type"`
+	AccountNumber      string `form:"account_number"`
+	Country            string `form:"country"`
+	Currency           string `form:"currency"`
+	Customer           string `form:"-"`
+	DefaultForCurrency bool   `form:"default_for_currency"`
+	RoutingNumber      string `form:"routing_number"`
 
 	// Token is a token referencing an external account like one returned from
 	// Stripe.js.
@@ -68,13 +67,13 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 	if len(a.Token) > 0 {
 		body.Add(sourceType, a.Token)
 
-		if a.Default {
-			body.Add("default_for_currency", strconv.FormatBool(a.Default))
+		if a.DefaultForCurrency {
+			body.Add("default_for_currency", strconv.FormatBool(a.DefaultForCurrency))
 		}
 	} else {
 		body.Add(sourceType+"[object]", "bank_account")
 		body.Add(sourceType+"[country]", a.Country)
-		body.Add(sourceType+"[account_number]", a.Account)
+		body.Add(sourceType+"[account_number]", a.AccountNumber)
 		body.Add(sourceType+"[currency]", a.Currency)
 
 		// These are optional and the API will fail if we try to send empty
@@ -88,12 +87,12 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 			body.Add(sourceType+"[account_holder_type]", a.AccountHolderType)
 		}
 
-		if len(a.Routing) > 0 {
-			body.Add(sourceType+"[routing_number]", a.Routing)
+		if len(a.RoutingNumber) > 0 {
+			body.Add(sourceType+"[routing_number]", a.RoutingNumber)
 		}
 
-		if a.Default {
-			body.Add(sourceType+"[default_for_currency]", strconv.FormatBool(a.Default))
+		if a.DefaultForCurrency {
+			body.Add(sourceType+"[default_for_currency]", strconv.FormatBool(a.DefaultForCurrency))
 		}
 	}
 }
@@ -103,36 +102,36 @@ type BankAccountListParams struct {
 	ListParams `form:"*"`
 
 	// The identifier of the parent account under which the bank accounts are
-	// nested. Either AccountID or Customer should be populated.
-	AccountID string `form:"-"`
+	// nested. Either Account or Customer should be populated.
+	Account string `form:"-"`
 
 	// The identifier of the parent customer under which the bank accounts are
-	// nested. Either AccountID or Customer should be populated.
+	// nested. Either Account or Customer should be populated.
 	Customer string `form:"-"`
 }
 
 // BankAccount represents a Stripe bank account.
 type BankAccount struct {
-	AccountHolderName string            `json:"account_holder_name"`
-	AccountHolderType string            `json:"account_holder_type"`
-	Country           string            `json:"country"`
-	Currency          Currency          `json:"currency"`
-	Customer          *Customer         `json:"customer"`
-	Default           bool              `json:"default_for_currency"`
-	Deleted           bool              `json:"deleted"`
-	Fingerprint       string            `json:"fingerprint"`
-	ID                string            `json:"id"`
-	LastFour          string            `json:"last4"`
-	Meta              map[string]string `json:"metadata"`
-	Name              string            `json:"bank_name"`
-	Routing           string            `json:"routing_number"`
-	Status            BankAccountStatus `json:"status"`
+	AccountHolderName  string            `json:"account_holder_name"`
+	AccountHolderType  string            `json:"account_holder_type"`
+	BankName           string            `json:"bank_name"`
+	Country            string            `json:"country"`
+	Currency           Currency          `json:"currency"`
+	Customer           *Customer         `json:"customer"`
+	DefaultForCurrency bool              `json:"default_for_currency"`
+	Deleted            bool              `json:"deleted"`
+	Fingerprint        string            `json:"fingerprint"`
+	ID                 string            `json:"id"`
+	Last4              string            `json:"last4"`
+	Metadata           map[string]string `json:"metadata"`
+	RoutingNumber      string            `json:"routing_number"`
+	Status             BankAccountStatus `json:"status"`
 }
 
 // BankAccountList is a list object for bank accounts.
 type BankAccountList struct {
 	ListMeta
-	Values []*BankAccount `json:"data"`
+	Data []*BankAccount `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a BankAccount.

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -16,10 +16,11 @@ type Client struct {
 }
 
 const (
-	NewAccount       stripe.BankAccountStatus = "new"
-	VerifiedAccount  stripe.BankAccountStatus = "verified"
-	ValidatedAccount stripe.BankAccountStatus = "validated"
-	ErroredAccount   stripe.BankAccountStatus = "errored"
+	NewAccount                stripe.BankAccountStatus = "new"
+	VerificationFAiledAccount stripe.BankAccountStatus = "verification_failed"
+	VerifiedAccount           stripe.BankAccountStatus = "verified"
+	ValidatedAccount          stripe.BankAccountStatus = "validated"
+	ErroredAccount            stripe.BankAccountStatus = "errored"
 )
 
 // New POSTs a new bank account.
@@ -40,7 +41,7 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 	if len(params.Customer) > 0 {
 		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", params.Customer), c.Key, body, &params.Params, ba)
 	} else {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, body, &params.Params, ba)
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts", params.Account), c.Key, body, &params.Params, ba)
 	}
 
 	return ba, err
@@ -66,10 +67,10 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 
 	if params != nil && len(params.Customer) > 0 {
 		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if params != nil && len(params.AccountID) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else if params != nil && len(params.Account) > 0 {
+		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
 	} else {
-		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
 
 	return ba, err
@@ -95,10 +96,10 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 
 	if len(params.Customer) > 0 {
 		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if len(params.AccountID) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else if len(params.Account) > 0 {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
 	} else {
-		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
 
 	return ba, err
@@ -124,10 +125,10 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 
 	if len(params.Customer) > 0 {
 		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if len(params.AccountID) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else if len(params.Account) > 0 {
+		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
 	} else {
-		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
 
 	return ba, err
@@ -153,14 +154,14 @@ func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 
 		if len(params.Customer) > 0 {
 			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts", params.Customer), c.Key, b, p, list)
-		} else if len(params.AccountID) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, b, p, list)
+		} else if len(params.Account) > 0 {
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.Account), c.Key, b, p, list)
 		} else {
-			err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+			err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 		}
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -57,7 +57,7 @@ func TestBankAccountList_ByCustomer(t *testing.T) {
 func TestBankAccountNew_ByAccount(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
 		Account:            "acct_123",
-		DefaultForCurrency: true,
+		DefaultForCurrency: stripe.Bool(true),
 		Token:              "tok_123",
 	})
 	assert.Nil(t, err)
@@ -67,7 +67,7 @@ func TestBankAccountNew_ByAccount(t *testing.T) {
 func TestBankAccountNew_ByCustomer(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
 		Customer:           "cus_123",
-		DefaultForCurrency: true,
+		DefaultForCurrency: stripe.Bool(true),
 		Token:              "tok_123",
 	})
 	assert.Nil(t, err)
@@ -77,7 +77,7 @@ func TestBankAccountNew_ByCustomer(t *testing.T) {
 func TestBankAccountUpdate_ByAccount(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
 		Account:            "acct_123",
-		DefaultForCurrency: true,
+		DefaultForCurrency: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -86,7 +86,7 @@ func TestBankAccountUpdate_ByAccount(t *testing.T) {
 func TestBankAccountUpdate_ByCustomer(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
 		Customer:           "cus_123",
-		DefaultForCurrency: true,
+		DefaultForCurrency: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBankAccountDel_ByAccount(t *testing.T) {
 	bankAcount, err := Del("ba_123", &stripe.BankAccountParams{
-		AccountID: "acct_123",
+		Account: "acct_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -25,7 +25,7 @@ func TestBankAccountDel_ByCustomer(t *testing.T) {
 }
 
 func TestBankAccountGet_ByAccount(t *testing.T) {
-	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{AccountID: "acct_123"})
+	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Account: "acct_123"})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
 }
@@ -56,9 +56,9 @@ func TestBankAccountList_ByCustomer(t *testing.T) {
 
 func TestBankAccountNew_ByAccount(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
-		AccountID: "acct_123",
-		Default:   true,
-		Token:     "tok_123",
+		Account:            "acct_123",
+		DefaultForCurrency: true,
+		Token:              "tok_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -66,9 +66,9 @@ func TestBankAccountNew_ByAccount(t *testing.T) {
 
 func TestBankAccountNew_ByCustomer(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
-		Customer: "cus_123",
-		Default:  true,
-		Token:    "tok_123",
+		Customer:           "cus_123",
+		DefaultForCurrency: true,
+		Token:              "tok_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -76,8 +76,8 @@ func TestBankAccountNew_ByCustomer(t *testing.T) {
 
 func TestBankAccountUpdate_ByAccount(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
-		AccountID: "acct_123",
-		Default:   true,
+		Account:            "acct_123",
+		DefaultForCurrency: true,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -85,8 +85,8 @@ func TestBankAccountUpdate_ByAccount(t *testing.T) {
 
 func TestBankAccountUpdate_ByCustomer(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
-		Customer: "cus_123",
-		Default:  true,
+		Customer:           "cus_123",
+		DefaultForCurrency: true,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -8,9 +8,9 @@ import (
 // For more details see https://stripe.com/docs/api/#list_bitcoin_receivers.
 type BitcoinReceiverListParams struct {
 	ListParams `form:"*"`
-	NotActive  bool `form:"active,invert"`
-	NotFilled  bool `form:"filled,invert"`
-	Uncaptured bool `form:"uncaptured_funds"`
+	Active     *bool `form:"active"`
+	Filled     *bool `form:"filled"`
+	Uncaptured bool  `form:"uncaptured_funds"`
 }
 
 // BitcoinReceiverParams is the set of parameters that can be used when creating a BitcoinReceiver.

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -45,12 +45,12 @@ type BitcoinReceiver struct {
 	Created               int64                   `json:"created"`
 	Currency              Currency                `json:"currency"`
 	Customer              string                  `json:"customer"`
-	Desc                  string                  `json:"description"`
+	Description           string                  `json:"description"`
 	Email                 string                  `json:"email"`
 	Filled                bool                    `json:"filled"`
 	ID                    string                  `json:"id"`
 	InboundAddress        string                  `json:"inbound_address"`
-	Meta                  map[string]string       `json:"metadata"`
+	Metadata              map[string]string       `json:"metadata"`
 	Payment               string                  `json:"payment"`
 	RefundAddress         string                  `json:"refund_address"`
 	RejectTransactions    bool                    `json:"reject_transactions"`
@@ -60,7 +60,7 @@ type BitcoinReceiver struct {
 // BitcoinReceiverList is a list of bitcoin receivers as retrieved from a list endpoint.
 type BitcoinReceiverList struct {
 	ListMeta
-	Values []*BitcoinReceiver `json:"data"`
+	Data []*BitcoinReceiver `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a BitcoinReceiver.

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -90,8 +90,8 @@ func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
 		list := &stripe.BitcoinReceiverList{}
 		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/bitcointransaction.go
+++ b/bitcointransaction.go
@@ -14,7 +14,7 @@ type BitcoinTransactionListParams struct {
 // For more details see https://stripe.com/docs/api/#retrieve_bitcoin_receiver
 type BitcoinTransactionList struct {
 	ListMeta
-	Values []*BitcoinTransaction `json:"data"`
+	Data []*BitcoinTransaction `json:"data"`
 }
 
 // BitcoinTransaction is the resource representing a Stripe bitcoin transaction.

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -36,8 +36,8 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 		list := &stripe.BitcoinTransactionList{}
 		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/card.go
+++ b/card.go
@@ -35,24 +35,24 @@ type Verification string
 // cards have some unusual logic on creates that necessitates manual handling
 // of all parameters. See AppendToAsCardSourceOrExternalAccount.
 type CardParams struct {
-	Params    `form:"*"`
-	Account   string `form:"-"`
-	Address1  string `form:"address_line1"`
-	Address2  string `form:"address_line2"`
-	CVC       string `form:"cvc"`
-	City      string `form:"address_city"`
-	Country   string `form:"address_country"`
-	Currency  string `form:"currency"`
-	Customer  string `form:"-"`
-	Default   bool   `form:"default_for_currency"`
-	Month     string `form:"exp_month"`
-	Name      string `form:"name"`
-	Number    string `form:"number"`
-	Recipient string `form:"-"`
-	State     string `form:"address_state"`
-	Token     string `form:"-"`
-	Year      string `form:"exp_year"`
-	Zip       string `form:"address_zip"`
+	Params             `form:"*"`
+	Account            string `form:"-"`
+	AddressCity        string `form:"address_city"`
+	AddressCountry     string `form:"address_country"`
+	AddressLine1       string `form:"address_line1"`
+	AddressLine2       string `form:"address_line2"`
+	AddressState       string `form:"address_state"`
+	AddressZip         string `form:"address_zip"`
+	CVC                string `form:"cvc"`
+	Currency           string `form:"currency"`
+	Customer           string `form:"-"`
+	DefaultForCurrency bool   `form:"default_for_currency"`
+	ExpMonth           string `form:"exp_month"`
+	ExpYear            string `form:"exp_year"`
+	Name               string `form:"name"`
+	Number             string `form:"number"`
+	Recipient          string `form:"-"`
+	Token              string `form:"-"`
 
 	// ID is used when tokenizing a card for shared customers
 	ID string `form:"*"`
@@ -71,8 +71,8 @@ type CardParams struct {
 // because the cards endpoint is a little unusual. There is one other resource
 // like it, which is bank account.
 func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, keyParts []string) {
-	if c.Default {
-		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(c.Default))
+	if c.DefaultForCurrency {
+		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(c.DefaultForCurrency))
 	}
 
 	if len(c.Token) > 0 {
@@ -96,44 +96,40 @@ func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, ke
 		body.Add(form.FormatKey(append(keyParts, cardSource, "currency")), c.Currency)
 	}
 
-	if c.Default {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "default_for_currency")), strconv.FormatBool(c.Default))
+	if len(c.ExpMonth) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), c.ExpMonth)
 	}
 
-	if len(c.Month) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), c.Month)
-	}
-
-	if len(c.Year) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), c.Year)
+	if len(c.ExpYear) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), c.ExpYear)
 	}
 
 	if len(c.Name) > 0 {
 		body.Add(form.FormatKey(append(keyParts, cardSource, "name")), c.Name)
 	}
 
-	if len(c.Address1) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), c.Address1)
+	if len(c.AddressCity) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), c.AddressCity)
 	}
 
-	if len(c.Address2) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), c.Address2)
+	if len(c.AddressCountry) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), c.AddressCountry)
 	}
 
-	if len(c.City) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), c.City)
+	if len(c.AddressLine1) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), c.AddressLine1)
 	}
 
-	if len(c.State) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), c.State)
+	if len(c.AddressLine2) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), c.AddressLine2)
 	}
 
-	if len(c.Zip) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), c.Zip)
+	if len(c.AddressState) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), c.AddressState)
 	}
 
-	if len(c.Country) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), c.Country)
+	if len(c.AddressZip) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), c.AddressZip)
 	}
 }
 
@@ -149,18 +145,21 @@ type CardListParams struct {
 // Card is the resource representing a Stripe credit/debit card.
 // For more details see https://stripe.com/docs/api#cards.
 type Card struct {
-	Address1      string       `json:"address_line1"`
-	Address1Check Verification `json:"address_line1_check"`
-	Address2      string       `json:"address_line2"`
-	Brand         CardBrand    `json:"brand"`
-	CVCCheck      Verification `json:"cvc_check"`
-	CardCountry   string       `json:"country"`
-	City          string       `json:"address_city"`
-	Country       string       `json:"address_country"`
-	Currency      Currency     `json:"currency"`
-	Customer      *Customer    `json:"customer"`
-	Default       bool         `json:"default_for_currency"`
-	Deleted       bool         `json:"deleted"`
+	AddressCity        string       `json:"address_city"`
+	AddressCountry     string       `json:"address_country"`
+	AddressLine1       string       `json:"address_line1"`
+	AddressLine1Check  Verification `json:"address_line1_check"`
+	AddressLine2       string       `json:"address_line2"`
+	AddressState       string       `json:"address_state"`
+	AddressZip         string       `json:"address_zip"`
+	AddressZipCheck    Verification `json:"address_zip_check"`
+	Brand              CardBrand    `json:"brand"`
+	CVCCheck           Verification `json:"cvc_check"`
+	Country            string       `json:"country"`
+	Currency           Currency     `json:"currency"`
+	Customer           *Customer    `json:"customer"`
+	DefaultForCurrency bool         `json:"default_for_currency"`
+	Deleted            bool         `json:"deleted"`
 
 	// Description is a succinct summary of the card's information.
 	//
@@ -168,10 +167,12 @@ type Card struct {
 	// as part of standard API requests.
 	Description string `json:"description"`
 
-	DynLastFour string      `json:"dynamic_last4"`
-	Fingerprint string      `json:"fingerprint"`
-	Funding     CardFunding `json:"funding"`
-	ID          string      `json:"id"`
+	DynamicLast4 string      `json:"dynamic_last4"`
+	ExpMonth     uint8       `json:"exp_month"`
+	ExpYear      uint16      `json:"exp_year"`
+	Fingerprint  string      `json:"fingerprint"`
+	Funding      CardFunding `json:"funding"`
+	ID           string      `json:"id"`
 
 	// IIN is the card's "Issuer Identification Number".
 	//
@@ -185,23 +186,18 @@ type Card struct {
 	// as part of standard API requests.
 	Issuer string `json:"issuer"`
 
-	LastFour           string             `json:"last4"`
-	Meta               map[string]string  `json:"metadata"`
-	Month              uint8              `json:"exp_month"`
+	Last4              string             `json:"last4"`
+	Metadata           map[string]string  `json:"metadata"`
 	Name               string             `json:"name"`
 	Recipient          *Recipient         `json:"recipient"`
-	State              string             `json:"address_state"`
 	ThreeDSecure       *ThreeDSecure      `json:"three_d_secure"`
 	TokenizationMethod TokenizationMethod `json:"tokenization_method"`
-	Year               uint16             `json:"exp_year"`
-	Zip                string             `json:"address_zip"`
-	ZipCheck           Verification       `json:"address_zip_check"`
 }
 
 // CardList is a list object for cards.
 type CardList struct {
 	ListMeta
-	Values []*Card `json:"data"`
+	Data []*Card `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Card.

--- a/card/client.go
+++ b/card/client.go
@@ -203,8 +203,8 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 			err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 		}
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -65,8 +65,8 @@ func TestCardNew_RequiresParams(t *testing.T) {
 
 func TestCardUpdate(t *testing.T) {
 	card, err := Update("card_123", &stripe.CardParams{
-		Customer: "cus_123",
-		Default:  true,
+		Customer:           "cus_123",
+		DefaultForCurrency: true,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)

--- a/charge.go
+++ b/charge.go
@@ -15,22 +15,22 @@ type FraudReport string
 // ChargeParams is the set of parameters that can be used when creating or updating a charge.
 // For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
-	Params        `form:"*"`
-	Amount        uint64              `form:"amount"`
-	Currency      Currency            `form:"currency"`
-	Customer      string              `form:"customer"`
-	Desc          string              `form:"description"`
-	Destination   *DestinationParams  `form:"destination"`
-	Email         string              `form:"receipt_email"`
-	ExchangeRate  float64             `form:"exchange_rate"`
-	Fee           uint64              `form:"application_fee"`
-	FraudDetails  *FraudDetailsParams `form:"fraud_details"`
-	NoCapture     bool                `form:"capture,invert"`
-	OnBehalfOf    string              `form:"on_behalf_of"`
-	Shipping      *ShippingDetails    `form:"shipping"`
-	Source        *SourceParams       `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	Statement     string              `form:"statement_descriptor"`
-	TransferGroup string              `form:"transfer_group"`
+	Params              `form:"*"`
+	Amount              uint64              `form:"amount"`
+	ApplicationFee      uint64              `form:"application_fee"`
+	Currency            Currency            `form:"currency"`
+	Customer            string              `form:"customer"`
+	Description         string              `form:"description"`
+	Destination         *DestinationParams  `form:"destination"`
+	ExchangeRate        float64             `form:"exchange_rate"`
+	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
+	NoCapture           bool                `form:"capture,invert"`
+	OnBehalfOf          string              `form:"on_behalf_of"`
+	ReceiptEmail        string              `form:"receipt_email"`
+	Shipping            *ShippingDetails    `form:"shipping"`
+	Source              *SourceParams       `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	StatementDescriptor string              `form:"statement_descriptor"`
+	TransferGroup       string              `form:"transfer_group"`
 }
 
 // SetSource adds valid sources to a ChargeParams object,
@@ -64,50 +64,50 @@ type ChargeListParams struct {
 // CaptureParams is the set of parameters that can be used when capturing a charge.
 // For more details see https://stripe.com/docs/api#charge_capture.
 type CaptureParams struct {
-	Params       `form:"*"`
-	Amount       uint64  `form:"amount"`
-	Email        string  `form:"receipt_email"`
-	ExchangeRate float64 `form:"exchange_rate"`
-	Fee          uint64  `form:"application_fee"`
-	Statement    string  `form:"statement_descriptor"`
+	Params              `form:"*"`
+	Amount              uint64  `form:"amount"`
+	ApplicationFee      uint64  `form:"application_fee"`
+	ExchangeRate        float64 `form:"exchange_rate"`
+	ReceiptEmail        string  `form:"receipt_email"`
+	StatementDescriptor string  `form:"statement_descriptor"`
 }
 
 // Charge is the resource representing a Stripe charge.
 // For more details see https://stripe.com/docs/api#charges.
 type Charge struct {
-	Amount         uint64            `json:"amount"`
-	AmountRefunded uint64            `json:"amount_refunded"`
-	Application    *Application      `json:"application"`
-	Captured       bool              `json:"captured"`
-	Created        int64             `json:"created"`
-	Currency       Currency          `json:"currency"`
-	Customer       *Customer         `json:"customer"`
-	Desc           string            `json:"description"`
-	Dest           *Account          `json:"destination"`
-	Dispute        *Dispute          `json:"dispute"`
-	Email          string            `json:"receipt_email"`
-	FailCode       string            `json:"failure_code"`
-	FailMsg        string            `json:"failure_message"`
-	Fee            *Fee              `json:"application_fee"`
-	FraudDetails   *FraudDetails     `json:"fraud_details"`
-	ID             string            `json:"id"`
-	Invoice        *Invoice          `json:"invoice"`
-	Live           bool              `json:"livemode"`
-	Meta           map[string]string `json:"metadata"`
-	Outcome        *ChargeOutcome    `json:"outcome"`
-	Paid           bool              `json:"paid"`
-	ReceiptNumber  string            `json:"receipt_number"`
-	Refunded       bool              `json:"refunded"`
-	Refunds        *RefundList       `json:"refunds"`
-	Review         *Review           `json:"review"`
-	Shipping       *ShippingDetails  `json:"shipping"`
-	Source         *PaymentSource    `json:"source"`
-	SourceTransfer *Transfer         `json:"source_transfer"`
-	Statement      string            `json:"statement_descriptor"`
-	Status         string            `json:"status"`
-	Transfer       *Transfer         `json:"transfer"`
-	TransferGroup  string            `json:"transfer_group"`
-	Tx             *Transaction      `json:"balance_transaction"`
+	Amount              uint64              `json:"amount"`
+	AmountRefunded      uint64              `json:"amount_refunded"`
+	Application         *Application        `json:"application"`
+	ApplicationFee      *ApplicationFee     `json:"application_fee"`
+	BalanceTransaction  *BalanceTransaction `json:"balance_transaction"`
+	Captured            bool                `json:"captured"`
+	Created             int64               `json:"created"`
+	Currency            Currency            `json:"currency"`
+	Customer            *Customer           `json:"customer"`
+	Description         string              `json:"description"`
+	Destination         *Account            `json:"destination"`
+	Dispute             *Dispute            `json:"dispute"`
+	FailureCode         string              `json:"failure_code"`
+	FailureMessage      string              `json:"failure_message"`
+	FraudDetails        *FraudDetails       `json:"fraud_details"`
+	ID                  string              `json:"id"`
+	Invoice             *Invoice            `json:"invoice"`
+	Livemode            bool                `json:"livemode"`
+	Metadata            map[string]string   `json:"metadata"`
+	Outcome             *ChargeOutcome      `json:"outcome"`
+	Paid                bool                `json:"paid"`
+	ReceiptEmail        string              `json:"receipt_email"`
+	ReceiptNumber       string              `json:"receipt_number"`
+	Refunded            bool                `json:"refunded"`
+	Refunds             *RefundList         `json:"refunds"`
+	Review              *Review             `json:"review"`
+	Shipping            *ShippingDetails    `json:"shipping"`
+	Source              *PaymentSource      `json:"source"`
+	SourceTransfer      *Transfer           `json:"source_transfer"`
+	StatementDescriptor string              `json:"statement_descriptor"`
+	Status              string              `json:"status"`
+	Transfer            *Transfer           `json:"transfer"`
+	TransferGroup       string              `json:"transfer_group"`
 }
 
 // UnmarshalJSON handles deserialization of a charge.
@@ -129,7 +129,7 @@ func (c *Charge) UnmarshalJSON(data []byte) error {
 // ChargeList is a list of charges as retrieved from a list endpoint.
 type ChargeList struct {
 	ListMeta
-	Values []*Charge `json:"data"`
+	Data []*Charge `json:"data"`
 }
 
 // FraudDetails is the structure detailing fraud status.
@@ -158,11 +158,11 @@ type ChargeOutcome struct {
 
 // ShippingDetails is the structure containing shipping information.
 type ShippingDetails struct {
-	Address  Address `json:"address" form:"address"`
-	Carrier  string  `json:"carrier" form:"carrier"`
-	Name     string  `json:"name" form:"name"`
-	Phone    string  `json:"phone" form:"phone"`
-	Tracking string  `json:"tracking_number" form:"tracking_number"`
+	Address        Address `json:"address" form:"address"`
+	Carrier        string  `json:"carrier" form:"carrier"`
+	Name           string  `json:"name" form:"name"`
+	Phone          string  `json:"phone" form:"phone"`
+	TrackingNumber string  `json:"tracking_number" form:"tracking_number"`
 }
 
 var depth int = -1

--- a/charge.go
+++ b/charge.go
@@ -18,13 +18,13 @@ type ChargeParams struct {
 	Params              `form:"*"`
 	Amount              uint64              `form:"amount"`
 	ApplicationFee      uint64              `form:"application_fee"`
+	Capture             *bool               `form:"capture"`
 	Currency            Currency            `form:"currency"`
 	Customer            string              `form:"customer"`
 	Description         string              `form:"description"`
 	Destination         *DestinationParams  `form:"destination"`
 	ExchangeRate        float64             `form:"exchange_rate"`
 	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
-	NoCapture           bool                `form:"capture,invert"`
 	OnBehalfOf          string              `form:"on_behalf_of"`
 	ReceiptEmail        string              `form:"receipt_email"`
 	Shipping            *ShippingDetails    `form:"shipping"`

--- a/charge/client.go
+++ b/charge/client.go
@@ -124,8 +124,8 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 		list := &stripe.ChargeList{}
 		err := c.B.Call("GET", "/charges", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/charge/client.go
+++ b/charge/client.go
@@ -79,7 +79,7 @@ func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, 
 	return charge, err
 }
 
-// Capture captures a previously created charge with NoCapture set to true.
+// Capture captures a charge not yet captured.
 // For more details see https://stripe.com/docs/api#charge_capture.
 func Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 	return getC().Capture(id, params)

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -71,7 +71,7 @@ func TestChargeMarkSafe(t *testing.T) {
 
 func TestChargeUpdate(t *testing.T) {
 	charge, err := Update("ch_123", &stripe.ChargeParams{
-		Desc: "Updated description",
+		Description: "Updated description",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)
@@ -80,7 +80,7 @@ func TestChargeUpdate(t *testing.T) {
 func TestChargeUpdateDispute(t *testing.T) {
 	charge, err := UpdateDispute("ch_123", &stripe.DisputeParams{
 		Evidence: &stripe.DisputeEvidenceParams{
-			ProductDesc: "original description",
+			ProductDescription: "original description",
 		},
 	})
 	assert.Nil(t, err)

--- a/client/api.go
+++ b/client/api.go
@@ -52,12 +52,12 @@ type API struct {
 	// Cards is the client used to invoke /cards APIs.
 	// For more details see https://stripe.com/docs/api#cards.
 	Cards *card.Client
-	// Subs is the client used to invoke /subscriptions APIs.
+	// Subscriptions is the client used to invoke /subscriptions APIs.
 	// For more details see https://stripe.com/docs/api#subscriptions.
-	Subs *sub.Client
-	// SubItems is the client used to invoke subscription's items-related APIs.
+	Subscriptions *sub.Client
+	// SubscriptionItems is the client used to invoke subscription's items-related APIs.
 	// For more details see https://stripe.com/docs/api#subscription_items.
-	SubItems *subitem.Client
+	SubscriptionItems *subitem.Client
 	// Plans is the client used to invoke /plans APIs.
 	// For more details see https://stripe.com/docs/api#plans.
 	Plans *plan.Client
@@ -160,8 +160,8 @@ func (a *API) Init(key string, backends *Backends) {
 	a.Charges = &charge.Client{B: backends.API, Key: key}
 	a.Customers = &customer.Client{B: backends.API, Key: key}
 	a.Cards = &card.Client{B: backends.API, Key: key}
-	a.Subs = &sub.Client{B: backends.API, Key: key}
-	a.SubItems = &subitem.Client{B: backends.API, Key: key}
+	a.Subscriptions = &sub.Client{B: backends.API, Key: key}
+	a.SubscriptionItems = &subitem.Client{B: backends.API, Key: key}
 	a.Plans = &plan.Client{B: backends.API, Key: key}
 	a.Coupons = &coupon.Client{B: backends.API, Key: key}
 	a.Discounts = &discount.Client{B: backends.API, Key: key}

--- a/countryspec.go
+++ b/countryspec.go
@@ -7,7 +7,7 @@ type Country string
 // For more details see https://stripe.com/docs/api#country_spec_object-verification_fields.
 type VerificationFieldsList struct {
 	AdditionalFields []string `json:"additional"`
-	MinimumFields    []string `json:"minimum"`
+	Minimum          []string `json:"minimum"`
 }
 
 // CountrySpec is the resource representing the rules required for a Stripe account.
@@ -24,7 +24,7 @@ type CountrySpec struct {
 // CountrySpecList is a list of country specs as retrieved from a list endpoint.
 type CountrySpecList struct {
 	ListMeta
-	Values []*CountrySpec `json:"data"`
+	Data []*CountrySpec `json:"data"`
 }
 
 // CountrySpecListParams are the parameters allowed during CountrySpec listing.

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -46,8 +46,8 @@ func (c Client) List(params *stripe.CountrySpecListParams) *Iter {
 		list := &stripe.CountrySpecList{}
 		err := c.B.Call("GET", "/country_specs", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/coupon.go
+++ b/coupon.go
@@ -9,15 +9,15 @@ type CouponDuration string
 // CouponParams is the set of parameters that can be used when creating a coupon.
 // For more details see https://stripe.com/docs/api#create_coupon.
 type CouponParams struct {
-	Params         `form:"*"`
-	Amount         uint64         `form:"amount_off"`
-	Currency       Currency       `form:"currency"`
-	Duration       CouponDuration `form:"duration"`
-	DurationPeriod uint64         `form:"duration_in_months"`
-	ID             string         `form:"id"`
-	Percent        uint64         `form:"percent_off"`
-	RedeemBy       int64          `form:"redeem_by"`
-	Redemptions    uint64         `form:"max_redemptions"`
+	Params           `form:"*"`
+	AmountOff        uint64         `form:"amount_off"`
+	Currency         Currency       `form:"currency"`
+	Duration         CouponDuration `form:"duration"`
+	DurationInMonths uint64         `form:"duration_in_months"`
+	ID               string         `form:"id"`
+	MaxRedemptions   uint64         `form:"max_redemptions"`
+	PercentOff       uint64         `form:"percent_off"`
+	RedeemBy         int64          `form:"redeem_by"`
 }
 
 // CouponListParams is the set of parameters that can be used when listing coupons.
@@ -31,26 +31,26 @@ type CouponListParams struct {
 // Coupon is the resource representing a Stripe coupon.
 // For more details see https://stripe.com/docs/api#coupons.
 type Coupon struct {
-	Amount         uint64            `json:"amount_off"`
-	Created        int64             `json:"created"`
-	Currency       Currency          `json:"currency"`
-	Deleted        bool              `json:"deleted"`
-	Duration       CouponDuration    `json:"duration"`
-	DurationPeriod uint64            `json:"duration_in_months"`
-	ID             string            `json:"id"`
-	Live           bool              `json:"livemode"`
-	Meta           map[string]string `json:"metadata"`
-	Percent        uint64            `json:"percent_off"`
-	RedeemBy       int64             `json:"redeem_by"`
-	Redeemed       uint64            `json:"times_redeemed"`
-	Redemptions    uint64            `json:"max_redemptions"`
-	Valid          bool              `json:"valid"`
+	AmountOff        uint64            `json:"amount_off"`
+	Created          int64             `json:"created"`
+	Currency         Currency          `json:"currency"`
+	Deleted          bool              `json:"deleted"`
+	Duration         CouponDuration    `json:"duration"`
+	DurationInMonths uint64            `json:"duration_in_months"`
+	ID               string            `json:"id"`
+	Livemode         bool              `json:"livemode"`
+	MaxRedemptions   uint64            `json:"max_redemptions"`
+	Metadata         map[string]string `json:"metadata"`
+	PercentOff       uint64            `json:"percent_off"`
+	RedeemBy         int64             `json:"redeem_by"`
+	TimesRedeemed    uint64            `json:"times_redeemed"`
+	Valid            bool              `json:"valid"`
 }
 
 // CouponList is a list of coupons as retrieved from a list endpoint.
 type CouponList struct {
 	ListMeta
-	Values []*Coupon `json:"data"`
+	Data []*Coupon `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Coupon.

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -119,8 +119,8 @@ func (c Client) List(params *stripe.CouponListParams) *Iter {
 		list := &stripe.CouponList{}
 		err := c.B.Call("GET", "/coupons", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -31,10 +31,10 @@ func TestCouponList(t *testing.T) {
 
 func TestCouponNew(t *testing.T) {
 	coupon, err := New(&stripe.CouponParams{
-		Duration:       "repeating",
-		DurationPeriod: 3,
-		ID:             "25OFF",
-		Percent:        25,
+		Duration:         "repeating",
+		DurationInMonths: 3,
+		ID:               "25OFF",
+		PercentOff:       25,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)
@@ -42,7 +42,7 @@ func TestCouponNew(t *testing.T) {
 
 func TestCouponUpdate(t *testing.T) {
 	coupon, err := Update("25OFF", &stripe.CouponParams{
-		Redemptions: 5,
+		MaxRedemptions: 5,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)

--- a/customer.go
+++ b/customer.go
@@ -7,23 +7,20 @@ import (
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
-	Params             `form:"*"`
-	AccountBalance     int64                    `form:"account_balance"`
-	AccountBalanceZero bool                     `form:"account_balance,zero"`
-	BusinessVatID      string                   `form:"business_vat_id"`
-	Coupon             string                   `form:"coupon"`
-	CouponEmpty        bool                     `form:"coupon,empty"`
-	DefaultSource      string                   `form:"default_source"`
-	Description        string                   `form:"description"`
-	Email              string                   `form:"email"`
-	Plan               string                   `form:"plan"`
-	Quantity           uint64                   `form:"quantity"`
-	Shipping           *CustomerShippingDetails `form:"shipping"`
-	Source             *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	TaxPercent         float64                  `form:"tax_percent"`
-	TaxPercentZero     bool                     `form:"tax_percent,zero"`
-	Token              string                   `form:"-"` // This doesn't seem to be used?
-	TrialEnd           int64                    `form:"trial_end"`
+	Params         `form:"*"`
+	AccountBalance *int64                   `form:"account_balance"`
+	BusinessVatID  string                   `form:"business_vat_id"`
+	Coupon         *string                  `form:"coupon"`
+	DefaultSource  string                   `form:"default_source"`
+	Description    string                   `form:"description"`
+	Email          string                   `form:"email"`
+	Plan           string                   `form:"plan"`
+	Quantity       uint64                   `form:"quantity"`
+	Shipping       *CustomerShippingDetails `form:"shipping"`
+	Source         *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxPercent     *float64                 `form:"tax_percent"`
+	Token          string                   `form:"-"` // This doesn't seem to be used?
+	TrialEnd       int64                    `form:"trial_end"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,

--- a/customer.go
+++ b/customer.go
@@ -7,23 +7,23 @@ import (
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
-	Params         `form:"*"`
-	Balance        int64                    `form:"account_balance"`
-	BalanceZero    bool                     `form:"account_balance,zero"`
-	BusinessVatID  string                   `form:"business_vat_id"`
-	Coupon         string                   `form:"coupon"`
-	CouponEmpty    bool                     `form:"coupon,empty"`
-	DefaultSource  string                   `form:"default_source"`
-	Desc           string                   `form:"description"`
-	Email          string                   `form:"email"`
-	Plan           string                   `form:"plan"`
-	Quantity       uint64                   `form:"quantity"`
-	Shipping       *CustomerShippingDetails `form:"shipping"`
-	Source         *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	TaxPercent     float64                  `form:"tax_percent"`
-	TaxPercentZero bool                     `form:"tax_percent,zero"`
-	Token          string                   `form:"-"` // This doesn't seem to be used?
-	TrialEnd       int64                    `form:"trial_end"`
+	Params             `form:"*"`
+	AccountBalance     int64                    `form:"account_balance"`
+	AccountBalanceZero bool                     `form:"account_balance,zero"`
+	BusinessVatID      string                   `form:"business_vat_id"`
+	Coupon             string                   `form:"coupon"`
+	CouponEmpty        bool                     `form:"coupon,empty"`
+	DefaultSource      string                   `form:"default_source"`
+	Description        string                   `form:"description"`
+	Email              string                   `form:"email"`
+	Plan               string                   `form:"plan"`
+	Quantity           uint64                   `form:"quantity"`
+	Shipping           *CustomerShippingDetails `form:"shipping"`
+	Source             *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxPercent         float64                  `form:"tax_percent"`
+	TaxPercentZero     bool                     `form:"tax_percent,zero"`
+	Token              string                   `form:"-"` // This doesn't seem to be used?
+	TrialEnd           int64                    `form:"trial_end"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,
@@ -45,28 +45,28 @@ type CustomerListParams struct {
 // Customer is the resource representing a Stripe customer.
 // For more details see https://stripe.com/docs/api#customers.
 type Customer struct {
-	Balance       int64                    `json:"account_balance"`
-	BusinessVatID string                   `json:"business_vat_id"`
-	Currency      Currency                 `json:"currency"`
-	Created       int64                    `json:"created"`
-	DefaultSource *PaymentSource           `json:"default_source"`
-	Deleted       bool                     `json:"deleted"`
-	Delinquent    bool                     `json:"delinquent"`
-	Desc          string                   `json:"description"`
-	Discount      *Discount                `json:"discount"`
-	Email         string                   `json:"email"`
-	ID            string                   `json:"id"`
-	Live          bool                     `json:"livemode"`
-	Meta          map[string]string        `json:"metadata"`
-	Shipping      *CustomerShippingDetails `json:"shipping"`
-	Sources       *SourceList              `json:"sources"`
-	Subs          *SubList                 `json:"subscriptions"`
+	AccountBalance int64                    `json:"account_balance"`
+	BusinessVatID  string                   `json:"business_vat_id"`
+	Created        int64                    `json:"created"`
+	Currency       Currency                 `json:"currency"`
+	DefaultSource  *PaymentSource           `json:"default_source"`
+	Deleted        bool                     `json:"deleted"`
+	Delinquent     bool                     `json:"delinquent"`
+	Description    string                   `json:"description"`
+	Discount       *Discount                `json:"discount"`
+	Email          string                   `json:"email"`
+	ID             string                   `json:"id"`
+	Livemode       bool                     `json:"livemode"`
+	Metadata       map[string]string        `json:"metadata"`
+	Shipping       *CustomerShippingDetails `json:"shipping"`
+	Sources        *SourceList              `json:"sources"`
+	Subscriptions  *SubscriptionList        `json:"subscriptions"`
 }
 
 // CustomerList is a list of customers as retrieved from a list endpoint.
 type CustomerList struct {
 	ListMeta
-	Values []*Customer `json:"data"`
+	Data []*Customer `json:"data"`
 }
 
 // CustomerShippingDetails is the structure containing shipping information.

--- a/customer/client.go
+++ b/customer/client.go
@@ -122,8 +122,8 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 		list := &stripe.CustomerList{}
 		err := c.B.Call("GET", "/customers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/discount.go
+++ b/discount.go
@@ -8,10 +8,10 @@ type DiscountParams struct {
 // Discount is the resource representing a Stripe discount.
 // For more details see https://stripe.com/docs/api#discounts.
 type Discount struct {
-	Coupon   *Coupon `json:"coupon"`
-	Customer string  `json:"customer"`
-	Deleted  bool    `json:"deleted"`
-	End      int64   `json:"end"`
-	Start    int64   `json:"start"`
-	Sub      string  `json:"subscription"`
+	Coupon       *Coupon `json:"coupon"`
+	Customer     string  `json:"customer"`
+	Deleted      bool    `json:"deleted"`
+	End          int64   `json:"end"`
+	Start        int64   `json:"start"`
+	Subscription string  `json:"subscription"`
 }

--- a/dispute.go
+++ b/dispute.go
@@ -27,31 +27,31 @@ type DisputeParams struct {
 // DisputeEvidenceParams is the set of parameters that can be used when submitting
 // evidence for disputes.
 type DisputeEvidenceParams struct {
-	ActivityLog                  string `form:"access_activity_log"`
+	AccessActivityLog            string `form:"access_activity_log"`
 	BillingAddress               string `form:"billing_address"`
 	CancellationPolicy           string `form:"cancellation_policy"`
-	CancellationPolicyDisclsoure string `form:"cancellation_policy_disclosure"`
+	CancellationPolicyDisclosure string `form:"cancellation_policy_disclosure"`
 	CancellationRebuttal         string `form:"cancellation_rebuttal"`
-	CustomerComm                 string `form:"customer_communication"`
-	CustomerEmail                string `form:"customer_email_address"`
-	CustomerIP                   string `form:"customer_purchase_ip"`
+	CustomerCommunication        string `form:"customer_communication"`
+	CustomerEmailAddress         string `form:"customer_email_address"`
 	CustomerName                 string `form:"customer_name"`
-	CustomerSig                  string `form:"customer_signature"`
-	DuplicateCharge              string `form:"duplicate_charge_id"`
-	DuplicateChargeDoc           string `form:"duplicate_charge_documentation"`
-	DuplicateChargeReason        string `form:"duplicate_charge_explanation"`
-	ProductDesc                  string `form:"product_description"`
+	CustomerPurchaseIP           string `form:"customer_purchase_ip"`
+	CustomerSignature            string `form:"customer_signature"`
+	DuplicateChargeDocumentation string `form:"duplicate_charge_documentation"`
+	DuplicateChargeExplanation   string `form:"duplicate_charge_explanation"`
+	DuplicateChargeID            string `form:"duplicate_charge_id"`
+	ProductDescription           string `form:"product_description"`
 	Receipt                      string `form:"receipt"`
 	RefundPolicy                 string `form:"refund_policy"`
 	RefundPolicyDisclosure       string `form:"refund_policy_disclosure"`
-	RefundRefusalReason          string `form:"refund_refusal_explanation"`
+	RefundRefusalExplanation     string `form:"refund_refusal_explanation"`
 	ServiceDate                  string `form:"service_date"`
-	ServiceDoc                   string `form:"service_documentation"`
+	ServiceDocumentation         string `form:"service_documentation"`
 	ShippingAddress              string `form:"shipping_address"`
 	ShippingCarrier              string `form:"shipping_carrier"`
 	ShippingDate                 string `form:"shipping_date"`
-	ShippingDoc                  string `form:"shipping_documentation"`
-	ShippingTracking             string `form:"shipping_tracking_number"`
+	ShippingDocumentation        string `form:"shipping_documentation"`
+	ShippingTrackingNumber       string `form:"shipping_tracking_number"`
 	UncategorizedFile            string `form:"uncategorized_file"`
 	UncategorizedText            string `form:"uncategorized_text"`
 }
@@ -67,34 +67,34 @@ type DisputeListParams struct {
 // Dispute is the resource representing a Stripe dispute.
 // For more details see https://stripe.com/docs/api#disputes.
 type Dispute struct {
-	Amount          uint64            `json:"amount"`
-	Charge          string            `json:"charge"`
-	Created         int64             `json:"created"`
-	Currency        Currency          `json:"currency"`
-	Evidence        *DisputeEvidence  `json:"evidence"`
-	EvidenceDetails *EvidenceDetails  `json:"evidence_details"`
-	ID              string            `json:"id"`
-	Live            bool              `json:"livemode"`
-	Meta            map[string]string `json:"metadata"`
-	Reason          DisputeReason     `json:"reason"`
-	Refundable      bool              `json:"is_charge_refundable"`
-	Status          DisputeStatus     `json:"status"`
-	Transactions    []*Transaction    `json:"balance_transactions"`
+	Amount              uint64                `json:"amount"`
+	BalanceTransactions []*BalanceTransaction `json:"balance_transactions"`
+	Charge              *Charge               `json:"charge"`
+	Created             int64                 `json:"created"`
+	Currency            Currency              `json:"currency"`
+	Evidence            *DisputeEvidence      `json:"evidence"`
+	EvidenceDetails     *EvidenceDetails      `json:"evidence_details"`
+	ID                  string                `json:"id"`
+	IsChargeRefundable  bool                  `json:"is_charge_refundable"`
+	Livemode            bool                  `json:"livemode"`
+	Metadata            map[string]string     `json:"metadata"`
+	Reason              DisputeReason         `json:"reason"`
+	Status              DisputeStatus         `json:"status"`
 }
 
 // DisputeList is a list of disputes as retrieved from a list endpoint.
 type DisputeList struct {
 	ListMeta
-	Values []*Dispute `json:"data"`
+	Data []*Dispute `json:"data"`
 }
 
 // EvidenceDetails is the structure representing more details about
 // the dispute.
 type EvidenceDetails struct {
-	Count       int   `json:"submission_count"`
-	DueDate     int64 `json:"due_by"`
-	HasEvidence bool  `json:"has_evidence"`
-	PastDue     bool  `json:"past_due"`
+	DueBy           int64 `json:"due_by"`
+	HasEvidence     bool  `json:"has_evidence"`
+	PastDue         bool  `json:"past_due"`
+	SubmissionCount int   `json:"submission_count"`
 }
 
 // DisputeEvidence is the structure that contains various details about
@@ -102,43 +102,43 @@ type EvidenceDetails struct {
 // Almost all fields are strings since there structures (i.e. address)
 // do not typically get parsed by anyone and are thus presented as-received.
 type DisputeEvidence struct {
-	ActivityLog                  string `json:"access_activity_log"`
+	AccessActivityLog            string `json:"access_activity_log"`
 	BillingAddress               string `json:"billing_address"`
 	CancellationPolicy           *File  `json:"cancellation_policy"`
 	CancellationPolicyDisclosure string `json:"cancellation_policy_disclosure"`
 	CancellationRebuttal         string `json:"cancellation_rebuttal"`
-	CustomerComm                 *File  `json:"customer_communication"`
-	CustomerEmail                string `json:"customer_email_address"`
-	CustomerIP                   string `json:"customer_purchase_ip"`
+	CustomerCommunication        *File  `json:"customer_communication"`
+	CustomerEmailAddress         string `json:"customer_email_address"`
 	CustomerName                 string `json:"customer_name"`
-	CustomerSig                  *File  `json:"customer_signature"`
-	DuplicateCharge              string `json:"duplicate_charge_id"`
-	DuplicateChargeDoc           *File  `json:"duplicate_charge_documentation"`
-	DuplicateChargeReason        string `json:"duplicate_charge_explanation"`
-	ProductDesc                  string `json:"product_description"`
+	CustomerPurchaseIP           string `json:"customer_purchase_ip"`
+	CustomerSignature            *File  `json:"customer_signature"`
+	DuplicateChargeDocumentation *File  `json:"duplicate_charge_documentation"`
+	DuplicateChargeExplanation   string `json:"duplicate_charge_explanation"`
+	DuplicateChargeID            string `json:"duplicate_charge_id"`
+	ProductDescription           string `json:"product_description"`
 	Receipt                      *File  `json:"receipt"`
 	RefundPolicy                 *File  `json:"refund_policy"`
 	RefundPolicyDisclosure       string `json:"refund_policy_disclosure"`
-	RefundRefusalReason          string `json:"refund_refusal_explanation"`
+	RefundRefusalExplanation     string `json:"refund_refusal_explanation"`
 	ServiceDate                  string `json:"service_date"`
-	ServiceDoc                   *File  `json:"service_documentation"`
+	ServiceDocumentation         *File  `json:"service_documentation"`
 	ShippingAddress              string `json:"shipping_address"`
 	ShippingCarrier              string `json:"shipping_carrier"`
 	ShippingDate                 string `json:"shipping_date"`
-	ShippingDoc                  *File  `json:"shipping_documentation"`
-	ShippingTracking             string `json:"shipping_tracking_number"`
+	ShippingDocumentation        *File  `json:"shipping_documentation"`
+	ShippingTrackingNumber       string `json:"shipping_tracking_number"`
 	UncategorizedFile            *File  `json:"uncategorized_file"`
 	UncategorizedText            string `json:"uncategorized_text"`
 }
 
 // File represents a link to downloadable content.
 type File struct {
-	Created int64  `json:"created"`
-	ID      string `json:"id"`
-	Mime    string `json:"mime_type"`
-	Purpose string `json:"purpose"`
-	Size    int    `json:"size"`
-	URL     string `json:"url"`
+	Created  int64  `json:"created"`
+	ID       string `json:"id"`
+	MIMEType string `json:"mime_type"`
+	Purpose  string `json:"purpose"`
+	Size     int    `json:"size"`
+	URL      string `json:"url"`
 }
 
 // UnmarshalJSON handles deserialization of a Dispute.

--- a/dispute.go
+++ b/dispute.go
@@ -21,7 +21,7 @@ type DisputeStatus string
 type DisputeParams struct {
 	Params   `form:"*"`
 	Evidence *DisputeEvidenceParams `form:"evidence"`
-	NoSubmit bool                   `form:"submit,invert"`
+	Submit   *bool                  `form:"submit"`
 }
 
 // DisputeEvidenceParams is the set of parameters that can be used when submitting

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -8,23 +8,23 @@ import (
 )
 
 const (
-	Duplicate    stripe.DisputeReason = "duplicate"
-	Fraudulent   stripe.DisputeReason = "fraudulent"
-	SubCanceled  stripe.DisputeReason = "subscription_canceled"
-	Unacceptable stripe.DisputeReason = "product_unacceptable"
-	NotReceived  stripe.DisputeReason = "product_not_received"
-	Unrecognized stripe.DisputeReason = "unrecognized"
-	Credit       stripe.DisputeReason = "credit_not_processed"
-	General      stripe.DisputeReason = "general"
+	CreditNotProcessed   stripe.DisputeReason = "credit_not_processed"
+	Duplicate            stripe.DisputeReason = "duplicate"
+	Fraudulent           stripe.DisputeReason = "fraudulent"
+	General              stripe.DisputeReason = "general"
+	ProductNotReceived   stripe.DisputeReason = "product_not_received"
+	ProductUnacceptable  stripe.DisputeReason = "product_unacceptable"
+	SubscriptionCanceled stripe.DisputeReason = "subscription_canceled"
+	Unrecognized         stripe.DisputeReason = "unrecognized"
 
-	Won             stripe.DisputeStatus = "won"
-	Lost            stripe.DisputeStatus = "lost"
-	Response        stripe.DisputeStatus = "needs_response"
-	Review          stripe.DisputeStatus = "under_review"
-	WarningResponse stripe.DisputeStatus = "warning_needs_response"
-	WarningReview   stripe.DisputeStatus = "warning_under_review"
-	ChargeRefunded  stripe.DisputeStatus = "charge_refunded"
-	WarningClosed   stripe.DisputeStatus = "warning_closed"
+	Lost                 stripe.DisputeStatus = "lost"
+	NeedsResponse        stripe.DisputeStatus = "needs_response"
+	ChargeRefunded       stripe.DisputeStatus = "charge_refunded"
+	UnderReview          stripe.DisputeStatus = "under_review"
+	WarningClosed        stripe.DisputeStatus = "warning_closed"
+	WarningNeedsResponse stripe.DisputeStatus = "warning_needs_response"
+	WarningUnderReview   stripe.DisputeStatus = "warning_under_review"
+	Won                  stripe.DisputeStatus = "won"
 )
 
 // Client is used to invoke dispute-related APIs.
@@ -77,8 +77,8 @@ func (c Client) List(params *stripe.DisputeListParams) *Iter {
 		list := &stripe.DisputeList{}
 		err := c.B.Call("GET", "/disputes", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -19,10 +19,10 @@ type EphemeralKey struct {
 		Type string `json:"type"`
 	} `json:"associated_objects"`
 
-	Created int64  `json:"created"`
-	Expires int64  `json:"expires"`
-	ID      string `json:"id"`
-	Live    bool   `json:"livemode"`
+	Created  int64  `json:"created"`
+	Expires  int64  `json:"expires"`
+	ID       string `json:"id"`
+	Livemode bool   `json:"livemode"`
 
 	// RawJSON is provided so that it may be passed back to the frontend
 	// unchanged.  Ephemeral keys are issued on behalf of another client which

--- a/error.go
+++ b/error.go
@@ -17,26 +17,19 @@ const (
 	ErrorTypePermission     ErrorType = "more_permissions_required"
 	ErrorTypeRateLimit      ErrorType = "rate_limit_error"
 
-	CardDeclined  ErrorCode = "card_declined"
-	ExpiredCard   ErrorCode = "expired_card"
-	IncorrectNum  ErrorCode = "incorrect_number"
-	InvalidCvc    ErrorCode = "invalid_cvc"
-	InvalidExpM   ErrorCode = "invalid_expiry_month"
-	InvalidExpY   ErrorCode = "invalid_expiry_year"
-	InvalidNum    ErrorCode = "invalid_number"
-	IncorrectCvc  ErrorCode = "incorrect_cvc"
-	IncorrectZip  ErrorCode = "incorrect_zip"
-	Missing       ErrorCode = "missing"
-	ProcessingErr ErrorCode = "processing_error"
-	RateLimit     ErrorCode = "rate_limit"
-
-	// These additional types are written purely for backward compatibility
-	// (the originals were given quite unsuitable names) and should be
-	// considered deprecated. Remove them on the next major version revision.
-
-	APIErr         ErrorType = ErrorTypeAPI
-	CardErr        ErrorType = ErrorTypeCard
-	InvalidRequest ErrorType = ErrorTypeInvalidRequest
+	ErrorCodeCardDeclined       ErrorCode = "card_declined"
+	ErrorCodeExpiredCard        ErrorCode = "expired_card"
+	ErrorCodeIncorrectCvc       ErrorCode = "incorrect_cvc"
+	ErrorCodeIncorrectZip       ErrorCode = "incorrect_zip"
+	ErrorCodeIncorrectNumber    ErrorCode = "incorrect_number"
+	ErrorCodeInvalidCvc         ErrorCode = "invalid_cvc"
+	ErrorCodeInvalidExpiryMonth ErrorCode = "invalid_expiry_month"
+	ErrorCodeInvalidExpiryYear  ErrorCode = "invalid_expiry_year"
+	ErrorCodeInvalidNumber      ErrorCode = "invalid_number"
+	ErrorCodeInvalidSwipeData   ErrorCode = "invalid_swipe_data"
+	ErrorCodeMissing            ErrorCode = "missing"
+	ErrorCodeProcessingError    ErrorCode = "processing_error"
+	ErrorCodeRateLimit          ErrorCode = "rate_limit"
 )
 
 // Error is the response returned when a call is unsuccessful.

--- a/error_test.go
+++ b/error_test.go
@@ -18,7 +18,7 @@ func TestErrorResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Request-Id", "req_123")
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, `{"error":{"message":"bar","type":"`+InvalidRequest+`"}}`)
+		fmt.Fprintln(w, `{"error":{"message":"bar","type":"`+ErrorTypeInvalidRequest+`"}}`)
 	}))
 	defer ts.Close()
 
@@ -32,7 +32,7 @@ func TestErrorResponse(t *testing.T) {
 	assert.Error(t, err)
 
 	stripeErr := err.(*Error)
-	assert.Equal(t, InvalidRequest, stripeErr.Type)
+	assert.Equal(t, ErrorTypeInvalidRequest, stripeErr.Type)
 	assert.Equal(t, "req_123", stripeErr.RequestID)
 	assert.Equal(t, 401, stripeErr.HTTPStatusCode)
 }

--- a/event.go
+++ b/event.go
@@ -9,14 +9,14 @@ import (
 // Event is the resource representing a Stripe event.
 // For more details see https://stripe.com/docs/api#events.
 type Event struct {
-	Account  string        `json:"account"`
-	Created  int64         `json:"created"`
-	Data     *EventData    `json:"data"`
-	ID       string        `json:"id"`
-	Live     bool          `json:"livemode"`
-	Request  *EventRequest `json:"request"`
-	Type     string        `json:"type"`
-	Webhooks uint64        `json:"pending_webhooks"`
+	Account         string        `json:"account"`
+	Created         int64         `json:"created"`
+	Data            *EventData    `json:"data"`
+	ID              string        `json:"id"`
+	Livemode        bool          `json:"livemode"`
+	PendingWebhooks uint64        `json:"pending_webhooks"`
+	Request         *EventRequest `json:"request"`
+	Type            string        `json:"type"`
 }
 
 // EventRequest contains information on a request that created an event.
@@ -33,15 +33,15 @@ type EventRequest struct {
 
 // EventData is the unmarshalled object as a map.
 type EventData struct {
-	Obj  map[string]interface{}
-	Prev map[string]interface{} `json:"previous_attributes"`
-	Raw  json.RawMessage        `json:"object"`
+	Object             map[string]interface{}
+	PreviousAttributes map[string]interface{} `json:"previous_attributes"`
+	Raw                json.RawMessage        `json:"object"`
 }
 
 // EventList is a list of events as retrieved from a list endpoint.
 type EventList struct {
 	ListMeta
-	Values []*Event `json:"data"`
+	Data []*Event `json:"data"`
 }
 
 // EventListParams is the set of parameters that can be used when listing events.
@@ -54,14 +54,14 @@ type EventListParams struct {
 	Types        []string          `form:"types"`
 }
 
-// GetObjValue returns the value from the e.Data.Obj bag based on the keys hierarchy.
-func (e *Event) GetObjValue(keys ...string) string {
-	return getValue(e.Data.Obj, keys)
+// GetObjectValue returns the value from the e.Data.Object bag based on the keys hierarchy.
+func (e *Event) GetObjectValue(keys ...string) string {
+	return getValue(e.Data.Object, keys)
 }
 
-// GetPrevValue returns the value from the e.Data.Prev bag based on the keys hierarchy.
-func (e *Event) GetPrevValue(keys ...string) string {
-	return getValue(e.Data.Prev, keys)
+// GetPreviousValue returns the value from the e.Data.Prev bag based on the keys hierarchy.
+func (e *Event) GetPreviousValue(keys ...string) string {
+	return getValue(e.Data.PreviousAttributes, keys)
 }
 
 // UnmarshalJSON handles deserialization of the EventData.
@@ -75,7 +75,7 @@ func (e *EventData) UnmarshalJSON(data []byte) error {
 	}
 
 	*e = EventData(ee)
-	return json.Unmarshal(e.Raw, &e.Obj)
+	return json.Unmarshal(e.Raw, &e.Object)
 }
 
 // getValue returns the value from the m map based on the keys.

--- a/event/client.go
+++ b/event/client.go
@@ -46,8 +46,8 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 		list := &stripe.EventList{}
 		err := c.B.Call("GET", "/events", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/event_test.go
+++ b/event_test.go
@@ -6,10 +6,10 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestGetObjValue(t *testing.T) {
+func TestGetObjectValue(t *testing.T) {
 	event := &Event{
 		Data: &EventData{
-			Obj: map[string]interface{}{
+			Object: map[string]interface{}{
 				"top_level_key": "top_level",
 				"integer_key":   123,
 				"map": map[string]interface{}{
@@ -29,27 +29,27 @@ func TestGetObjValue(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "top_level", event.GetObjValue("top_level_key"))
+	assert.Equal(t, "top_level", event.GetObjectValue("top_level_key"))
 
 	// Check that it coerces non-string values into strings (this behavior is
 	// somewhat questionable, but I'm going with how it already works)
-	assert.Equal(t, "123", event.GetObjValue("integer_key"))
+	assert.Equal(t, "123", event.GetObjectValue("integer_key"))
 
-	assert.Equal(t, "nested", event.GetObjValue("map", "nested_key"))
-	assert.Equal(t, "index-1", event.GetObjValue("slice", "1"))
+	assert.Equal(t, "nested", event.GetObjectValue("map", "nested_key"))
+	assert.Equal(t, "index-1", event.GetObjectValue("slice", "1"))
 	assert.Equal(t, "slice_nested",
-		event.GetObjValue("slice_of_maps", "0", "slice_nested_key"))
+		event.GetObjectValue("slice_of_maps", "0", "slice_nested_key"))
 
 	// By design a `nil` just returns an empty string
-	assert.Equal(t, "", event.GetObjValue("bad_key"))
+	assert.Equal(t, "", event.GetObjectValue("bad_key"))
 
 	// Panic conditions. Usually the function tries to just return a value is
 	// fairly forgiving, but it does panic under certain obviously impossible
 	// cases.
 	assert.PanicsWithValue(t, "Cannot access nested slice element with non-integer key: string_key", func() {
-		event.GetObjValue("slice", "string_key")
+		event.GetObjectValue("slice", "string_key")
 	})
 	assert.PanicsWithValue(t, "Cannot descend into non-map non-slice object with key: bad_key", func() {
-		event.GetObjValue("top_level_key", "bad_key")
+		event.GetObjectValue("top_level_key", "bad_key")
 	})
 }

--- a/example_test.go
+++ b/example_test.go
@@ -19,7 +19,7 @@ func ExampleCharge_new() {
 		Currency: currency.USD,
 	}
 	params.SetSource("tok_visa")
-	params.AddMeta("key", "value")
+	params.AddMetadata("key", "value")
 
 	ch, err := charge.New(params)
 
@@ -34,9 +34,9 @@ func ExampleCharge_get() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.ChargeParams{}
-	params.Expand("customer")
-	params.Expand("application")
-	params.Expand("balance_transaction")
+	params.AddExpand("customer")
+	params.AddExpand("application")
+	params.AddExpand("balance_transaction")
 
 	ch, err := charge.Get("ch_example_id", params)
 
@@ -55,7 +55,7 @@ func ExampleInvoice_update() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.InvoiceParams{
-		Desc: "updated description",
+		Description: "updated description",
 	}
 
 	inv, err := invoice.Update("sub_example_id", params)
@@ -64,7 +64,7 @@ func ExampleInvoice_update() {
 		log.Fatal(err)
 	}
 
-	log.Printf("%v\n", inv.Desc)
+	log.Printf("%v\n", inv.Description)
 }
 
 func ExampleCustomer_delete() {

--- a/fee.go
+++ b/fee.go
@@ -2,55 +2,54 @@ package stripe
 
 import "encoding/json"
 
-// FeeParams is the set of parameters that can be used when refunding an application fee.
+// ApplicationFeeParams is the set of parameters that can be used when refunding an application fee.
 // For more details see https://stripe.com/docs/api#refund_application_fee.
-type FeeParams struct {
+type ApplicationFeeParams struct {
 	Params `form:"*"`
-	Amount uint64
 }
 
-// FeeListParams is the set of parameters that can be used when listing application fees.
+// ApplicationFeeListParams is the set of parameters that can be used when listing application fees.
 // For more details see https://stripe.com/docs/api#list_application_fees.
-type FeeListParams struct {
+type ApplicationFeeListParams struct {
 	ListParams   `form:"*"`
 	Charge       string            `form:"charge"`
 	Created      int64             `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 
-// Fee is the resource representing a Stripe application fee.
+// ApplicationFee is the resource representing a Stripe application fee.
 // For more details see https://stripe.com/docs/api#application_fees.
-type Fee struct {
-	Account                *Account       `json:"account"`
-	Amount                 uint64         `json:"amount"`
-	AmountRefunded         uint64         `json:"amount_refunded"`
-	App                    string         `json:"application"`
-	Charge                 *Charge        `json:"charge"`
-	Created                int64          `json:"created"`
-	Currency               Currency       `json:"currency"`
-	ID                     string         `json:"id"`
-	Live                   bool           `json:"livemode"`
-	OriginatingTransaction *Charge        `json:"originating_transaction"`
-	Refunded               bool           `json:"refunded"`
-	Refunds                *FeeRefundList `json:"refunds"`
-	Tx                     *Transaction   `json:"balance_transaction"`
+type ApplicationFee struct {
+	Account                *Account                  `json:"account"`
+	Amount                 uint64                    `json:"amount"`
+	AmountRefunded         uint64                    `json:"amount_refunded"`
+	Application            string                    `json:"application"`
+	BalanceTransaction     *BalanceTransaction       `json:"balance_transaction"`
+	Charge                 *Charge                   `json:"charge"`
+	Created                int64                     `json:"created"`
+	Currency               Currency                  `json:"currency"`
+	ID                     string                    `json:"id"`
+	Livemode               bool                      `json:"livemode"`
+	OriginatingTransaction *Charge                   `json:"originating_transaction"`
+	Refunded               bool                      `json:"refunded"`
+	Refunds                *ApplicationFeeRefundList `json:"refunds"`
 }
 
-// FeeList is a list of fees as retrieved from a list endpoint.
-type FeeList struct {
+//ApplicationFeeList is a list of application fees as retrieved from a list endpoint.
+type ApplicationFeeList struct {
 	ListMeta
-	Values []*Fee `json:"data"`
+	Data []*ApplicationFee `json:"data"`
 }
 
-// UnmarshalJSON handles deserialization of a Fee.
+// UnmarshalJSON handles deserialization of an ApplicationFee.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (f *Fee) UnmarshalJSON(data []byte) error {
-	type appfee Fee
+func (f *ApplicationFee) UnmarshalJSON(data []byte) error {
+	type appfee ApplicationFee
 	var ff appfee
 	err := json.Unmarshal(data, &ff)
 	if err == nil {
-		*f = Fee(ff)
+		*f = ApplicationFee(ff)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		f.ID = string(data[1 : len(data)-1])

--- a/fee/client.go
+++ b/fee/client.go
@@ -16,11 +16,11 @@ type Client struct {
 
 // Get returns the details of an application fee.
 // For more details see https://stripe.com/docs/api#retrieve_application_fee.
-func Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
+func Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
+func (c Client) Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -30,7 +30,7 @@ func (c Client) Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
 		form.AppendTo(body, params)
 	}
 
-	fee := &stripe.Fee{}
+	fee := &stripe.ApplicationFee{}
 	err := c.B.Call("GET", fmt.Sprintf("application_fees/%v", id), c.Key, body, commonParams, fee)
 
 	return fee, err
@@ -38,11 +38,11 @@ func (c Client) Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
 
 // List returns a list of application fees.
 // For more details see https://stripe.com/docs/api#list_application_fees.
-func List(params *stripe.FeeListParams) *Iter {
+func List(params *stripe.ApplicationFeeListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.FeeListParams) *Iter {
+func (c Client) List(params *stripe.ApplicationFeeListParams) *Iter {
 	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -55,11 +55,11 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.FeeList{}
+		list := &stripe.ApplicationFeeList{}
 		err := c.B.Call("GET", "/application_fees", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -67,17 +67,17 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Fees.
+// Iter is an iterator for lists of ApplicationFees.
 // The embedded Iter carries methods with it;
 // see its documentation for details.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Fee returns the most recent Fee
+// ApplicationFee returns the most recent ApplicationFee
 // visited by a call to Next.
-func (i *Iter) Fee() *stripe.Fee {
-	return i.Current().(*stripe.Fee)
+func (i *Iter) ApplicationFee() *stripe.ApplicationFee {
+	return i.Current().(*stripe.ApplicationFee)
 }
 
 func getC() Client {

--- a/fee/client_test.go
+++ b/fee/client_test.go
@@ -8,17 +8,17 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestFeeGet(t *testing.T) {
+func TestApplicationFeeGet(t *testing.T) {
 	fee, err := Get("fee_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, fee)
 }
 
-func TestFeeList(t *testing.T) {
-	i := List(&stripe.FeeListParams{})
+func TestApplicationFeeList(t *testing.T) {
+	i := List(&stripe.ApplicationFeeListParams{})
 
 	// Verify that we can get at least one fee
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.Fee())
+	assert.NotNil(t, i.ApplicationFee())
 }

--- a/feerefund.go
+++ b/feerefund.go
@@ -4,48 +4,48 @@ import (
 	"encoding/json"
 )
 
-// FeeRefundParams is the set of parameters that can be used when refunding a fee.
+// ApplicationFeeRefundParams is the set of parameters that can be used when refunding an application fee.
 // For more details see https://stripe.com/docs/api#fee_refund.
-type FeeRefundParams struct {
-	Params `form:"*"`
-	Amount uint64 `form:"amount"`
-	Fee    string `form:"-"` // Included in the URL
+type ApplicationFeeRefundParams struct {
+	Params         `form:"*"`
+	Amount         uint64 `form:"amount"`
+	ApplicationFee string `form:"-"` // Included in the URL
 }
 
-// FeeRefundListParams is the set of parameters that can be used when listing fee refunds.
+// ApplicationFeeRefundListParams is the set of parameters that can be used when listing application fee refunds.
 // For more details see https://stripe.com/docs/api#list_fee_refunds.
-type FeeRefundListParams struct {
-	ListParams `form:"*"`
-	Fee        string `form:"-"` // Included in the URL
+type ApplicationFeeRefundListParams struct {
+	ListParams     `form:"*"`
+	ApplicationFee string `form:"-"` // Included in the URL
 }
 
-// FeeRefund is the resource representing a Stripe fee refund.
+// ApplicationFeeRefund is the resource representing a Stripe application fee refund.
 // For more details see https://stripe.com/docs/api#fee_refunds.
-type FeeRefund struct {
-	Amount   uint64            `json:"amount"`
-	Created  int64             `json:"created"`
-	Currency Currency          `json:"currency"`
-	Fee      string            `json:"fee"`
-	ID       string            `json:"id"`
-	Meta     map[string]string `json:"metadata"`
-	Tx       *Transaction      `json:"balance_transaction"`
+type ApplicationFeeRefund struct {
+	Amount             uint64              `json:"amount"`
+	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
+	Created            int64               `json:"created"`
+	Currency           Currency            `json:"currency"`
+	Fee                string              `json:"fee"`
+	ID                 string              `json:"id"`
+	Metadata           map[string]string   `json:"metadata"`
 }
 
-// FeeRefundList is a list object for fee refunds.
-type FeeRefundList struct {
+// ApplicationFeeRefundList is a list object for application fee refunds.
+type ApplicationFeeRefundList struct {
 	ListMeta
-	Values []*FeeRefund `json:"data"`
+	Data []*ApplicationFeeRefund `json:"data"`
 }
 
-// UnmarshalJSON handles deserialization of a FeeRefund.
+// UnmarshalJSON handles deserialization of a ApplicationFeeRefund.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (f *FeeRefund) UnmarshalJSON(data []byte) error {
-	type feerefund FeeRefund
+func (f *ApplicationFeeRefund) UnmarshalJSON(data []byte) error {
+	type feerefund ApplicationFeeRefund
 	var ff feerefund
 	err := json.Unmarshal(data, &ff)
 	if err == nil {
-		*f = FeeRefund(ff)
+		*f = ApplicationFeeRefund(ff)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		f.ID = string(data[1 : len(data)-1])

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -16,80 +16,80 @@ type Client struct {
 
 // New refunds the application fee collected.
 // For more details see https://stripe.com/docs/api#refund_application_fee.
-func New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func New(params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	return getC().New(params)
 }
 
-func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func (c Client) New(params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.Fee == "" {
-		return nil, fmt.Errorf("params.Fee must be set")
+	if params.ApplicationFee == "" {
+		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", params.Fee), c.Key, body, &params.Params, refund)
+	refund := &stripe.ApplicationFeeRefund{}
+	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", params.ApplicationFee), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
 
 // Get returns the details of a fee refund.
 // For more details see https://stripe.com/docs/api#retrieve_fee_refund.
-func Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func Get(id string, params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func (c Client) Get(id string, params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.Fee == "" {
-		return nil, fmt.Errorf("params.Fee must be set")
+	if params.ApplicationFee == "" {
+		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", params.Fee, id), c.Key, body, &params.Params, refund)
+	refund := &stripe.ApplicationFeeRefund{}
+	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", params.ApplicationFee, id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
 
 // Update updates a refund's properties.
 // For more details see https://stripe.com/docs/api#update_refund.
-func Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func Update(id string, params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	return getC().Update(id, params)
 }
 
-func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func (c Client) Update(id string, params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.Fee == "" {
-		return nil, fmt.Errorf("params.Fee must be set")
+	if params.ApplicationFee == "" {
+		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", params.Fee, id), c.Key, body, &params.Params, refund)
+	refund := &stripe.ApplicationFeeRefund{}
+	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", params.ApplicationFee, id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
 
 // List returns a list of fee refunds.
 // For more details see https://stripe.com/docs/api#list_fee_refunds.
-func List(params *stripe.FeeRefundListParams) *Iter {
+func List(params *stripe.ApplicationFeeRefundListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
+func (c Client) List(params *stripe.ApplicationFeeRefundListParams) *Iter {
 	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -99,11 +99,11 @@ func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.FeeRefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.Fee), c.Key, b, p, list)
+		list := &stripe.ApplicationFeeRefundList{}
+		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.ApplicationFee), c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -111,17 +111,17 @@ func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of FeeRefunds.
+// Iter is an iterator for lists of ApplicationFeeRefunds.
 // The embedded Iter carries methods with it;
 // see its documentation for details.
 type Iter struct {
 	*stripe.Iter
 }
 
-// FeeRefund returns the most recent FeeRefund
+// ApplicationFeeRefund returns the most recent ApplicationFeeRefund
 // visited by a call to Next.
-func (i *Iter) FeeRefund() *stripe.FeeRefund {
-	return i.Current().(*stripe.FeeRefund)
+func (i *Iter) ApplicationFeeRefund() *stripe.ApplicationFeeRefund {
+	return i.Current().(*stripe.ApplicationFeeRefund)
 }
 
 func getC() Client {

--- a/feerefund/client_test.go
+++ b/feerefund/client_test.go
@@ -8,38 +8,38 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestFeeRefundGet(t *testing.T) {
-	refund, err := Get("fr_123", &stripe.FeeRefundParams{
-		Fee: "fee_123",
+func TestApplicationFeeRefundGet(t *testing.T) {
+	refund, err := Get("fr_123", &stripe.ApplicationFeeRefundParams{
+		ApplicationFee: "fee_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)
 }
 
-func TestFeeRefundList(t *testing.T) {
-	i := List(&stripe.FeeRefundListParams{
-		Fee: "fee_123",
+func TestApplicationFeeRefundList(t *testing.T) {
+	i := List(&stripe.ApplicationFeeRefundListParams{
+		ApplicationFee: "fee_123",
 	})
 
 	// Verify that we can get at least one refund
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.FeeRefund())
+	assert.NotNil(t, i.ApplicationFeeRefund())
 }
 
-func TestFeeRefundNew(t *testing.T) {
-	refund, err := New(&stripe.FeeRefundParams{
-		Fee: "fee_123",
+func TestApplicationFeeRefundNew(t *testing.T) {
+	refund, err := New(&stripe.ApplicationFeeRefundParams{
+		ApplicationFee: "fee_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)
 }
 
-func TestFeeRefundUpdate(t *testing.T) {
-	refund, err := Update("fr_123", &stripe.FeeRefundParams{
-		Fee: "fee_123",
+func TestApplicationFeeRefundUpdate(t *testing.T) {
+	refund, err := Update("fr_123", &stripe.ApplicationFeeRefundParams{
+		ApplicationFee: "fee_123",
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/fileupload.go
+++ b/fileupload.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"mime/multipart"
-	"os"
 	"path/filepath"
 )
 
@@ -13,10 +12,6 @@ import (
 // For more details see https://stripe.com/docs/api#create_file_upload.
 type FileUploadParams struct {
 	Params `form:"*"`
-
-	// File is a deprecated form of FileReader and Filename that will do the same thing, but
-	// allows referencing a file directly. Please prefer the use of FileReader and Filename instead.
-	File *os.File
 
 	// FileReader is a reader with the contents of the file that should be uploaded.
 	FileReader io.Reader
@@ -54,7 +49,7 @@ type FileUpload struct {
 // FileUploadList is a list of file uploads as retrieved from a list endpoint.
 type FileUploadList struct {
 	ListMeta
-	Values []*FileUpload `json:"data"`
+	Data []*FileUpload `json:"data"`
 }
 
 // AppendDetails adds the file upload details to an io.ReadWriter. It returns
@@ -80,16 +75,6 @@ func (f *FileUploadParams) AppendDetails(body io.ReadWriter) (string, error) {
 		}
 
 		_, err = io.Copy(part, f.FileReader)
-		if err != nil {
-			return "", err
-		}
-	} else if f.File != nil {
-		part, err := writer.CreateFormFile("file", filepath.Base(f.File.Name()))
-		if err != nil {
-			return "", err
-		}
-
-		_, err = io.Copy(part, f.File)
 		if err != nil {
 			return "", err
 		}

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -88,8 +88,8 @@ func (c Client) List(params *stripe.FileUploadListParams) *Iter {
 		list := &stripe.FileUploadList{}
 		err := c.B.Call("GET", "/files", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/fileupload/client_test.go
+++ b/fileupload/client_test.go
@@ -62,8 +62,9 @@ func TestFileUploadList(t *testing.T) {
 	}
 
 	uploadParams := &stripe.FileUploadParams{
-		Purpose: "dispute_evidence",
-		File:    f,
+		Purpose:    "dispute_evidence",
+		FileReader: f,
+		Filename:   f.Name(),
 	}
 
 	_, err = New(uploadParams)

--- a/form/form.go
+++ b/form/form.go
@@ -59,12 +59,6 @@ type formOptions struct {
 	// empty string is a string's zero value and wouldn't normally be encoded.
 	Empty bool
 
-	// Invert indicates that a boolean field's value should be inverted. False
-	// is the zero value for a boolean so it's convention in the library to
-	// specify a `No*` field to allow a false to be passed to the API. These
-	// fields should be annotated with `invert`.
-	Invert bool
-
 	// Zero indicates a field that's specifically defined to workaround the
 	// fact because 0 is the "zero value" of all int/float types, we can't
 	// properly encode an explicit 0. It indicates that an explicit zero should
@@ -159,8 +153,6 @@ func boolEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero 
 		switch {
 		case options.Empty:
 			values.Add(FormatKey(keyParts), "")
-		case options.Invert:
-			values.Add(FormatKey(keyParts), strconv.FormatBool(false))
 		case options.Zero:
 			values.Add(FormatKey(keyParts), "0")
 		}
@@ -387,11 +379,11 @@ func makeStructEncoder(t reflect.Type) *structEncoder {
 		fldKind := fldTyp.Kind()
 
 		if Strict && options != nil &&
-			(options.Empty || options.Invert || options.Zero) &&
+			(options.Empty || options.Zero) &&
 			fldKind != reflect.Bool {
 
 			panic(fmt.Sprintf(
-				"Cannot specify `empty`, `invert`, or `zero` for non-boolean field; on: %s/%s",
+				"Cannot specify `empty`, or `zero` for non-boolean field; on: %s/%s",
 				t.Name(), reflectField.Name,
 			))
 		}
@@ -467,12 +459,6 @@ func parseTag(tag string) (string, *formOptions) {
 				options = &formOptions{}
 			}
 			options.IndexedArray = true
-
-		case "invert":
-			if options == nil {
-				options = &formOptions{}
-			}
-			options.Invert = true
 
 		case "zero":
 			if options == nil {

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -51,8 +51,6 @@ type testStruct struct {
 	Int64    int64  `form:"int64"`
 	Int64Ptr *int64 `form:"int64_ptr"`
 
-	Inverted bool `form:"inverted,invert"`
-
 	Map map[string]interface{} `form:"map"`
 
 	Slice    []string  `form:"slice"`
@@ -217,8 +215,6 @@ func TestAppendTo(t *testing.T) {
 		{"int64_ptr", &testStruct{Int64Ptr: &int64Val}, "123"},
 		{"int64_ptr", &testStruct{Int64Ptr: &int64Val0}, "0"},
 		{"int64_ptr", &testStruct{}, ""},
-
-		{"inverted", &testStruct{Inverted: true}, "false"},
 
 		// Tests map
 		{

--- a/invoice.go
+++ b/invoice.go
@@ -14,30 +14,26 @@ type InvoiceBilling string
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
 	Params              `form:"*"`
-	ApplicationFee      uint64         `form:"application_fee"`
-	ApplicationFeeZero  bool           `form:"application_fee,zero"`
+	ApplicationFee      *uint64        `form:"application_fee"`
 	Billing             InvoiceBilling `form:"billing"`
-	Closed              bool           `form:"closed"`
+	Closed              *bool          `form:"closed"`
 	Customer            string         `form:"customer"`
 	DaysUntilDue        uint64         `form:"days_until_due"`
 	Description         string         `form:"description"`
 	DueDate             int64          `form:"due_date"`
 	Forgiven            bool           `form:"forgiven"`
-	NoClosed            bool           `form:"closed,invert"`
 	Paid                bool           `form:"paid"`
 	StatementDescriptor string         `form:"statement_descriptor"`
 	Subscription        string         `form:"subscription"`
-	TaxPercent          float64        `form:"tax_percent"`
-	TaxPercentZero      bool           `form:"tax_percent,zero"`
+	TaxPercent          *float64       `form:"tax_percent"`
 
 	// These are all for exclusive use by GetNext.
 
 	SubscriptionItems         []*SubscriptionItemsParams `form:"subscription_items,indexed"`
-	SubscriptionNoProrate     bool                       `form:"subscription_prorate,invert"`
 	SubscriptionPlan          string                     `form:"subscription_plan"`
+	SubscriptionProrate       *bool                      `form:"subscription_prorate"`
 	SubscriptionProrationDate int64                      `form:"subscription_proration_date"`
-	SubscriptionQuantity      uint64                     `form:"subscription_quantity"`
-	SubscriptionQuantityZero  bool                       `form:"subscription_quantity,zero"`
+	SubscriptionQuantity      *uint64                    `form:"subscription_quantity"`
 	SubscriptionTrialEnd      int64                      `form:"subscription_trial_end"`
 }
 

--- a/invoice.go
+++ b/invoice.go
@@ -13,44 +13,44 @@ type InvoiceBilling string
 // InvoiceParams is the set of parameters that can be used when creating or updating an invoice.
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
-	Params         `form:"*"`
-	Billing        InvoiceBilling `form:"billing"`
-	Closed         bool           `form:"closed"`
-	Customer       string         `form:"customer"`
-	DaysUntilDue   uint64         `form:"days_until_due"`
-	Desc           string         `form:"description"`
-	DueDate        int64          `form:"due_date"`
-	Fee            uint64         `form:"application_fee"`
-	FeeZero        bool           `form:"application_fee,zero"`
-	Forgive        bool           `form:"forgiven"`
-	NoClosed       bool           `form:"closed,invert"`
-	Paid           bool           `form:"paid"`
-	Statement      string         `form:"statement_descriptor"`
-	Sub            string         `form:"subscription"`
-	TaxPercent     float64        `form:"tax_percent"`
-	TaxPercentZero bool           `form:"tax_percent,zero"`
+	Params              `form:"*"`
+	ApplicationFee      uint64         `form:"application_fee"`
+	ApplicationFeeZero  bool           `form:"application_fee,zero"`
+	Billing             InvoiceBilling `form:"billing"`
+	Closed              bool           `form:"closed"`
+	Customer            string         `form:"customer"`
+	DaysUntilDue        uint64         `form:"days_until_due"`
+	Description         string         `form:"description"`
+	DueDate             int64          `form:"due_date"`
+	Forgiven            bool           `form:"forgiven"`
+	NoClosed            bool           `form:"closed,invert"`
+	Paid                bool           `form:"paid"`
+	StatementDescriptor string         `form:"statement_descriptor"`
+	Subscription        string         `form:"subscription"`
+	TaxPercent          float64        `form:"tax_percent"`
+	TaxPercentZero      bool           `form:"tax_percent,zero"`
 
 	// These are all for exclusive use by GetNext.
 
-	SubItems         []*SubItemsParams `form:"subscription_items,indexed"`
-	SubNoProrate     bool              `form:"subscription_prorate,invert"`
-	SubPlan          string            `form:"subscription_plan"`
-	SubProrationDate int64             `form:"subscription_proration_date"`
-	SubQuantity      uint64            `form:"subscription_quantity"`
-	SubQuantityZero  bool              `form:"subscription_quantity,zero"`
-	SubTrialEnd      int64             `form:"subscription_trial_end"`
+	SubscriptionItems         []*SubscriptionItemsParams `form:"subscription_items,indexed"`
+	SubscriptionNoProrate     bool                       `form:"subscription_prorate,invert"`
+	SubscriptionPlan          string                     `form:"subscription_plan"`
+	SubscriptionProrationDate int64                      `form:"subscription_proration_date"`
+	SubscriptionQuantity      uint64                     `form:"subscription_quantity"`
+	SubscriptionQuantityZero  bool                       `form:"subscription_quantity,zero"`
+	SubscriptionTrialEnd      int64                      `form:"subscription_trial_end"`
 }
 
 // InvoiceListParams is the set of parameters that can be used when listing invoices.
 // For more details see https://stripe.com/docs/api#list_customer_invoices.
 type InvoiceListParams struct {
-	ListParams `form:"*"`
-	Billing    InvoiceBilling    `form:"billing"`
-	Customer   string            `form:"customer"`
-	Date       int64             `form:"date"`
-	DateRange  *RangeQueryParams `form:"date"`
-	DueDate    int64             `form:"due_date"`
-	Sub        string            `form:"subscription"`
+	ListParams   `form:"*"`
+	Billing      InvoiceBilling    `form:"billing"`
+	Customer     string            `form:"customer"`
+	Date         int64             `form:"date"`
+	DateRange    *RangeQueryParams `form:"date"`
+	DueDate      int64             `form:"due_date"`
+	Subscription string            `form:"subscription"`
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.
@@ -63,51 +63,51 @@ type InvoiceLineListParams struct {
 	// ID is the invoice ID to list invoice lines for.
 	ID string `form:"-"` // Goes in the URL
 
-	Sub string `form:"subscription"`
+	Subscription string `form:"subscription"`
 }
 
 // Invoice is the resource representing a Stripe invoice.
 // For more details see https://stripe.com/docs/api#invoice_object.
 type Invoice struct {
-	Amount        int64             `json:"amount_due"`
-	Attempted     bool              `json:"attempted"`
-	Attempts      uint64            `json:"attempt_count"`
-	Billing       InvoiceBilling    `json:"billing"`
-	Charge        *Charge           `json:"charge"`
-	Closed        bool              `json:"closed"`
-	Currency      Currency          `json:"currency"`
-	Customer      *Customer         `json:"customer"`
-	Date          int64             `json:"date"`
-	Desc          string            `json:"description"`
-	Discount      *Discount         `json:"discount"`
-	DueDate       int64             `json:"due_date"`
-	End           int64             `json:"period_end"`
-	EndBalance    int64             `json:"ending_balance"`
-	Fee           uint64            `json:"application_fee"`
-	Forgive       bool              `json:"forgiven"`
-	ID            string            `json:"id"`
-	Lines         *InvoiceLineList  `json:"lines"`
-	Live          bool              `json:"livemode"`
-	Meta          map[string]string `json:"metadata"`
-	NextAttempt   int64             `json:"next_payment_attempt"`
-	Number        string            `json:"number"`
-	Paid          bool              `json:"paid"`
-	ReceiptNumber string            `json:"receipt_number"`
-	Start         int64             `json:"period_start"`
-	StartBalance  int64             `json:"starting_balance"`
-	Statement     string            `json:"statement_descriptor"`
-	Sub           string            `json:"subscription"`
-	Subtotal      int64             `json:"subtotal"`
-	Tax           int64             `json:"tax"`
-	TaxPercent    float64           `json:"tax_percent"`
-	Total         int64             `json:"total"`
-	Webhook       int64             `json:"webhooks_delivered_at"`
+	AmountDue           int64             `json:"amount_due"`
+	ApplicationFee      uint64            `json:"application_fee"`
+	AttemptCount        uint64            `json:"attempt_count"`
+	Attempted           bool              `json:"attempted"`
+	Billing             InvoiceBilling    `json:"billing"`
+	Charge              *Charge           `json:"charge"`
+	Closed              bool              `json:"closed"`
+	Currency            Currency          `json:"currency"`
+	Customer            *Customer         `json:"customer"`
+	Date                int64             `json:"date"`
+	Description         string            `json:"description"`
+	Discount            *Discount         `json:"discount"`
+	DueDate             int64             `json:"due_date"`
+	EndingBalance       int64             `json:"ending_balance"`
+	Forgiven            bool              `json:"forgiven"`
+	ID                  string            `json:"id"`
+	Lines               *InvoiceLineList  `json:"lines"`
+	Livemode            bool              `json:"livemode"`
+	Metadata            map[string]string `json:"metadata"`
+	NextPaymentAttempt  int64             `json:"next_payment_attempt"`
+	Number              string            `json:"number"`
+	Paid                bool              `json:"paid"`
+	PeriodEnd           int64             `json:"period_end"`
+	PeriodStart         int64             `json:"period_start"`
+	ReceiptNumber       string            `json:"receipt_number"`
+	StartingBalance     int64             `json:"starting_balance"`
+	StatementDescriptor string            `json:"statement_descriptor"`
+	Subscription        string            `json:"subscription"`
+	Subtotal            int64             `json:"subtotal"`
+	Tax                 int64             `json:"tax"`
+	TaxPercent          float64           `json:"tax_percent"`
+	Total               int64             `json:"total"`
+	WebhooksDeliveredAt int64             `json:"webhooks_delivered_at"`
 }
 
 // InvoiceList is a list of invoices as retrieved from a list endpoint.
 type InvoiceList struct {
 	ListMeta
-	Values []*Invoice `json:"data"`
+	Data []*Invoice `json:"data"`
 }
 
 // InvoiceLine is the resource representing a Stripe invoice line item.
@@ -115,16 +115,16 @@ type InvoiceList struct {
 type InvoiceLine struct {
 	Amount       int64             `json:"amount"`
 	Currency     Currency          `json:"currency"`
-	Desc         string            `json:"description"`
+	Description  string            `json:"description"`
 	Discountable bool              `json:"discountable"`
 	ID           string            `json:"id"`
-	Live         bool              `json:"live_mode"`
-	Meta         map[string]string `json:"metadata"`
+	Livemode     bool              `json:"live_mode"`
+	Metadata     map[string]string `json:"metadata"`
 	Period       *Period           `json:"period"`
 	Plan         *Plan             `json:"plan"`
 	Proration    bool              `json:"proration"`
 	Quantity     int64             `json:"quantity"`
-	Sub          string            `json:"subscription"`
+	Subscription string            `json:"subscription"`
 	Type         InvoiceLineType   `json:"type"`
 }
 
@@ -137,7 +137,7 @@ type Period struct {
 // InvoiceLineList is a list object for invoice line items.
 type InvoiceLineList struct {
 	ListMeta
-	Values []*InvoiceLine `json:"data"`
+	Data []*InvoiceLine `json:"data"`
 }
 
 // InvoicePayParams is the set of parameters that can be used when

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -139,8 +139,8 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 		list := &stripe.InvoiceList{}
 		err := c.B.Call("GET", "/invoices", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -164,8 +164,8 @@ func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 		list := &stripe.InvoiceLineList{}
 		err := c.B.Call("GET", fmt.Sprintf("/invoices/%v/lines", params.ID), c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -52,7 +52,7 @@ func TestInvoicePay(t *testing.T) {
 
 func TestInvoiceUpdate(t *testing.T) {
 	invoice, err := Update("in_123", &stripe.InvoiceParams{
-		Closed: true,
+		Closed: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -5,15 +5,14 @@ import "encoding/json"
 // InvoiceItemParams is the set of parameters that can be used when creating or updating an invoice item.
 // For more details see https://stripe.com/docs/api#create_invoiceitem and https://stripe.com/docs/api#update_invoiceitem.
 type InvoiceItemParams struct {
-	Params         `form:"*"`
-	Amount         int64    `form:"amount"`
-	Currency       Currency `form:"currency"`
-	Customer       string   `form:"customer"`
-	Description    string   `form:"description"`
-	Discountable   bool     `form:"discountable"`
-	Invoice        string   `form:"invoice"`
-	NoDiscountable bool     `form:"discountable,invert"`
-	Subscription   string   `form:"subscription"`
+	Params       `form:"*"`
+	Amount       int64    `form:"amount"`
+	Currency     Currency `form:"currency"`
+	Customer     string   `form:"customer"`
+	Description  string   `form:"description"`
+	Discountable *bool    `form:"discountable"`
+	Invoice      string   `form:"invoice"`
+	Subscription string   `form:"subscription"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -9,11 +9,11 @@ type InvoiceItemParams struct {
 	Amount         int64    `form:"amount"`
 	Currency       Currency `form:"currency"`
 	Customer       string   `form:"customer"`
-	Desc           string   `form:"description"`
+	Description    string   `form:"description"`
 	Discountable   bool     `form:"discountable"`
 	Invoice        string   `form:"invoice"`
 	NoDiscountable bool     `form:"discountable,invert"`
-	Sub            string   `form:"subscription"`
+	Subscription   string   `form:"subscription"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.
@@ -33,23 +33,23 @@ type InvoiceItem struct {
 	Customer     *Customer         `json:"customer"`
 	Date         int64             `json:"date"`
 	Deleted      bool              `json:"deleted"`
-	Desc         string            `json:"description"`
+	Description  string            `json:"description"`
 	Discountable bool              `json:"discountable"`
 	ID           string            `json:"id"`
 	Invoice      *Invoice          `json:"invoice"`
-	Live         bool              `json:"livemode"`
-	Meta         map[string]string `json:"metadata"`
+	Livemode     bool              `json:"livemode"`
+	Metadata     map[string]string `json:"metadata"`
 	Period       *Period           `json:"period"`
 	Plan         *Plan             `json:"plan"`
 	Proration    bool              `json:"proration"`
 	Quantity     int64             `json:"quantity"`
-	Sub          string            `json:"subscription"`
+	Subscription *Subscription     `json:"subscription"`
 }
 
 // InvoiceItemList is a list of invoice items as retrieved from a list endpoint.
 type InvoiceItemList struct {
 	ListMeta
-	Values []*InvoiceItem `json:"data"`
+	Data []*InvoiceItem `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of an InvoiceItem.

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -116,8 +116,8 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 		list := &stripe.InvoiceItemList{}
 		err := c.B.Call("GET", "/invoiceitems", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/invoiceitem/client_test.go
+++ b/invoiceitem/client_test.go
@@ -42,7 +42,7 @@ func TestInvoiceItemNew(t *testing.T) {
 
 func TestInvoiceItemUpdate(t *testing.T) {
 	item, err := Update("ii_123", &stripe.InvoiceItemParams{
-		Desc: "Updated description",
+		Description: "Updated description",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/iter.go
+++ b/iter.go
@@ -50,7 +50,7 @@ func GetIter(params *ListParams, qs *form.Values, query Query) *Iter {
 
 func (it *Iter) getPage() {
 	it.values, it.meta, it.err = it.query(it.qs)
-	if it.params.End != "" {
+	if it.params.EndingBefore != "" {
 		// We are moving backward,
 		// but items arrive in forward order.
 		reverse(it.values)
@@ -63,14 +63,14 @@ func (it *Iter) getPage() {
 // It returns false when the iterator stops
 // at the end of the list.
 func (it *Iter) Next() bool {
-	if len(it.values) == 0 && it.meta.More && !it.params.Single {
+	if len(it.values) == 0 && it.meta.HasMore && !it.params.Single {
 		// determine if we're moving forward or backwards in paging
-		if it.params.End != "" {
-			it.params.End = listItemID(it.cur)
-			it.qs.Set(endbefore, it.params.End)
+		if it.params.EndingBefore != "" {
+			it.params.EndingBefore = listItemID(it.cur)
+			it.qs.Set(EndingBefore, it.params.EndingBefore)
 		} else {
-			it.params.Start = listItemID(it.cur)
-			it.qs.Set(startafter, it.params.Start)
+			it.params.StartingAfter = listItemID(it.cur)
+			it.qs.Set(StartingAfter, it.params.StartingAfter)
 		}
 		it.getPage()
 	}

--- a/iter_test.go
+++ b/iter_test.go
@@ -44,7 +44,7 @@ func TestIterOneErr(t *testing.T) {
 
 func TestIterPage2Empty(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{&item{"x"}}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
 		{nil, ListMeta{}, nil},
 	}
 	want := []interface{}{&item{"x"}}
@@ -56,7 +56,7 @@ func TestIterPage2Empty(t *testing.T) {
 
 func TestIterPage2EmptyErr(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{&item{"x"}}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
 		{nil, ListMeta{}, errTest},
 	}
 	want := []interface{}{&item{"x"}}
@@ -68,8 +68,8 @@ func TestIterPage2EmptyErr(t *testing.T) {
 
 func TestIterTwoPages(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
-		{[]interface{}{2}, ListMeta{0, false, ""}, nil},
+		{[]interface{}{&item{"x"}}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{[]interface{}{2}, ListMeta{HasMore: false, TotalCount: 0, URL: ""}, nil},
 	}
 	want := []interface{}{&item{"x"}, 2}
 	g, gerr := collect(GetIter(nil, nil, tq.query))
@@ -80,8 +80,8 @@ func TestIterTwoPages(t *testing.T) {
 
 func TestIterTwoPagesErr(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
-		{[]interface{}{2}, ListMeta{0, false, ""}, errTest},
+		{[]interface{}{&item{"x"}}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{[]interface{}{2}, ListMeta{HasMore: false, TotalCount: 0, URL: ""}, errTest},
 	}
 	want := []interface{}{&item{"x"}, 2}
 	g, gerr := collect(GetIter(nil, nil, tq.query))
@@ -93,7 +93,7 @@ func TestIterTwoPagesErr(t *testing.T) {
 func TestIterReversed(t *testing.T) {
 	tq := testQuery{{[]interface{}{1, 2}, ListMeta{}, nil}}
 	want := []interface{}{2, 1}
-	g, gerr := collect(GetIter(&ListParams{End: "x"}, nil, tq.query))
+	g, gerr := collect(GetIter(&ListParams{EndingBefore: "x"}, nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -101,11 +101,11 @@ func TestIterReversed(t *testing.T) {
 
 func TestIterReversedTwoPages(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"3"}, 4}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{&item{"3"}, 4}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
 		{[]interface{}{1, 2}, ListMeta{}, nil},
 	}
 	want := []interface{}{4, &item{"3"}, 2, 1}
-	g, gerr := collect(GetIter(&ListParams{End: "x"}, nil, tq.query))
+	g, gerr := collect(GetIter(&ListParams{EndingBefore: "x"}, nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)

--- a/loginlink.go
+++ b/loginlink.go
@@ -10,5 +10,5 @@ type LoginLinkParams struct {
 // For more details see https://stripe.com/docs/api#login_link_object
 type LoginLink struct {
 	Created int64  `json:"created"`
-	Url     string `json:"url"`
+	URL     string `json:"url"`
 }

--- a/order.go
+++ b/order.go
@@ -67,12 +67,12 @@ const (
 )
 
 type DeliveryEstimate struct {
-	Type EstimateType `json:"type"`
-	// If Type == Range
-	Earliest string `json:"earliest"`
-	Latest   string `json:"latest"`
 	// If Type == Exact
 	Date string `json:"date"`
+	// If Type == Range
+	Earliest string       `json:"earliest"`
+	Latest   string       `json:"latest"`
+	Type     EstimateType `json:"type"`
 }
 
 type Order struct {
@@ -87,8 +87,8 @@ type Order struct {
 	Email                  string            `json:"email"`
 	ID                     string            `json:"id"`
 	Items                  []OrderItem       `json:"items"`
-	Live                   bool              `json:"livemode"`
-	Meta                   map[string]string `json:"metadata"`
+	Livemode               bool              `json:"livemode"`
+	Metadata               map[string]string `json:"metadata"`
 	Returns                *OrderReturnList  `json:"returns"`
 	SelectedShippingMethod *string           `json:"selected_shipping_method"`
 	Shipping               Shipping          `json:"shipping"`
@@ -101,7 +101,7 @@ type Order struct {
 // OrderList is a list of orders as retrieved from a list endpoint.
 type OrderList struct {
 	ListMeta
-	Values []*Order `json:"data"`
+	Data []*Order `json:"data"`
 }
 
 // OrderListParams is the set of parameters that can be used when
@@ -118,10 +118,10 @@ type OrderListParams struct {
 // StatusTransitions are the timestamps at which the order status was updated
 // https://stripe.com/docs/api#order_object
 type StatusTransitions struct {
-	Canceled  int64 `json:"canceled"`
-	Fulfilled int64 `json:"fulfiled"`
-	Paid      int64 `json:"paid"`
-	Returned  int64 `json:"returned"`
+	Canceled int64 `json:"canceled"`
+	Fulfiled int64 `json:"fulfiled"`
+	Paid     int64 `json:"paid"`
+	Returned int64 `json:"returned"`
 }
 
 // OrderPayParams is the set of parameters that can be used when

--- a/order/client.go
+++ b/order/client.go
@@ -134,8 +134,8 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 		list := &stripe.OrderList{}
 		err := c.B.Call("GET", "/orders", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -8,15 +8,15 @@ type OrderReturn struct {
 	Currency Currency    `json:"currency"`
 	ID       string      `json:"id"`
 	Items    []OrderItem `json:"items"`
+	Livemode bool        `json:"livemode"`
 	Order    Order       `json:"order"`
-	Live     bool        `json:"livemode"`
 	Refund   *Refund     `json:"refund"`
 }
 
 // OrderReturnList is a list of returns as retrieved from a list endpoint.
 type OrderReturnList struct {
 	ListMeta
-	Values []*OrderReturn `json:"data"`
+	Data []*OrderReturn `json:"data"`
 }
 
 // OrderReturnListParams is the set of parameters that can be used when listing

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -32,8 +32,8 @@ func (c Client) List(params *stripe.OrderReturnListParams) *Iter {
 		list := &stripe.OrderReturnList{}
 		err := c.B.Call("GET", "/order_returns", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/params.go
+++ b/params.go
@@ -13,17 +13,13 @@ import (
 )
 
 const (
-	endbefore  = "ending_before"
-	startafter = "starting_after"
+	EndingBefore  = "ending_before"
+	StartingAfter = "starting_after"
 )
 
 // Params is the structure that contains the common properties
 // of any *Params structure.
 type Params struct {
-	// Account is deprecated form of StripeAccount that will do the same thing.
-	// Please use StripeAccount instead.
-	Account string `form:"-"` // Passed as header
-
 	// Context used for request. It may carry deadlines, cancelation signals,
 	// and other request-scoped values across API boundaries and between
 	// processes.
@@ -34,14 +30,14 @@ type Params struct {
 	// key or query the state of the API.
 	Context context.Context `form:"-"`
 
-	Exp   []string     `form:"expand"`
-	Extra *ExtraValues `form:"*"`
+	Expand []string     `form:"expand"`
+	Extra  *ExtraValues `form:"*"`
 
 	// Headers may be used to provide extra header lines on the HTTP request.
 	Headers http.Header `form:"-"`
 
 	IdempotencyKey string            `form:"-"` // Passed as header
-	Meta           map[string]string `form:"metadata"`
+	Metadata       map[string]string `form:"metadata"`
 
 	// StripeAccount may contain the ID of a connected account. By including
 	// this field, the request is made as if it originated from the connected
@@ -79,10 +75,10 @@ type ListParams struct {
 	// key or query the state of the API.
 	Context context.Context `form:"-"`
 
-	End     string   `form:"ending_before"`
-	Exp     []string `form:"expand"`
-	Filters Filters  `form:"*"`
-	Limit   int      `form:"limit"`
+	EndingBefore string   `form:"ending_before"`
+	Expand       []string `form:"expand"`
+	Filters      Filters  `form:"*"`
+	Limit        int      `form:"limit"`
 
 	// Single specifies whether this is a single page iterator. By default,
 	// listing through an iterator will automatically grab additional pages as
@@ -90,7 +86,7 @@ type ListParams struct {
 	// page, set this to true.
 	Single bool `form:"-"` // Not an API parameter
 
-	Start string `form:"starting_after"`
+	StartingAfter string `form:"starting_after"`
 
 	// StripeAccount may contain the ID of a connected account. By including
 	// this field, the request is made as if it originated from the connected
@@ -103,9 +99,9 @@ type ListParams struct {
 // of List iterators. The Count property is only populated if the
 // total_count include option is passed in (see tests for example).
 type ListMeta struct {
-	Count uint32 `json:"total_count"`
-	More  bool   `json:"has_more"`
-	URL   string `json:"url"`
+	HasMore    bool   `json:"has_more"`
+	TotalCount uint32 `json:"total_count"`
+	URL        string `json:"url"`
 }
 
 // RangeQueryParams are a set of generic request parameters that are used on
@@ -166,29 +162,23 @@ func NewIdempotencyKey() string {
 	return fmt.Sprintf("%v_%v", now, base64.URLEncoding.EncodeToString(buf)[:6])
 }
 
-// SetAccount sets a value for the Stripe-Account header.
-func (p *Params) SetAccount(val string) {
-	p.Account = val
-	p.StripeAccount = val
-}
-
 // SetStripeAccount sets a value for the Stripe-Account header.
 func (p *Params) SetStripeAccount(val string) {
 	p.StripeAccount = val
 }
 
-// Expand appends a new field to expand.
-func (p *Params) Expand(f string) {
-	p.Exp = append(p.Exp, f)
+// AddExpand appends a new field to expand.
+func (p *Params) AddExpand(f string) {
+	p.Expand = append(p.Expand, f)
 }
 
-// AddMeta adds a new key-value pair to the Metadata.
-func (p *Params) AddMeta(key, value string) {
-	if p.Meta == nil {
-		p.Meta = make(map[string]string)
+// AddMetadata adds a new key-value pair to the Metadata.
+func (p *Params) AddMetadata(key, value string) {
+	if p.Metadata == nil {
+		p.Metadata = make(map[string]string)
 	}
 
-	p.Meta[key] = value
+	p.Metadata[key] = value
 }
 
 // AddExtra adds a new arbitrary key-value pair to the request data
@@ -200,9 +190,9 @@ func (p *Params) AddExtra(key, value string) {
 	p.Extra.Add(key, value)
 }
 
-// Expand appends a new field to expand.
-func (p *ListParams) Expand(f string) {
-	p.Exp = append(p.Exp, f)
+// AddExpand appends a new field to expand.
+func (p *ListParams) AddExpand(f string) {
+	p.Expand = append(p.Expand, f)
 }
 
 // ToParams converts a ListParams to a Params by moving over any fields that

--- a/params_test.go
+++ b/params_test.go
@@ -76,9 +76,9 @@ func TestListParams_Nested(t *testing.T) {
 	params := &testListParams{
 		Field: "field_value",
 		ListParams: stripe.ListParams{
-			End:   "acct_123",
-			Limit: 100,
-			Start: "acct_123",
+			EndingBefore:  "acct_123",
+			Limit:         100,
+			StartingAfter: "acct_123",
 		},
 	}
 
@@ -145,13 +145,13 @@ func TestParams_AppendTo_Nested(t *testing.T) {
 	params := &testParams{
 		Field: "field_value",
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},
 		SubParams: &testSubParams{
 			Params: stripe.Params{
-				Meta: map[string]string{
+				Metadata: map[string]string{
 					"sub_foo": "bar",
 				},
 			},
@@ -204,7 +204,7 @@ func TestListParams_Expand(t *testing.T) {
 		p := stripe.ListParams{}
 
 		for _, exp := range testCase.Expand {
-			p.Expand(exp)
+			p.AddExpand(exp)
 		}
 
 		body := valuesFromArray(testCase.InitialBody)
@@ -223,30 +223,12 @@ func TestListParams_ToParams(t *testing.T) {
 	assert.Equal(t, listParams.StripeAccount, params.StripeAccount)
 }
 
-func TestParams_SetAccount(t *testing.T) {
-	p := &stripe.Params{}
-	p.SetAccount(TestMerchantID)
-
-	if p.Account != TestMerchantID {
-		t.Fatalf("Expected Account of %v but got %v.", TestMerchantID, p.Account)
-	}
-
-	if p.StripeAccount != TestMerchantID {
-		t.Fatalf("Expected StripeAccount of %v but got %v.", TestMerchantID, p.StripeAccount)
-	}
-}
-
 func TestParams_SetStripeAccount(t *testing.T) {
 	p := &stripe.Params{}
 	p.SetStripeAccount(TestMerchantID)
 
 	if p.StripeAccount != TestMerchantID {
 		t.Fatalf("Expected Account of %v but got %v.", TestMerchantID, p.StripeAccount)
-	}
-
-	// Check that we don't set the deprecated parameter.
-	if p.Account != "" {
-		t.Fatalf("Expected empty Account but got %v.", TestMerchantID)
 	}
 }
 

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -111,7 +111,7 @@ type PaymentSource struct {
 // SourceList is a list object for cards.
 type SourceList struct {
 	ListMeta
-	Values []*PaymentSource `json:"data"`
+	Data []*PaymentSource `json:"data"`
 }
 
 // SourceListParams are used to enumerate the payment sources that are attached

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -137,8 +137,8 @@ func (s Client) List(params *stripe.SourceListParams) *Iter {
 			err = errors.New("Invalid source params: customer needs to be set")
 		}
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/paymentsource_test.go
+++ b/paymentsource_test.go
@@ -61,8 +61,8 @@ func TestPaymentSource_MarshalJSON(t *testing.T) {
 			Type: PaymentSourceBankAccount,
 			ID:   id,
 			BankAccount: &BankAccount{
-				ID:   id,
-				Name: name,
+				ID:                id,
+				AccountHolderName: name,
 			},
 		}
 
@@ -77,6 +77,6 @@ func TestPaymentSource_MarshalJSON(t *testing.T) {
 		assert.Equal(t, unmarshalled.ID, id)
 		assert.NotNil(t, unmarshalled.BankAccount)
 		assert.Equal(t, unmarshalled.BankAccount.ID, id)
-		assert.Equal(t, unmarshalled.BankAccount.Name, name)
+		assert.Equal(t, unmarshalled.BankAccount.AccountHolderName, name)
 	}
 }

--- a/payout.go
+++ b/payout.go
@@ -81,32 +81,32 @@ type PayoutListParams struct {
 // Payout is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payouts.
 type Payout struct {
-	Amount                    int64             `json:"amount"`
-	ArrivalDate               int64             `json:"arrival_date"`
-	Automatic                 bool              `json:"automatic"`
-	BalanceTransaction        *Transaction      `json:"balance_transaction"`
-	Bank                      *BankAccount      `json:"bank_account"`
-	Card                      *Card             `json:"card"`
-	Created                   int64             `json:"created"`
-	Currency                  Currency          `json:"currency"`
-	Destination               PayoutDestination `json:"destination"`
-	FailCode                  PayoutFailureCode `json:"failure_code"`
-	FailMessage               string            `json:"failure_message"`
-	FailureBalanceTransaction *Transaction      `json:"failure_balance_transaction"`
-	ID                        string            `json:"id"`
-	Live                      bool              `json:"livemode"`
-	Meta                      map[string]string `json:"metadata"`
-	Method                    PayoutMethodType  `json:"method"`
-	SourceType                PayoutSourceType  `json:"source_type"`
-	StatementDescriptor       string            `json:"statement_descriptor"`
-	Status                    PayoutStatus      `json:"status"`
-	Type                      PayoutType        `json:"type"`
+	Amount                    int64               `json:"amount"`
+	ArrivalDate               int64               `json:"arrival_date"`
+	Automatic                 bool                `json:"automatic"`
+	BalanceTransaction        *BalanceTransaction `json:"balance_transaction"`
+	BankAccount               *BankAccount        `json:"bank_account"`
+	Card                      *Card               `json:"card"`
+	Created                   int64               `json:"created"`
+	Currency                  Currency            `json:"currency"`
+	Destination               PayoutDestination   `json:"destination"`
+	FailureBalanceTransaction *BalanceTransaction `json:"failure_balance_transaction"`
+	FailureCode               PayoutFailureCode   `json:"failure_code"`
+	FailureMessage            string              `json:"failure_message"`
+	ID                        string              `json:"id"`
+	Livemode                  bool                `json:"livemode"`
+	Metadata                  map[string]string   `json:"metadata"`
+	Method                    PayoutMethodType    `json:"method"`
+	SourceType                PayoutSourceType    `json:"source_type"`
+	StatementDescriptor       string              `json:"statement_descriptor"`
+	Status                    PayoutStatus        `json:"status"`
+	Type                      PayoutType          `json:"type"`
 }
 
 // PayoutList is a list of payouts as retrieved from a list endpoint.
 type PayoutList struct {
 	ListMeta
-	Values []*Payout `json:"data"`
+	Data []*Payout `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Payout.

--- a/payout/client.go
+++ b/payout/client.go
@@ -145,8 +145,8 @@ func (c Client) List(params *stripe.PayoutListParams) *Iter {
 		list := &stripe.PayoutList{}
 		err := c.B.Call("GET", "/payouts", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/payout/client_test.go
+++ b/payout/client_test.go
@@ -41,7 +41,7 @@ func TestPayoutNew(t *testing.T) {
 func TestPayoutUpdate(t *testing.T) {
 	payout, err := Update("tr_123", &stripe.PayoutParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/plan.go
+++ b/plan.go
@@ -7,24 +7,24 @@ type PlanInterval string
 // Plan is the resource representing a Stripe plan.
 // For more details see https://stripe.com/docs/api#plans.
 type Plan struct {
-	Amount        uint64            `json:"amount"`
-	Created       int64             `json:"created"`
-	Currency      Currency          `json:"currency"`
-	Deleted       bool              `json:"deleted"`
-	ID            string            `json:"id"`
-	Interval      PlanInterval      `json:"interval"`
-	IntervalCount uint64            `json:"interval_count"`
-	Live          bool              `json:"livemode"`
-	Meta          map[string]string `json:"metadata"`
-	Nickname      string            `json:"nickname"`
-	Product       string            `json:"product"`
-	TrialPeriod   uint64            `json:"trial_period_days"`
+	Amount          uint64            `json:"amount"`
+	Created         int64             `json:"created"`
+	Currency        Currency          `json:"currency"`
+	Deleted         bool              `json:"deleted"`
+	ID              string            `json:"id"`
+	Interval        PlanInterval      `json:"interval"`
+	IntervalCount   uint64            `json:"interval_count"`
+	Livemode        bool              `json:"livemode"`
+	Metadata        map[string]string `json:"metadata"`
+	Nickname        string            `json:"nickname"`
+	Product         string            `json:"product"`
+	TrialPeriodDays uint64            `json:"trial_period_days"`
 }
 
 // PlanList is a list of plans as returned from a list endpoint.
 type PlanList struct {
 	ListMeta
-	Values []*Plan `json:"data"`
+	Data []*Plan `json:"data"`
 }
 
 // PlanListParams is the set of parameters that can be used when listing plans.
@@ -38,15 +38,15 @@ type PlanListParams struct {
 // PlanParams is the set of parameters that can be used when creating or updating a plan.
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
-	Params        `form:"*"`
-	Amount        uint64         `form:"amount"`
-	AmountZero    bool           `form:"amount,zero"`
-	Currency      Currency       `form:"currency"`
-	ID            string         `form:"id"`
-	Interval      PlanInterval   `form:"interval"`
-	IntervalCount uint64         `form:"interval_count"`
-	Nickname      string         `form:"nickname"`
-	Product       *ProductParams `form:"product"`
-	ProductID     *string        `form:"product"`
-	TrialPeriod   uint64         `form:"trial_period_days"`
+	Params          `form:"*"`
+	Amount          uint64         `form:"amount"`
+	AmountZero      bool           `form:"amount,zero"`
+	Currency        Currency       `form:"currency"`
+	ID              string         `form:"id"`
+	Interval        PlanInterval   `form:"interval"`
+	IntervalCount   uint64         `form:"interval_count"`
+	Nickname        string         `form:"nickname"`
+	Product         *ProductParams `form:"product"`
+	ProductID       *string        `form:"product"`
+	TrialPeriodDays uint64         `form:"trial_period_days"`
 }

--- a/plan/client.go
+++ b/plan/client.go
@@ -126,8 +126,8 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 		list := &stripe.PlanList{}
 		err := c.B.Call("GET", "/plans", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/plan_test.go
+++ b/plan_test.go
@@ -58,7 +58,7 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		{"product[name]", &PlanParams{Product: &productParams}, "Sapphire Elite"},
 		{"product[statement_descriptor]", &PlanParams{Product: &productParams}, "SAPPHIRE"},
 		{"product", &PlanParams{ProductID: &productId}, "prod_123abc"},
-		{"trial_period_days", &PlanParams{TrialPeriod: 123}, strconv.FormatUint(123, 10)},
+		{"trial_period_days", &PlanParams{TrialPeriodDays: 123}, strconv.FormatUint(123, 10)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {

--- a/product.go
+++ b/product.go
@@ -31,10 +31,10 @@ type PackageDimensions struct {
 type ProductParams struct {
 	Params              `form:"*"`
 	Active              *bool              `form:"active"`
-	Attrs               []string           `form:"attributes"`
+	Attributes          []string           `form:"attributes"`
 	Caption             string             `form:"caption"`
 	DeactivateOn        []string           `form:"deactivate_on"`
-	Desc                string             `form:"description"`
+	Description         string             `form:"description"`
 	ID                  string             `form:"id"`
 	Images              []string           `form:"images"`
 	Name                string             `form:"name"`
@@ -49,29 +49,29 @@ type ProductParams struct {
 // For more details see https://stripe.com/docs/api#products.
 type Product struct {
 	Active              bool               `json:"active"`
-	Attrs               []string           `json:"attributes"`
+	Attributes          []string           `json:"attributes"`
 	Caption             string             `json:"caption"`
 	Created             int64              `json:"created"`
 	DeactivateOn        []string           `json:"deactivate_on"`
-	Desc                string             `json:"description"`
+	Description         string             `json:"description"`
 	ID                  string             `json:"id"`
 	Images              []string           `json:"images"`
-	Live                bool               `json:"livemode"`
-	Meta                map[string]string  `json:"metadata"`
+	Livemode            bool               `json:"livemode"`
+	Metadata            map[string]string  `json:"metadata"`
 	Name                string             `json:"name"`
 	PackageDimensions   *PackageDimensions `json:"package_dimensions"`
 	Shippable           bool               `json:"shippable"`
-	Skus                *SKUList           `json:"skus"`
 	StatementDescriptor string             `json:"statement_descriptor"`
+	Skus                *SKUList           `json:"skus"`
+	Type                ProductType        `json:"type"`
 	URL                 string             `json:"url"`
 	Updated             int64              `json:"updated"`
-	Type                ProductType        `json:"type"`
 }
 
 // ProductList is a list of products as retrieved from a list endpoint.
 type ProductList struct {
 	ListMeta
-	Values []*Product `json:"data"`
+	Data []*Product `json:"data"`
 }
 
 // ProductListParams is the set of parameters that can be used when

--- a/product/client.go
+++ b/product/client.go
@@ -103,8 +103,8 @@ func (c Client) List(params *stripe.ProductListParams) *Iter {
 		list := &stripe.ProductList{}
 		err := c.B.Call("GET", "/products", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -34,13 +34,13 @@ func TestProductNew(t *testing.T) {
 	shippable := true
 
 	product, err := New(&stripe.ProductParams{
-		Active:    &active,
-		Name:      "Test Name",
-		Desc:      "This is a description",
-		Caption:   "This is a caption",
-		Attrs:     []string{"attr1", "attr2"},
-		URL:       "http://example.com",
-		Shippable: &shippable,
+		Active:      &active,
+		Name:        "Test Name",
+		Description: "This is a description",
+		Caption:     "This is a caption",
+		Attributes:  []string{"attr1", "attr2"},
+		URL:         "http://example.com",
+		Shippable:   &shippable,
 		PackageDimensions: &stripe.PackageDimensions{
 			Height: 2.234,
 			Length: 5.10,

--- a/recipient.go
+++ b/recipient.go
@@ -15,10 +15,10 @@ type RecipientType string
 type RecipientParams struct {
 	Params `form:"*"`
 
-	Bank        *BankAccountParams `form:"-"` // Kind of an abberation because a bank account's token will be replace the rest of its data. Keep this in a custom AppendTo for now.
+	BankAccount *BankAccountParams `form:"-"` // Kind of an abberation because a bank account's token will be replace the rest of its data. Keep this in a custom AppendTo for now.
 	Card        *CardParams        `form:"card"`
 	DefaultCard string             `form:"default_card"`
-	Desc        string             `form:"description"`
+	Description string             `form:"description"`
 	Email       string             `form:"email"`
 	Name        string             `form:"name"`
 	TaxID       string             `form:"tax_id"`
@@ -30,11 +30,11 @@ type RecipientParams struct {
 // This was probably the wrong way to go about this, but grandfather the
 // behavior for the time being.
 func (p *RecipientParams) AppendTo(body *form.Values, keyParts []string) {
-	if p.Bank != nil {
-		if len(p.Bank.Token) > 0 {
-			body.Add("bank_account", p.Bank.Token)
+	if p.BankAccount != nil {
+		if len(p.BankAccount.Token) > 0 {
+			body.Add("bank_account", p.BankAccount.Token)
 		} else {
-			form.AppendToPrefixed(body, p.Bank, append(keyParts, "bank_account"))
+			form.AppendToPrefixed(body, p.BankAccount, append(keyParts, "bank_account"))
 		}
 	}
 }
@@ -49,25 +49,25 @@ type RecipientListParams struct {
 // Recipient is the resource representing a Stripe recipient.
 // For more details see https://stripe.com/docs/api#recipients.
 type Recipient struct {
-	Bank        *BankAccount      `json:"active_account"`
-	Cards       *CardList         `json:"cards"`
-	Created     int64             `json:"created"`
-	DefaultCard *Card             `json:"default_card"`
-	Deleted     bool              `json:"deleted"`
-	Desc        string            `json:"description"`
-	Email       string            `json:"email"`
-	ID          string            `json:"id"`
-	Live        bool              `json:"livemode"`
-	Meta        map[string]string `json:"metadata"`
-	MigratedTo  *Account          `json:"migrated_to"`
-	Name        string            `json:"name"`
-	Type        RecipientType     `json:"type"`
+	ActiveAccount *BankAccount      `json:"active_account"`
+	Cards         *CardList         `json:"cards"`
+	Created       int64             `json:"created"`
+	DefaultCard   *Card             `json:"default_card"`
+	Deleted       bool              `json:"deleted"`
+	Description   string            `json:"description"`
+	Email         string            `json:"email"`
+	ID            string            `json:"id"`
+	Livemode      bool              `json:"livemode"`
+	Metadata      map[string]string `json:"metadata"`
+	MigratedTo    *Account          `json:"migrated_to"`
+	Name          string            `json:"name"`
+	Type          RecipientType     `json:"type"`
 }
 
 // RecipientList is a list of recipients as retrieved from a list endpoint.
 type RecipientList struct {
 	ListMeta
-	Values []*Recipient `json:"data"`
+	Data []*Recipient `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Recipient.

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -108,8 +108,8 @@ func (c Client) List(params *stripe.RecipientListParams) *Iter {
 		list := &stripe.RecipientList{}
 		err := c.B.Call("GET", "/recipients", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -25,7 +25,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{Bank: &BankAccountParams{Token: "ba_123"}}
+		params := &RecipientParams{BankAccount: &BankAccountParams{Token: "ba_123"}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -33,7 +33,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{Bank: &BankAccountParams{Account: "123"}}
+		params := &RecipientParams{BankAccount: &BankAccountParams{AccountNumber: "123"}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/recipienttransfer.go
+++ b/recipienttransfer.go
@@ -57,30 +57,30 @@ type RecipientTransferDestination struct {
 // RecipientTransfer is the resource representing a Stripe recipient_transfer.
 // For more details see https://stripe.com/docs/api#recipient_transfers.
 type RecipientTransfer struct {
-	Amount             int64                        `json:"amount"`
-	AmountReversed     int64                        `json:"amount_reversed"`
-	BalanceTransaction *Transaction                 `json:"balance_transaction"`
-	Bank               *BankAccount                 `json:"bank_account"`
-	Card               *Card                        `json:"card"`
-	Created            int64                        `json:"created"`
-	Currency           Currency                     `json:"currency"`
-	Date               int64                        `json:"date"`
-	Desc               string                       `json:"description"`
-	Dest               RecipientTransferDestination `json:"destination"`
-	FailCode           RecipientTransferFailCode    `json:"failure_code"`
-	FailMsg            string                       `json:"failure_message"`
-	ID                 string                       `json:"id"`
-	Live               bool                         `json:"livemode"`
-	Meta               map[string]string            `json:"metadata"`
-	Method             RecipientTransferMethodType  `json:"method"`
-	Recipient          *Recipient                   `json:"recipient"`
-	Reversals          *ReversalList                `json:"reversals"`
-	Reversed           bool                         `json:"reversed"`
-	SourceTx           *TransactionSource           `json:"source_transaction"`
-	SourceType         RecipientTransferSourceType  `json:"source_type"`
-	Statement          string                       `json:"statement_descriptor"`
-	Status             RecipientTransferStatus      `json:"status"`
-	Type               RecipientTransferType        `json:"type"`
+	Amount              int64                        `json:"amount"`
+	AmountReversed      int64                        `json:"amount_reversed"`
+	BalanceTransaction  *BalanceTransaction          `json:"balance_transaction"`
+	BankAccount         *BankAccount                 `json:"bank_account"`
+	Card                *Card                        `json:"card"`
+	Created             int64                        `json:"created"`
+	Currency            Currency                     `json:"currency"`
+	Date                int64                        `json:"date"`
+	Description         string                       `json:"description"`
+	Destination         RecipientTransferDestination `json:"destination"`
+	FailureCode         RecipientTransferFailCode    `json:"failure_code"`
+	FailureMessage      string                       `json:"failure_message"`
+	ID                  string                       `json:"id"`
+	Livemode            bool                         `json:"livemode"`
+	Metadata            map[string]string            `json:"metadata"`
+	Method              RecipientTransferMethodType  `json:"method"`
+	Recipient           *Recipient                   `json:"recipient"`
+	Reversals           *ReversalList                `json:"reversals"`
+	Reversed            bool                         `json:"reversed"`
+	SourceTransaction   *BalanceTransactionSource    `json:"source_transaction"`
+	SourceType          RecipientTransferSourceType  `json:"source_type"`
+	StatementDescriptor string                       `json:"statement_descriptor"`
+	Status              RecipientTransferStatus      `json:"status"`
+	Type                RecipientTransferType        `json:"type"`
 }
 
 // UnmarshalJSON handles deserialization of a RecipientTransfer.

--- a/refund.go
+++ b/refund.go
@@ -14,12 +14,12 @@ type RefundStatus string
 // RefundParams is the set of parameters that can be used when refunding a charge.
 // For more details see https://stripe.com/docs/api#refund.
 type RefundParams struct {
-	Params   `form:"*"`
-	Amount   uint64       `form:"amount"`
-	Charge   string       `form:"charge"`
-	Fee      bool         `form:"refund_application_fee"`
-	Reason   RefundReason `form:"reason"`
-	Transfer bool         `form:"reverse_transfer"`
+	Params               `form:"*"`
+	Amount               uint64       `form:"amount"`
+	Charge               string       `form:"charge"`
+	Reason               RefundReason `form:"reason"`
+	RefundApplicationFee bool         `form:"refund_application_fee"`
+	ReverseTransfer      bool         `form:"reverse_transfer"`
 }
 
 // RefundListParams is the set of parameters that can be used when listing refunds.
@@ -31,22 +31,22 @@ type RefundListParams struct {
 // Refund is the resource representing a Stripe refund.
 // For more details see https://stripe.com/docs/api#refunds.
 type Refund struct {
-	Amount        uint64            `json:"amount"`
-	Charge        *Charge           `json:"charge"`
-	Created       int64             `json:"created"`
-	Currency      Currency          `json:"currency"`
-	ID            string            `json:"id"`
-	Meta          map[string]string `json:"metadata"`
-	Reason        RefundReason      `json:"reason"`
-	ReceiptNumber string            `json:"receipt_number"`
-	Status        RefundStatus      `json:"status"`
-	Tx            *Transaction      `json:"balance_transaction"`
+	Amount             uint64              `json:"amount"`
+	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
+	Charge             *Charge             `json:"charge"`
+	Created            int64               `json:"created"`
+	Currency           Currency            `json:"currency"`
+	ID                 string              `json:"id"`
+	Metadata           map[string]string   `json:"metadata"`
+	Reason             RefundReason        `json:"reason"`
+	ReceiptNumber      string              `json:"receipt_number"`
+	Status             RefundStatus        `json:"status"`
 }
 
 // RefundList is a list object for refunds.
 type RefundList struct {
 	ListMeta
-	Values []*Refund `json:"data"`
+	Data []*Refund `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Refund.

--- a/refund/client.go
+++ b/refund/client.go
@@ -91,8 +91,8 @@ func (c Client) List(params *stripe.RefundListParams) *Iter {
 		list := &stripe.RefundList{}
 		err := c.B.Call("GET", "/refunds", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -34,7 +34,7 @@ func TestRefundNew(t *testing.T) {
 func TestRefundUpdate(t *testing.T) {
 	refund, err := Update("gold", &stripe.RefundParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/reversal.go
+++ b/reversal.go
@@ -4,10 +4,10 @@ import "encoding/json"
 
 // ReversalParams is the set of parameters that can be used when reversing a transfer.
 type ReversalParams struct {
-	Params   `form:"*"`
-	Transfer string `form:"-"` // Included in URL
-	Amount   uint64 `form:"amount"`
-	Fee      bool   `form:"refund_application_fee"`
+	Params               `form:"*"`
+	Amount               uint64 `form:"amount"`
+	RefundApplicationFee bool   `form:"refund_application_fee"`
+	Transfer             string `form:"-"` // Included in URL
 }
 
 // ReversalListParams is the set of parameters that can be used when listing reversals.
@@ -18,19 +18,19 @@ type ReversalListParams struct {
 
 // Reversal represents a transfer reversal.
 type Reversal struct {
-	Amount   uint64            `json:"amount"`
-	Created  int64             `json:"created"`
-	Currency Currency          `json:"currency"`
-	ID       string            `json:"id"`
-	Meta     map[string]string `json:"metadata"`
-	Transfer string            `json:"transfer"`
-	Tx       *Transaction      `json:"balance_transaction"`
+	Amount             uint64              `json:"amount"`
+	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
+	Created            int64               `json:"created"`
+	Currency           Currency            `json:"currency"`
+	ID                 string              `json:"id"`
+	Metadata           map[string]string   `json:"metadata"`
+	Transfer           string              `json:"transfer"`
 }
 
 // ReversalList is a list of object for reversals.
 type ReversalList struct {
 	ListMeta
-	Values []*Reversal `json:"data"`
+	Data []*Reversal `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Reversal.

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -78,8 +78,8 @@ func (c Client) List(params *stripe.ReversalListParams) *Iter {
 		list := &stripe.ReversalList{}
 		err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals", params.Transfer), c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/reversal/client_test.go
+++ b/reversal/client_test.go
@@ -39,7 +39,7 @@ func TestReversalNew(t *testing.T) {
 func TestReversalUpdate(t *testing.T) {
 	reversal, err := Update("trr_123", &stripe.ReversalParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/review.go
+++ b/review.go
@@ -17,12 +17,12 @@ const (
 )
 
 type Review struct {
-	Charge  *Charge    `json:"charge"`
-	Created int64      `json:"created"`
-	ID      string     `json:"id"`
-	Live    bool       `json:"livemode"`
-	Open    bool       `json:"open"`
-	Reason  ReasonType `json:"reason"`
+	Charge   *Charge    `json:"charge"`
+	Created  int64      `json:"created"`
+	ID       string     `json:"id"`
+	Livemode bool       `json:"livemode"`
+	Open     bool       `json:"open"`
+	Reason   ReasonType `json:"reason"`
 }
 
 func (r *Review) UnmarshalJSON(data []byte) error {

--- a/sku.go
+++ b/sku.go
@@ -5,9 +5,9 @@ import "encoding/json"
 type SKUParams struct {
 	Params            `form:"*"`
 	Active            *bool              `form:"active"`
-	Attrs             map[string]string  `form:"attributes"`
+	Attributes        map[string]string  `form:"attributes"`
 	Currency          string             `form:"currency"`
-	Desc              string             `form:"description"`
+	Description       string             `form:"description"`
 	ID                string             `form:"id"`
 	Image             string             `form:"image"`
 	Inventory         Inventory          `form:"inventory"`
@@ -24,15 +24,15 @@ type Inventory struct {
 
 type SKU struct {
 	Active            bool               `json:"active"`
-	Attrs             map[string]string  `json:"attributes"`
+	Attributes        map[string]string  `json:"attributes"`
 	Created           int64              `json:"created"`
 	Currency          string             `json:"currency"`
-	Desc              string             `json:"description"`
+	Description       string             `json:"description"`
 	ID                string             `json:"id"`
 	Image             string             `json:"image"`
 	Inventory         Inventory          `json:"inventory"`
-	Live              bool               `json:"livemode"`
-	Meta              map[string]string  `json:"metadata"`
+	Livemode          bool               `json:"livemode"`
+	Metadata          map[string]string  `json:"metadata"`
 	PackageDimensions *PackageDimensions `json:"package_dimensions"`
 	Price             int64              `json:"price"`
 	Product           Product            `json:"product"`
@@ -41,7 +41,7 @@ type SKU struct {
 
 type SKUList struct {
 	ListMeta
-	Values []*SKU `json:"data"`
+	Data []*SKU `json:"data"`
 }
 
 type SKUListParams struct {

--- a/sku/client.go
+++ b/sku/client.go
@@ -103,8 +103,8 @@ func (c Client) List(params *stripe.SKUListParams) *Iter {
 		list := &stripe.SKUList{}
 		err := c.B.Call("GET", "/skus", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/sku/client_test.go
+++ b/sku/client_test.go
@@ -32,13 +32,13 @@ func TestSKUList(t *testing.T) {
 func TestSKUNew(t *testing.T) {
 	active := true
 	sku, err := New(&stripe.SKUParams{
-		Active:    &active,
-		Attrs:     map[string]string{"attr1": "val1", "attr2": "val2"},
-		Price:     499,
-		Currency:  "usd",
-		Inventory: stripe.Inventory{Type: "bucket", Value: "limited"},
-		Product:   "prod_123",
-		Image:     "http://example.com/foo.png",
+		Active:     &active,
+		Attributes: map[string]string{"attr1": "val1", "attr2": "val2"},
+		Price:      499,
+		Currency:   "usd",
+		Inventory:  stripe.Inventory{Type: "bucket", Value: "limited"},
+		Product:    "prod_123",
+		Image:      "http://example.com/foo.png",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sku)

--- a/source.go
+++ b/source.go
@@ -196,8 +196,8 @@ type Source struct {
 	Currency            Currency              `json:"currency"`
 	Flow                SourceFlow            `json:"flow"`
 	ID                  string                `json:"id"`
-	Live                bool                  `json:"livemode"`
-	Meta                map[string]string     `json:"metadata"`
+	Livemode            bool                  `json:"livemode"`
+	Metadata            map[string]string     `json:"metadata"`
 	Owner               SourceOwner           `json:"owner"`
 	Receiver            *ReceiverFlow         `json:"receiver,omitempty"`
 	Redirect            *RedirectFlow         `json:"redirect,omitempty"`

--- a/stripe.go
+++ b/stripe.go
@@ -285,11 +285,6 @@ func (s *BackendConfiguration) NewRequest(method, path, key, contentType string,
 			req.Header.Add("Idempotency-Key", idempotency)
 		}
 
-		// Support the value of the old Account field for now.
-		if account := strings.TrimSpace(params.Account); account != "" {
-			req.Header.Add("Stripe-Account", account)
-		}
-
 		// But prefer StripeAccount.
 		if stripeAccount := strings.TrimSpace(params.StripeAccount); stripeAccount != "" {
 			req.Header.Add("Stripe-Account", stripeAccount)

--- a/stripe.go
+++ b/stripe.go
@@ -480,3 +480,115 @@ func initUserAgent() {
 	}
 	encodedStripeUserAgent = string(marshaled)
 }
+
+// Bool returns a pointer to the bool value passed in.
+func Bool(v bool) *bool {
+	return &v
+}
+
+// BoolValue returns the value of the bool pointer passed in or
+// false if the pointer is nil.
+func BoolValue(v *bool) bool {
+	if v != nil {
+		return *v
+	}
+	return false
+}
+
+// String returns a pointer to the string value passed in.
+func String(v string) *string {
+	return &v
+}
+
+// StringValue returns the value of the string pointer passed in or
+// "" if the pointer is nil.
+func StringValue(v *string) string {
+	if v != nil {
+		return *v
+	}
+	return ""
+}
+
+// Int returns a pointer to the int value passed in.
+func Int(v int) *int {
+	return &v
+}
+
+// IntValue returns the value of the int pointer passed in or
+// 0 if the pointer is nil.
+func IntValue(v *int) int {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// UInt returns a pointer to the uint value passed in.
+func UInt(v uint) *uint {
+	return &v
+}
+
+// UIntValue returns the value of the uint pointer passed in or
+// 0 if the pointer is nil.
+func UIntValue(v *uint) uint {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int64 returns a pointer to the int64 value passed in.
+func Int64(v int64) *int64 {
+	return &v
+}
+
+// Int64Value returns the value of the int64 pointer passed in or
+// 0 if the pointer is nil.
+func Int64Value(v *int64) int64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// UInt64 returns a pointer to the uint64 value passed in.
+func UInt64(v uint64) *uint64 {
+	return &v
+}
+
+// UInt64Value returns the value of the uint64 pointer passed in or
+// 0 if the pointer is nil.
+func UInt64Value(v *uint64) uint64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Float32 returns a pointer to the float32 value passed in.
+func Float32(v float32) *float32 {
+	return &v
+}
+
+// Float32Value returns the value of the float32 pointer passed in or
+// 0 if the pointer is nil.
+func Float32Value(v *float32) float32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Float64 returns a pointer to the float64 value passed in.
+func Float64(v float64) *float64 {
+	return &v
+}
+
+// Float64Value returns the value of the float64 pointer passed in or
+// 0 if the pointer is nil.
+func Float64Value(v *float64) float64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -105,15 +105,6 @@ func TestStripeAccount(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, TestMerchantID, req.Header.Get("Stripe-Account"))
-
-	// Also test the deprecated Account field for now as well. This should be
-	// identical to the exercise above.
-	p = &stripe.Params{Account: TestMerchantID}
-
-	req, err = c.NewRequest("", "", "", "", nil, p)
-	assert.NoError(t, err)
-
-	assert.Equal(t, TestMerchantID, req.Header.Get("Stripe-Account"))
 }
 
 func TestUserAgent(t *testing.T) {
@@ -219,7 +210,7 @@ func TestResponseToError(t *testing.T) {
 	// An error that contains expected fields which we're going to serialize to
 	// JSON and inject into our conversion function.
 	expectedErr := &stripe.Error{
-		Code:  stripe.Missing,
+		Code:  stripe.ErrorCodeMissing,
 		Msg:   "That card was declined",
 		Param: "expiry_date",
 		Type:  stripe.ErrorTypeCard,

--- a/sub.go
+++ b/sub.go
@@ -6,52 +6,52 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
-// SubStatus is the list of allowed values for the subscription's status.
+// SubscriptionStatus is the list of allowed values for the subscription's status.
 // Allowed values are "trialing", "active", "past_due", "canceled", "unpaid", "all".
-type SubStatus string
+type SubscriptionStatus string
 
-// SubBilling is the type of billing method for this subscription's invoices.
+// SubscriptionBilling is the type of billing method for this subscription's invoices.
 // Currently supported values are "send_invoice" and "charge_automatically".
-type SubBilling string
+type SubscriptionBilling string
 
-// SubParams is the set of parameters that can be used when creating or updating a subscription.
+// SubscriptionParams is the set of parameters that can be used when creating or updating a subscription.
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
-type SubParams struct {
+type SubscriptionParams struct {
 	Params                      `form:"*"`
-	Billing                     SubBilling        `form:"billing"`
-	BillingCycleAnchor          int64             `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow       bool              `form:"-"` // See custom AppendTo
-	BillingCycleAnchorUnchanged bool              `form:"-"` // See custom AppendTo
-	Card                        *CardParams       `form:"card"`
-	Coupon                      string            `form:"coupon"`
-	CouponEmpty                 bool              `form:"coupon,empty"`
-	Customer                    string            `form:"customer"`
-	DaysUntilDue                uint64            `form:"days_until_due"`
-	FeePercent                  float64           `form:"application_fee_percent"`
-	FeePercentZero              bool              `form:"application_fee_percent,zero"`
-	Items                       []*SubItemsParams `form:"items,indexed"`
-	NoProrate                   bool              `form:"prorate,invert"`
-	OnBehalfOf                  string            `form:"on_behalf_of"`
-	Plan                        string            `form:"plan"`
-	ProrationDate               int64             `form:"proration_date"`
-	Quantity                    uint64            `form:"quantity"`
-	QuantityZero                bool              `form:"quantity,zero"`
-	TaxPercent                  float64           `form:"tax_percent"`
-	TaxPercentZero              bool              `form:"tax_percent,zero"`
-	Token                       string            `form:"card"`
-	TrialEnd                    int64             `form:"trial_end"`
-	TrialEndNow                 bool              `form:"-"` // See custom AppendTo
-	TrialPeriod                 int64             `form:"trial_period_days"`
+	ApplicationFeePercent       float64                    `form:"application_fee_percent"`
+	ApplicationFeePercentZero   bool                       `form:"application_fee_percent,zero"`
+	Billing                     SubscriptionBilling        `form:"billing"`
+	BillingCycleAnchor          int64                      `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       bool                       `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged bool                       `form:"-"` // See custom AppendTo
+	Card                        *CardParams                `form:"card"`
+	Coupon                      string                     `form:"coupon"`
+	CouponEmpty                 bool                       `form:"coupon,empty"`
+	Customer                    string                     `form:"customer"`
+	DaysUntilDue                uint64                     `form:"days_until_due"`
+	Items                       []*SubscriptionItemsParams `form:"items,indexed"`
+	NoProrate                   bool                       `form:"prorate,invert"`
+	OnBehalfOf                  string                     `form:"on_behalf_of"`
+	Plan                        string                     `form:"plan"`
+	ProrationDate               int64                      `form:"proration_date"`
+	Quantity                    uint64                     `form:"quantity"`
+	QuantityZero                bool                       `form:"quantity,zero"`
+	Source                      string                     `form:"source"`
+	TaxPercent                  float64                    `form:"tax_percent"`
+	TaxPercentZero              bool                       `form:"tax_percent,zero"`
+	TrialEnd                    int64                      `form:"trial_end"`
+	TrialEndNow                 bool                       `form:"-"` // See custom AppendTo
+	TrialPeriodDays             int64                      `form:"trial_period_days"`
 
 	// Used for Cancel
 
-	EndCancel bool `form:"at_period_end"`
+	AtPeriodEnd bool `form:"at_period_end"`
 }
 
-// AppendTo implements custom encoding logic for SubParams so that the special
+// AppendTo implements custom encoding logic for SubscriptionParams so that the special
 // "now" value for billing_cycle_anchor and trial_end can be implemented
 // (they're otherwise timestamps rather than strings).
-func (p *SubParams) AppendTo(body *form.Values, keyParts []string) {
+func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.BillingCycleAnchorNow {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "now")
 	}
@@ -65,9 +65,9 @@ func (p *SubParams) AppendTo(body *form.Values, keyParts []string) {
 	}
 }
 
-// SubItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription
+// SubscriptionItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
-type SubItemsParams struct {
+type SubscriptionItemsParams struct {
 	Params       `form:"*"`
 	Deleted      bool   `form:"deleted"`
 	ID           string `form:"id"`
@@ -76,60 +76,60 @@ type SubItemsParams struct {
 	QuantityZero bool   `form:"quantity,zero"`
 }
 
-// SubListParams is the set of parameters that can be used when listing active subscriptions.
+// SubscriptionListParams is the set of parameters that can be used when listing active subscriptions.
 // For more details see https://stripe.com/docs/api#list_subscriptions.
-type SubListParams struct {
+type SubscriptionListParams struct {
 	ListParams   `form:"*"`
-	Billing      SubBilling        `form:"billing"`
-	Created      int64             `form:"created"`
-	CreatedRange *RangeQueryParams `form:"created"`
-	Customer     string            `form:"customer"`
-	Plan         string            `form:"plan"`
-	Status       SubStatus         `form:"status"`
+	Billing      SubscriptionBilling `form:"billing"`
+	Created      int64               `form:"created"`
+	CreatedRange *RangeQueryParams   `form:"created"`
+	Customer     string              `form:"customer"`
+	Plan         string              `form:"plan"`
+	Status       SubscriptionStatus  `form:"status"`
 }
 
-// Sub is the resource representing a Stripe subscription.
+// Subscription is the resource representing a Stripe subscription.
 // For more details see https://stripe.com/docs/api#subscriptions.
-type Sub struct {
-	Billing            SubBilling        `json:"billing"`
-	BillingCycleAnchor int64             `json:"billing_cycle_anchor"`
-	Canceled           int64             `json:"canceled_at"`
-	Created            int64             `json:"created"`
-	Customer           *Customer         `json:"customer"`
-	DaysUntilDue       uint64            `json:"days_until_due"`
-	Discount           *Discount         `json:"discount"`
-	EndCancel          bool              `json:"cancel_at_period_end"`
-	Ended              int64             `json:"ended_at"`
-	FeePercent         float64           `json:"application_fee_percent"`
-	ID                 string            `json:"id"`
-	Items              *SubItemList      `json:"items"`
-	Meta               map[string]string `json:"metadata"`
-	PeriodEnd          int64             `json:"current_period_end"`
-	PeriodStart        int64             `json:"current_period_start"`
-	Plan               *Plan             `json:"plan"`
-	Quantity           uint64            `json:"quantity"`
-	Start              int64             `json:"start"`
-	Status             SubStatus         `json:"status"`
-	TaxPercent         float64           `json:"tax_percent"`
-	TrialEnd           int64             `json:"trial_end"`
-	TrialStart         int64             `json:"trial_start"`
+type Subscription struct {
+	ApplicationFeePercent float64               `json:"application_fee_percent"`
+	Billing               SubscriptionBilling   `json:"billing"`
+	BillingCycleAnchor    int64                 `json:"billing_cycle_anchor"`
+	CanceledAt            int64                 `json:"canceled_at"`
+	Created               int64                 `json:"created"`
+	CurrentPeriodEnd      int64                 `json:"current_period_end"`
+	CurrentPeriodStart    int64                 `json:"current_period_start"`
+	Customer              *Customer             `json:"customer"`
+	DaysUntilDue          uint64                `json:"days_until_due"`
+	Discount              *Discount             `json:"discount"`
+	CancelAtPeriodEnd     bool                  `json:"cancel_at_period_end"`
+	EndedAt               int64                 `json:"ended_at"`
+	ID                    string                `json:"id"`
+	Items                 *SubscriptionItemList `json:"items"`
+	Metadata              map[string]string     `json:"metadata"`
+	Plan                  *Plan                 `json:"plan"`
+	Quantity              uint64                `json:"quantity"`
+	Start                 int64                 `json:"start"`
+	Status                SubscriptionStatus    `json:"status"`
+	TaxPercent            float64               `json:"tax_percent"`
+	TrialEnd              int64                 `json:"trial_end"`
+	TrialStart            int64                 `json:"trial_start"`
 }
 
-// SubList is a list object for subscriptions.
-type SubList struct {
+// SubscriptionList is a list object for subscriptions.
+type SubscriptionList struct {
 	ListMeta
-	Values []*Sub `json:"data"`
+	Data []*Subscription `json:"data"`
 }
 
-// UnmarshalJSON handles deserialization of a Sub.
+// UnmarshalJSON handles deserialization of a Subscription.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (s *Sub) UnmarshalJSON(data []byte) error {
-	type sub Sub
+func (s *Subscription) UnmarshalJSON(data []byte) error {
+	type sub Subscription
 	var ss sub
 	err := json.Unmarshal(data, &ss)
 	if err == nil {
-		*s = Sub(ss)
+		*s = Subscription(ss)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		s.ID = string(data[1 : len(data)-1])

--- a/sub.go
+++ b/sub.go
@@ -18,27 +18,23 @@ type SubscriptionBilling string
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubscriptionParams struct {
 	Params                      `form:"*"`
-	ApplicationFeePercent       float64                    `form:"application_fee_percent"`
-	ApplicationFeePercentZero   bool                       `form:"application_fee_percent,zero"`
+	ApplicationFeePercent       *float64                   `form:"application_fee_percent"`
 	Billing                     SubscriptionBilling        `form:"billing"`
 	BillingCycleAnchor          int64                      `form:"billing_cycle_anchor"`
 	BillingCycleAnchorNow       bool                       `form:"-"` // See custom AppendTo
 	BillingCycleAnchorUnchanged bool                       `form:"-"` // See custom AppendTo
 	Card                        *CardParams                `form:"card"`
-	Coupon                      string                     `form:"coupon"`
-	CouponEmpty                 bool                       `form:"coupon,empty"`
+	Coupon                      *string                    `form:"coupon"`
 	Customer                    string                     `form:"customer"`
 	DaysUntilDue                uint64                     `form:"days_until_due"`
 	Items                       []*SubscriptionItemsParams `form:"items,indexed"`
-	NoProrate                   bool                       `form:"prorate,invert"`
 	OnBehalfOf                  string                     `form:"on_behalf_of"`
 	Plan                        string                     `form:"plan"`
+	Prorate                     *bool                      `form:"prorate"`
 	ProrationDate               int64                      `form:"proration_date"`
-	Quantity                    uint64                     `form:"quantity"`
-	QuantityZero                bool                       `form:"quantity,zero"`
+	Quantity                    *uint64                    `form:"quantity"`
 	Source                      string                     `form:"source"`
-	TaxPercent                  float64                    `form:"tax_percent"`
-	TaxPercentZero              bool                       `form:"tax_percent,zero"`
+	TaxPercent                  *float64                   `form:"tax_percent"`
 	TrialEnd                    int64                      `form:"trial_end"`
 	TrialEndNow                 bool                       `form:"-"` // See custom AppendTo
 	TrialPeriodDays             int64                      `form:"trial_period_days"`
@@ -68,12 +64,11 @@ func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
 // SubscriptionItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubscriptionItemsParams struct {
-	Params       `form:"*"`
-	Deleted      bool   `form:"deleted"`
-	ID           string `form:"id"`
-	Plan         string `form:"plan"`
-	Quantity     uint64 `form:"quantity"`
-	QuantityZero bool   `form:"quantity,zero"`
+	Params   `form:"*"`
+	Deleted  bool    `form:"deleted"`
+	ID       string  `form:"id"`
+	Plan     string  `form:"plan"`
+	Quantity *uint64 `form:"quantity"`
 }
 
 // SubscriptionListParams is the set of parameters that can be used when listing active subscriptions.

--- a/sub/client.go
+++ b/sub/client.go
@@ -9,12 +9,12 @@ import (
 )
 
 const (
-	Trialing stripe.SubStatus = "trialing"
-	Active   stripe.SubStatus = "active"
-	PastDue  stripe.SubStatus = "past_due"
-	Canceled stripe.SubStatus = "canceled"
-	Unpaid   stripe.SubStatus = "unpaid"
-	All      stripe.SubStatus = "all"
+	Trialing stripe.SubscriptionStatus = "trialing"
+	Active   stripe.SubscriptionStatus = "active"
+	PastDue  stripe.SubscriptionStatus = "past_due"
+	Canceled stripe.SubscriptionStatus = "canceled"
+	Unpaid   stripe.SubscriptionStatus = "unpaid"
+	All      stripe.SubscriptionStatus = "all"
 )
 
 // Client is used to invoke /subscriptions APIs.
@@ -25,11 +25,11 @@ type Client struct {
 
 // New POSTS a new subscription for a customer.
 // For more details see https://stripe.com/docs/api#create_subscription.
-func New(params *stripe.SubParams) (*stripe.Sub, error) {
+func New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().New(params)
 }
 
-func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
+func (c Client) New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -39,7 +39,7 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 		form.AppendTo(body, params)
 	}
 
-	sub := &stripe.Sub{}
+	sub := &stripe.Subscription{}
 	err := c.B.Call("POST", "/subscriptions", c.Key, body, commonParams, sub)
 
 	return sub, err
@@ -47,11 +47,11 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 
 // Get returns the details of a subscription.
 // For more details see https://stripe.com/docs/api#retrieve_subscription.
-func Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -61,7 +61,7 @@ func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 		commonParams = &params.Params
 	}
 
-	sub := &stripe.Sub{}
+	sub := &stripe.Subscription{}
 	err := c.B.Call("GET", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
 
 	return sub, err
@@ -69,11 +69,11 @@ func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 
 // Update updates a subscription's properties.
 // For more details see https://stripe.com/docs/api#update_subscription.
-func Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().Update(id, params)
 }
 
-func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -83,7 +83,7 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 		form.AppendTo(body, params)
 	}
 
-	sub := &stripe.Sub{}
+	sub := &stripe.Subscription{}
 	err := c.B.Call("POST", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
 
 	return sub, err
@@ -91,11 +91,11 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 // Cancel removes a subscription.
 // For more details see https://stripe.com/docs/api#cancel_subscription.
-func Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func Cancel(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().Cancel(id, params)
 }
 
-func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func (c Client) Cancel(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -105,7 +105,7 @@ func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error)
 		form.AppendTo(body, params)
 	}
 
-	sub := &stripe.Sub{}
+	sub := &stripe.Subscription{}
 	err := c.B.Call("DELETE", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
 
 	return sub, err
@@ -113,11 +113,11 @@ func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 // List returns a list of subscriptions.
 // For more details see https://stripe.com/docs/api#list_subscriptions.
-func List(params *stripe.SubListParams) *Iter {
+func List(params *stripe.SubscriptionListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SubListParams) *Iter {
+func (c Client) List(params *stripe.SubscriptionListParams) *Iter {
 	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -130,11 +130,11 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.SubList{}
+		list := &stripe.SubscriptionList{}
 		err := c.B.Call("GET", "/subscriptions", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -149,10 +149,10 @@ type Iter struct {
 	*stripe.Iter
 }
 
-// Sub returns the most recent Sub
+// Subscription returns the most recent Subscription
 // visited by a call to Next.
-func (i *Iter) Sub() *stripe.Sub {
-	return i.Current().(*stripe.Sub)
+func (i *Iter) Subscription() *stripe.Subscription {
+	return i.Current().(*stripe.Subscription)
 }
 
 func getC() Client {

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -9,29 +9,29 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestSubCancel(t *testing.T) {
+func TestSubscriptionCancel(t *testing.T) {
 	subscription, err := Cancel("sub_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
 }
 
-func TestSubGet(t *testing.T) {
+func TestSubscriptionGet(t *testing.T) {
 	subscription, err := Get("sub_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
 }
 
-func TestSubList(t *testing.T) {
-	i := List(&stripe.SubListParams{})
+func TestSubscriptionList(t *testing.T) {
+	i := List(&stripe.SubscriptionListParams{})
 
 	// Verify that we can get at least one subscription
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.Sub())
+	assert.NotNil(t, i.Subscription())
 }
 
-func TestSubNew(t *testing.T) {
-	subscription, err := New(&stripe.SubParams{
+func TestSubscriptionNew(t *testing.T) {
+	subscription, err := New(&stripe.SubscriptionParams{
 		Customer:           "cus_123",
 		Plan:               "plan_123",
 		Quantity:           10,
@@ -44,10 +44,10 @@ func TestSubNew(t *testing.T) {
 	assert.NotNil(t, subscription)
 }
 
-func TestSubNew_WithItems(t *testing.T) {
-	subscription, err := New(&stripe.SubParams{
+func TestSubscriptionNew_WithItems(t *testing.T) {
+	subscription, err := New(&stripe.SubscriptionParams{
 		Customer: "cus_123",
-		Items: []*stripe.SubItemsParams{
+		Items: []*stripe.SubscriptionItemsParams{
 			{
 				Plan:         "gold",
 				QuantityZero: true,
@@ -58,8 +58,8 @@ func TestSubNew_WithItems(t *testing.T) {
 	assert.NotNil(t, subscription)
 }
 
-func TestSubUpdate(t *testing.T) {
-	subscription, err := Update("sub_123", &stripe.SubParams{
+func TestSubscriptionUpdate(t *testing.T) {
+	subscription, err := Update("sub_123", &stripe.SubscriptionParams{
 		NoProrate:      true,
 		QuantityZero:   true,
 		TaxPercentZero: true,

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -34,8 +34,8 @@ func TestSubscriptionNew(t *testing.T) {
 	subscription, err := New(&stripe.SubscriptionParams{
 		Customer:           "cus_123",
 		Plan:               "plan_123",
-		Quantity:           10,
-		TaxPercent:         20.0,
+		Quantity:           stripe.UInt64(10),
+		TaxPercent:         stripe.Float64(20.0),
 		BillingCycleAnchor: time.Now().AddDate(0, 0, 12).Unix(),
 		Billing:            "send_invoice",
 		DaysUntilDue:       30,
@@ -49,8 +49,8 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 		Customer: "cus_123",
 		Items: []*stripe.SubscriptionItemsParams{
 			{
-				Plan:         "gold",
-				QuantityZero: true,
+				Plan:     "gold",
+				Quantity: stripe.UInt64(0),
 			},
 		},
 	})
@@ -60,9 +60,9 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 
 func TestSubscriptionUpdate(t *testing.T) {
 	subscription, err := Update("sub_123", &stripe.SubscriptionParams{
-		NoProrate:      true,
-		QuantityZero:   true,
-		TaxPercentZero: true,
+		Prorate:    stripe.Bool(true),
+		Quantity:   stripe.UInt64(0),
+		TaxPercent: stripe.Float64(0),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)

--- a/sub_test.go
+++ b/sub_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
-func TestSubParams_AppendTo(t *testing.T) {
+func TestSubscriptionParams_AppendTo(t *testing.T) {
 	{
-		params := &SubParams{BillingCycleAnchorNow: true}
+		params := &SubscriptionParams{BillingCycleAnchorNow: true}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -17,7 +17,7 @@ func TestSubParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SubParams{BillingCycleAnchorUnchanged: true}
+		params := &SubscriptionParams{BillingCycleAnchorUnchanged: true}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -25,7 +25,7 @@ func TestSubParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SubParams{TrialEndNow: true}
+		params := &SubscriptionParams{TrialEndNow: true}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/subitem.go
+++ b/subitem.go
@@ -4,13 +4,12 @@ package stripe
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
 type SubscriptionItemParams struct {
 	Params        `form:"*"`
-	ID            string `form:"-"` // Handled in URL
-	NoProrate     bool   `form:"prorate,invert"`
-	Plan          string `form:"plan"`
-	ProrationDate int64  `form:"proration_date"`
-	Quantity      uint64 `form:"quantity"`
-	QuantityZero  bool   `form:"quantity,zero"`
-	Subscription  string `form:"subscription"`
+	ID            string  `form:"-"` // Handled in URL
+	Plan          string  `form:"plan"`
+	Prorate       *bool   `form:"prorate"`
+	ProrationDate int64   `form:"proration_date"`
+	Quantity      *uint64 `form:"quantity"`
+	Subscription  string  `form:"subscription"`
 }
 
 // SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.

--- a/subitem.go
+++ b/subitem.go
@@ -1,8 +1,8 @@
 package stripe
 
-// SubItemParams is the set of parameters that can be used when creating or updating a subscription item.
+// SubscriptionItemParams is the set of parameters that can be used when creating or updating a subscription item.
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
-type SubItemParams struct {
+type SubscriptionItemParams struct {
 	Params        `form:"*"`
 	ID            string `form:"-"` // Handled in URL
 	NoProrate     bool   `form:"prorate,invert"`
@@ -10,29 +10,29 @@ type SubItemParams struct {
 	ProrationDate int64  `form:"proration_date"`
 	Quantity      uint64 `form:"quantity"`
 	QuantityZero  bool   `form:"quantity,zero"`
-	Sub           string `form:"subscription"`
+	Subscription  string `form:"subscription"`
 }
 
-// SubItemListParams is the set of parameters that can be used when listing invoice items.
+// SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
-type SubItemListParams struct {
-	ListParams `form:"*"`
-	Sub        string `form:"subscription"`
+type SubscriptionItemListParams struct {
+	ListParams   `form:"*"`
+	Subscription string `form:"subscription"`
 }
 
-// SubItem is the resource representing a Stripe subscription item.
+// SubscriptionItem is the resource representing a Stripe subscription item.
 // For more details see https://stripe.com/docs/api#subscription_items.
-type SubItem struct {
+type SubscriptionItem struct {
 	Created  int64             `json:"created"`
 	Deleted  bool              `json:"deleted"`
 	ID       string            `json:"id"`
-	Meta     map[string]string `json:"metadata"`
+	Metadata map[string]string `json:"metadata"`
 	Plan     *Plan             `json:"plan"`
 	Quantity uint64            `json:"quantity"`
 }
 
-// SubItemList is a list of invoice items as retrieved from a list endpoint.
-type SubItemList struct {
+// SubscriptionItemList is a list of invoice items as retrieved from a list endpoint.
+type SubscriptionItemList struct {
 	ListMeta
-	Values []*SubItem `json:"data"`
+	Data []*SubscriptionItem `json:"data"`
 }

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -1,4 +1,4 @@
-// Package sub provides the /subscriptions APIs
+// Package subitem provides the /subscription_items APIs
 package subitem
 
 import (
@@ -16,11 +16,11 @@ type Client struct {
 
 // New POSTS a new subscription for a customer.
 // For more details see https://stripe.com/docs/api#create_subscription_item.
-func New(params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().New(params)
 }
 
-func (c Client) New(params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func (c Client) New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 	token := c.Key
@@ -31,18 +31,18 @@ func (c Client) New(params *stripe.SubItemParams) (*stripe.SubItem, error) {
 		form.AppendTo(body, params)
 	}
 
-	item := &stripe.SubItem{}
+	item := &stripe.SubscriptionItem{}
 	err := c.B.Call("POST", "/subscription_items", token, body, commonParams, item)
 	return item, err
 }
 
 // Get returns the details of a subscription.
 // For more details see https://stripe.com/docs/api#retrieve_subscription.
-func Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -52,7 +52,7 @@ func (c Client) Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 		form.AppendTo(body, params)
 	}
 
-	item := &stripe.SubItem{}
+	item := &stripe.SubscriptionItem{}
 	err := c.B.Call("GET", fmt.Sprintf("/subscription_items/%v", id), c.Key, body, commonParams, item)
 
 	return item, err
@@ -60,11 +60,11 @@ func (c Client) Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 
 // Update updates a subscription's properties.
 // For more details see https://stripe.com/docs/api#update_subscription.
-func Update(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Update(id, params)
 }
 
-func (c Client) Update(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 	token := c.Key
@@ -75,7 +75,7 @@ func (c Client) Update(id string, params *stripe.SubItemParams) (*stripe.SubItem
 		form.AppendTo(body, params)
 	}
 
-	subi := &stripe.SubItem{}
+	subi := &stripe.SubscriptionItem{}
 	err := c.B.Call("POST", fmt.Sprintf("/subscription_items/%v", id), token, body, commonParams, subi)
 
 	return subi, err
@@ -83,11 +83,11 @@ func (c Client) Update(id string, params *stripe.SubItemParams) (*stripe.SubItem
 
 // Del removes a subscription item.
 // For more details see https://stripe.com/docs/api#cancel_subscription.
-func Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Del(id, params)
 }
 
-func (c Client) Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -97,7 +97,7 @@ func (c Client) Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 		commonParams = &params.Params
 	}
 
-	item := &stripe.SubItem{}
+	item := &stripe.SubscriptionItem{}
 	err := c.B.Call("DELETE", fmt.Sprintf("/subscription_items/%v", id), c.Key, body, commonParams, item)
 
 	return item, err
@@ -105,11 +105,11 @@ func (c Client) Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 
 // List returns a list of subscription items.
 // For more details see https://stripe.com/docs/api#list_subscription_items.
-func List(params *stripe.SubItemListParams) *Iter {
+func List(params *stripe.SubscriptionItemListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SubItemListParams) *Iter {
+func (c Client) List(params *stripe.SubscriptionItemListParams) *Iter {
 	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -122,11 +122,11 @@ func (c Client) List(params *stripe.SubItemListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.SubItemList{}
+		list := &stripe.SubscriptionItemList{}
 		err := c.B.Call("GET", "/subscription_items", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -134,17 +134,17 @@ func (c Client) List(params *stripe.SubItemListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Subs.
+// Iter is an iterator for lists of Subscriptions.
 // The embedded Iter carries methods with it;
 // see its documentation for details.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Sub returns the most recent Sub
+// SubscriptionItem returns the most recent SubscriptionItem
 // visited by a call to Next.
-func (i *Iter) SubItem() *stripe.SubItem {
-	return i.Current().(*stripe.SubItem)
+func (i *Iter) SubscriptionItem() *stripe.SubscriptionItem {
+	return i.Current().(*stripe.SubscriptionItem)
 }
 
 func getC() Client {

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -31,7 +31,7 @@ func TestSubscriptionItemList(t *testing.T) {
 
 func TestSubscriptionItemNew(t *testing.T) {
 	item, err := New(&stripe.SubscriptionItemParams{
-		Quantity:     99,
+		Quantity:     stripe.UInt64(99),
 		Plan:         "plan_123",
 		Subscription: "sub_123",
 	})
@@ -41,7 +41,7 @@ func TestSubscriptionItemNew(t *testing.T) {
 
 func TestSubscriptionItemUpdate(t *testing.T) {
 	item, err := Update("si_123", &stripe.SubscriptionItemParams{
-		Quantity: 10,
+		Quantity: stripe.UInt64(10),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -8,39 +8,39 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestSubItemDel(t *testing.T) {
+func TestSubscriptionItemDel(t *testing.T) {
 	item, err := Del("si_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, item)
 }
 
-func TestSubItemGet(t *testing.T) {
+func TestSubscriptionItemGet(t *testing.T) {
 	item, err := Get("si_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, item)
 }
 
-func TestSubItemList(t *testing.T) {
-	i := List(&stripe.SubItemListParams{})
+func TestSubscriptionItemList(t *testing.T) {
+	i := List(&stripe.SubscriptionItemListParams{})
 
 	// Verify that we can get at least one item
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.SubItem())
+	assert.NotNil(t, i.SubscriptionItem())
 }
 
-func TestSubItemNew(t *testing.T) {
-	item, err := New(&stripe.SubItemParams{
-		Quantity: 99,
-		Plan:     "plan_123",
-		Sub:      "sub_123",
+func TestSubscriptionItemNew(t *testing.T) {
+	item, err := New(&stripe.SubscriptionItemParams{
+		Quantity:     99,
+		Plan:         "plan_123",
+		Subscription: "sub_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)
 }
 
-func TestSubItemUpdate(t *testing.T) {
-	item, err := Update("si_123", &stripe.SubItemParams{
+func TestSubscriptionItemUpdate(t *testing.T) {
+	item, err := Update("si_123", &stripe.SubscriptionItemParams{
 		Quantity: 10,
 	})
 	assert.Nil(t, err)

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -22,7 +22,7 @@ type ThreeDSecure struct {
 	Created       int64              `json:"created"`
 	Currency      Currency           `json:"currency"`
 	ID            string             `json:"id"`
-	Live          bool               `json:"livemode"`
+	Livemode      bool               `json:"livemode"`
 	RedirectURL   string             `json:"redirect_url"`
 	Status        ThreeDSecureStatus `json:"status"`
 	Supported     string             `json:"supported"`

--- a/token.go
+++ b/token.go
@@ -7,10 +7,10 @@ type TokenType string
 // TokenParams is the set of parameters that can be used when creating a token.
 // For more details see https://stripe.com/docs/api#create_card_token and https://stripe.com/docs/api#create_bank_account_token.
 type TokenParams struct {
-	Params   `form:"*"`
-	Bank     *BankAccountParams `form:"bank_account"`
-	Card     *CardParams        `form:"card"`
-	Customer string             `form:"customer"`
+	Params      `form:"*"`
+	BankAccount *BankAccountParams `form:"bank_account"`
+	Card        *CardParams        `form:"card"`
+	Customer    string             `form:"customer"`
 
 	// Email is an undocumented parameter used by Stripe Checkout
 	// It may be removed from the API without notice.
@@ -22,19 +22,19 @@ type TokenParams struct {
 // Token is the resource representing a Stripe token.
 // For more details see https://stripe.com/docs/api#tokens.
 type Token struct {
-	Bank     *BankAccount `json:"bank_account"`
-	Card     *Card        `json:"card"`
-	ClientIP string       `json:"client_ip"`
-	Created  int64        `json:"created"`
+	BankAccount *BankAccount `json:"bank_account"`
+	Card        *Card        `json:"card"`
+	ClientIP    string       `json:"client_ip"`
+	Created     int64        `json:"created"`
 
 	// Email is an undocumented field but included for all tokens created
 	// with Stripe Checkout.
 	Email string `json:"email"`
 
-	ID   string    `json:"id"`
-	Live bool      `json:"livemode"`
-	Type TokenType `json:"type"`
-	Used bool      `json:"used"`
+	ID       string    `json:"id"`
+	Livemode bool      `json:"livemode"`
+	Type     TokenType `json:"type"`
+	Used     bool      `json:"used"`
 }
 
 // PIIParams are parameters for personal identifiable information (PII).

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -16,10 +16,10 @@ func TestTokenGet(t *testing.T) {
 
 func TestTokenNew_WithBankAccount(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
-		Bank: &stripe.BankAccountParams{
-			Country: "US",
-			Routing: "110000000",
-			Account: "000123456789",
+		BankAccount: &stripe.BankAccountParams{
+			Country:       "US",
+			RoutingNumber: "110000000",
+			AccountNumber: "000123456789",
 		},
 	})
 	assert.Nil(t, err)
@@ -29,9 +29,9 @@ func TestTokenNew_WithBankAccount(t *testing.T) {
 func TestTokenNew_WithCard(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
 		Card: &stripe.CardParams{
-			Number: "4242424242424242", // raw PAN as we're testing token creation
-			Month:  "10",
-			Year:   "20",
+			Number:   "4242424242424242", // raw PAN as we're testing token creation
+			ExpMonth: "10",
+			ExpYear:  "20",
 		},
 	})
 	assert.Nil(t, err)
@@ -63,7 +63,7 @@ func TestTokenNew_SharedCustomerCard(t *testing.T) {
 
 func TestTokenNew_SharedCustomerBankAccount(t *testing.T) {
 	params := &stripe.TokenParams{
-		Bank: &stripe.BankAccountParams{
+		BankAccount: &stripe.BankAccountParams{
 			ID: "ba_123",
 		},
 		Customer: "cus_123",

--- a/transfer.go
+++ b/transfer.go
@@ -17,13 +17,13 @@ type TransferDestination struct {
 // TransferParams is the set of parameters that can be used when creating or updating a transfer.
 // For more details see https://stripe.com/docs/api#create_transfer and https://stripe.com/docs/api#update_transfer.
 type TransferParams struct {
-	Params        `form:"*"`
-	Amount        int64              `form:"amount"`
-	Currency      Currency           `form:"currency"`
-	Dest          string             `form:"destination"`
-	SourceTx      string             `form:"source_transaction"`
-	SourceType    TransferSourceType `form:"source_type"`
-	TransferGroup string             `form:"transfer_group"`
+	Params            `form:"*"`
+	Amount            int64              `form:"amount"`
+	Currency          Currency           `form:"currency"`
+	Destination       string             `form:"destination"`
+	SourceTransaction string             `form:"source_transaction"`
+	SourceType        TransferSourceType `form:"source_type"`
+	TransferGroup     string             `form:"transfer_group"`
 }
 
 // TransferListParams is the set of parameters that can be used when listing transfers.
@@ -32,35 +32,33 @@ type TransferListParams struct {
 	ListParams    `form:"*"`
 	Created       int64             `form:"created"`
 	CreatedRange  *RangeQueryParams `form:"created"`
-	Currency      Currency          `form:"currency"`
-	Dest          string            `form:"destination"`
+	Destination   string            `form:"destination"`
 	TransferGroup string            `form:"transfer_group"`
 }
 
 // Transfer is the resource representing a Stripe transfer.
 // For more details see https://stripe.com/docs/api#transfers.
 type Transfer struct {
-	Amount         int64               `json:"amount"`
-	AmountReversed int64               `json:"amount_reversed"`
-	Created        int64               `json:"created"`
-	Currency       Currency            `json:"currency"`
-	Dest           TransferDestination `json:"destination"`
-	DestPayment    string              `json:"destination_payment"`
-	ID             string              `json:"id"`
-	Live           bool                `json:"livemode"`
-	Meta           map[string]string   `json:"metadata"`
-	Reversals      *ReversalList       `json:"reversals"`
-	Reversed       bool                `json:"reversed"`
-	SourceTx       *TransactionSource  `json:"source_transaction"`
-	Statement      string              `json:"statement_descriptor"`
-	TransferGroup  string              `json:"transfer_group"`
-	Tx             *Transaction        `json:"balance_transaction"`
+	Amount             int64                     `json:"amount"`
+	AmountReversed     int64                     `json:"amount_reversed"`
+	BalanceTransaction *BalanceTransaction       `json:"balance_transaction"`
+	Created            int64                     `json:"created"`
+	Currency           Currency                  `json:"currency"`
+	Destination        TransferDestination       `json:"destination"`
+	DestinationPayment string                    `json:"destination_payment"`
+	ID                 string                    `json:"id"`
+	Livemode           bool                      `json:"livemode"`
+	Metadata           map[string]string         `json:"metadata"`
+	Reversals          *ReversalList             `json:"reversals"`
+	Reversed           bool                      `json:"reversed"`
+	SourceTransaction  *BalanceTransactionSource `json:"source_transaction"`
+	TransferGroup      string                    `json:"transfer_group"`
 }
 
 // TransferList is a list of transfers as retrieved from a list endpoint.
 type TransferList struct {
 	ListMeta
-	Values []*Transfer `json:"data"`
+	Data []*Transfer `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Transfer.

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -103,8 +103,8 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 		list := &stripe.TransferList{}
 		err := c.B.Call("GET", "/transfers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -25,10 +25,10 @@ func TestTransferList(t *testing.T) {
 
 func TestTransferNew(t *testing.T) {
 	transfer, err := New(&stripe.TransferParams{
-		Amount:   123,
-		Currency: "usd",
-		Dest:     "acct_123",
-		SourceTx: "ch_123",
+		Amount:            123,
+		Currency:          "usd",
+		Destination:       "acct_123",
+		SourceTransaction: "ch_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, transfer)
@@ -37,7 +37,7 @@ func TestTransferNew(t *testing.T) {
 func TestTransferUpdate(t *testing.T) {
 	transfer, err := Update("tr_123", &stripe.TransferParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -30,24 +30,24 @@ func TestTransferUnmarshal(t *testing.T) {
 		t.Errorf("Problem deserializing transfer, got ID %v", transfer.ID)
 	}
 
-	source_tx := transfer.SourceTx
-	if source_tx == nil {
-		t.Errorf("Problem deserializing transfer, didn't get a SourceTx")
+	source_transaction := transfer.SourceTransaction
+	if source_transaction == nil {
+		t.Errorf("Problem deserializing transfer, didn't get a SourceTransaction")
 	}
 
-	if source_tx.ID != "ch_1234" {
+	if source_transaction.ID != "ch_1234" {
 		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for ID")
 	}
 
-	if source_tx.Type != TransactionSourceCharge {
+	if source_transaction.Type != BalanceTransactionSourceTypeCharge {
 		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for Type")
 	}
 
-	if source_tx.Charge == nil {
+	if source_transaction.Charge == nil {
 		t.Errorf("Problem deserializing transfer.source_transaction, didn't get a Charge")
 	}
 
-	if source_tx.Charge.ID != "ch_1234" {
+	if source_transaction.Charge.ID != "ch_1234" {
 		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for Charge.ID")
 	}
 }


### PR DESCRIPTION
This PR ensures that all properties in the library matches the official API. Names are not shortened anymore making it easier to associated a given parameter to its API counterpart.

We can't list all the changes one by one as those are extensive but here are the ones likely to impact most integrations:
* All properties with the word url in it now have the same case such as `BusinessURL`.
* All properties with the word four in it now use a digit such as `DynamicLast4` or `SSNLast4`.
* Renamed confusing properties such as `Account` on `BankAccount` becoming `AccountNumber` to avoid confusing with its Connect counterpart which is now named `Account` instead of `AccountID`.
* Properties such as `MonthAnchor` or constants such as `Month` are now renamed to match the corresponding parameter/value in the API `MonthlyAnchor` and `Monthly`.
* `Meta` and `Live` have been renamed to `Metadata` and `Livemode` on all classes
* `Values` on List objects has been renamed to `Data`
* Some classes have been renamed. 
  * `Owner` is now `AdditionalOwner`,
  * `Transaction` is now `BalanceTransaction` with all constants and corresponding classes renamed to match this
  * references to `Tx` were also replaced by `BalanceTransaction` in classes, properties and constants
  * `Fee` and `FeeRefund` have been renamed to `ApplicationFee` and `ApplicationFeeRefund` along with all related classes, properties and constants.
  * `Sub` has been renamed to `Subscription` along with all related classes, properties and constants.
* Card parameters have been renamed such as `City` becoming `AddressCity` and `Month` becoming `ExpMonth.
* Errors codes have been prefixed with `ErrorCode` such as `ErrorCodeCardDeclined` or `ErrorCodeIncorrectZip`.
* Event properties are now named `Object` and `PreviousAttributes` and methods `GetObjectValue()` and `GetPreviousValue()`.
* Pagination properties have been renamed to `StartingAfter`, `EndingBefore` and `HasMore`.
* `AddMeta()` has been renamed to `AddMetadata()`, `Expand()` to `AddExpand()`

