### PR TITLE
Add support for coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 *.test
+*.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 before_install:
   - go get -u github.com/stretchr/testify/require
 
+  # Install code coverage / coveralls tooling
+  - go get -u golang.org/x/tools/cmd/cover
+  - go get -u github.com/modocache/gover
+  - go get -u github.com/mattn/goveralls
+
   # Unpack and start the Stripe API stub so that the test suite can talk to it
   - |
     if [ ! -d "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}" ]; then
@@ -35,5 +40,12 @@ matrix:
 
 script:
   - make
+  - make coverage
+
+after_script:
+  # Merge all coverage reports located in subdirectories and put them under: gover.coverprofile
+  - gover
+  # Send code coverage report to coveralls.io
+  - goveralls -service=travis-ci -coverprofile=gover.coverprofile
 
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,11 @@ test:
 
 vet:
 	go vet ./...
+
+coverage:
+	# go currently cannot create coverage profiles when testing multiple packages, so we test each package
+	# independently. This issue should be fixed in Go 1.10 (https://github.com/golang/go/issues/6909).
+	go list ./... | xargs -n1 -I {} -P 4 go test -covermode=count -coverprofile=../../../{}/profile.coverprofile {}
+
+clean:
+	find . -name \*.coverprofile -delete

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Go Stripe [![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/stripe/stripe-go) [![Build Status](https://travis-ci.org/stripe/stripe-go.svg?branch=master)](https://travis-ci.org/stripe/stripe-go)
+# Go Stripe
+
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/stripe/stripe-go)
+[![Build Status](https://travis-ci.org/stripe/stripe-go.svg?branch=master)](https://travis-ci.org/stripe/stripe-go)
+[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-go/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-go?branch=master)
 
 ## Summary
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds support for coveralls.io to the Go library.

This requires testing each package separately, because Go cannot create coverage profiles when testing multiple packages (cf. https://github.com/golang/go/issues/6909). We then use [`gover`](https://github.com/sozorogami/gover) to merge the multiple coverage profiles in a single file and [`goveralls`](https://github.com/mattn/goveralls) to send the data to coveralls.io.

I'm annoyed that this requires running the test suite a second time, but can't find a way around it. It looks like the Go issue is fixed in 1.10, so hopefully at some point we will be able to just run the test suite once with `go test -race -covermode=atomic -coverprofile=cover.out`.
