### PR TITLE
Upgrade stripe-mock to 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.2.0
+    - STRIPE_MOCK_VERSION=0.3.0
 
 go:
   - 1.7

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -23,7 +23,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.2.0"
+	MockMinimumVersion = "0.3.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Includes a new bundled OpenAPI spec that has some fairly nice improvements compared to the last one.