### PR TITLE
Make `account_holder_name`/`account_holder_type` truly optional

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -71,10 +71,19 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 	} else {
 		body.Add(sourceType+"[object]", "bank_account")
 		body.Add(sourceType+"[country]", a.Country)
-		body.Add(sourceType+"[account_holder_name]", a.AccountHolderName)
-		body.Add(sourceType+"[account_holder_type]", a.AccountHolderType)
 		body.Add(sourceType+"[account_number]", a.Account)
 		body.Add(sourceType+"[currency]", a.Currency)
+
+		// These are optional and the API will fail if we try to send empty
+		// values in for them, so make sure to check that they're actually set
+		// before encoding them.
+		if len(a.AccountHolderName) > 0 {
+			body.Add(sourceType+"[account_holder_name]", a.AccountHolderName)
+		}
+
+		if len(a.AccountHolderType) > 0 {
+			body.Add(sourceType+"[account_holder_type]", a.AccountHolderType)
+		}
 
 		if len(a.Routing) > 0 {
 			body.Add(sourceType+"[routing_number]", a.Routing)

--- a/bankaccount_test.go
+++ b/bankaccount_test.go
@@ -1,0 +1,48 @@
+package stripe
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/form"
+)
+
+func TestBankAccountParams_AppendToAsSourceOrExternalAccount(t *testing.T) {
+	// We should add more tests for all the various corner cases here ...
+
+	// Includes account_holder_name
+	{
+		params := &BankAccountParams{AccountHolderName: "Tyrion"}
+		body := &form.Values{}
+		params.AppendToAsSourceOrExternalAccount(body)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"Tyrion"}, body.Get("external_account[account_holder_name]"))
+	}
+
+	// Does not include account_holder_name if empty
+	{
+		params := &BankAccountParams{}
+		body := &form.Values{}
+		params.AppendToAsSourceOrExternalAccount(body)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string(nil), body.Get("external_account[account_holder_name]"))
+	}
+
+	// Includes account_holder_name
+	{
+		params := &BankAccountParams{AccountHolderType: "individual"}
+		body := &form.Values{}
+		params.AppendToAsSourceOrExternalAccount(body)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"individual"}, body.Get("external_account[account_holder_type]"))
+	}
+
+	// Does not include account_holder_name if empty
+	{
+		params := &BankAccountParams{}
+		body := &form.Values{}
+		params.AppendToAsSourceOrExternalAccount(body)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string(nil), body.Get("external_account[account_holder_type]"))
+	}
+}


### PR DESCRIPTION
When encoding a bank account we shouldn't send `account_holder_name` or
`account_holder_type` unless they're given values. Sending an empty
value will cause an API error in cases where the request would have
otherwise been valid.

Fixes the other part of #485.

r? @remi-stripe