### PR TITLE
Add support for /v1/exchange_rates API requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.3.0
+    - STRIPE_MOCK_VERSION=0.4.0
 
 go:
   - 1.7

--- a/charge.go
+++ b/charge.go
@@ -22,6 +22,7 @@ type ChargeParams struct {
 	Desc          string              `form:"description"`
 	Destination   *DestinationParams  `form:"destination"`
 	Email         string              `form:"receipt_email"`
+	ExchangeRate  float64             `form:"exchange_rate"`
 	Fee           uint64              `form:"application_fee"`
 	FraudDetails  *FraudDetailsParams `form:"fraud_details"`
 	NoCapture     bool                `form:"capture,invert"`
@@ -63,11 +64,12 @@ type ChargeListParams struct {
 // CaptureParams is the set of parameters that can be used when capturing a charge.
 // For more details see https://stripe.com/docs/api#charge_capture.
 type CaptureParams struct {
-	Params    `form:"*"`
-	Amount    uint64 `form:"amount"`
-	Email     string `form:"receipt_email"`
-	Fee       uint64 `form:"application_fee"`
-	Statement string `form:"statement_descriptor"`
+	Params       `form:"*"`
+	Amount       uint64  `form:"amount"`
+	Email        string  `form:"receipt_email"`
+	ExchangeRate float64 `form:"exchange_rate"`
+	Fee          uint64  `form:"application_fee"`
+	Statement    string  `form:"statement_descriptor"`
 }
 
 // Charge is the resource representing a Stripe charge.

--- a/client/api.go
+++ b/client/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stripe/stripe-go/dispute"
 	"github.com/stripe/stripe-go/ephemeralkey"
 	"github.com/stripe/stripe-go/event"
+	"github.com/stripe/stripe-go/exchangerate"
 	"github.com/stripe/stripe-go/fee"
 	"github.com/stripe/stripe-go/feerefund"
 	"github.com/stripe/stripe-go/fileupload"
@@ -145,6 +146,8 @@ type API struct {
 	// PaymentSource is used to invoke /sources APIs.
 	// For more details see https://stripe.com/docs/api.
 	PaymentSource *paymentsource.Client
+	// ExchangeRates is the client used to invoke /exchange_rates APIs.
+	ExchangeRates *exchangerate.Client
 }
 
 // Init initializes the Stripe client with the appropriate secret key
@@ -189,6 +192,7 @@ func (a *API) Init(key string, backends *Backends) {
 	a.Skus = &sku.Client{B: backends.API, Key: key}
 	a.Sources = &source.Client{B: backends.API, Key: key}
 	a.PaymentSource = &paymentsource.Client{B: backends.API, Key: key}
+	a.ExchangeRates = &exchangerate.Client{B: backends.API, Key: key}
 }
 
 // New creates a new Stripe client with the appropriate secret key

--- a/exchangerate.go
+++ b/exchangerate.go
@@ -1,0 +1,19 @@
+package stripe
+
+// ExchangeRate is the resource representing the currency exchange rates at
+// a given time.
+type ExchangeRate struct {
+	ID    string               `json:"id"`
+	Rates map[Currency]float64 `json:"rates"`
+}
+
+// ExchangeRateList is a list of exchange rates as retrieved from a list endpoint.
+type ExchangeRateList struct {
+	ListMeta
+	Values []*ExchangeRate `json:"data"`
+}
+
+// ExchangeRateListParams are the parameters allowed during ExchangeRate listing.
+type ExchangeRateListParams struct {
+	ListParams `form:"*"`
+}

--- a/exchangerate/client.go
+++ b/exchangerate/client.go
@@ -1,0 +1,72 @@
+// Package exchangerate provides the /exchange_rates APIs
+package exchangerate
+
+import (
+	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
+)
+
+// Client is used to invoke /exchange_rates and exchangerates-related APIs.
+type Client struct {
+	B   stripe.Backend
+	Key string
+}
+
+// Get returns an ExchangeRate for a given currency
+func Get(currency string) (*stripe.ExchangeRate, error) {
+	return getC().Get(currency)
+}
+
+func (c Client) Get(currency string) (*stripe.ExchangeRate, error) {
+	exchangeRate := &stripe.ExchangeRate{}
+	err := c.B.Call("GET", "/exchange_rates/"+currency, c.Key, nil, nil, exchangeRate)
+
+	return exchangeRate, err
+}
+
+// List lists available ExchangeRates.
+func List(params *stripe.ExchangeRateListParams) *Iter {
+	return getC().List(params)
+}
+
+func (c Client) List(params *stripe.ExchangeRateListParams) *Iter {
+	var body *form.Values
+	var lp *stripe.ListParams
+	var p *stripe.Params
+
+	if params != nil {
+		body = &form.Values{}
+		form.AppendTo(body, params)
+		lp = &params.ListParams
+		p = params.ToParams()
+	}
+
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+		list := &stripe.ExchangeRateList{}
+		err := c.B.Call("GET", "/exchange_rates", c.Key, b, p, list)
+
+		ret := make([]interface{}, len(list.Values))
+		for i, v := range list.Values {
+			ret[i] = v
+		}
+
+		return ret, list.ListMeta, err
+	})}
+}
+
+// Iter is an iterator for lists of ExchangeRates.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
+type Iter struct {
+	*stripe.Iter
+}
+
+// ExchangeRate returns the most recent ExchangeRate
+// visited by a call to Next.
+func (i *Iter) ExchangeRate() *stripe.ExchangeRate {
+	return i.Current().(*stripe.ExchangeRate)
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
+}

--- a/exchangerate/client_test.go
+++ b/exchangerate/client_test.go
@@ -1,0 +1,24 @@
+package exchangerate
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go"
+	_ "github.com/stripe/stripe-go/testing"
+)
+
+func TestExchangeRateGet(t *testing.T) {
+	rates, err := Get("usd")
+	assert.Nil(t, err)
+	assert.NotNil(t, rates)
+}
+
+func TestExchangeRateList(t *testing.T) {
+	i := List(&stripe.ExchangeRateListParams{})
+
+	// Verify that we can get at least one exchange_rate
+	assert.True(t, i.Next())
+	assert.Nil(t, i.Err())
+	assert.NotNil(t, i.ExchangeRate())
+}

--- a/exchangerate_test.go
+++ b/exchangerate_test.go
@@ -1,0 +1,35 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExchangeRateUnmarshal(t *testing.T) {
+	exchangeRateData := map[string]interface{}{
+		"id":     "usd",
+		"object": "exchange_rate",
+		"rates": map[string]interface{}{
+			"eur": 0.845876,
+		},
+	}
+
+	bytes, err := json.Marshal(&exchangeRateData)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var exchangeRate ExchangeRate
+	err = json.Unmarshal(bytes, &exchangeRate)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if exchangeRate.Rates == nil {
+		t.Errorf("Problem deserializing rates, got nothing.")
+	}
+
+	if exchangeRate.Rates["eur"] != 0.845876 {
+		t.Errorf("Problem deserializing rates[eur], got %v", exchangeRate.Rates["eur"])
+	}
+}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -23,7 +23,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.3.0"
+	MockMinimumVersion = "0.4.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @alixander-stripe

Adds support for the new `/v1/exchange_rates` endpoints as well as passing the `exchange_rate` parameter in charge creation/update/capture requests.

Tests are skipped for now as stripe-mock does not support the new endpoints yet.
