### PR TITLE
Fix Source creation so that TypeData is passed properly

### DIFF
--- a/source.go
+++ b/source.go
@@ -191,6 +191,10 @@ type Source struct {
 // AppendTo implements custom encoding logic for SourceObjectParams so that the special
 // "TypeData" value for is sent as the correct parameter based on the Source type
 func (p *SourceObjectParams) AppendTo(body *form.Values, keyParts []string) {
+	if len(p.TypeData) > 0 && len(p.Type) == 0 {
+		panic("You can not fill TypeData if you don't explicitly set Type")
+	}
+
 	for k, vs := range p.TypeData {
 		body.Add(form.FormatKey(append(keyParts, p.Type, k)), vs)
 	}

--- a/source.go
+++ b/source.go
@@ -2,6 +2,8 @@ package stripe
 
 import (
 	"encoding/json"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // SourceStatus represents the possible statuses of a source object.
@@ -83,7 +85,7 @@ type SourceObjectParams struct {
 	Redirect *RedirectParams    `form:"redirect"`
 	Token    string             `form:"token"`
 	Type     string             `form:"type"`
-	TypeData map[string]string  `form:"*"`
+	TypeData map[string]string  `form:"-"`
 	Usage    SourceUsage        `form:"usage"`
 }
 
@@ -184,6 +186,14 @@ type Source struct {
 	TypeData     map[string]interface{}
 	Usage        SourceUsage       `json:"usage"`
 	Verification *VerificationFlow `json:"verification,omitempty"`
+}
+
+// AppendTo implements custom encoding logic for SourceObjectParams so that the special
+// "TypeData" value for is sent as the correct parameter based on the Source type
+func (p *SourceObjectParams) AppendTo(body *form.Values, keyParts []string) {
+	for k, vs := range p.TypeData {
+		body.Add(form.FormatKey(append(keyParts, p.Type, k)), vs)
+	}
 }
 
 // UnmarshalJSON handles deserialization of an Source. This custom unmarshaling

--- a/source_test.go
+++ b/source_test.go
@@ -12,6 +12,7 @@ func TestSourceObjectParams_AppendTo(t *testing.T) {
 	// encoding
 	{
 		params := &SourceObjectParams{
+			Type: "source_type",
 			TypeData: map[string]string{
 				"foo": "bar",
 			},
@@ -19,6 +20,6 @@ func TestSourceObjectParams_AppendTo(t *testing.T) {
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
-		assert.Equal(t, []string{"bar"}, body.Get("foo"))
+		assert.Equal(t, []string{"bar"}, body.Get("source_type[foo]"))
 	}
 }


### PR DESCRIPTION
The TypeData values are specific to each source type. When the parameters are sent, they have to be passed to the API under the source's type's name so for 3DS you pass `three_d_secure[card]` for example while for Sofort you pass `sofort[country]`.

This uses a custom `AppendTo` for `SourceObjectParams` so that the `TypeData` properties are looped over and encoded with the right level based on the current Source's type.

r? @brandur-stripe 

I've confirmed it works for 3DS now but I was not sure if there was an easier way that looping over `p.TypeData` ourselves.

Fixes https://github.com/stripe/stripe-go/issues/460