### PR TITLE
Send `object=bank_account` when using `AccountExternalAccountParams`

### DIFF
--- a/account.go
+++ b/account.go
@@ -104,9 +104,13 @@ type AccountExternalAccountParams struct {
 
 // AppendTo implements custom encoding logic for AccountExternalAccountParams
 // so that we can send the special required `object` field up along with the
-// other specified parameters.
+// other specified parameters or the token value
 func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []string) {
-	body.Add(form.FormatKey(append(keyParts, "object")), "bank_account")
+	if len(p.Token) > 0 {
+		body.Add(form.FormatKey(keyParts), p.Token)
+	} else {
+		body.Add(form.FormatKey(append(keyParts, "object")), "bank_account")
+	}
 }
 
 // PayoutScheduleParams are the parameters allowed for payout schedules.

--- a/account.go
+++ b/account.go
@@ -102,6 +102,13 @@ type AccountExternalAccountParams struct {
 	Token             string `form:"token"`
 }
 
+// AppendTo implements custom encoding logic for AccountExternalAccountParams
+// so that we can send the special required `object` field up along with the
+// other specified parameters.
+func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []string) {
+	body.Add(form.FormatKey(append(keyParts, "object")), "bank_account")
+}
+
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
 	Delay        uint64   `form:"delay_days"`

--- a/account_test.go
+++ b/account_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
+func TestAccountExternalAccountParams_AppendTo(t *testing.T) {
+	params := &AccountExternalAccountParams{}
+	body := &form.Values{}
+	form.AppendTo(body, params)
+	t.Logf("body = %+v", body)
+	assert.Equal(t, []string{"bank_account"}, body.Get("object"))
+}
+
 func TestAccountUnmarshal(t *testing.T) {
 	accountData := map[string]interface{}{
 		"id": "acct_123",

--- a/account_test.go
+++ b/account_test.go
@@ -9,11 +9,25 @@ import (
 )
 
 func TestAccountExternalAccountParams_AppendTo(t *testing.T) {
-	params := &AccountExternalAccountParams{}
-	body := &form.Values{}
-	form.AppendTo(body, params)
-	t.Logf("body = %+v", body)
-	assert.Equal(t, []string{"bank_account"}, body.Get("object"))
+	{
+		params := &AccountExternalAccountParams{}
+		body := &form.Values{}
+		form.AppendTo(body, params)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"bank_account"}, body.Get("object"))
+	}
+
+	{
+		params := &AccountExternalAccountParams{Token: "tok_123"}
+		body := &form.Values{}
+
+		// 0-length keyParts are not allowed, so call AppendTo directly (as
+		// opposed to through the form package) and inject a realistic set
+		params.AppendTo(body, []string{"external_account"})
+
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"tok_123"}, body.Get("external_account"))
+	}
 }
 
 func TestAccountUnmarshal(t *testing.T) {


### PR DESCRIPTION
When using `AccountExternalAccountParams` for creating a bank account
from an account, sending an `object` field is required. Here we give the
params struct a custom `AppendTo` so that we can comply with this logic.

Partial fix for #485.

r? @ob-stripe