### PR TITLE
Support source sharing via Stripe Connect

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -37,6 +37,9 @@ type BankAccountParams struct {
 	// Token is a token referencing an external account like one returned from
 	// Stripe.js.
 	Token string `form:"-"`
+
+	// ID is used when tokenizing a bank account for shared customers
+	ID string `form:"*"`
 }
 
 // AppendToAsSourceOrExternalAccount appends the given BankAccountParams as

--- a/card.go
+++ b/card.go
@@ -53,6 +53,9 @@ type CardParams struct {
 	Token     string `form:"-"`
 	Year      string `form:"exp_year"`
 	Zip       string `form:"address_zip"`
+
+	// ID is used when tokenizing a card for shared customers
+	ID string `form:"*"`
 }
 
 // AppendToAsCardSourceOrExternalAccount appends the given CardParams as either a

--- a/source.go
+++ b/source.go
@@ -81,6 +81,7 @@ type SourceObjectParams struct {
 	Currency            Currency           `form:"currency"`
 	Customer            string             `form:"customer"`
 	Flow                SourceFlow         `form:"flow"`
+	OriginalSource      string             `form:"original_source"`
 	Owner               *SourceOwnerParams `form:"owner"`
 	Redirect            *RedirectParams    `form:"redirect"`
 	StatementDescriptor string             `form:"statement_descriptor"`

--- a/source/client_test.go
+++ b/source/client_test.go
@@ -45,3 +45,16 @@ func TestSourceDetach(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, source)
 }
+
+func TestSourceSharing(t *testing.T) {
+	params := &stripe.SourceObjectParams{
+		Type:           "card",
+		Customer:       "cus_123",
+		OriginalSource: "src_123",
+		Usage:          stripe.UsageReusable,
+	}
+	params.SetStripeAccount("acct_123")
+	source, err := New(params)
+	assert.Nil(t, err)
+	assert.NotNil(t, source)
+}

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -47,3 +47,29 @@ func TestTokenNew_WithPII(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, token)
 }
+
+func TestTokenNew_SharedCustomerCard(t *testing.T) {
+	params := &stripe.TokenParams{
+		Card: &stripe.CardParams{
+			ID: "card_123",
+		},
+		Customer: "cus_123",
+	}
+	params.SetStripeAccount("acct_123")
+	token, err := New(params)
+	assert.Nil(t, err)
+	assert.NotNil(t, token)
+}
+
+func TestTokenNew_SharedCustomerBankAccount(t *testing.T) {
+	params := &stripe.TokenParams{
+		Bank: &stripe.BankAccountParams{
+			ID: "ba_123",
+		},
+		Customer: "cus_123",
+	}
+	params.SetStripeAccount("acct_123")
+	token, err := New(params)
+	assert.Nil(t, err)
+	assert.NotNil(t, token)
+}


### PR DESCRIPTION
When using Stripe Connect, you can clone a card/bank account/source form the platform to a connected account. This PR adds support for all of this:
- Creating a new token on a connected account passing the customer id in `customer` and the card id in `card`.
- Creating a new token on a connected account passing the customer id in `customer` and the bank account id in `bank_account`.
- Creating a new Source on a connected account passing the customer id in `customer` and the Source id in `original_source`.

This fixes https://github.com/stripe/stripe-go/issues/499

r? @brandur-stripe 