### PR TITLE
Adds support for attaching sources to customers

### DIFF
--- a/source.go
+++ b/source.go
@@ -90,6 +90,14 @@ type SourceObjectParams struct {
 	Usage               SourceUsage        `form:"usage"`
 }
 
+// SourceObjectAttachParams is the set of parameters that can be used when attaching
+// a source to a customer.
+type SourceObjectAttachParams struct {
+	Params   `form:"*"`
+	Customer string `form:"-"`
+	Source   string `form:"source"`
+}
+
 // SourceObjectDetachParams is the set of parameters that can be used when detaching
 // a source from a customer.
 type SourceObjectDetachParams struct {

--- a/source/client.go
+++ b/source/client.go
@@ -87,6 +87,33 @@ func getC() Client {
 	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
 }
 
+// Attach attaches the source to a customer object.
+func Attach(params *stripe.SourceObjectAttachParams) (*stripe.Source, error) {
+	return getC().Attach(params)
+}
+
+func (c Client) Attach(params *stripe.SourceObjectAttachParams) (*stripe.Source, error) {
+	var body *form.Values
+	var commonParams *stripe.Params
+
+	if params != nil {
+		commonParams = &params.Params
+		body = &form.Values{}
+		form.AppendTo(body, params)
+	}
+
+	source := &stripe.Source{}
+	var err error
+
+	if len(params.Customer) > 0 {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", params.Customer), c.Key, body, commonParams, source)
+	} else {
+		err = errors.New("Invalid source detach params: Customer needs to be set")
+	}
+
+	return source, err
+}
+
 // Detach detaches the source from its customer object.
 func Detach(id string, params *stripe.SourceObjectDetachParams) (*stripe.Source, error) {
 	return getC().Detach(id, params)

--- a/source/client_test.go
+++ b/source/client_test.go
@@ -38,6 +38,15 @@ func TestSourceUpdate(t *testing.T) {
 	assert.NotNil(t, source)
 }
 
+func TestSourceAttach(t *testing.T) {
+	source, err := Attach(&stripe.SourceObjectAttachParams{
+		Customer: "cus_123",
+		Source:   "src_123",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, source)
+}
+
 func TestSourceDetach(t *testing.T) {
 	source, err := Detach("src_123", &stripe.SourceObjectDetachParams{
 		Customer: "cus_123",


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @stan-stripe @will-stripe

We merged #473 yesterday, but I did not realize the Go library lacked a method for attaching sources to customers! This PR fixes that.
