### PR TITLE
Rename language fields in Stripe's user agent to start with `lang`

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -111,8 +111,8 @@ type Backends struct {
 type stripeClientUserAgent struct {
 	Application     *AppInfo `json:"application"`
 	BindingsVersion string   `json:"bindings_version"`
-	Language        string   `json:"language"`
-	LanguageVersion string   `json:"language_version"`
+	Language        string   `json:"lang"`
+	LanguageVersion string   `json:"lang_version"`
 	Publisher       string   `json:"publisher"`
 	Uname           string   `json:"uname"`
 }

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -170,12 +170,12 @@ func TestStripeClientUserAgent(t *testing.T) {
 	//
 
 	assert.Empty(t, userAgent["application"])
-	assert.Equal(t, "go", userAgent["language"])
-	assert.Equal(t, runtime.Version(), userAgent["language_version"])
+	assert.Equal(t, "go", userAgent["lang"])
+	assert.Equal(t, runtime.Version(), userAgent["lang_version"])
 
 	// Anywhere these tests are running can reasonable be expected to have a
 	// `uname` to run, so do this basic check.
-	assert.NotEqual(t, stripe.UnknownPlatform, userAgent["language_version"])
+	assert.NotEqual(t, stripe.UnknownPlatform, userAgent["lang_version"])
 }
 
 func TestStripeClientUserAgentWithAppInfo(t *testing.T) {


### PR DESCRIPTION
I noticed this as I was looking at a dashboard that @ob-stripe produced today.
Other languages send language and language version as `lang` and `lang_version`
while we were using the fully expanded `language_*` here. I'm changing it here
for consistency with other libraries, but I'm also going to patch the server
because there are so many Go libraries out there that could potentially be
reporting if we supported both styles.

r? @ob-stripe