### PR TITLE
Upgrade stripe-mock to 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.1.23
+    - STRIPE_MOCK_VERSION=0.2.0
 
 go:
   - 1.7

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// MockMinimumVersion is the minimum acceptible version for stripe-mock.
-	MockMinimumVersion = "0.1.23"
+	MockMinimumVersion = "0.2.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
This pulls us onto the new version of stripe-mock which should be
checking parameters more accurately now that it's on OpenAPI 3.0.