### PR TITLE
Error early when params not specified for card functions

### DIFF
--- a/card/client.go
+++ b/card/client.go
@@ -41,6 +41,10 @@ func New(params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	body := &form.Values{}
 
 	// Note that we call this special append method instead of the standard one
@@ -71,6 +75,10 @@ func Get(id string, params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -103,6 +111,10 @@ func Update(id string, params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
@@ -129,6 +141,10 @@ func Del(id string, params *stripe.CardParams) (*stripe.Card, error) {
 }
 
 func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -166,13 +182,19 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 	var lp *stripe.ListParams
 	var p *stripe.Params
 
-	form.AppendTo(body, params)
-	lp = &params.ListParams
-	p = params.ToParams()
+	if params != nil {
+		form.AppendTo(body, params)
+		lp = &params.ListParams
+		p = params.ToParams()
+	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CardList{}
 		var err error
+
+		if params == nil {
+			return nil, list.ListMeta, errors.New("params should not be nil")
+		}
 
 		if len(params.Account) > 0 {
 			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, b, p, list)

--- a/card/client.go
+++ b/card/client.go
@@ -148,12 +148,9 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	var body *form.Values
 	var commonParams *stripe.Params
 
-	if params != nil {
-		body = &form.Values{}
-
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
+	body = &form.Values{}
+	form.AppendTo(body, params)
+	commonParams = &params.Params
 
 	card := &stripe.Card{}
 	var err error

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -16,6 +16,11 @@ func TestCardDel(t *testing.T) {
 	assert.NotNil(t, card)
 }
 
+func TestCardDel_RequiresParams(t *testing.T) {
+	_, err := Del("card_123", nil)
+	assert.Error(t, err, "params should not be nil")
+}
+
 func TestCardGet(t *testing.T) {
 	card, err := Get("card_123", &stripe.CardParams{
 		Customer: "cus_123",
@@ -24,13 +29,24 @@ func TestCardGet(t *testing.T) {
 	assert.NotNil(t, card)
 }
 
-func TestCardListByCustomer(t *testing.T) {
+func TestCardGet_RequiresParams(t *testing.T) {
+	_, err := Get("card_123", nil)
+	assert.Error(t, err, "params should not be nil")
+}
+
+func TestCardList_ByCustomer(t *testing.T) {
 	i := List(&stripe.CardListParams{Customer: "cus_123"})
 
 	// Verify that we can get at least one card
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Card())
+}
+
+func TestCardList_RequiresParams(t *testing.T) {
+	i := List(nil)
+	assert.False(t, i.Next())
+	assert.Error(t, i.Err(), "params should not be nil")
 }
 
 func TestCardNew(t *testing.T) {
@@ -42,6 +58,11 @@ func TestCardNew(t *testing.T) {
 	assert.NotNil(t, card)
 }
 
+func TestCardNew_RequiresParams(t *testing.T) {
+	_, err := New(nil)
+	assert.Error(t, err, "params should not be nil")
+}
+
 func TestCardUpdate(t *testing.T) {
 	card, err := Update("card_123", &stripe.CardParams{
 		Customer: "cus_123",
@@ -49,4 +70,9 @@ func TestCardUpdate(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)
+}
+
+func TestCardUpdate_RequiresParams(t *testing.T) {
+	_, err := Update("card_123", nil)
+	assert.Error(t, err, "params should not be nil")
 }


### PR DESCRIPTION
Card-related API calls are a bit of an unusual case because we need to
have an instantiated params struct in order to determine the correct URL
to which to make the request. Previously, if a `nil` was passed to any
of these functions, we'd panic as we tried to access one of its members.

This patch just makes the params requirement a little more explicit by
returning an error if any of card functions is called with `nil` params.

Fixes #483.

r? @remi-stripe