### PR TITLE
Parse zero-val pointers

### DIFF
--- a/form/form.go
+++ b/form/form.go
@@ -146,7 +146,8 @@ func FormatKey(parts []string) string {
 // ---
 
 func boolEncoder(values *Values, v reflect.Value, keyParts []string, options *formOptions) {
-	if !v.Bool() && !(options != nil && options.EncodeZeroVal) {
+	val := v.Bool()
+	if !val && !(options != nil && options.EncodeZeroVal) {
 		return
 	}
 
@@ -159,11 +160,10 @@ func boolEncoder(values *Values, v reflect.Value, keyParts []string, options *fo
 		case options.Zero:
 			values.Add(FormatKey(keyParts), "0")
 		case options.EncodeZeroVal:
-			fmt.Println(strconv.FormatBool(v.Bool()))
-			values.Add(FormatKey(keyParts), strconv.FormatBool(v.Bool()))
+			values.Add(FormatKey(keyParts), strconv.FormatBool(val))
 		}
 	} else {
-		values.Add(FormatKey(keyParts), strconv.FormatBool(v.Bool()))
+		values.Add(FormatKey(keyParts), strconv.FormatBool(val))
 	}
 }
 

--- a/form/form.go
+++ b/form/form.go
@@ -29,13 +29,13 @@ type Appender interface {
 
 // encoderFunc is used to encode any type from a request.
 //
-// A note about encodeZeroVal:
+// A note about encodeZero:
 // Since some types in the Stripe API are defaulted to non-zero values, and Go defaults types to their zero values,
 // any type that has a Stripe API default of a non-zero value is defined as a go pointer, meaning nil defaults to
 // the Stripe API non-zero value. To override this, a check is made to see if the value is the zero-value for that
-// type. If it is, and encodeZeroVal is true, it's encoded. This is ignored as a parameter when dealing with types
+// type. If it is, and encodeZero is true, it's encoded. This is ignored as a parameter when dealing with types
 // like structs, where the decision can not be made preemptivelys.
-type encoderFunc func(values *Values, v reflect.Value, keyParts []string, encodeZeroVal bool, options *formOptions)
+type encoderFunc func(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions)
 
 // field represents a single field found in a struct. It caches information
 // about that field so that we can make encoding faster.
@@ -148,9 +148,9 @@ func FormatKey(parts []string) string {
 
 // ---
 
-func boolEncoder(values *Values, v reflect.Value, keyParts []string, encodeZeroVal bool, options *formOptions) {
+func boolEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
 	val := v.Bool()
-	if !val && !encodeZeroVal {
+	if !val && !encodeZero {
 		return
 	}
 
@@ -212,17 +212,17 @@ func buildStructEncoder(t reflect.Type) encoderFunc {
 	return se.encode
 }
 
-func float32Encoder(values *Values, v reflect.Value, keyParts []string, encodeZeroVal bool, options *formOptions) {
+func float32Encoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
 	val := v.Float()
-	if val == 0.0 && !encodeZeroVal {
+	if val == 0.0 && !encodeZero {
 		return
 	}
 	values.Add(FormatKey(keyParts), strconv.FormatFloat(val, 'f', 4, 32))
 }
 
-func float64Encoder(values *Values, v reflect.Value, keyParts []string, encodeZeroVal bool, options *formOptions) {
+func float64Encoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
 	val := v.Float()
-	if val == 0.0 && !encodeZeroVal {
+	if val == 0.0 && !encodeZero {
 		return
 	}
 	values.Add(FormatKey(keyParts), strconv.FormatFloat(val, 'f', 4, 64))
@@ -287,9 +287,9 @@ func getCachedOrBuildTypeEncoder(t reflect.Type) encoderFunc {
 	return f
 }
 
-func intEncoder(values *Values, v reflect.Value, keyParts []string, encodeZeroVal bool, options *formOptions) {
+func intEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
 	val := v.Int()
-	if val == 0 && !encodeZeroVal {
+	if val == 0 && !encodeZero {
 		return
 	}
 	values.Add(FormatKey(keyParts), strconv.FormatInt(val, 10))
@@ -316,17 +316,17 @@ func mapEncoder(values *Values, v reflect.Value, keyParts []string, _ bool, _ *f
 	}
 }
 
-func stringEncoder(values *Values, v reflect.Value, keyParts []string, encodeZeroVal bool, options *formOptions) {
+func stringEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
 	val := v.String()
-	if val == "" && !encodeZeroVal {
+	if val == "" && !encodeZero {
 		return
 	}
 	values.Add(FormatKey(keyParts), val)
 }
 
-func uintEncoder(values *Values, v reflect.Value, keyParts []string, encodeZeroVal bool, options *formOptions) {
+func uintEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
 	val := v.Uint()
-	if val == 0 && !encodeZeroVal {
+	if val == 0 && !encodeZero {
 		return
 	}
 	values.Add(FormatKey(keyParts), strconv.FormatUint(val, 10))

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -132,18 +132,26 @@ func TestAppendTo(t *testing.T) {
 	var boolValF = false
 
 	var float32Val float32 = 1.2345
+	var float32Val0 float32
 
 	var float64Val = 1.2345
+	var float64Val0 = 0.0
 
 	var intVal = 123
+	var intVal0 = 0
 	var int8Val int8 = 123
+	var int8Val0 int8
 	var int16Val int16 = 123
+	var int16Val0 int16
 	var int32Val int32 = 123
+	var int32Val0 int32
 	var int64Val int64 = 123
+	var int64Val0 int64
 
 	var sliceVal = []string{"1", "2", "3"}
 
 	var stringVal = "123"
+	var stringVal0 = ""
 
 	var subStructVal = testSubStruct{
 		SubSubStruct: testSubSubStruct{
@@ -152,10 +160,15 @@ func TestAppendTo(t *testing.T) {
 	}
 
 	var uintVal uint = 123
+	var uintVal0 uint
 	var uint8Val uint8 = 123
+	var uint8Val0 uint8
 	var uint16Val uint16 = 123
+	var uint16Val0 uint16
 	var uint32Val uint32 = 123
+	var uint32Val0 uint32
 	var uint64Val uint64 = 123
+	var uint64Val0 uint64
 
 	testCases := []struct {
 		field string
@@ -167,7 +180,7 @@ func TestAppendTo(t *testing.T) {
 		{"array_indexed[2]", &testStruct{ArrayIndexed: arrayVal}, "3"},
 
 		{"bool", &testStruct{Bool: boolValT}, "true"},
-		{"bool_ptr", &testStruct{BoolPtr: nil}, ""},
+		{"bool_ptr", &testStruct{}, ""},
 		{"bool_ptr", &testStruct{BoolPtr: &boolValT}, "true"},
 		{"bool_ptr", &testStruct{BoolPtr: &boolValF}, "false"},
 
@@ -175,20 +188,34 @@ func TestAppendTo(t *testing.T) {
 
 		{"float32", &testStruct{Float32: float32Val}, "1.2345"},
 		{"float32_ptr", &testStruct{Float32Ptr: &float32Val}, "1.2345"},
+		{"float32_ptr", &testStruct{Float32Ptr: &float32Val0}, "0.000"},
+		{"float32_ptr", &testStruct{}, ""},
 
 		{"float64", &testStruct{Float64: float64Val}, "1.2345"},
 		{"float64_ptr", &testStruct{Float64Ptr: &float64Val}, "1.2345"},
+		{"float64_ptr", &testStruct{Float64Ptr: &float64Val0}, "0.0000"},
+		{"float64_ptr", &testStruct{}, ""},
 
 		{"int", &testStruct{Int: intVal}, "123"},
 		{"int_ptr", &testStruct{IntPtr: &intVal}, "123"},
+		{"int_ptr", &testStruct{IntPtr: &intVal0}, "0"},
+		{"int_ptr", &testStruct{}, ""},
 		{"int8", &testStruct{Int8: int8Val}, "123"},
 		{"int8_ptr", &testStruct{Int8Ptr: &int8Val}, "123"},
+		{"int8_ptr", &testStruct{Int8Ptr: &int8Val0}, "0"},
+		{"int8_ptr", &testStruct{}, ""},
 		{"int16", &testStruct{Int16: int16Val}, "123"},
 		{"int16_ptr", &testStruct{Int16Ptr: &int16Val}, "123"},
+		{"int16_ptr", &testStruct{Int16Ptr: &int16Val0}, "0"},
+		{"int16_ptr", &testStruct{}, ""},
 		{"int32", &testStruct{Int32: int32Val}, "123"},
 		{"int32_ptr", &testStruct{Int32Ptr: &int32Val}, "123"},
+		{"int32_ptr", &testStruct{Int32Ptr: &int32Val0}, "0"},
+		{"int32_ptr", &testStruct{}, ""},
 		{"int64", &testStruct{Int64: int64Val}, "123"},
 		{"int64_ptr", &testStruct{Int64Ptr: &int64Val}, "123"},
+		{"int64_ptr", &testStruct{Int64Ptr: &int64Val0}, "0"},
+		{"int64_ptr", &testStruct{}, ""},
 
 		{"inverted", &testStruct{Inverted: true}, "false"},
 
@@ -214,6 +241,8 @@ func TestAppendTo(t *testing.T) {
 
 		{"string", &testStruct{String: stringVal}, stringVal},
 		{"string_ptr", &testStruct{StringPtr: &stringVal}, stringVal},
+		{"string_ptr", &testStruct{StringPtr: &stringVal0}, stringVal0},
+		{"string_ptr", &testStruct{}, stringVal0},
 
 		{"substruct[subsubstruct][string]", &testStruct{SubStruct: subStructVal}, "123"},
 		{"substruct_ptr[subsubstruct][string]", &testStruct{SubStructPtr: &subStructVal}, "123"},
@@ -223,14 +252,24 @@ func TestAppendTo(t *testing.T) {
 
 		{"uint", &testStruct{Uuint: uintVal}, "123"},
 		{"uint_ptr", &testStruct{UuintPtr: &uintVal}, "123"},
+		{"uint_ptr", &testStruct{UuintPtr: &uintVal0}, "0"},
+		{"uint_ptr", &testStruct{}, ""},
 		{"uint8", &testStruct{Uuint8: uint8Val}, "123"},
 		{"uint8_ptr", &testStruct{Uuint8Ptr: &uint8Val}, "123"},
+		{"uint8_ptr", &testStruct{Uuint8Ptr: &uint8Val0}, "0"},
+		{"uint8_ptr", &testStruct{}, ""},
 		{"uint16", &testStruct{Uuint16: uint16Val}, "123"},
 		{"uint16_ptr", &testStruct{Uuint16Ptr: &uint16Val}, "123"},
+		{"uint16_ptr", &testStruct{Uuint16Ptr: &uint16Val0}, "0"},
+		{"uint16_ptr", &testStruct{}, ""},
 		{"uint32", &testStruct{Uuint32: uint32Val}, "123"},
 		{"uint32_ptr", &testStruct{Uuint32Ptr: &uint32Val}, "123"},
+		{"uint32_ptr", &testStruct{Uuint32Ptr: &uint32Val0}, "0"},
+		{"uint32_ptr", &testStruct{}, ""},
 		{"uint64", &testStruct{Uuint64: uint64Val}, "123"},
 		{"uint64_ptr", &testStruct{Uuint64Ptr: &uint64Val}, "123"},
+		{"uint64_ptr", &testStruct{Uuint64Ptr: &uint64Val0}, "0"},
+		{"uint64_ptr", &testStruct{}, ""},
 
 		{"zeroed", &testStruct{Zeroed: true}, "0"},
 	}

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -128,7 +128,8 @@ func BenchmarkAppendTo(b *testing.B) {
 func TestAppendTo(t *testing.T) {
 	var arrayVal = [3]string{"1", "2", "3"}
 
-	var boolVal = true
+	var boolValT = true
+	var boolValF = false
 
 	var float32Val float32 = 1.2345
 
@@ -165,8 +166,10 @@ func TestAppendTo(t *testing.T) {
 
 		{"array_indexed[2]", &testStruct{ArrayIndexed: arrayVal}, "3"},
 
-		{"bool", &testStruct{Bool: boolVal}, "true"},
-		{"bool_ptr", &testStruct{BoolPtr: &boolVal}, "true"},
+		{"bool", &testStruct{Bool: boolValT}, "true"},
+		{"bool_ptr", &testStruct{BoolPtr: nil}, ""},
+		{"bool_ptr", &testStruct{BoolPtr: &boolValT}, "true"},
+		{"bool_ptr", &testStruct{BoolPtr: &boolValF}, "false"},
 
 		{"emptied", &testStruct{Emptied: true}, ""},
 

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -188,7 +188,7 @@ func TestAppendTo(t *testing.T) {
 
 		{"float32", &testStruct{Float32: float32Val}, "1.2345"},
 		{"float32_ptr", &testStruct{Float32Ptr: &float32Val}, "1.2345"},
-		{"float32_ptr", &testStruct{Float32Ptr: &float32Val0}, "0.000"},
+		{"float32_ptr", &testStruct{Float32Ptr: &float32Val0}, "0.0000"},
 		{"float32_ptr", &testStruct{}, ""},
 
 		{"float64", &testStruct{Float64: float64Val}, "1.2345"},


### PR DESCRIPTION
If a boolean value is meant to be `true` by default, `stripe-go` uses a pointer to a bool, and uses `nil` to render no url parameter, which ends up being `true` to the stripe-api.

Unfortunately, there was no ability to pass a pointer to a boolean of `true`. This attempts to fix it in a non-breaking, non-major change or refactor way.

I made some smaller changes as well to assist in the readability (since I had to do a lot of that -- reading).