### PR TITLE
Properly pass the Params parameters for sku and product

### DIFF
--- a/product/client.go
+++ b/product/client.go
@@ -24,6 +24,7 @@ func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
 	var commonParams *stripe.Params
 
 	if params != nil {
+		commonParams = &params.Params
 		body = &form.Values{}
 		form.AppendTo(body, params)
 	}
@@ -47,6 +48,7 @@ func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product
 	var commonParams *stripe.Params
 
 	if params != nil {
+		commonParams = &params.Params
 		body = &form.Values{}
 		form.AppendTo(body, params)
 	}
@@ -59,15 +61,24 @@ func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product
 
 // Get returns the details of an product
 // For more details see https://stripe.com/docs/api#retrieve_product.
-func Get(id string) (*stripe.Product, error) {
-	return getC().Get(id)
+func Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
+	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string) (*stripe.Product, error) {
-	product := &stripe.Product{}
-	err := c.B.Call("GET", "/products/"+id, c.Key, nil, nil, product)
+func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
+	var body *form.Values
+	var commonParams *stripe.Params
 
-	return product, err
+	if params != nil {
+		commonParams = &params.Params
+		body = &form.Values{}
+		form.AppendTo(body, params)
+	}
+
+	p := &stripe.Product{}
+	err := c.B.Call("GET", "/products/"+id, c.Key, body, commonParams, p)
+
+	return p, err
 }
 
 // List returns a list of products.
@@ -132,10 +143,10 @@ func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, e
 		commonParams = &params.Params
 	}
 
-	product := &stripe.Product{}
-	err := c.B.Call("DELETE", "/products/"+id, c.Key, body, commonParams, product)
+	p := &stripe.Product{}
+	err := c.B.Call("DELETE", "/products/"+id, c.Key, body, commonParams, p)
 
-	return product, err
+	return p, err
 }
 
 func getC() Client {

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -15,7 +15,7 @@ func TestProductDel(t *testing.T) {
 }
 
 func TestProductGet(t *testing.T) {
-	product, err := Get("prod_123")
+	product, err := Get("prod_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, product)
 }

--- a/sku/client.go
+++ b/sku/client.go
@@ -24,14 +24,15 @@ func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
 	var commonParams *stripe.Params
 
 	if params != nil {
+		commonParams = &params.Params
 		body = &form.Values{}
 		form.AppendTo(body, params)
 	}
 
-	p := &stripe.SKU{}
-	err := c.B.Call("POST", "/skus", c.Key, body, commonParams, p)
+	s := &stripe.SKU{}
+	err := c.B.Call("POST", "/skus", c.Key, body, commonParams, s)
 
-	return p, err
+	return s, err
 }
 
 // Update updates a SKU's properties.
@@ -47,14 +48,15 @@ func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error)
 	var commonParams *stripe.Params
 
 	if params != nil {
+		commonParams = &params.Params
 		body = &form.Values{}
 		form.AppendTo(body, params)
 	}
 
-	p := &stripe.SKU{}
-	err := c.B.Call("POST", "/skus/"+id, c.Key, body, commonParams, p)
+	s := &stripe.SKU{}
+	err := c.B.Call("POST", "/skus/"+id, c.Key, body, commonParams, s)
 
-	return p, err
+	return s, err
 }
 
 // Get returns the details of an sku
@@ -64,7 +66,6 @@ func Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 }
 
 func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	sku := &stripe.SKU{}
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -73,9 +74,11 @@ func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 		body = &form.Values{}
 		form.AppendTo(body, params)
 	}
-	err := c.B.Call("GET", "/skus/"+id, c.Key, body, commonParams, sku)
 
-	return sku, err
+	s := &stripe.SKU{}
+	err := c.B.Call("GET", "/skus/"+id, c.Key, body, commonParams, s)
+
+	return s, err
 }
 
 // List returns a list of skus.
@@ -135,15 +138,15 @@ func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	var commonParams *stripe.Params
 
 	if params != nil {
+		commonParams = &params.Params
 		body = &form.Values{}
 		form.AppendTo(body, params)
-		commonParams = &params.Params
 	}
 
-	sku := &stripe.SKU{}
-	err := c.B.Call("DELETE", "/skus/"+id, c.Key, body, commonParams, sku)
+	s := &stripe.SKU{}
+	err := c.B.Call("DELETE", "/skus/"+id, c.Key, body, commonParams, s)
 
-	return sku, err
+	return s, err
 }
 
 func getC() Client {


### PR DESCRIPTION
This properly sends the extra parameters in params.Params for sku and for product
This also adds the ability to pass `ProductParams` to the Get for the product resource

Fixes https://github.com/stripe/stripe-go/issues/466

r? @brandur-stripe 