### PR TITLE
Move all booleans to boolean pointers

### DIFF
--- a/account.go
+++ b/account.go
@@ -62,25 +62,107 @@ const (
 // AccountParams are the parameters allowed during account creation/updates.
 type AccountParams struct {
 	Params                    `form:"*"`
-	BusinessName              string                        `form:"business_name"`
-	BusinessPrimaryColor      string                        `form:"business_primary_color"`
-	BusinessURL               string                        `form:"business_url"`
-	Country                   string                        `form:"country"`
+	BusinessName              *string                       `form:"business_name"`
+	BusinessPrimaryColor      *string                       `form:"business_primary_color"`
+	BusinessURL               *string                       `form:"business_url"`
+	Country                   *string                       `form:"country"`
 	DebitNegativeBalances     *bool                         `form:"debit_negative_balances"`
-	DefaultCurrency           string                        `form:"default_currency"`
-	Email                     string                        `form:"email"`
+	DefaultCurrency           *string                       `form:"default_currency"`
+	Email                     *string                       `form:"email"`
 	ExternalAccount           *AccountExternalAccountParams `form:"external_account"`
-	FromRecipient             string                        `form:"from_recipient"`
-	LegalEntity               *LegalEntity                  `form:"legal_entity"`
+	FromRecipient             *string                       `form:"from_recipient"`
+	LegalEntity               *LegalEntityParams            `form:"legal_entity"`
 	PayoutSchedule            *PayoutScheduleParams         `form:"payout_schedule"`
-	PayoutStatementDescriptor string                        `form:"payout_statement_descriptor"`
-	ProductDescription        string                        `form:"product_description"`
-	StatementDescriptor       string                        `form:"statement_descriptor"`
-	SupportEmail              string                        `form:"support_email"`
-	SupportPhone              string                        `form:"support_phone"`
-	SupportURL                string                        `form:"support_url"`
+	PayoutStatementDescriptor *string                       `form:"payout_statement_descriptor"`
+	ProductDescription        *string                       `form:"product_description"`
+	StatementDescriptor       *string                       `form:"statement_descriptor"`
+	SupportEmail              *string                       `form:"support_email"`
+	SupportPhone              *string                       `form:"support_phone"`
+	SupportURL                *string                       `form:"support_url"`
 	TOSAcceptance             *TOSAcceptanceParams          `form:"tos_acceptance"`
-	Type                      AccountType                   `form:"type"`
+	Type                      *string                       `form:"type"`
+}
+
+// LegalEntityParams represents a legal_entity during account creation/updates.
+type LegalEntityParams struct {
+	AdditionalOwners []AdditionalOwnerParams `form:"additional_owners,indexed"`
+
+	// AdditionalOwnersEmpty can be set to clear a legal entity's additional
+	// owners.
+	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
+
+	Address                  *AccountAddressParams       `form:"address"`
+	AddressKana              *AccountAddressParams       `form:"address_kana"`
+	AddressKanji             *AccountAddressParams       `form:"address_kanji"`
+	BusinessName             *string                     `form:"business_name"`
+	BusinessNameKana         *string                     `form:"business_name_kana"`
+	BusinessNameKanji        *string                     `form:"business_name_kanji"`
+	BusinessTaxID            *string                     `form:"business_tax_id"`
+	BusinessTaxIDProvided    *bool                       `form:"-"`
+	BusinessVatID            *string                     `form:"business_vat_id"`
+	BusinessVatIDProvided    *bool                       `form:"-"`
+	DOB                      *DOBParams                  `form:"dob"`
+	FirstName                *string                     `form:"first_name"`
+	FirstNameKana            *string                     `form:"first_name_kana"`
+	FirstNameKanji           *string                     `form:"first_name_kanji"`
+	Gender                   *string                     `form:"gender"`
+	LastName                 *string                     `form:"last_name"`
+	LastNameKana             *string                     `form:"last_name_kana"`
+	LastNameKanji            *string                     `form:"last_name_kanji"`
+	MaidenName               *string                     `form:"maiden_name"`
+	PersonalAddress          *AccountAddressParams       `form:"personal_address"`
+	PersonalAddressKana      *AccountAddressParams       `form:"personal_address_kana"`
+	PersonalAddressKanji     *AccountAddressParams       `form:"personal_address_kanji"`
+	PersonalIDNumber         *string                     `form:"personal_id_number"`
+	PersonalIDNumberProvided *bool                       `form:"-"`
+	PhoneNumber              *string                     `form:"phone_number"`
+	SSNLast4                 *string                     `form:"ssn_last_4"`
+	SSNLast4Provided         *bool                       `form:"-"`
+	Type                     *string                     `form:"type"`
+	Verification             *IdentityVerificationParams `form:"verification"`
+}
+
+// AccountAddressParams represents an address during account creation/updates.
+type AccountAddressParams struct {
+	City       *string `form:"city"`
+	Country    *string `form:"country"`
+	Line1      *string `form:"line1"`
+	Line2      *string `form:"line2"`
+	PostalCode *string `form:"postal_code"`
+	State      *string `form:"state"`
+
+	// Town/cho-me. Note that this is only used for Kana/Kanji representations
+	// of an address.
+	Town *string `form:"town"`
+}
+
+// DOBParams represents a DOB during account creation/updates.
+type DOBParams struct {
+	Day   *int `form:"day"`
+	Month *int `form:"month"`
+	Year  *int `form:"year"`
+}
+
+// TOSAcceptanceParams represents tos_acceptance during account creation/updates.
+type TOSAcceptanceParams struct {
+	Date      int64  `form:"date"`
+	IP        string `form:"ip"`
+	UserAgent string `form:"user_agent"`
+}
+
+// AdditionalOwnerParams represents an additional owner during account creation/updates.
+type AdditionalOwnerParams struct {
+	Address      *AccountAddressParams       `form:"address"`
+	DOB          *DOBParams                  `form:"dob"`
+	FirstName    *string                     `form:"first_name"`
+	LastName     *string                     `form:"last_name"`
+	MaidenName   *string                     `form:"maiden_name"`
+	Verification *IdentityVerificationParams `form:"verification"`
+}
+
+// IdentityVerification represents a verification during account creation/updates.
+type IdentityVerificationParams struct {
+	Document *IdentityDocument `form:"document"`
 }
 
 // AccountListParams are the parameters allowed during account listing.
@@ -93,21 +175,21 @@ type AccountListParams struct {
 // or everything else.
 type AccountExternalAccountParams struct {
 	Params            `form:"*"`
-	AccountNumber     string `form:"account_number"`
-	AccountHolderName string `form:"account_holder_name"`
-	AccountHolderType string `form:"account_holder_type"`
-	Country           string `form:"country"`
-	Currency          string `form:"currency"`
-	RoutingNumber     string `form:"routing_number"`
-	Token             string `form:"token"`
+	AccountNumber     *string `form:"account_number"`
+	AccountHolderName *string `form:"account_holder_name"`
+	AccountHolderType *string `form:"account_holder_type"`
+	Country           *string `form:"country"`
+	Currency          *string `form:"currency"`
+	RoutingNumber     *string `form:"routing_number"`
+	Token             *string `form:"token"`
 }
 
 // AppendTo implements custom encoding logic for AccountExternalAccountParams
 // so that we can send the special required `object` field up along with the
 // other specified parameters or the token value
 func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []string) {
-	if len(p.Token) > 0 {
-		body.Add(form.FormatKey(keyParts), p.Token)
+	if p.Token != nil {
+		body.Add(form.FormatKey(keyParts), StringValue(p.Token))
 	} else {
 		body.Add(form.FormatKey(append(keyParts, "object")), "bank_account")
 	}
@@ -115,11 +197,11 @@ func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []st
 
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
-	DelayDays        uint64   `form:"delay_days"`
-	DelayDaysMinimum *bool    `form:"-"` // See custom AppendTo
-	Interval         Interval `form:"interval"`
-	MonthlyAnchor    uint64   `form:"monthly_anchor"`
-	WeeklyAnchor     string   `form:"weekly_anchor"`
+	DelayDays        *uint64 `form:"delay_days"`
+	DelayDaysMinimum *bool   `form:"-"` // See custom AppendTo
+	Interval         *string `form:"interval"`
+	MonthlyAnchor    *uint64 `form:"monthly_anchor"`
+	WeeklyAnchor     *string `form:"weekly_anchor"`
 }
 
 func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
@@ -277,62 +359,57 @@ func (ea *ExternalAccount) UnmarshalJSON(b []byte) error {
 
 // LegalEntity is the structure for properties related to an account's legal state.
 type LegalEntity struct {
-	AdditionalOwners []AdditionalOwner `json:"additional_owners" form:"additional_owners,indexed"`
-
-	// AdditionalOwnersEmpty can be set to clear a legal entity's additional
-	// owners.
-	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
-
-	Address                  Address              `json:"address" form:"address"`
-	AddressKana              Address              `json:"address_kana" form:"address_kana"`
-	AddressKanji             Address              `json:"address_kanji" form:"address_kanji"`
-	BusinessName             string               `json:"business_name" form:"business_name"`
-	BusinessNameKana         string               `json:"business_name_kana" form:"business_name_kana"`
-	BusinessNameKanji        string               `json:"business_name_kanji" form:"business_name_kanji"`
-	BusinessTaxID            string               `json:"-" form:"business_tax_id"`
-	BusinessTaxIDProvided    bool                 `json:"business_tax_id_provided" form:"-"`
-	BusinessVatID            string               `json:"-" form:"business_vat_id"`
-	BusinessVatIDProvided    bool                 `json:"business_vat_id_provided" form:"-"`
-	DOB                      DOB                  `json:"dob" form:"dob"`
-	FirstName                string               `json:"first_name" form:"first_name"`
-	FirstNameKana            string               `json:"first_name_kana" form:"first_name_kana"`
-	FirstNameKanji           string               `json:"first_name_kanji" form:"first_name_kanji"`
-	Gender                   Gender               `json:"gender" form:"gender"`
-	LastName                 string               `json:"last_name" form:"last_name"`
-	LastNameKana             string               `json:"last_name_kana" form:"last_name_kana"`
-	LastNameKanji            string               `json:"last_name_kanji" form:"last_name_kanji"`
-	MaidenName               string               `json:"maiden_name" form:"maiden_name"`
-	PersonalAddress          Address              `json:"personal_address" form:"personal_address"`
-	PersonalAddressKana      Address              `json:"personal_address_kana" form:"personal_address_kana"`
-	PersonalAddressKanji     Address              `json:"personal_address_kanji" form:"personal_address_kanji"`
-	PersonalIDNumber         string               `json:"-" form:"personal_id_number"`
-	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided" form:"-"`
-	PhoneNumber              string               `json:"phone_number" form:"phone_number"`
-	SSNLast4                 string               `json:"-" form:"ssn_last_4"`
-	SSNLast4Provided         bool                 `json:"ssn_last_4_provided" form:"-"`
-	Type                     LegalEntityType      `json:"type" form:"type"`
-	Verification             IdentityVerification `json:"verification" form:"verification"`
+	AdditionalOwners         []AdditionalOwner    `json:"additional_owners"`
+	Address                  AccountAddress       `json:"address"`
+	AddressKana              AccountAddress       `json:"address_kana"`
+	AddressKanji             AccountAddress       `json:"address_kanji"`
+	BusinessName             string               `json:"business_name"`
+	BusinessNameKana         string               `json:"business_name_kana"`
+	BusinessNameKanji        string               `json:"business_name_kanji"`
+	BusinessTaxID            string               `json:"-"`
+	BusinessTaxIDProvided    bool                 `json:"business_tax_id_provided"`
+	BusinessVatID            string               `json:"-"`
+	BusinessVatIDProvided    bool                 `json:"business_vat_id_provided"`
+	DOB                      DOB                  `json:"dob"`
+	FirstName                string               `json:"first_name"`
+	FirstNameKana            string               `json:"first_name_kana"`
+	FirstNameKanji           string               `json:"first_name_kanji"`
+	Gender                   Gender               `json:"gender"`
+	LastName                 string               `json:"last_name"`
+	LastNameKana             string               `json:"last_name_kana"`
+	LastNameKanji            string               `json:"last_name_kanji"`
+	MaidenName               string               `json:"maiden_name"`
+	PersonalAddress          AccountAddress       `json:"personal_address"`
+	PersonalAddressKana      AccountAddress       `json:"personal_address_kana"`
+	PersonalAddressKanji     AccountAddress       `json:"personal_address_kanji"`
+	PersonalIDNumber         string               `json:"-"`
+	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided"`
+	PhoneNumber              string               `json:"phone_number"`
+	SSNLast4                 string               `json:"-"`
+	SSNLast4Provided         bool                 `json:"ssn_last_4_provided"`
+	Type                     LegalEntityType      `json:"type"`
+	Verification             IdentityVerification `json:"verification"`
 }
 
 // Address is the structure for an account address.
-type Address struct {
-	City       string `json:"city" form:"city"`
-	Country    string `json:"country" form:"country"`
-	Line1      string `json:"line1" form:"line1"`
-	Line2      string `json:"line2" form:"line2"`
-	PostalCode string `json:"postal_code" form:"postal_code"`
-	State      string `json:"state" form:"state"`
+type AccountAddress struct {
+	City       string `json:"city"`
+	Country    string `json:"country"`
+	Line1      string `json:"line1"`
+	Line2      string `json:"line2"`
+	PostalCode string `json:"postal_code"`
+	State      string `json:"state"`
 
 	// Town/cho-me. Note that this is only used for Kana/Kanji representations
 	// of an address.
-	Town string `json:"town" form:"town"`
+	Town string `json:"town"`
 }
 
 // DOB is a structure for an account owner's date of birth.
 type DOB struct {
-	Day   int `json:"day" form:"day"`
-	Month int `json:"month" form:"month"`
-	Year  int `json:"year" form:"year"`
+	Day   int `json:"day"`
+	Month int `json:"month"`
+	Year  int `json:"year"`
 }
 
 // Gender is the gender of an account owner. International regulations require
@@ -341,20 +418,20 @@ type Gender string
 
 // AdditionalOwner is the structure for an account owner.
 type AdditionalOwner struct {
-	Address      Address              `json:"address" form:"address"`
-	DOB          DOB                  `json:"dob" form:"dob"`
-	FirstName    string               `json:"first_name" form:"first_name"`
-	LastName     string               `json:"last_name" form:"last_name"`
-	MaidenName   string               `json:"maiden_name" form:"maiden_name"`
-	Verification IdentityVerification `json:"verification" form:"verification"`
+	Address      AccountAddress       `json:"address"`
+	DOB          DOB                  `json:"dob"`
+	FirstName    string               `json:"first_name"`
+	LastName     string               `json:"last_name"`
+	MaidenName   string               `json:"maiden_name"`
+	Verification IdentityVerification `json:"verification"`
 }
 
 // IdentityVerification is the structure for an account's verification.
 type IdentityVerification struct {
-	Details     *string                         `json:"details" form:"-"`
-	DetailsCode IdentityVerificationDetailsCode `json:"details_code" form:"-"`
-	Document    *IdentityDocument               `json:"document" form:"document"`
-	Status      IdentityVerificationStatus      `json:"status" form:"-"`
+	Details     *string                         `json:"details"`
+	DetailsCode IdentityVerificationDetailsCode `json:"details_code"`
+	Document    *IdentityDocument               `json:"document"`
+	Status      IdentityVerificationStatus      `json:"status"`
 }
 
 // IdentityDocument is the structure for an identity document.
@@ -383,24 +460,17 @@ func (d *IdentityDocument) AppendTo(body *form.Values, keyParts []string) {
 
 // PayoutSchedule is the structure for an account's payout schedule.
 type PayoutSchedule struct {
-	DelayDays     uint64   `json:"delay_days" form:"delay_days"`
-	Interval      Interval `json:"interval" form:"interval"`
-	MonthlyAnchor uint64   `json:"monthly_anchor" form:"monthly_anchor"`
-	WeeklyAnchor  string   `json:"weekly_anchor" form:"weekly_anchor"`
-}
-
-// TOSAcceptanceParams is the structure for TOS acceptance.
-type TOSAcceptanceParams struct {
-	Date      int64  `json:"date" form:"date"`
-	IP        string `json:"ip" form:"ip"`
-	UserAgent string `json:"user_agent" form:"user_agent"`
+	DelayDays     uint64   `json:"delay_days"`
+	Interval      Interval `json:"interval"`
+	MonthlyAnchor uint64   `json:"monthly_anchor"`
+	WeeklyAnchor  string   `json:"weekly_anchor"`
 }
 
 // AccountRejectParams is the structure for the Reject function.
 type AccountRejectParams struct {
 	// Reason is the reason that an account was rejected. It should be given a
 	// value of one of `fraud`, `terms_of_service`, or `other`.
-	Reason string `json:"reason" form:"reason"`
+	Reason string `form:"reason"`
 }
 
 // UnmarshalJSON handles deserialization of an IdentityDocument.

--- a/account.go
+++ b/account.go
@@ -91,35 +91,31 @@ type LegalEntityParams struct {
 	// owners.
 	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
 
-	Address                  *AccountAddressParams       `form:"address"`
-	AddressKana              *AccountAddressParams       `form:"address_kana"`
-	AddressKanji             *AccountAddressParams       `form:"address_kanji"`
-	BusinessName             *string                     `form:"business_name"`
-	BusinessNameKana         *string                     `form:"business_name_kana"`
-	BusinessNameKanji        *string                     `form:"business_name_kanji"`
-	BusinessTaxID            *string                     `form:"business_tax_id"`
-	BusinessTaxIDProvided    *bool                       `form:"-"`
-	BusinessVatID            *string                     `form:"business_vat_id"`
-	BusinessVatIDProvided    *bool                       `form:"-"`
-	DOB                      *DOBParams                  `form:"dob"`
-	FirstName                *string                     `form:"first_name"`
-	FirstNameKana            *string                     `form:"first_name_kana"`
-	FirstNameKanji           *string                     `form:"first_name_kanji"`
-	Gender                   *string                     `form:"gender"`
-	LastName                 *string                     `form:"last_name"`
-	LastNameKana             *string                     `form:"last_name_kana"`
-	LastNameKanji            *string                     `form:"last_name_kanji"`
-	MaidenName               *string                     `form:"maiden_name"`
-	PersonalAddress          *AccountAddressParams       `form:"personal_address"`
-	PersonalAddressKana      *AccountAddressParams       `form:"personal_address_kana"`
-	PersonalAddressKanji     *AccountAddressParams       `form:"personal_address_kanji"`
-	PersonalIDNumber         *string                     `form:"personal_id_number"`
-	PersonalIDNumberProvided *bool                       `form:"-"`
-	PhoneNumber              *string                     `form:"phone_number"`
-	SSNLast4                 *string                     `form:"ssn_last_4"`
-	SSNLast4Provided         *bool                       `form:"-"`
-	Type                     *string                     `form:"type"`
-	Verification             *IdentityVerificationParams `form:"verification"`
+	Address              *AccountAddressParams       `form:"address"`
+	AddressKana          *AccountAddressParams       `form:"address_kana"`
+	AddressKanji         *AccountAddressParams       `form:"address_kanji"`
+	BusinessName         *string                     `form:"business_name"`
+	BusinessNameKana     *string                     `form:"business_name_kana"`
+	BusinessNameKanji    *string                     `form:"business_name_kanji"`
+	BusinessTaxID        *string                     `form:"business_tax_id"`
+	BusinessVatID        *string                     `form:"business_vat_id"`
+	DOB                  *DOBParams                  `form:"dob"`
+	FirstName            *string                     `form:"first_name"`
+	FirstNameKana        *string                     `form:"first_name_kana"`
+	FirstNameKanji       *string                     `form:"first_name_kanji"`
+	Gender               *string                     `form:"gender"`
+	LastName             *string                     `form:"last_name"`
+	LastNameKana         *string                     `form:"last_name_kana"`
+	LastNameKanji        *string                     `form:"last_name_kanji"`
+	MaidenName           *string                     `form:"maiden_name"`
+	PersonalAddress      *AccountAddressParams       `form:"personal_address"`
+	PersonalAddressKana  *AccountAddressParams       `form:"personal_address_kana"`
+	PersonalAddressKanji *AccountAddressParams       `form:"personal_address_kanji"`
+	PersonalIDNumber     *string                     `form:"personal_id_number"`
+	PhoneNumber          *string                     `form:"phone_number"`
+	SSNLast4             *string                     `form:"ssn_last_4"`
+	Type                 *string                     `form:"type"`
+	Verification         *IdentityVerificationParams `form:"verification"`
 }
 
 // AccountAddressParams represents an address during account creation/updates.
@@ -145,9 +141,9 @@ type DOBParams struct {
 
 // TOSAcceptanceParams represents tos_acceptance during account creation/updates.
 type TOSAcceptanceParams struct {
-	Date      int64  `form:"date"`
-	IP        string `form:"ip"`
-	UserAgent string `form:"user_agent"`
+	Date      *int64  `form:"date"`
+	IP        *string `form:"ip"`
+	UserAgent *string `form:"user_agent"`
 }
 
 // AdditionalOwnerParams represents an additional owner during account creation/updates.
@@ -228,8 +224,8 @@ type Account struct {
 	ID                    string               `json:"id"`
 
 	Keys *struct {
-		Publish string `json:"publishable"`
-		Secret  string `json:"secret"`
+		Publishable string `json:"publishable"`
+		Secret      string `json:"secret"`
 	} `json:"keys"`
 
 	LegalEntity               *LegalEntity      `json:"legal_entity"`
@@ -252,7 +248,7 @@ type Account struct {
 		UserAgent string `json:"user_agent"`
 	} `json:"tos_acceptance"`
 
-	Type AccountType
+	Type AccountType `json:"type"`
 
 	Verification *struct {
 		DisabledReason string   `json:"disabled_reason"`
@@ -366,9 +362,7 @@ type LegalEntity struct {
 	BusinessName             string               `json:"business_name"`
 	BusinessNameKana         string               `json:"business_name_kana"`
 	BusinessNameKanji        string               `json:"business_name_kanji"`
-	BusinessTaxID            string               `json:"-"`
 	BusinessTaxIDProvided    bool                 `json:"business_tax_id_provided"`
-	BusinessVatID            string               `json:"-"`
 	BusinessVatIDProvided    bool                 `json:"business_vat_id_provided"`
 	DOB                      DOB                  `json:"dob"`
 	FirstName                string               `json:"first_name"`
@@ -382,10 +376,8 @@ type LegalEntity struct {
 	PersonalAddress          AccountAddress       `json:"personal_address"`
 	PersonalAddressKana      AccountAddress       `json:"personal_address_kana"`
 	PersonalAddressKanji     AccountAddress       `json:"personal_address_kanji"`
-	PersonalIDNumber         string               `json:"-"`
 	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided"`
 	PhoneNumber              string               `json:"phone_number"`
-	SSNLast4                 string               `json:"-"`
 	SSNLast4Provided         bool                 `json:"ssn_last_4_provided"`
 	Type                     LegalEntityType      `json:"type"`
 	Verification             IdentityVerification `json:"verification"`
@@ -470,7 +462,7 @@ type PayoutSchedule struct {
 type AccountRejectParams struct {
 	// Reason is the reason that an account was rejected. It should be given a
 	// value of one of `fraud`, `terms_of_service`, or `other`.
-	Reason string `form:"reason"`
+	Reason *string `form:"reason"`
 }
 
 // UnmarshalJSON handles deserialization of an IdentityDocument.

--- a/account/client.go
+++ b/account/client.go
@@ -21,8 +21,8 @@ func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 
 	// Type is now required on creation and not allowed on update
 	// It can't be passed if you pass `from_recipient` though
-	if len(params.FromRecipient) == 0 {
-		body.Add("type", string(params.Type))
+	if params.FromRecipient != nil {
+		body.Add("type", stripe.StringValue(params.Type))
 	}
 
 	form.AppendTo(body, params)

--- a/account/client.go
+++ b/account/client.go
@@ -115,8 +115,8 @@ func Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, err
 
 func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, error) {
 	body := &form.Values{}
-	if len(params.Reason) > 0 {
-		body.Add("reason", params.Reason)
+	if params.Reason != nil {
+		body.Add("reason", stripe.StringValue(params.Reason))
 	}
 	acct := &stripe.Account{}
 	err := c.B.Call("POST", "/accounts/"+id+"/reject", c.Key, body, nil, acct)

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -59,9 +59,9 @@ func TestAccountNew(t *testing.T) {
 			},
 		},
 		TOSAcceptance: &stripe.TOSAcceptanceParams{
-			IP:        "127.0.0.1",
-			Date:      1437578361,
-			UserAgent: "Mozilla/5.0",
+			IP:        stripe.String("127.0.0.1"),
+			Date:      stripe.Int64(1437578361),
+			UserAgent: stripe.String("Mozilla/5.0"),
 		},
 	})
 	assert.Nil(t, err)
@@ -70,7 +70,7 @@ func TestAccountNew(t *testing.T) {
 
 func TestAccountReject(t *testing.T) {
 	account, err := Reject("acct_123", &stripe.AccountRejectParams{
-		Reason: "fraud",
+		Reason: stripe.String("fraud"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, account)

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -37,25 +37,25 @@ func TestAccountList(t *testing.T) {
 
 func TestAccountNew(t *testing.T) {
 	account, err := New(&stripe.AccountParams{
-		Type:                  stripe.AccountTypeCustom,
-		Country:               "CA",
-		BusinessURL:           "www.stripe.com",
-		BusinessName:          "Stripe",
-		BusinessPrimaryColor:  "#ffffff",
+		Type:                  stripe.String(string(stripe.AccountTypeCustom)),
+		Country:               stripe.String("CA"),
+		BusinessURL:           stripe.String("www.stripe.com"),
+		BusinessName:          stripe.String("Stripe"),
+		BusinessPrimaryColor:  stripe.String("#ffffff"),
 		DebitNegativeBalances: stripe.Bool(true),
-		SupportEmail:          "foo@bar.com",
-		SupportURL:            "www.stripe.com",
-		SupportPhone:          "4151234567",
-		LegalEntity: &stripe.LegalEntity{
-			Type:         stripe.Individual,
-			BusinessName: "Stripe Go",
-			AdditionalOwners: []stripe.AdditionalOwner{
-				{FirstName: "Jane"},
+		SupportEmail:          stripe.String("foo@bar.com"),
+		SupportURL:            stripe.String("www.stripe.com"),
+		SupportPhone:          stripe.String("4151234567"),
+		LegalEntity: &stripe.LegalEntityParams{
+			Type:         stripe.String(string(stripe.Individual)),
+			BusinessName: stripe.String("Stripe Go"),
+			AdditionalOwners: []stripe.AdditionalOwnerParams{
+				{FirstName: stripe.String("Jane")},
 			},
-			DOB: stripe.DOB{
-				Day:   1,
-				Month: 2,
-				Year:  1990,
+			DOB: &stripe.DOBParams{
+				Day:   stripe.Int(1),
+				Month: stripe.Int(2),
+				Year:  stripe.Int(1990),
 			},
 		},
 		TOSAcceptance: &stripe.TOSAcceptanceParams{
@@ -78,15 +78,15 @@ func TestAccountReject(t *testing.T) {
 
 func TestAccountUpdate(t *testing.T) {
 	account, err := Update("acct_123", &stripe.AccountParams{
-		Type:    stripe.AccountTypeCustom,
-		Country: "CA",
-		LegalEntity: &stripe.LegalEntity{
-			Address: stripe.Address{
-				Country:    "CA",
-				City:       "Montreal",
-				PostalCode: "H2Y 1C6",
-				Line1:      "275, rue Notre-Dame Est",
-				State:      "QC",
+		Type:    stripe.String(string(stripe.AccountTypeCustom)),
+		Country: stripe.String("CA"),
+		LegalEntity: &stripe.LegalEntityParams{
+			Address: &stripe.AccountAddressParams{
+				Country:    stripe.String("CA"),
+				City:       stripe.String("Montreal"),
+				PostalCode: stripe.String("H2Y 1C6"),
+				Line1:      stripe.String("275, rue Notre-Dame Est"),
+				State:      stripe.String("QC"),
 			},
 		},
 	})

--- a/account_test.go
+++ b/account_test.go
@@ -47,6 +47,7 @@ func TestAccountUnmarshal(t *testing.T) {
 				},
 			},
 		},
+		"type": "custom",
 	}
 
 	bytes, err := json.Marshal(&accountData)
@@ -56,6 +57,7 @@ func TestAccountUnmarshal(t *testing.T) {
 	err = json.Unmarshal(bytes, &account)
 	assert.NoError(t, err)
 
+	assert.Equal(t, AccountTypeCustom, account.Type)
 	assert.Equal(t, "acct_123", account.ID)
 	assert.Equal(t, true, account.ExternalAccounts.HasMore)
 

--- a/account_test.go
+++ b/account_test.go
@@ -18,7 +18,7 @@ func TestAccountExternalAccountParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &AccountExternalAccountParams{Token: "tok_123"}
+		params := &AccountExternalAccountParams{Token: String("tok_123")}
 		body := &form.Values{}
 
 		// 0-length keyParts are not allowed, so call AppendTo directly (as

--- a/address.go
+++ b/address.go
@@ -2,10 +2,10 @@ package stripe
 
 // Standard address parameters.
 type AddressParams struct {
-	City       string `form:"city"`
-	Country    string `form:"country"`
-	Line1      string `form:"line1"`
-	Line2      string `form:"line2"`
-	PostalCode string `form:"postal_code"`
-	State      string `form:"state"`
+	City       *string `form:"city"`
+	Country    *string `form:"country"`
+	Line1      *string `form:"line1"`
+	Line2      *string `form:"line2"`
+	PostalCode *string `form:"postal_code"`
+	State      *string `form:"state"`
 }

--- a/address.go
+++ b/address.go
@@ -9,3 +9,13 @@ type AddressParams struct {
 	PostalCode *string `form:"postal_code"`
 	State      *string `form:"state"`
 }
+
+// Standard address resource.
+type Address struct {
+	City       string `json:"city"`
+	Country    string `json:"country"`
+	Line1      string `json:"line1"`
+	Line2      string `json:"line2"`
+	PostalCode string `json:"postal_code"`
+	State      string `json:"state"`
+}

--- a/applepaydomain.go
+++ b/applepaydomain.go
@@ -3,7 +3,7 @@ package stripe
 // ApplePayDomainParams is the set of parameters that can be used when creating an ApplePayDomain object.
 type ApplePayDomainParams struct {
 	Params     `form:"*"`
-	DomainName string `form:"domain_name"`
+	DomainName *string `form:"domain_name"`
 }
 
 // ApplePayDomain is the resource representing a Stripe ApplePayDomain object

--- a/applepaydomain/client_test.go
+++ b/applepaydomain/client_test.go
@@ -31,7 +31,7 @@ func TestApplePayDomainList(t *testing.T) {
 
 func TestApplePayDomainNew(t *testing.T) {
 	domain, err := New(&stripe.ApplePayDomainParams{
-		DomainName: "example.com",
+		DomainName: stripe.String("example.com"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, domain)

--- a/balance.go
+++ b/balance.go
@@ -72,14 +72,14 @@ type BalanceTransactionParams struct {
 // For more details see https://stripe.com/docs/api/#balance_history.
 type BalanceTransactionListParams struct {
 	ListParams       `form:"*"`
-	AvailableOn      int64                  `form:"available_on"`
-	AvailableOnRange *RangeQueryParams      `form:"available_on"`
-	Created          int64                  `form:"created"`
-	CreatedRange     *RangeQueryParams      `form:"created"`
-	Currency         string                 `form:"currency"`
-	Payout           string                 `form:"payout"`
-	Source           string                 `form:"source"`
-	Type             BalanceTransactionType `form:"type"`
+	AvailableOn      *int64            `form:"available_on"`
+	AvailableOnRange *RangeQueryParams `form:"available_on"`
+	Created          *int64            `form:"created"`
+	CreatedRange     *RangeQueryParams `form:"created"`
+	Currency         *string           `form:"currency"`
+	Payout           *string           `form:"payout"`
+	Source           *string           `form:"source"`
+	Type             *string           `form:"type"`
 }
 
 // Balance is the resource representing your Stripe balance.

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -22,23 +22,23 @@ type BankAccountParams struct {
 
 	// Account is the identifier of the parent account under which bank
 	// accounts are nested.
-	Account string `form:"-"`
+	Account *string `form:"-"`
 
-	AccountHolderName  string `form:"account_holder_name"`
-	AccountHolderType  string `form:"account_holder_type"`
-	AccountNumber      string `form:"account_number"`
-	Country            string `form:"country"`
-	Currency           string `form:"currency"`
-	Customer           string `form:"-"`
-	DefaultForCurrency *bool  `form:"default_for_currency"`
-	RoutingNumber      string `form:"routing_number"`
+	AccountHolderName  *string `form:"account_holder_name"`
+	AccountHolderType  *string `form:"account_holder_type"`
+	AccountNumber      *string `form:"account_number"`
+	Country            *string `form:"country"`
+	Currency           *string `form:"currency"`
+	Customer           *string `form:"-"`
+	DefaultForCurrency *bool   `form:"default_for_currency"`
+	RoutingNumber      *string `form:"routing_number"`
 
 	// Token is a token referencing an external account like one returned from
 	// Stripe.js.
-	Token string `form:"-"`
+	Token *string `form:"-"`
 
 	// ID is used when tokenizing a bank account for shared customers
-	ID string `form:"*"`
+	ID *string `form:"*"`
 }
 
 // AppendToAsSourceOrExternalAccount appends the given BankAccountParams as
@@ -54,7 +54,7 @@ type BankAccountParams struct {
 // because the bank accounts endpoint is a little unusual. There is one other
 // resource like it, which is cards.
 func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values) {
-	isCustomer := len(a.Customer) > 0
+	isCustomer := a.Customer != nil
 
 	var sourceType string
 	if isCustomer {
@@ -64,31 +64,31 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 	}
 
 	// Use token (if exists) or a dictionary containing a user’s bank account details.
-	if len(a.Token) > 0 {
-		body.Add(sourceType, a.Token)
+	if a.Token != nil {
+		body.Add(sourceType, StringValue(a.Token))
 
 		if a.DefaultForCurrency != nil {
 			body.Add("default_for_currency", strconv.FormatBool(BoolValue(a.DefaultForCurrency)))
 		}
 	} else {
 		body.Add(sourceType+"[object]", "bank_account")
-		body.Add(sourceType+"[country]", a.Country)
-		body.Add(sourceType+"[account_number]", a.AccountNumber)
-		body.Add(sourceType+"[currency]", a.Currency)
+		body.Add(sourceType+"[country]", StringValue(a.Country))
+		body.Add(sourceType+"[account_number]", StringValue(a.AccountNumber))
+		body.Add(sourceType+"[currency]", StringValue(a.Currency))
 
 		// These are optional and the API will fail if we try to send empty
 		// values in for them, so make sure to check that they're actually set
 		// before encoding them.
-		if len(a.AccountHolderName) > 0 {
-			body.Add(sourceType+"[account_holder_name]", a.AccountHolderName)
+		if a.AccountHolderName != nil {
+			body.Add(sourceType+"[account_holder_name]", StringValue(a.AccountHolderName))
 		}
 
-		if len(a.AccountHolderType) > 0 {
-			body.Add(sourceType+"[account_holder_type]", a.AccountHolderType)
+		if a.AccountHolderType != nil {
+			body.Add(sourceType+"[account_holder_type]", StringValue(a.AccountHolderType))
 		}
 
-		if len(a.RoutingNumber) > 0 {
-			body.Add(sourceType+"[routing_number]", a.RoutingNumber)
+		if a.RoutingNumber != nil {
+			body.Add(sourceType+"[routing_number]", StringValue(a.RoutingNumber))
 		}
 
 		if a.DefaultForCurrency != nil {
@@ -103,11 +103,11 @@ type BankAccountListParams struct {
 
 	// The identifier of the parent account under which the bank accounts are
 	// nested. Either Account or Customer should be populated.
-	Account string `form:"-"`
+	Account *string `form:"-"`
 
 	// The identifier of the parent customer under which the bank accounts are
 	// nested. Either Account or Customer should be populated.
-	Customer string `form:"-"`
+	Customer *string `form:"-"`
 }
 
 // BankAccount represents a Stripe bank account.

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -38,10 +38,10 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 
 	ba := &stripe.BankAccount{}
 	var err error
-	if len(params.Customer) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", params.Customer), c.Key, body, &params.Params, ba)
+	if params.Customer != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, ba)
 	} else {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts", params.Account), c.Key, body, &params.Params, ba)
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, ba)
 	}
 
 	return ba, err
@@ -65,10 +65,10 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	ba := &stripe.BankAccount{}
 	var err error
 
-	if params != nil && len(params.Customer) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if params != nil && len(params.Account) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
+	if params != nil && params.Customer != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+	} else if params != nil && params.Account != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -94,10 +94,10 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 	ba := &stripe.BankAccount{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if len(params.Account) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
+	if params.Customer != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/bank_accounts/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+	} else if params.Account != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -123,10 +123,10 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	ba := &stripe.BankAccount{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if len(params.Account) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
+	if params.Customer != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/bank_accounts/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+	} else if params.Account != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -152,10 +152,10 @@ func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 		list := &stripe.BankAccountList{}
 		var err error
 
-		if len(params.Customer) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts", params.Customer), c.Key, b, p, list)
-		} else if len(params.Account) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.Account), c.Key, b, p, list)
+		if params.Customer != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts", stripe.StringValue(params.Customer)), c.Key, b, p, list)
+		} else if params.Account != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", stripe.StringValue(params.Account)), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 		}

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBankAccountDel_ByAccount(t *testing.T) {
 	bankAcount, err := Del("ba_123", &stripe.BankAccountParams{
-		Account: "acct_123",
+		Account: stripe.String("acct_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -18,26 +18,26 @@ func TestBankAccountDel_ByAccount(t *testing.T) {
 
 func TestBankAccountDel_ByCustomer(t *testing.T) {
 	bankAcount, err := Del("ba_123", &stripe.BankAccountParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
 }
 
 func TestBankAccountGet_ByAccount(t *testing.T) {
-	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Account: "acct_123"})
+	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Account: stripe.String("acct_123")})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
 }
 
 func TestBankAccountGet_ByCustomer(t *testing.T) {
-	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Customer: "cus_123"})
+	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Customer: stripe.String("cus_123")})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
 }
 
 func TestBankAccountList_ByAccount(t *testing.T) {
-	i := List(&stripe.BankAccountListParams{Customer: "acct_123"})
+	i := List(&stripe.BankAccountListParams{Customer: stripe.String("acct_123")})
 
 	// Verify that we can get at least one bank account
 	assert.True(t, i.Next())
@@ -46,7 +46,7 @@ func TestBankAccountList_ByAccount(t *testing.T) {
 }
 
 func TestBankAccountList_ByCustomer(t *testing.T) {
-	i := List(&stripe.BankAccountListParams{Customer: "cus_123"})
+	i := List(&stripe.BankAccountListParams{Customer: stripe.String("cus_123")})
 
 	// Verify that we can get at least one bank account
 	assert.True(t, i.Next())
@@ -56,9 +56,9 @@ func TestBankAccountList_ByCustomer(t *testing.T) {
 
 func TestBankAccountNew_ByAccount(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
-		Account:            "acct_123",
+		Account:            stripe.String("acct_123"),
 		DefaultForCurrency: stripe.Bool(true),
-		Token:              "tok_123",
+		Token:              stripe.String("tok_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -66,9 +66,9 @@ func TestBankAccountNew_ByAccount(t *testing.T) {
 
 func TestBankAccountNew_ByCustomer(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
-		Customer:           "cus_123",
+		Customer:           stripe.String("cus_123"),
 		DefaultForCurrency: stripe.Bool(true),
-		Token:              "tok_123",
+		Token:              stripe.String("tok_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -76,7 +76,7 @@ func TestBankAccountNew_ByCustomer(t *testing.T) {
 
 func TestBankAccountUpdate_ByAccount(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
-		Account:            "acct_123",
+		Account:            stripe.String("acct_123"),
 		DefaultForCurrency: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
@@ -85,7 +85,7 @@ func TestBankAccountUpdate_ByAccount(t *testing.T) {
 
 func TestBankAccountUpdate_ByCustomer(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
-		Customer:           "cus_123",
+		Customer:           stripe.String("cus_123"),
 		DefaultForCurrency: stripe.Bool(true),
 	})
 	assert.Nil(t, err)

--- a/bankaccount_test.go
+++ b/bankaccount_test.go
@@ -12,7 +12,7 @@ func TestBankAccountParams_AppendToAsSourceOrExternalAccount(t *testing.T) {
 
 	// Includes account_holder_name
 	{
-		params := &BankAccountParams{AccountHolderName: "Tyrion"}
+		params := &BankAccountParams{AccountHolderName: String("Tyrion")}
 		body := &form.Values{}
 		params.AppendToAsSourceOrExternalAccount(body)
 		t.Logf("body = %+v", body)
@@ -30,7 +30,7 @@ func TestBankAccountParams_AppendToAsSourceOrExternalAccount(t *testing.T) {
 
 	// Includes account_holder_name
 	{
-		params := &BankAccountParams{AccountHolderType: "individual"}
+		params := &BankAccountParams{AccountHolderType: String(string(Individual))}
 		body := &form.Values{}
 		params.AppendToAsSourceOrExternalAccount(body)
 		t.Logf("body = %+v", body)

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -10,17 +10,17 @@ type BitcoinReceiverListParams struct {
 	ListParams `form:"*"`
 	Active     *bool `form:"active"`
 	Filled     *bool `form:"filled"`
-	Uncaptured bool  `form:"uncaptured_funds"`
+	Uncaptured *bool `form:"uncaptured_funds"`
 }
 
 // BitcoinReceiverParams is the set of parameters that can be used when creating a BitcoinReceiver.
 // For more details see https://stripe.com/docs/api/#create_bitcoin_receiver.
 type BitcoinReceiverParams struct {
 	Params   `form:"*"`
-	Amount   uint64   `form:"amount"`
-	Currency Currency `form:"currency"`
-	Desc     string   `form:"description"`
-	Email    string   `form:"email"`
+	Amount   *uint64 `form:"amount"`
+	Currency *string `form:"currency"`
+	Desc     *string `form:"description"`
+	Email    *string `form:"email"`
 }
 
 // BitcoinReceiverUpdateParams is the set of parameters that can be used when
@@ -28,9 +28,9 @@ type BitcoinReceiverParams struct {
 // https://stripe.com/docs/api/#update_bitcoin_receiver.
 type BitcoinReceiverUpdateParams struct {
 	Params     `form:"*"`
-	Desc       string `form:"description"`
-	Email      string `form:"email"`
-	RefundAddr string `form:"refund_address"`
+	Desc       *string `form:"description"`
+	Email      *string `form:"email"`
+	RefundAddr *string `form:"refund_address"`
 }
 
 // BitcoinReceiver is the resource representing a Stripe bitcoin receiver.

--- a/bitcointransaction.go
+++ b/bitcointransaction.go
@@ -5,8 +5,8 @@ import "encoding/json"
 // BitcoinTransactionListParams is the set of parameters that can be used when listing BitcoinTransactions.
 type BitcoinTransactionListParams struct {
 	ListParams `form:"*"`
-	Customer   string `form:"customer"`
-	Receiver   string `form:"-"` // Sent in with the URL
+	Customer   *string `form:"customer"`
+	Receiver   *string `form:"-"` // Sent in with the URL
 }
 
 // BitcoinTransactionList is a list object for BitcoinTransactions.

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -34,7 +34,7 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinTransactionList{}
-		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", stripe.StringValue(params.Receiver)), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/bitcointransaction/client_test.go
+++ b/bitcointransaction/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBitcoinTransactionList(t *testing.T) {
 	i := List(&stripe.BitcoinTransactionListParams{
-		Receiver: "btcrcv_123",
+		Receiver: stripe.String("btcrcv_123"),
 	})
 
 	// Verify that we can get at least one transaction

--- a/card.go
+++ b/card.go
@@ -36,23 +36,23 @@ type Verification string
 // of all parameters. See AppendToAsCardSourceOrExternalAccount.
 type CardParams struct {
 	Params             `form:"*"`
-	Account            string `form:"-"`
-	AddressCity        string `form:"address_city"`
-	AddressCountry     string `form:"address_country"`
-	AddressLine1       string `form:"address_line1"`
-	AddressLine2       string `form:"address_line2"`
-	AddressState       string `form:"address_state"`
-	AddressZip         string `form:"address_zip"`
-	CVC                string `form:"cvc"`
-	Currency           string `form:"currency"`
-	Customer           string `form:"-"`
-	DefaultForCurrency bool   `form:"default_for_currency"`
-	ExpMonth           string `form:"exp_month"`
-	ExpYear            string `form:"exp_year"`
-	Name               string `form:"name"`
-	Number             string `form:"number"`
-	Recipient          string `form:"-"`
-	Token              string `form:"-"`
+	Account            *string `form:"-"`
+	AddressCity        *string `form:"address_city"`
+	AddressCountry     *string `form:"address_country"`
+	AddressLine1       *string `form:"address_line1"`
+	AddressLine2       *string `form:"address_line2"`
+	AddressState       *string `form:"address_state"`
+	AddressZip         *string `form:"address_zip"`
+	CVC                *string `form:"cvc"`
+	Currency           *string `form:"currency"`
+	Customer           *string `form:"-"`
+	DefaultForCurrency *bool   `form:"default_for_currency"`
+	ExpMonth           *string `form:"exp_month"`
+	ExpYear            *string `form:"exp_year"`
+	Name               *string `form:"name"`
+	Number             *string `form:"number"`
+	Recipient          *string `form:"-"`
+	Token              *string `form:"-"`
 
 	// ID is used when tokenizing a card for shared customers
 	ID string `form:"*"`
@@ -71,65 +71,65 @@ type CardParams struct {
 // because the cards endpoint is a little unusual. There is one other resource
 // like it, which is bank account.
 func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, keyParts []string) {
-	if c.DefaultForCurrency {
-		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(c.DefaultForCurrency))
+	if c.DefaultForCurrency != nil {
+		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(BoolValue(c.DefaultForCurrency)))
 	}
 
-	if len(c.Token) > 0 {
-		if len(c.Account) > 0 {
-			body.Add(form.FormatKey(append(keyParts, "external_account")), c.Token)
+	if c.Token != nil {
+		if c.Account != nil {
+			body.Add(form.FormatKey(append(keyParts, "external_account")), StringValue(c.Token))
 		} else {
-			body.Add(form.FormatKey(append(keyParts, cardSource)), c.Token)
+			body.Add(form.FormatKey(append(keyParts, cardSource)), StringValue(c.Token))
 		}
 	}
 
-	if len(c.Number) > 0 {
+	if c.Number != nil {
 		body.Add(form.FormatKey(append(keyParts, cardSource, "object")), "card")
-		body.Add(form.FormatKey(append(keyParts, cardSource, "number")), c.Number)
+		body.Add(form.FormatKey(append(keyParts, cardSource, "number")), StringValue(c.Number))
 	}
 
-	if len(c.CVC) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "cvc")), c.CVC)
+	if c.CVC != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "cvc")), StringValue(c.CVC))
 	}
 
-	if len(c.Currency) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "currency")), c.Currency)
+	if c.Currency != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "currency")), StringValue(c.Currency))
 	}
 
-	if len(c.ExpMonth) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), c.ExpMonth)
+	if c.ExpMonth != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), StringValue(c.ExpMonth))
 	}
 
-	if len(c.ExpYear) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), c.ExpYear)
+	if c.ExpYear != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), StringValue(c.ExpYear))
 	}
 
-	if len(c.Name) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "name")), c.Name)
+	if c.Name != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "name")), StringValue(c.Name))
 	}
 
-	if len(c.AddressCity) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), c.AddressCity)
+	if c.AddressCity != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), StringValue(c.AddressCity))
 	}
 
-	if len(c.AddressCountry) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), c.AddressCountry)
+	if c.AddressCountry != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), StringValue(c.AddressCountry))
 	}
 
-	if len(c.AddressLine1) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), c.AddressLine1)
+	if c.AddressLine1 != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), StringValue(c.AddressLine1))
 	}
 
-	if len(c.AddressLine2) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), c.AddressLine2)
+	if c.AddressLine2 != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), StringValue(c.AddressLine2))
 	}
 
-	if len(c.AddressState) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), c.AddressState)
+	if c.AddressState != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), StringValue(c.AddressState))
 	}
 
-	if len(c.AddressZip) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), c.AddressZip)
+	if c.AddressZip != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), StringValue(c.AddressZip))
 	}
 }
 
@@ -137,9 +137,9 @@ func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, ke
 // For more details see https://stripe.com/docs/api#list_cards.
 type CardListParams struct {
 	ListParams `form:"*"`
-	Account    string `form:"-"`
-	Customer   string `form:"-"`
-	Recipient  string `form:"-"`
+	Account    *string `form:"-"`
+	Customer   *string `form:"-"`
+	Recipient  *string `form:"-"`
 }
 
 // Card is the resource representing a Stripe credit/debit card.

--- a/card/client.go
+++ b/card/client.go
@@ -55,12 +55,12 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	card := &stripe.Card{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, body, &params.Params, card)
-	} else if len(params.Customer) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/cards", params.Customer), c.Key, body, &params.Params, card)
-	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards", params.Recipient), c.Key, body, &params.Params, card)
+	if params.Account != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, card)
+	} else if params.Customer != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/cards", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, card)
+	} else if params.Recipient != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards", stripe.StringValue(params.Recipient)), c.Key, body, &params.Params, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -91,12 +91,12 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	card := &stripe.Card{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts/%v", params.Account, id), c.Key, body, commonParams, card)
-	} else if len(params.Customer) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards/%v", params.Customer, id), c.Key, body, commonParams, card)
-	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards/%v", params.Recipient, id), c.Key, body, commonParams, card)
+	if params.Account != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
+	} else if params.Customer != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
+	} else if params.Recipient != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -121,12 +121,12 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 	card := &stripe.Card{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts/%v", params.Account, id), c.Key, body, &params.Params, card)
-	} else if len(params.Customer) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/cards/%v", params.Customer, id), c.Key, body, &params.Params, card)
-	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards/%v", params.Recipient, id), c.Key, body, &params.Params, card)
+	if params.Account != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, &params.Params, card)
+	} else if params.Customer != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/cards/%v", stripe.StringValue(params.Customer), id), c.Key, body, &params.Params, card)
+	} else if params.Recipient != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, &params.Params, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -155,12 +155,12 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	card := &stripe.Card{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/external_accounts/%v", params.Account, id), c.Key, body, commonParams, card)
-	} else if len(params.Customer) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/cards/%v", params.Customer, id), c.Key, body, commonParams, card)
-	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/recipients/%v/cards/%v", params.Recipient, id), c.Key, body, commonParams, card)
+	if params.Account != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
+	} else if params.Customer != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/cards/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
+	} else if params.Recipient != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -193,12 +193,12 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 			return nil, list.ListMeta, errors.New("params should not be nil")
 		}
 
-		if len(params.Account) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, b, p, list)
-		} else if len(params.Customer) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards", params.Customer), c.Key, b, p, list)
-		} else if len(params.Recipient) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", params.Recipient), c.Key, b, p, list)
+		if params.Account != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", stripe.StringValue(params.Account)), c.Key, b, p, list)
+		} else if params.Customer != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards", stripe.StringValue(params.Customer)), c.Key, b, p, list)
+		} else if params.Recipient != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", stripe.StringValue(params.Recipient)), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 		}

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCardDel(t *testing.T) {
 	card, err := Del("card_123", &stripe.CardParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)
@@ -23,7 +23,7 @@ func TestCardDel_RequiresParams(t *testing.T) {
 
 func TestCardGet(t *testing.T) {
 	card, err := Get("card_123", &stripe.CardParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)
@@ -35,7 +35,7 @@ func TestCardGet_RequiresParams(t *testing.T) {
 }
 
 func TestCardList_ByCustomer(t *testing.T) {
-	i := List(&stripe.CardListParams{Customer: "cus_123"})
+	i := List(&stripe.CardListParams{Customer: stripe.String("cus_123")})
 
 	// Verify that we can get at least one card
 	assert.True(t, i.Next())
@@ -51,8 +51,8 @@ func TestCardList_RequiresParams(t *testing.T) {
 
 func TestCardNew(t *testing.T) {
 	card, err := New(&stripe.CardParams{
-		Customer: "cus_123",
-		Token:    "tok_123",
+		Customer: stripe.String("cus_123"),
+		Token:    stripe.String("tok_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)
@@ -65,8 +65,8 @@ func TestCardNew_RequiresParams(t *testing.T) {
 
 func TestCardUpdate(t *testing.T) {
 	card, err := Update("card_123", &stripe.CardParams{
-		Customer:           "cus_123",
-		DefaultForCurrency: true,
+		Customer:           stripe.String("cus_123"),
+		DefaultForCurrency: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)

--- a/charge.go
+++ b/charge.go
@@ -25,7 +25,6 @@ type ChargeParams struct {
 	Destination         *DestinationParams  `form:"destination"`
 	ExchangeRate        float64             `form:"exchange_rate"`
 	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
-	NoCapture           bool                `form:"capture,invert"`
 	OnBehalfOf          string              `form:"on_behalf_of"`
 	ReceiptEmail        string              `form:"receipt_email"`
 	Shipping            *ShippingDetails    `form:"shipping"`

--- a/charge.go
+++ b/charge.go
@@ -16,21 +16,30 @@ type FraudReport string
 // For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
 	Params              `form:"*"`
-	Amount              *uint64             `form:"amount"`
-	ApplicationFee      *uint64             `form:"application_fee"`
-	Capture             *bool               `form:"capture"`
-	Currency            *string             `form:"currency"`
-	Customer            *string             `form:"customer"`
-	Description         *string             `form:"description"`
-	Destination         *DestinationParams  `form:"destination"`
-	ExchangeRate        *float64            `form:"exchange_rate"`
-	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
-	OnBehalfOf          *string             `form:"on_behalf_of"`
-	ReceiptEmail        *string             `form:"receipt_email"`
-	Shipping            *ShippingDetails    `form:"shipping"`
-	Source              *SourceParams       `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	StatementDescriptor *string             `form:"statement_descriptor"`
-	TransferGroup       *string             `form:"transfer_group"`
+	Amount              *uint64                `form:"amount"`
+	ApplicationFee      *uint64                `form:"application_fee"`
+	Capture             *bool                  `form:"capture"`
+	Currency            *string                `form:"currency"`
+	Customer            *string                `form:"customer"`
+	Description         *string                `form:"description"`
+	Destination         *DestinationParams     `form:"destination"`
+	ExchangeRate        *float64               `form:"exchange_rate"`
+	FraudDetails        *FraudDetailsParams    `form:"fraud_details"`
+	OnBehalfOf          *string                `form:"on_behalf_of"`
+	ReceiptEmail        *string                `form:"receipt_email"`
+	Shipping            *ShippingDetailsParams `form:"shipping"`
+	Source              *SourceParams          `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	StatementDescriptor *string                `form:"statement_descriptor"`
+	TransferGroup       *string                `form:"transfer_group"`
+}
+
+// ShippingDetailsParams is the structure containing shipping information as parameters
+type ShippingDetailsParams struct {
+	Address        *AddressParams `form:"address"`
+	Carrier        *string        `form:"carrier"`
+	Name           *string        `form:"name"`
+	Phone          *string        `form:"phone"`
+	TrackingNumber *string        `form:"tracking_number"`
 }
 
 // SetSource adds valid sources to a ChargeParams object,
@@ -158,11 +167,11 @@ type ChargeOutcome struct {
 
 // ShippingDetails is the structure containing shipping information.
 type ShippingDetails struct {
-	Address        Address `json:"address" form:"address"`
-	Carrier        string  `json:"carrier" form:"carrier"`
-	Name           string  `json:"name" form:"name"`
-	Phone          string  `json:"phone" form:"phone"`
-	TrackingNumber string  `json:"tracking_number" form:"tracking_number"`
+	Address        Address `json:"address"`
+	Carrier        string  `json:"carrier"`
+	Name           string  `json:"name"`
+	Phone          string  `json:"phone"`
+	TrackingNumber string  `json:"tracking_number"`
 }
 
 var depth int = -1

--- a/charge.go
+++ b/charge.go
@@ -25,6 +25,7 @@ type ChargeParams struct {
 	Destination         *DestinationParams  `form:"destination"`
 	ExchangeRate        float64             `form:"exchange_rate"`
 	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
+	NoCapture           bool                `form:"capture,invert"`
 	OnBehalfOf          string              `form:"on_behalf_of"`
 	ReceiptEmail        string              `form:"receipt_email"`
 	Shipping            *ShippingDetails    `form:"shipping"`

--- a/charge.go
+++ b/charge.go
@@ -16,21 +16,21 @@ type FraudReport string
 // For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
 	Params              `form:"*"`
-	Amount              uint64              `form:"amount"`
-	ApplicationFee      uint64              `form:"application_fee"`
+	Amount              *uint64             `form:"amount"`
+	ApplicationFee      *uint64             `form:"application_fee"`
 	Capture             *bool               `form:"capture"`
-	Currency            Currency            `form:"currency"`
-	Customer            string              `form:"customer"`
-	Description         string              `form:"description"`
+	Currency            *string             `form:"currency"`
+	Customer            *string             `form:"customer"`
+	Description         *string             `form:"description"`
 	Destination         *DestinationParams  `form:"destination"`
-	ExchangeRate        float64             `form:"exchange_rate"`
+	ExchangeRate        *float64            `form:"exchange_rate"`
 	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
-	OnBehalfOf          string              `form:"on_behalf_of"`
-	ReceiptEmail        string              `form:"receipt_email"`
+	OnBehalfOf          *string             `form:"on_behalf_of"`
+	ReceiptEmail        *string             `form:"receipt_email"`
 	Shipping            *ShippingDetails    `form:"shipping"`
 	Source              *SourceParams       `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	StatementDescriptor string              `form:"statement_descriptor"`
-	TransferGroup       string              `form:"transfer_group"`
+	StatementDescriptor *string             `form:"statement_descriptor"`
+	TransferGroup       *string             `form:"transfer_group"`
 }
 
 // SetSource adds valid sources to a ChargeParams object,
@@ -42,34 +42,34 @@ func (p *ChargeParams) SetSource(sp interface{}) error {
 }
 
 type DestinationParams struct {
-	Account string `form:"account"`
-	Amount  uint64 `form:"amount"`
+	Account *string `form:"account"`
+	Amount  *uint64 `form:"amount"`
 }
 
 // FraudDetailsParams provides information on the fraud details for a charge.
 type FraudDetailsParams struct {
-	UserReport FraudReport `form:"user_report"`
+	UserReport *string `form:"user_report"`
 }
 
 // ChargeListParams is the set of parameters that can be used when listing charges.
 // For more details see https://stripe.com/docs/api#list_charges.
 type ChargeListParams struct {
 	ListParams    `form:"*"`
-	Created       int64             `form:"created"`
+	Created       *int64            `form:"created"`
 	CreatedRange  *RangeQueryParams `form:"created"`
-	Customer      string            `form:"customer"`
-	TransferGroup string            `form:"transfer_group"`
+	Customer      *string           `form:"customer"`
+	TransferGroup *string           `form:"transfer_group"`
 }
 
 // CaptureParams is the set of parameters that can be used when capturing a charge.
 // For more details see https://stripe.com/docs/api#charge_capture.
 type CaptureParams struct {
 	Params              `form:"*"`
-	Amount              uint64  `form:"amount"`
-	ApplicationFee      uint64  `form:"application_fee"`
-	ExchangeRate        float64 `form:"exchange_rate"`
-	ReceiptEmail        string  `form:"receipt_email"`
-	StatementDescriptor string  `form:"statement_descriptor"`
+	Amount              *uint64  `form:"amount"`
+	ApplicationFee      *uint64  `form:"application_fee"`
+	ExchangeRate        *float64 `form:"exchange_rate"`
+	ReceiptEmail        *string  `form:"receipt_email"`
+	StatementDescriptor *string  `form:"statement_descriptor"`
 }
 
 // Charge is the resource representing a Stripe charge.

--- a/charge/client.go
+++ b/charge/client.go
@@ -143,7 +143,7 @@ func (c Client) MarkFraudulent(id string) (*stripe.Charge, error) {
 		id,
 		&stripe.ChargeParams{
 			FraudDetails: &stripe.FraudDetailsParams{
-				UserReport: ReportFraudulent,
+				UserReport: stripe.String(string(ReportFraudulent)),
 			},
 		},
 	)
@@ -159,7 +159,7 @@ func (c Client) MarkSafe(id string) (*stripe.Charge, error) {
 		id,
 		&stripe.ChargeParams{
 			FraudDetails: &stripe.FraudDetailsParams{
-				UserReport: ReportSafe,
+				UserReport: stripe.String(string(ReportSafe)),
 			},
 		},
 	)

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -47,6 +47,14 @@ func TestChargeNew(t *testing.T) {
 		Amount:   stripe.UInt64(123),
 		Currency: stripe.String(string(currency.USD)),
 		Source:   &stripe.SourceParams{Token: stripe.String("src_123")},
+		Shipping: &stripe.ShippingDetailsParams{
+			Address: &stripe.AddressParams{
+				Line1: stripe.String("line1"),
+				City:  stripe.String("city"),
+			},
+			Carrier: stripe.String("carrier"),
+			Name:    stripe.String("name"),
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -45,7 +45,7 @@ func TestChargeNew(t *testing.T) {
 	charge, err := New(&stripe.ChargeParams{
 		Amount:   123,
 		Currency: "usd",
-		Source:   &stripe.SourceParams{Token: "src_123"},
+		Source:   &stripe.SourceParams{Token: stripe.String("src_123")},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -43,8 +44,8 @@ func TestChargeMarkFraudulent(t *testing.T) {
 
 func TestChargeNew(t *testing.T) {
 	charge, err := New(&stripe.ChargeParams{
-		Amount:   123,
-		Currency: "usd",
+		Amount:   stripe.UInt64(123),
+		Currency: stripe.String(string(currency.USD)),
 		Source:   &stripe.SourceParams{Token: stripe.String("src_123")},
 	})
 	assert.Nil(t, err)
@@ -53,8 +54,8 @@ func TestChargeNew(t *testing.T) {
 
 func TestChargeNew_WithSetSource(t *testing.T) {
 	params := stripe.ChargeParams{
-		Amount:   123,
-		Currency: "usd",
+		Amount:   stripe.UInt64(123),
+		Currency: stripe.String(string(currency.USD)),
 	}
 	params.SetSource("tok_123")
 
@@ -71,7 +72,7 @@ func TestChargeMarkSafe(t *testing.T) {
 
 func TestChargeUpdate(t *testing.T) {
 	charge, err := Update("ch_123", &stripe.ChargeParams{
-		Description: "Updated description",
+		Description: stripe.String("Updated description"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)
@@ -80,7 +81,7 @@ func TestChargeUpdate(t *testing.T) {
 func TestChargeUpdateDispute(t *testing.T) {
 	charge, err := UpdateDispute("ch_123", &stripe.DisputeParams{
 		Evidence: &stripe.DisputeEvidenceParams{
-			ProductDescription: "original description",
+			ProductDescription: stripe.String("original description"),
 		},
 	})
 	assert.Nil(t, err)

--- a/charge_test.go
+++ b/charge_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestChargeParams_AppendTo(t *testing.T) {
 	{
-		params := &ChargeParams{Amount: 123}
+		params := &ChargeParams{Amount: UInt64(123)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -17,7 +17,7 @@ func TestChargeParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &ChargeParams{Source: &SourceParams{Card: &CardParams{Number: "4242424242424242"}}}
+		params := &ChargeParams{Source: &SourceParams{Card: &CardParams{Number: String("4242424242424242")}}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/coupon.go
+++ b/coupon.go
@@ -10,21 +10,21 @@ type CouponDuration string
 // For more details see https://stripe.com/docs/api#create_coupon.
 type CouponParams struct {
 	Params           `form:"*"`
-	AmountOff        uint64         `form:"amount_off"`
-	Currency         Currency       `form:"currency"`
-	Duration         CouponDuration `form:"duration"`
-	DurationInMonths uint64         `form:"duration_in_months"`
-	ID               string         `form:"id"`
-	MaxRedemptions   uint64         `form:"max_redemptions"`
-	PercentOff       uint64         `form:"percent_off"`
-	RedeemBy         int64          `form:"redeem_by"`
+	AmountOff        *uint64 `form:"amount_off"`
+	Currency         *string `form:"currency"`
+	Duration         *string `form:"duration"`
+	DurationInMonths *uint64 `form:"duration_in_months"`
+	ID               *string `form:"id"`
+	MaxRedemptions   *uint64 `form:"max_redemptions"`
+	PercentOff       *uint64 `form:"percent_off"`
+	RedeemBy         *int64  `form:"redeem_by"`
 }
 
 // CouponListParams is the set of parameters that can be used when listing coupons.
 // For more detail see https://stripe.com/docs/api#list_coupons.
 type CouponListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -31,10 +32,11 @@ func TestCouponList(t *testing.T) {
 
 func TestCouponNew(t *testing.T) {
 	coupon, err := New(&stripe.CouponParams{
-		Duration:         "repeating",
-		DurationInMonths: 3,
-		ID:               "25OFF",
-		PercentOff:       25,
+		Currency:         stripe.String(string(currency.USD)),
+		Duration:         stripe.String(string(Repeating)),
+		DurationInMonths: stripe.UInt64(3),
+		ID:               stripe.String("25OFF"),
+		PercentOff:       stripe.UInt64(25),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)
@@ -42,7 +44,7 @@ func TestCouponNew(t *testing.T) {
 
 func TestCouponUpdate(t *testing.T) {
 	coupon, err := Update("25OFF", &stripe.CouponParams{
-		MaxRedemptions: 5,
+		MaxRedemptions: stripe.UInt64(5),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)

--- a/customer.go
+++ b/customer.go
@@ -8,19 +8,26 @@ import (
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
 	Params         `form:"*"`
-	AccountBalance *int64                   `form:"account_balance"`
-	BusinessVatID  string                   `form:"business_vat_id"`
-	Coupon         *string                  `form:"coupon"`
-	DefaultSource  string                   `form:"default_source"`
-	Description    string                   `form:"description"`
-	Email          string                   `form:"email"`
-	Plan           string                   `form:"plan"`
-	Quantity       uint64                   `form:"quantity"`
-	Shipping       *CustomerShippingDetails `form:"shipping"`
-	Source         *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	TaxPercent     *float64                 `form:"tax_percent"`
-	Token          string                   `form:"-"` // This doesn't seem to be used?
-	TrialEnd       int64                    `form:"trial_end"`
+	AccountBalance *int64                         `form:"account_balance"`
+	BusinessVatID  *string                        `form:"business_vat_id"`
+	Coupon         *string                        `form:"coupon"`
+	DefaultSource  *string                        `form:"default_source"`
+	Description    *string                        `form:"description"`
+	Email          *string                        `form:"email"`
+	Plan           *string                        `form:"plan"`
+	Quantity       *uint64                        `form:"quantity"`
+	Shipping       *CustomerShippingDetailsParams `form:"shipping"`
+	Source         *SourceParams                  `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxPercent     *float64                       `form:"tax_percent"`
+	Token          *string                        `form:"-"` // This doesn't seem to be used?
+	TrialEnd       *int64                         `form:"trial_end"`
+}
+
+// CustomerShippingDetailsParams is the structure containing shipping information.
+type CustomerShippingDetailsParams struct {
+	Address *AddressParams `form:"address"`
+	Name    *string        `form:"name"`
+	Phone   *string        `form:"phone"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,
@@ -35,7 +42,7 @@ func (cp *CustomerParams) SetSource(sp interface{}) error {
 // For more details see https://stripe.com/docs/api#list_customers.
 type CustomerListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 
@@ -68,9 +75,9 @@ type CustomerList struct {
 
 // CustomerShippingDetails is the structure containing shipping information.
 type CustomerShippingDetails struct {
-	Address Address `json:"address" form:"address"`
-	Name    string  `json:"name" form:"name"`
-	Phone   string  `json:"phone" form:"phone"`
+	Address Address `json:"address"`
+	Name    string  `json:"name"`
+	Phone   string  `json:"phone"`
 }
 
 // UnmarshalJSON handles deserialization of a Customer.

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -31,7 +31,14 @@ func TestCustomerList(t *testing.T) {
 
 func TestCustomerNew(t *testing.T) {
 	customer, err := New(&stripe.CustomerParams{
-		Email: "foo@example.com",
+		Email: stripe.String("foo@example.com"),
+		Shipping: &stripe.CustomerShippingDetailsParams{
+			Address: &stripe.AddressParams{
+				Line1: stripe.String("line1"),
+				City:  stripe.String("city"),
+			},
+			Name: stripe.String("name"),
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, customer)
@@ -45,7 +52,7 @@ func TestCustomerNew_NilParams(t *testing.T) {
 
 func TestCustomerUpdate(t *testing.T) {
 	customer, err := Update("cus_123", &stripe.CustomerParams{
-		Email: "foo@example.com",
+		Email: stripe.String("foo@example.com"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, customer)

--- a/dispute.go
+++ b/dispute.go
@@ -27,40 +27,40 @@ type DisputeParams struct {
 // DisputeEvidenceParams is the set of parameters that can be used when submitting
 // evidence for disputes.
 type DisputeEvidenceParams struct {
-	AccessActivityLog            string `form:"access_activity_log"`
-	BillingAddress               string `form:"billing_address"`
-	CancellationPolicy           string `form:"cancellation_policy"`
-	CancellationPolicyDisclosure string `form:"cancellation_policy_disclosure"`
-	CancellationRebuttal         string `form:"cancellation_rebuttal"`
-	CustomerCommunication        string `form:"customer_communication"`
-	CustomerEmailAddress         string `form:"customer_email_address"`
-	CustomerName                 string `form:"customer_name"`
-	CustomerPurchaseIP           string `form:"customer_purchase_ip"`
-	CustomerSignature            string `form:"customer_signature"`
-	DuplicateChargeDocumentation string `form:"duplicate_charge_documentation"`
-	DuplicateChargeExplanation   string `form:"duplicate_charge_explanation"`
-	DuplicateChargeID            string `form:"duplicate_charge_id"`
-	ProductDescription           string `form:"product_description"`
-	Receipt                      string `form:"receipt"`
-	RefundPolicy                 string `form:"refund_policy"`
-	RefundPolicyDisclosure       string `form:"refund_policy_disclosure"`
-	RefundRefusalExplanation     string `form:"refund_refusal_explanation"`
-	ServiceDate                  string `form:"service_date"`
-	ServiceDocumentation         string `form:"service_documentation"`
-	ShippingAddress              string `form:"shipping_address"`
-	ShippingCarrier              string `form:"shipping_carrier"`
-	ShippingDate                 string `form:"shipping_date"`
-	ShippingDocumentation        string `form:"shipping_documentation"`
-	ShippingTrackingNumber       string `form:"shipping_tracking_number"`
-	UncategorizedFile            string `form:"uncategorized_file"`
-	UncategorizedText            string `form:"uncategorized_text"`
+	AccessActivityLog            *string `form:"access_activity_log"`
+	BillingAddress               *string `form:"billing_address"`
+	CancellationPolicy           *string `form:"cancellation_policy"`
+	CancellationPolicyDisclosure *string `form:"cancellation_policy_disclosure"`
+	CancellationRebuttal         *string `form:"cancellation_rebuttal"`
+	CustomerCommunication        *string `form:"customer_communication"`
+	CustomerEmailAddress         *string `form:"customer_email_address"`
+	CustomerName                 *string `form:"customer_name"`
+	CustomerPurchaseIP           *string `form:"customer_purchase_ip"`
+	CustomerSignature            *string `form:"customer_signature"`
+	DuplicateChargeDocumentation *string `form:"duplicate_charge_documentation"`
+	DuplicateChargeExplanation   *string `form:"duplicate_charge_explanation"`
+	DuplicateChargeID            *string `form:"duplicate_charge_id"`
+	ProductDescription           *string `form:"product_description"`
+	Receipt                      *string `form:"receipt"`
+	RefundPolicy                 *string `form:"refund_policy"`
+	RefundPolicyDisclosure       *string `form:"refund_policy_disclosure"`
+	RefundRefusalExplanation     *string `form:"refund_refusal_explanation"`
+	ServiceDate                  *string `form:"service_date"`
+	ServiceDocumentation         *string `form:"service_documentation"`
+	ShippingAddress              *string `form:"shipping_address"`
+	ShippingCarrier              *string `form:"shipping_carrier"`
+	ShippingDate                 *string `form:"shipping_date"`
+	ShippingDocumentation        *string `form:"shipping_documentation"`
+	ShippingTrackingNumber       *string `form:"shipping_tracking_number"`
+	UncategorizedFile            *string `form:"uncategorized_file"`
+	UncategorizedText            *string `form:"uncategorized_text"`
 }
 
 // DisputeListParams is the set of parameters that can be used when listing disputes.
 // For more details see https://stripe.com/docs/api#list_disputes.
 type DisputeListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 

--- a/dispute/client_test.go
+++ b/dispute/client_test.go
@@ -32,7 +32,7 @@ func TestDisputeList(t *testing.T) {
 func TestDisputeUpdate(t *testing.T) {
 	dispute, err := Update("dp_123", &stripe.DisputeParams{
 		Evidence: &stripe.DisputeEvidenceParams{
-			CustomerName: "A Name",
+			CustomerName: stripe.String("A Name"),
 		},
 	})
 	assert.Nil(t, err)

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -7,8 +7,8 @@ import "encoding/json"
 // For more details see https://stripe.com/docs/api#ephemeral_keys.
 type EphemeralKeyParams struct {
 	Params        `form:"*"`
-	Customer      string `form:"customer"`
-	StripeVersion string `form:"-"` // This goes in the `Stripe-Version` header
+	Customer      *string `form:"customer"`
+	StripeVersion *string `form:"-"` // This goes in the `Stripe-Version` header
 }
 
 // EphemeralKey is the resource representing a Stripe ephemeral key.

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -24,19 +24,17 @@ func New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
 // New POSTs new ephemeral keys.
 // For more details see https://stripe.com/docs/api#create_ephemeral_key.
 func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
-	if params.StripeVersion == "" {
+	if params.StripeVersion == nil || len(stripe.StringValue(params.StripeVersion)) == 0 {
 		return nil, fmt.Errorf("params.StripeVersion must be specified")
 	}
 
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	if len(params.StripeVersion) > 0 {
-		if params.Headers == nil {
-			params.Headers = make(http.Header)
-		}
-		params.Headers.Add("Stripe-Version", params.StripeVersion)
+	if params.Headers == nil {
+		params.Headers = make(http.Header)
 	}
+	params.Headers.Add("Stripe-Version", stripe.StringValue(params.StripeVersion))
 
 	ephemeralKey := &stripe.EphemeralKey{}
 	err := c.B.Call("POST", "ephemeral_keys", c.Key, body, &params.Params, ephemeralKey)

--- a/ephemeralkey/client_test.go
+++ b/ephemeralkey/client_test.go
@@ -16,8 +16,8 @@ func TestEphemeralKeyDel(t *testing.T) {
 
 func TestEphemeralKeyNew(t *testing.T) {
 	key, err := New(&stripe.EphemeralKeyParams{
-		Customer:      "cus_123",
-		StripeVersion: "2018-02-06",
+		Customer:      stripe.String("cus_123"),
+		StripeVersion: stripe.String("2018-02-06"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, key)

--- a/event.go
+++ b/event.go
@@ -48,9 +48,9 @@ type EventList struct {
 // For more details see https://stripe.com/docs/api#list_events.
 type EventListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Type         string            `form:"type"`
+	Type         *string           `form:"type"`
 	Types        []string          `form:"types"`
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -55,7 +55,7 @@ func ExampleInvoice_update() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.InvoiceParams{
-		Description: "updated description",
+		Description: stripe.String("updated description"),
 	}
 
 	inv, err := invoice.Update("sub_example_id", params)

--- a/example_test.go
+++ b/example_test.go
@@ -15,8 +15,8 @@ func ExampleCharge_new() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.ChargeParams{
-		Amount:   1000,
-		Currency: currency.USD,
+		Amount:   stripe.UInt64(1000),
+		Currency: stripe.String(string(currency.USD)),
 	}
 	params.SetSource("tok_visa")
 	params.AddMetadata("key", "value")

--- a/exchangerate/client_test.go
+++ b/exchangerate/client_test.go
@@ -5,11 +5,12 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
 func TestExchangeRateGet(t *testing.T) {
-	rates, err := Get("usd")
+	rates, err := Get(string(currency.USD))
 	assert.Nil(t, err)
 	assert.NotNil(t, rates)
 }

--- a/fee.go
+++ b/fee.go
@@ -12,8 +12,8 @@ type ApplicationFeeParams struct {
 // For more details see https://stripe.com/docs/api#list_application_fees.
 type ApplicationFeeListParams struct {
 	ListParams   `form:"*"`
-	Charge       string            `form:"charge"`
-	Created      int64             `form:"created"`
+	Charge       *string           `form:"charge"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 

--- a/feerefund.go
+++ b/feerefund.go
@@ -8,15 +8,15 @@ import (
 // For more details see https://stripe.com/docs/api#fee_refund.
 type ApplicationFeeRefundParams struct {
 	Params         `form:"*"`
-	Amount         uint64 `form:"amount"`
-	ApplicationFee string `form:"-"` // Included in the URL
+	Amount         *uint64 `form:"amount"`
+	ApplicationFee *string `form:"-"` // Included in the URL
 }
 
 // ApplicationFeeRefundListParams is the set of parameters that can be used when listing application fee refunds.
 // For more details see https://stripe.com/docs/api#list_fee_refunds.
 type ApplicationFeeRefundListParams struct {
 	ListParams     `form:"*"`
-	ApplicationFee string `form:"-"` // Included in the URL
+	ApplicationFee *string `form:"-"` // Included in the URL
 }
 
 // ApplicationFeeRefund is the resource representing a Stripe application fee refund.

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -24,7 +24,7 @@ func (c Client) New(params *stripe.ApplicationFeeRefundParams) (*stripe.Applicat
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ApplicationFee == "" {
+	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
@@ -32,7 +32,7 @@ func (c Client) New(params *stripe.ApplicationFeeRefundParams) (*stripe.Applicat
 	form.AppendTo(body, params)
 
 	refund := &stripe.ApplicationFeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", params.ApplicationFee), c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -47,7 +47,7 @@ func (c Client) Get(id string, params *stripe.ApplicationFeeRefundParams) (*stri
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ApplicationFee == "" {
+	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
@@ -55,7 +55,7 @@ func (c Client) Get(id string, params *stripe.ApplicationFeeRefundParams) (*stri
 	form.AppendTo(body, params)
 
 	refund := &stripe.ApplicationFeeRefund{}
-	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", params.ApplicationFee, id), c.Key, body, &params.Params, refund)
+	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -70,7 +70,7 @@ func (c Client) Update(id string, params *stripe.ApplicationFeeRefundParams) (*s
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ApplicationFee == "" {
+	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
@@ -78,7 +78,7 @@ func (c Client) Update(id string, params *stripe.ApplicationFeeRefundParams) (*s
 	form.AppendTo(body, params)
 
 	refund := &stripe.ApplicationFeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", params.ApplicationFee, id), c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -100,7 +100,7 @@ func (c Client) List(params *stripe.ApplicationFeeRefundListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplicationFeeRefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.ApplicationFee), c.Key, b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/feerefund/client_test.go
+++ b/feerefund/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestApplicationFeeRefundGet(t *testing.T) {
 	refund, err := Get("fr_123", &stripe.ApplicationFeeRefundParams{
-		ApplicationFee: "fee_123",
+		ApplicationFee: stripe.String("fee_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)
@@ -18,7 +18,7 @@ func TestApplicationFeeRefundGet(t *testing.T) {
 
 func TestApplicationFeeRefundList(t *testing.T) {
 	i := List(&stripe.ApplicationFeeRefundListParams{
-		ApplicationFee: "fee_123",
+		ApplicationFee: stripe.String("fee_123"),
 	})
 
 	// Verify that we can get at least one refund
@@ -29,7 +29,7 @@ func TestApplicationFeeRefundList(t *testing.T) {
 
 func TestApplicationFeeRefundNew(t *testing.T) {
 	refund, err := New(&stripe.ApplicationFeeRefundParams{
-		ApplicationFee: "fee_123",
+		ApplicationFee: stripe.String("fee_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)
@@ -37,7 +37,7 @@ func TestApplicationFeeRefundNew(t *testing.T) {
 
 func TestApplicationFeeRefundUpdate(t *testing.T) {
 	refund, err := Update("fr_123", &stripe.ApplicationFeeRefundParams{
-		ApplicationFee: "fee_123",
+		ApplicationFee: stripe.String("fee_123"),
 		Params: stripe.Params{
 			Metadata: map[string]string{
 				"foo": "bar",

--- a/fileupload.go
+++ b/fileupload.go
@@ -17,18 +17,18 @@ type FileUploadParams struct {
 	FileReader io.Reader
 
 	// Filename is just the name of the file without path information.
-	Filename string
+	Filename *string
 
-	Purpose FileUploadPurpose
+	Purpose *string
 }
 
 // FileUploadListParams is the set of parameters that can be used when listing
 // file uploads. For more details see https://stripe.com/docs/api#list_file_uploads.
 type FileUploadListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Purpose      FileUploadPurpose `form:"purpose"`
+	Purpose      *string           `form:"purpose"`
 }
 
 // FileUploadPurpose is the purpose of a particular file upload. Allowed values
@@ -59,8 +59,8 @@ func (f *FileUploadParams) AppendDetails(body io.ReadWriter) (string, error) {
 	writer := multipart.NewWriter(body)
 	var err error
 
-	if len(f.Purpose) > 0 {
-		err = writer.WriteField("purpose", string(f.Purpose))
+	if f.Purpose != nil {
+		err = writer.WriteField("purpose", StringValue(f.Purpose))
 		if err != nil {
 			return "", err
 		}
@@ -68,8 +68,8 @@ func (f *FileUploadParams) AppendDetails(body io.ReadWriter) (string, error) {
 
 	// Support both FileReader/Filename and File with
 	// the former being the newer preferred version
-	if f.FileReader != nil && f.Filename != "" {
-		part, err := writer.CreateFormFile("file", filepath.Base(f.Filename))
+	if f.FileReader != nil && f.Filename != nil {
+		part, err := writer.CreateFormFile("file", filepath.Base(StringValue(f.Filename)))
 		if err != nil {
 			return "", err
 		}

--- a/fileupload/client_test.go
+++ b/fileupload/client_test.go
@@ -37,9 +37,9 @@ func TestFileUploadNewThenGet(t *testing.T) {
 	}
 
 	uploadParams := &stripe.FileUploadParams{
-		Purpose:    "dispute_evidence",
+		Purpose:    stripe.String(string(DisputeEvidenceFile)),
 		FileReader: f,
-		Filename:   f.Name(),
+		Filename:   stripe.String(f.Name()),
 	}
 
 	target, err := New(uploadParams)
@@ -62,9 +62,9 @@ func TestFileUploadList(t *testing.T) {
 	}
 
 	uploadParams := &stripe.FileUploadParams{
-		Purpose:    "dispute_evidence",
+		Purpose:    stripe.String(string(DisputeEvidenceFile)),
 		FileReader: f,
-		Filename:   f.Name(),
+		Filename:   stripe.String(f.Name()),
 	}
 
 	_, err = New(uploadParams)

--- a/invoice.go
+++ b/invoice.go
@@ -14,39 +14,39 @@ type InvoiceBilling string
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
 	Params              `form:"*"`
-	ApplicationFee      *uint64        `form:"application_fee"`
-	Billing             InvoiceBilling `form:"billing"`
-	Closed              *bool          `form:"closed"`
-	Customer            string         `form:"customer"`
-	DaysUntilDue        uint64         `form:"days_until_due"`
-	Description         string         `form:"description"`
-	DueDate             int64          `form:"due_date"`
-	Forgiven            bool           `form:"forgiven"`
-	Paid                bool           `form:"paid"`
-	StatementDescriptor string         `form:"statement_descriptor"`
-	Subscription        string         `form:"subscription"`
-	TaxPercent          *float64       `form:"tax_percent"`
+	ApplicationFee      *uint64  `form:"application_fee"`
+	Billing             *string  `form:"billing"`
+	Closed              *bool    `form:"closed"`
+	Customer            *string  `form:"customer"`
+	DaysUntilDue        *uint64  `form:"days_until_due"`
+	Description         *string  `form:"description"`
+	DueDate             *int64   `form:"due_date"`
+	Forgiven            *bool    `form:"forgiven"`
+	Paid                *bool    `form:"paid"`
+	StatementDescriptor *string  `form:"statement_descriptor"`
+	Subscription        *string  `form:"subscription"`
+	TaxPercent          *float64 `form:"tax_percent"`
 
 	// These are all for exclusive use by GetNext.
 
 	SubscriptionItems         []*SubscriptionItemsParams `form:"subscription_items,indexed"`
-	SubscriptionPlan          string                     `form:"subscription_plan"`
+	SubscriptionPlan          *string                    `form:"subscription_plan"`
 	SubscriptionProrate       *bool                      `form:"subscription_prorate"`
-	SubscriptionProrationDate int64                      `form:"subscription_proration_date"`
+	SubscriptionProrationDate *int64                     `form:"subscription_proration_date"`
 	SubscriptionQuantity      *uint64                    `form:"subscription_quantity"`
-	SubscriptionTrialEnd      int64                      `form:"subscription_trial_end"`
+	SubscriptionTrialEnd      *int64                     `form:"subscription_trial_end"`
 }
 
 // InvoiceListParams is the set of parameters that can be used when listing invoices.
 // For more details see https://stripe.com/docs/api#list_customer_invoices.
 type InvoiceListParams struct {
 	ListParams   `form:"*"`
-	Billing      InvoiceBilling    `form:"billing"`
-	Customer     string            `form:"customer"`
-	Date         int64             `form:"date"`
+	Billing      *string           `form:"billing"`
+	Customer     *string           `form:"customer"`
+	Date         *int64            `form:"date"`
 	DateRange    *RangeQueryParams `form:"date"`
-	DueDate      int64             `form:"due_date"`
-	Subscription string            `form:"subscription"`
+	DueDate      *int64            `form:"due_date"`
+	Subscription *string           `form:"subscription"`
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.
@@ -54,12 +54,12 @@ type InvoiceListParams struct {
 type InvoiceLineListParams struct {
 	ListParams `form:"*"`
 
-	Customer string `form:"customer"`
+	Customer *string `form:"customer"`
 
 	// ID is the invoice ID to list invoice lines for.
-	ID string `form:"-"` // Goes in the URL
+	ID *string `form:"-"` // Goes in the URL
 
-	Subscription string `form:"subscription"`
+	Subscription *string `form:"subscription"`
 }
 
 // Invoice is the resource representing a Stripe invoice.
@@ -141,7 +141,7 @@ type InvoiceLineList struct {
 // https://stripe.com/docs/api#pay_invoice.
 type InvoicePayParams struct {
 	Params `form:"*"`
-	Source string `form:"source"`
+	Source *string `form:"source"`
 }
 
 // UnmarshalJSON handles deserialization of an Invoice.

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -25,7 +25,7 @@ func TestInvoiceList(t *testing.T) {
 
 func TestInvoiceListLines(t *testing.T) {
 	i := ListLines(&stripe.InvoiceLineListParams{
-		ID: "in_123",
+		ID: stripe.String("in_123"),
 	})
 
 	// Verify that we can get at least one invoice
@@ -36,7 +36,8 @@ func TestInvoiceListLines(t *testing.T) {
 
 func TestInvoiceNew(t *testing.T) {
 	invoice, err := New(&stripe.InvoiceParams{
-		Customer: "cus_123",
+		Billing:  stripe.String("charge_automatically"),
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)
@@ -44,7 +45,7 @@ func TestInvoiceNew(t *testing.T) {
 
 func TestInvoicePay(t *testing.T) {
 	invoice, err := Pay("in_123", &stripe.InvoicePayParams{
-		Source: "src_123",
+		Source: stripe.String("src_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)
@@ -52,7 +53,8 @@ func TestInvoicePay(t *testing.T) {
 
 func TestInvoiceUpdate(t *testing.T) {
 	invoice, err := Update("in_123", &stripe.InvoiceParams{
-		Closed: stripe.Bool(true),
+		Forgiven: stripe.Bool(true),
+		Closed:   stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -6,22 +6,22 @@ import "encoding/json"
 // For more details see https://stripe.com/docs/api#create_invoiceitem and https://stripe.com/docs/api#update_invoiceitem.
 type InvoiceItemParams struct {
 	Params       `form:"*"`
-	Amount       int64    `form:"amount"`
-	Currency     Currency `form:"currency"`
-	Customer     string   `form:"customer"`
-	Description  string   `form:"description"`
-	Discountable *bool    `form:"discountable"`
-	Invoice      string   `form:"invoice"`
-	Subscription string   `form:"subscription"`
+	Amount       *int64  `form:"amount"`
+	Currency     *string `form:"currency"`
+	Customer     *string `form:"customer"`
+	Description  *string `form:"description"`
+	Discountable *bool   `form:"discountable"`
+	Invoice      *string `form:"invoice"`
+	Subscription *string `form:"subscription"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
 type InvoiceItemListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Customer     string            `form:"customer"`
+	Customer     *string           `form:"customer"`
 }
 
 // InvoiceItem is the resource represneting a Stripe invoice item.

--- a/invoiceitem/client_test.go
+++ b/invoiceitem/client_test.go
@@ -32,9 +32,9 @@ func TestInvoiceItemList(t *testing.T) {
 
 func TestInvoiceItemNew(t *testing.T) {
 	item, err := New(&stripe.InvoiceItemParams{
-		Amount:   123,
-		Currency: currency.USD,
-		Customer: "cus_123",
+		Amount:   stripe.Int64(123),
+		Currency: stripe.String(string(currency.USD)),
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)
@@ -42,7 +42,7 @@ func TestInvoiceItemNew(t *testing.T) {
 
 func TestInvoiceItemUpdate(t *testing.T) {
 	item, err := Update("ii_123", &stripe.InvoiceItemParams{
-		Description: "Updated description",
+		Description: stripe.String("Updated description"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/loginlink.go
+++ b/loginlink.go
@@ -3,7 +3,7 @@ package stripe
 // LoginLinkParams is the set of parameters that can be used when creating a login_link.
 // For more details see https://stripe.com/docs/api#create_login_link.
 type LoginLinkParams struct {
-	Account string `form:"-"` // Included in URL
+	Account *string `form:"-"` // Included in URL
 }
 
 // LoginLink is the resource representing a login link for Express accounts.

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -27,8 +27,8 @@ func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 	loginLink := &stripe.LoginLink{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/login_links", params.Account), c.Key, body, nil, loginLink)
+	if params.Account != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/login_links", stripe.StringValue(params.Account)), c.Key, body, nil, loginLink)
 	} else {
 		err = errors.New("Invalid login link params: Account must be set")
 	}

--- a/loginlink/client_test.go
+++ b/loginlink/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestLoginLinkNew(t *testing.T) {
 	link, err := New(&stripe.LoginLinkParams{
-		Account: "acct_EXPRESS",
+		Account: stripe.String("acct_EXPRESS"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, link)

--- a/order.go
+++ b/order.go
@@ -17,25 +17,25 @@ const (
 
 type OrderParams struct {
 	Params   `form:"*"`
-	Coupon   string             `form:"coupon"`
-	Currency Currency           `form:"currency"`
-	Customer string             `form:"customer"`
-	Email    string             `form:"email"`
+	Coupon   *string            `form:"coupon"`
+	Currency *string            `form:"currency"`
+	Customer *string            `form:"customer"`
+	Email    *string            `form:"email"`
 	Items    []*OrderItemParams `form:"items,indexed"`
 	Shipping *ShippingParams    `form:"shipping"`
 }
 
 type ShippingParams struct {
 	Address *AddressParams `form:"address"`
-	Name    string         `form:"name"`
-	Phone   string         `form:"phone"`
+	Name    *string        `form:"name"`
+	Phone   *string        `form:"phone"`
 }
 
 type OrderUpdateParams struct {
 	Params                 `form:"*"`
-	Coupon                 string      `form:"coupon"`
-	SelectedShippingMethod string      `form:"selected_shipping_method"`
-	Status                 OrderStatus `form:"status"`
+	Coupon                 *string `form:"coupon"`
+	SelectedShippingMethod *string `form:"selected_shipping_method"`
+	Status                 *string `form:"status"`
 }
 
 // OrderReturnParams is the set of parameters that can be used when returning
@@ -109,10 +109,10 @@ type OrderList struct {
 // https://stripe.com/docs/api#list_orders.
 type OrderListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 	IDs          []string          `form:"ids"`
-	Status       OrderStatus       `form:"status"`
+	Status       *string           `form:"status"`
 }
 
 // StatusTransitions are the timestamps at which the order status was updated
@@ -129,9 +129,9 @@ type StatusTransitions struct {
 // https://stripe.com/docs/api#pay_order.
 type OrderPayParams struct {
 	Params         `form:"*"`
-	ApplicationFee int64         `form:"application_fee"`
-	Customer       string        `form:"customer"`
-	Email          string        `form:"email"`
+	ApplicationFee *int64        `form:"application_fee"`
+	Customer       *string       `form:"customer"`
+	Email          *string       `form:"email"`
 	Source         *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 

--- a/order/client.go
+++ b/order/client.go
@@ -75,7 +75,7 @@ func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, er
 	var commonParams *stripe.Params
 
 	if params != nil {
-		if params.Source == nil && len(params.Customer) == 0 {
+		if params.Source == nil && params.Customer == nil {
 			err := errors.New("Invalid order pay params: either customer or a source must be set")
 			return nil, err
 		}

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -25,7 +26,7 @@ func TestOrderList(t *testing.T) {
 
 func TestOrderNew(t *testing.T) {
 	order, err := New(&stripe.OrderParams{
-		Currency: "usd",
+		Currency: stripe.String(string(currency.USD)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, order)
@@ -33,7 +34,7 @@ func TestOrderNew(t *testing.T) {
 
 func TestOrderPay(t *testing.T) {
 	order, err := Pay("or_123", &stripe.OrderPayParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, order)
@@ -47,7 +48,7 @@ func TestOrderReturn(t *testing.T) {
 
 func TestOrderUpdate(t *testing.T) {
 	order, err := Update("or_123", &stripe.OrderUpdateParams{
-		Status: "fulfilled",
+		Status: stripe.String(string(stripe.StatusFulfilled)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, order)

--- a/orderitem.go
+++ b/orderitem.go
@@ -8,12 +8,12 @@ import (
 )
 
 type OrderItemParams struct {
-	Amount      int64              `form:"amount"`
-	Currency    Currency           `form:"currency"`
-	Description string             `form:"description"`
-	Parent      string             `form:"parent"`
-	Quantity    *int64             `form:"quantity"`
-	Type        orderitem.ItemType `form:"type"`
+	Amount      *int64  `form:"amount"`
+	Currency    *string `form:"currency"`
+	Description *string `form:"description"`
+	Parent      *string `form:"parent"`
+	Quantity    *int64  `form:"quantity"`
+	Type        *string `form:"type"`
 }
 
 type OrderItem struct {

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -23,9 +23,9 @@ type OrderReturnList struct {
 // returns. For more details, see: https://stripe.com/docs/api#list_order_returns.
 type OrderReturnListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Order        string            `form:"order"`
+	Order        *string           `form:"order"`
 }
 
 // UnmarshalJSON handles deserialization of an OrderReturn.

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -11,7 +11,7 @@ import (
 // arbitrary payment source.
 type SourceParams struct {
 	Card  *CardParams `form:"-"`
-	Token string      `form:"source"`
+	Token *string     `form:"source"`
 }
 
 func (p *SourceParams) AppendTo(body *form.Values, keyParts []string) {
@@ -25,7 +25,7 @@ func (p *SourceParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#sources
 type CustomerSourceParams struct {
 	Params   `form:"*"`
-	Customer string        `form:"-"` // Goes in the URL
+	Customer *string       `form:"-"` // Goes in the URL
 	Source   *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 
@@ -34,7 +34,7 @@ type CustomerSourceParams struct {
 type SourceVerifyParams struct {
 	Params   `form:"*"`
 	Amounts  [2]int64 `form:"amounts"` // Amounts is used when verifying bank accounts
-	Customer string   `form:"-"`       // Goes in the URL
+	Customer *string  `form:"-"`       // Goes in the URL
 	Values   []string `form:"values"`  // Values is used when verifying sources
 }
 
@@ -62,7 +62,7 @@ func SourceParamsFor(obj interface{}) (*SourceParams, error) {
 		}
 	case string:
 		sp = &SourceParams{
-			Token: p,
+			Token: &p,
 		}
 	default:
 		err = fmt.Errorf("Unsupported source type %s", p)
@@ -118,7 +118,7 @@ type SourceList struct {
 // to a Customer.
 type SourceListParams struct {
 	ListParams `form:"*"`
-	Customer   string `form:"-"` // Handled in URL
+	Customer   *string `form:"-"` // Handled in URL
 }
 
 // UnmarshalJSON handles deserialization of a PaymentSource.

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -28,8 +28,8 @@ func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources", params.Customer), s.Key, body, &params.Params, source)
+	if params.Customer != nil {
+		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), s.Key, body, &params.Params, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -56,8 +56,8 @@ func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), s.Key, body, commonParams, source)
+	if params.Customer != nil {
+		err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -78,8 +78,8 @@ func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), s.Key, body, &params.Params, source)
+	if params.Customer != nil {
+		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -106,8 +106,8 @@ func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), s.Key, body, commonParams, source)
+	if params.Customer != nil {
+		err = s.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -131,8 +131,8 @@ func (s Client) List(params *stripe.SourceListParams) *Iter {
 		list := &stripe.SourceList{}
 		var err error
 
-		if len(params.Customer) > 0 {
-			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", params.Customer), s.Key, b, p, list)
+		if params.Customer != nil {
+			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), s.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid source params: customer needs to be set")
 		}
@@ -159,8 +159,8 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v/verify", params.Customer, id), s.Key, body, &params.Params, source)
+	if params.Customer != nil {
+		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v/verify", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
 	} else if len(params.Values) > 0 {
 		err = s.B.Call("POST", fmt.Sprintf("/sources/%v/verify", id), s.Key, body, &params.Params, source)
 	} else {

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSourceGet(t *testing.T) {
 	source, err := Get("card_123", &stripe.CustomerSourceParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, source)
@@ -18,7 +18,7 @@ func TestSourceGet(t *testing.T) {
 
 func TestSourceList(t *testing.T) {
 	i := List(&stripe.SourceListParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 
 	// Verify that we can get at least one source
@@ -29,7 +29,7 @@ func TestSourceList(t *testing.T) {
 
 func TestSourceNew(t *testing.T) {
 	params := &stripe.CustomerSourceParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	}
 	params.SetSource("tok_123")
 
@@ -40,7 +40,7 @@ func TestSourceNew(t *testing.T) {
 
 func TestSourceUpdate(t *testing.T) {
 	params := &stripe.CustomerSourceParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	}
 	params.SetSource(&stripe.CardParams{
 		Name: "Updated Name",
@@ -53,7 +53,7 @@ func TestSourceUpdate(t *testing.T) {
 
 func TestSourceVerify(t *testing.T) {
 	source, err := Verify("ba_123", &stripe.SourceVerifyParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 		Amounts:  [2]int64{32, 45},
 	})
 	assert.Nil(t, err)

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -43,7 +43,7 @@ func TestSourceUpdate(t *testing.T) {
 		Customer: stripe.String("cus_123"),
 	}
 	params.SetSource(&stripe.CardParams{
-		Name: "Updated Name",
+		Name: stripe.String("Updated Name"),
 	})
 
 	source, err := Update("card_123", params)

--- a/paymentsource_test.go
+++ b/paymentsource_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSourceParams_AppendTo(t *testing.T) {
 	{
-		params := &SourceParams{Token: "tok_123"}
+		params := &SourceParams{Token: String("tok_123")}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/paymentsource_test.go
+++ b/paymentsource_test.go
@@ -18,7 +18,7 @@ func TestSourceParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SourceParams{Card: &CardParams{Number: "4242424242424242"}}
+		params := &SourceParams{Card: &CardParams{Number: String("4242424242424242")}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/payout.go
+++ b/payout.go
@@ -58,24 +58,24 @@ type PayoutDestination struct {
 // For more details see https://stripe.com/docs/api#create_payout and https://stripe.com/docs/api#update_payout.
 type PayoutParams struct {
 	Params              `form:"*"`
-	Amount              int64            `form:"amount"`
-	Currency            Currency         `form:"currency"`
-	Destination         string           `form:"destination"`
-	Method              PayoutMethodType `form:"method"`
-	SourceType          PayoutSourceType `form:"source_type"`
-	StatementDescriptor string           `form:"statement_descriptor"`
+	Amount              *int64  `form:"amount"`
+	Currency            *string `form:"currency"`
+	Destination         *string `form:"destination"`
+	Method              *string `form:"method"`
+	SourceType          *string `form:"source_type"`
+	StatementDescriptor *string `form:"statement_descriptor"`
 }
 
 // PayoutListParams is the set of parameters that can be used when listing payouts.
 // For more details see https://stripe.com/docs/api#list_payouts.
 type PayoutListParams struct {
 	ListParams       `form:"*"`
-	ArrivalDate      int64             `form:"arrival_date"`
+	ArrivalDate      *int64            `form:"arrival_date"`
 	ArrivalDateRange *RangeQueryParams `form:"arrival_date"`
-	Created          int64             `form:"created"`
+	Created          *int64            `form:"created"`
 	CreatedRange     *RangeQueryParams `form:"created"`
-	Destination      string            `form:"destination"`
-	Status           PayoutStatus      `form:"status"`
+	Destination      *string           `form:"destination"`
+	Status           *string           `form:"status"`
 }
 
 // Payout is the resource representing a Stripe payout.

--- a/payout/client_test.go
+++ b/payout/client_test.go
@@ -5,17 +5,18 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
 func TestPayoutCancel(t *testing.T) {
-	payout, err := Cancel("tr_123", nil)
+	payout, err := Cancel("po_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, payout)
 }
 
 func TestPayoutGet(t *testing.T) {
-	payout, err := Get("tr_123", nil)
+	payout, err := Get("po_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, payout)
 }
@@ -31,8 +32,8 @@ func TestPayoutList(t *testing.T) {
 
 func TestPayoutNew(t *testing.T) {
 	payout, err := New(&stripe.PayoutParams{
-		Amount:   123,
-		Currency: "usd",
+		Amount:   stripe.Int64(123),
+		Currency: stripe.String(string(currency.USD)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, payout)

--- a/plan.go
+++ b/plan.go
@@ -31,7 +31,7 @@ type PlanList struct {
 // For more details see https://stripe.com/docs/api#list_plans.
 type PlanListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 
@@ -39,14 +39,13 @@ type PlanListParams struct {
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
 	Params          `form:"*"`
-	Amount          uint64         `form:"amount"`
-	AmountZero      bool           `form:"amount,zero"`
+	Amount          *uint64        `form:"amount"`
 	Currency        Currency       `form:"currency"`
-	ID              string         `form:"id"`
+	ID              *string        `form:"id"`
 	Interval        PlanInterval   `form:"interval"`
-	IntervalCount   uint64         `form:"interval_count"`
-	Nickname        string         `form:"nickname"`
+	IntervalCount   *uint64        `form:"interval_count"`
+	Nickname        *string        `form:"nickname"`
 	Product         *ProductParams `form:"product"`
 	ProductID       *string        `form:"product"`
-	TrialPeriodDays uint64         `form:"trial_period_days"`
+	TrialPeriodDays *uint64        `form:"trial_period_days"`
 }

--- a/plan.go
+++ b/plan.go
@@ -40,9 +40,9 @@ type PlanListParams struct {
 type PlanParams struct {
 	Params          `form:"*"`
 	Amount          *uint64        `form:"amount"`
-	Currency        Currency       `form:"currency"`
+	Currency        *string        `form:"currency"`
 	ID              *string        `form:"id"`
-	Interval        PlanInterval   `form:"interval"`
+	Interval        *string        `form:"interval"`
 	IntervalCount   *uint64        `form:"interval_count"`
 	Nickname        *string        `form:"nickname"`
 	Product         *ProductParams `form:"product"`

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -32,12 +33,12 @@ func TestPlanList(t *testing.T) {
 func TestPlanNew(t *testing.T) {
 	plan, err := New(&stripe.PlanParams{
 		Amount:   stripe.UInt64(1),
-		Currency: stripe.String("usd"),
+		Currency: stripe.String(string(currency.USD)),
 		ID:       stripe.String("sapphire-elite"),
 		Interval: stripe.String("month"),
 		Product: &stripe.ProductParams{
-			Name: "Sapphire Elite",
-			Type: stripe.ProductTypeService,
+			Name: stripe.String("Sapphire Elite"),
+			Type: stripe.String(string(stripe.ProductTypeService)),
 		},
 	})
 	assert.Nil(t, err)
@@ -48,7 +49,7 @@ func TestPlanNewWithProductID(t *testing.T) {
 	productId := "prod_12345abc"
 	plan, err := New(&stripe.PlanParams{
 		Amount:    stripe.UInt64(1),
-		Currency:  stripe.String("usd"),
+		Currency:  stripe.String(string(currency.USD)),
 		ID:        stripe.String("sapphire-elite"),
 		Interval:  stripe.String("month"),
 		ProductID: &productId,

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -32,9 +32,9 @@ func TestPlanList(t *testing.T) {
 func TestPlanNew(t *testing.T) {
 	plan, err := New(&stripe.PlanParams{
 		Amount:   stripe.UInt64(1),
-		Currency: "usd",
+		Currency: stripe.String("usd"),
 		ID:       stripe.String("sapphire-elite"),
-		Interval: "month",
+		Interval: stripe.String("month"),
 		Product: &stripe.ProductParams{
 			Name: "Sapphire Elite",
 			Type: stripe.ProductTypeService,
@@ -48,9 +48,9 @@ func TestPlanNewWithProductID(t *testing.T) {
 	productId := "prod_12345abc"
 	plan, err := New(&stripe.PlanParams{
 		Amount:    stripe.UInt64(1),
-		Currency:  "usd",
+		Currency:  stripe.String("usd"),
 		ID:        stripe.String("sapphire-elite"),
-		Interval:  "month",
+		Interval:  stripe.String("month"),
 		ProductID: &productId,
 	})
 	assert.Nil(t, err)

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -31,9 +31,9 @@ func TestPlanList(t *testing.T) {
 
 func TestPlanNew(t *testing.T) {
 	plan, err := New(&stripe.PlanParams{
-		Amount:   1,
+		Amount:   stripe.UInt64(1),
 		Currency: "usd",
-		ID:       "sapphire-elite",
+		ID:       stripe.String("sapphire-elite"),
 		Interval: "month",
 		Product: &stripe.ProductParams{
 			Name: "Sapphire Elite",
@@ -47,9 +47,9 @@ func TestPlanNew(t *testing.T) {
 func TestPlanNewWithProductID(t *testing.T) {
 	productId := "prod_12345abc"
 	plan, err := New(&stripe.PlanParams{
-		Amount:    1,
+		Amount:    stripe.UInt64(1),
 		Currency:  "usd",
-		ID:        "sapphire-elite",
+		ID:        stripe.String("sapphire-elite"),
 		Interval:  "month",
 		ProductID: &productId,
 	})
@@ -59,7 +59,7 @@ func TestPlanNewWithProductID(t *testing.T) {
 
 func TestPlanUpdate(t *testing.T) {
 	plan, err := Update("gold", &stripe.PlanParams{
-		Nickname: "Updated nickame",
+		Nickname: stripe.String("Updated nickame"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, plan)

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -35,7 +35,7 @@ func TestPlanNew(t *testing.T) {
 		Amount:   stripe.UInt64(1),
 		Currency: stripe.String(string(currency.USD)),
 		ID:       stripe.String("sapphire-elite"),
-		Interval: stripe.String("month"),
+		Interval: stripe.String(string(Month)),
 		Product: &stripe.ProductParams{
 			Name: stripe.String("Sapphire Elite"),
 			Type: stripe.String(string(stripe.ProductTypeService)),
@@ -46,13 +46,12 @@ func TestPlanNew(t *testing.T) {
 }
 
 func TestPlanNewWithProductID(t *testing.T) {
-	productId := "prod_12345abc"
 	plan, err := New(&stripe.PlanParams{
 		Amount:    stripe.UInt64(1),
 		Currency:  stripe.String(string(currency.USD)),
 		ID:        stripe.String("sapphire-elite"),
-		Interval:  stripe.String("month"),
-		ProductID: &productId,
+		Interval:  stripe.String(string(Month)),
+		ProductID: stripe.String("prod_12345abc"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, plan)

--- a/plan_test.go
+++ b/plan_test.go
@@ -40,9 +40,9 @@ func TestPlanListParams_AppendTo_Empty(t *testing.T) {
 
 func TestPlanParams_AppendTo(t *testing.T) {
 	productParams := ProductParams{
-		Name:                "Sapphire Elite",
-		StatementDescriptor: "SAPPHIRE",
-		Type:                ProductTypeService,
+		Name:                String("Sapphire Elite"),
+		StatementDescriptor: String("SAPPHIRE"),
+		Type:                String(string(ProductTypeService)),
 	}
 	productId := "prod_123abc"
 	testCases := []struct {

--- a/plan_test.go
+++ b/plan_test.go
@@ -51,9 +51,9 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		want   interface{}
 	}{
 		{"amount", &PlanParams{Amount: UInt64(123)}, strconv.FormatUint(123, 10)},
-		{"currency", &PlanParams{Currency: "USD"}, "USD"},
+		{"currency", &PlanParams{Currency: String("usd")}, "usd"},
 		{"id", &PlanParams{ID: String("sapphire-elite")}, "sapphire-elite"},
-		{"interval", &PlanParams{Interval: "month"}, "month"},
+		{"interval", &PlanParams{Interval: String("month")}, "month"},
 		{"interval_count", &PlanParams{IntervalCount: UInt64(3)}, strconv.FormatUint(3, 10)},
 		{"product[name]", &PlanParams{Product: &productParams}, "Sapphire Elite"},
 		{"product[statement_descriptor]", &PlanParams{Product: &productParams}, "SAPPHIRE"},

--- a/plan_test.go
+++ b/plan_test.go
@@ -14,7 +14,7 @@ func TestPlanListParams_AppendTo(t *testing.T) {
 		params *PlanListParams
 		want   interface{}
 	}{
-		{"created", &PlanListParams{Created: 123}, strconv.FormatInt(123, 10)},
+		{"created", &PlanListParams{Created: Int64(123)}, strconv.FormatInt(123, 10)},
 		{
 			"created[gt]",
 			&PlanListParams{CreatedRange: &RangeQueryParams{GreaterThan: 123}},
@@ -50,15 +50,15 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		params *PlanParams
 		want   interface{}
 	}{
-		{"amount", &PlanParams{Amount: 123}, strconv.FormatUint(123, 10)},
+		{"amount", &PlanParams{Amount: UInt64(123)}, strconv.FormatUint(123, 10)},
 		{"currency", &PlanParams{Currency: "USD"}, "USD"},
-		{"id", &PlanParams{ID: "sapphire-elite"}, "sapphire-elite"},
+		{"id", &PlanParams{ID: String("sapphire-elite")}, "sapphire-elite"},
 		{"interval", &PlanParams{Interval: "month"}, "month"},
-		{"interval_count", &PlanParams{IntervalCount: 3}, strconv.FormatUint(3, 10)},
+		{"interval_count", &PlanParams{IntervalCount: UInt64(3)}, strconv.FormatUint(3, 10)},
 		{"product[name]", &PlanParams{Product: &productParams}, "Sapphire Elite"},
 		{"product[statement_descriptor]", &PlanParams{Product: &productParams}, "SAPPHIRE"},
 		{"product", &PlanParams{ProductID: &productId}, "prod_123abc"},
-		{"trial_period_days", &PlanParams{TrialPeriodDays: 123}, strconv.FormatUint(123, 10)},
+		{"trial_period_days", &PlanParams{TrialPeriodDays: UInt64(123)}, strconv.FormatUint(123, 10)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {

--- a/product.go
+++ b/product.go
@@ -61,8 +61,8 @@ type Product struct {
 	Name                string             `json:"name"`
 	PackageDimensions   *PackageDimensions `json:"package_dimensions"`
 	Shippable           bool               `json:"shippable"`
-	StatementDescriptor string             `json:"statement_descriptor"`
 	Skus                *SKUList           `json:"skus"`
+	StatementDescriptor string             `json:"statement_descriptor"`
 	Type                ProductType        `json:"type"`
 	URL                 string             `json:"url"`
 	Updated             int64              `json:"updated"`

--- a/product.go
+++ b/product.go
@@ -18,10 +18,10 @@ const (
 // PackageDimensions represents the dimension of a product or a sku from the
 // perspective of shipping.
 type PackageDimensionsParams struct {
-	Height *float64 `json:"height" form:"height"`
-	Length *float64 `json:"length" form:"length"`
-	Weight *float64 `json:"weight" form:"weight"`
-	Width  *float64 `json:"width" form:"width"`
+	Height *float64 `form:"height"`
+	Length *float64 `form:"length"`
+	Weight *float64 `form:"weight"`
+	Width  *float64 `form:"width"`
 }
 
 // ProductParams is the set of parameters that can be used
@@ -48,10 +48,10 @@ type ProductParams struct {
 // PackageDimensions represents the dimension of a product or a sku from the
 // perspective of shipping.
 type PackageDimensions struct {
-	Height float64 `json:"height" form:"height"`
-	Length float64 `json:"length" form:"length"`
-	Weight float64 `json:"weight" form:"weight"`
-	Width  float64 `json:"width" form:"width"`
+	Height float64 `json:"height"`
+	Length float64 `json:"length"`
+	Weight float64 `json:"weight"`
+	Width  float64 `json:"width"`
 }
 
 // Product is the resource representing a Stripe product.

--- a/product.go
+++ b/product.go
@@ -17,11 +17,11 @@ const (
 
 // PackageDimensions represents the dimension of a product or a sku from the
 // perspective of shipping.
-type PackageDimensions struct {
-	Height float64 `json:"height" form:"height"`
-	Length float64 `json:"length" form:"length"`
-	Weight float64 `json:"weight" form:"weight"`
-	Width  float64 `json:"width" form:"width"`
+type PackageDimensionsParams struct {
+	Height *float64 `json:"height" form:"height"`
+	Length *float64 `json:"length" form:"length"`
+	Weight *float64 `json:"weight" form:"weight"`
+	Width  *float64 `json:"width" form:"width"`
 }
 
 // ProductParams is the set of parameters that can be used
@@ -30,19 +30,28 @@ type PackageDimensions struct {
 // and https://stripe.com/docs/api#update_product.
 type ProductParams struct {
 	Params              `form:"*"`
-	Active              *bool              `form:"active"`
-	Attributes          []string           `form:"attributes"`
-	Caption             string             `form:"caption"`
-	DeactivateOn        []string           `form:"deactivate_on"`
-	Description         string             `form:"description"`
-	ID                  string             `form:"id"`
-	Images              []string           `form:"images"`
-	Name                string             `form:"name"`
-	PackageDimensions   *PackageDimensions `form:"package_dimensions"`
-	Shippable           *bool              `form:"shippable"`
-	StatementDescriptor string             `form:"statement_descriptor"`
-	Type                ProductType        `form:"type"`
-	URL                 string             `form:"url"`
+	Active              *bool                    `form:"active"`
+	Attributes          []string                 `form:"attributes"`
+	Caption             *string                  `form:"caption"`
+	DeactivateOn        []string                 `form:"deactivate_on"`
+	Description         *string                  `form:"description"`
+	ID                  *string                  `form:"id"`
+	Images              []string                 `form:"images"`
+	Name                *string                  `form:"name"`
+	PackageDimensions   *PackageDimensionsParams `form:"package_dimensions"`
+	Shippable           *bool                    `form:"shippable"`
+	StatementDescriptor *string                  `form:"statement_descriptor"`
+	Type                *string                  `form:"type"`
+	URL                 *string                  `form:"url"`
+}
+
+// PackageDimensions represents the dimension of a product or a sku from the
+// perspective of shipping.
+type PackageDimensions struct {
+	Height float64 `json:"height" form:"height"`
+	Length float64 `json:"length" form:"length"`
+	Weight float64 `json:"weight" form:"weight"`
+	Width  float64 `json:"width" form:"width"`
 }
 
 // Product is the resource representing a Stripe product.

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -30,17 +30,14 @@ func TestProductList(t *testing.T) {
 }
 
 func TestProductNew(t *testing.T) {
-	active := true
-	shippable := true
-
 	product, err := New(&stripe.ProductParams{
-		Active:      &active,
+		Active:      stripe.Bool(true),
 		Name:        stripe.String("Test Name"),
 		Description: stripe.String("This is a description"),
 		Caption:     stripe.String("This is a caption"),
 		Attributes:  []string{"attr1", "attr2"},
 		URL:         stripe.String("http://example.com"),
-		Shippable:   &shippable,
+		Shippable:   stripe.Bool(true),
 		PackageDimensions: &stripe.PackageDimensionsParams{
 			Height: stripe.Float64(2.234),
 			Length: stripe.Float64(5.10),

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -35,19 +35,19 @@ func TestProductNew(t *testing.T) {
 
 	product, err := New(&stripe.ProductParams{
 		Active:      &active,
-		Name:        "Test Name",
-		Description: "This is a description",
-		Caption:     "This is a caption",
+		Name:        stripe.String("Test Name"),
+		Description: stripe.String("This is a description"),
+		Caption:     stripe.String("This is a caption"),
 		Attributes:  []string{"attr1", "attr2"},
-		URL:         "http://example.com",
+		URL:         stripe.String("http://example.com"),
 		Shippable:   &shippable,
-		PackageDimensions: &stripe.PackageDimensions{
-			Height: 2.234,
-			Length: 5.10,
-			Width:  6.50,
-			Weight: 10,
+		PackageDimensions: &stripe.PackageDimensionsParams{
+			Height: stripe.Float64(2.234),
+			Length: stripe.Float64(5.10),
+			Width:  stripe.Float64(6.50),
+			Weight: stripe.Float64(10),
 		},
-		Type: stripe.ProductTypeGood,
+		Type: stripe.String(string(stripe.ProductTypeGood)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, product)
@@ -55,7 +55,7 @@ func TestProductNew(t *testing.T) {
 
 func TestProductUpdate(t *testing.T) {
 	product, err := Update("prod_123", &stripe.ProductParams{
-		Name: "Updated Name",
+		Name: stripe.String("Updated Name"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, product)

--- a/recipient.go
+++ b/recipient.go
@@ -31,8 +31,8 @@ type RecipientParams struct {
 // behavior for the time being.
 func (p *RecipientParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.BankAccount != nil {
-		if len(p.BankAccount.Token) > 0 {
-			body.Add("bank_account", p.BankAccount.Token)
+		if p.BankAccount.Token != nil {
+			body.Add("bank_account", StringValue(p.BankAccount.Token))
 		} else {
 			form.AppendToPrefixed(body, p.BankAccount, append(keyParts, "bank_account"))
 		}

--- a/recipient.go
+++ b/recipient.go
@@ -17,13 +17,13 @@ type RecipientParams struct {
 
 	BankAccount *BankAccountParams `form:"-"` // Kind of an abberation because a bank account's token will be replace the rest of its data. Keep this in a custom AppendTo for now.
 	Card        *CardParams        `form:"card"`
-	DefaultCard string             `form:"default_card"`
-	Description string             `form:"description"`
-	Email       string             `form:"email"`
-	Name        string             `form:"name"`
-	TaxID       string             `form:"tax_id"`
-	Token       string             `form:"card"`
-	Type        RecipientType      `form:"-"` // Doesn't seem to be used anywhere
+	DefaultCard *string            `form:"default_card"`
+	Description *string            `form:"description"`
+	Email       *string            `form:"email"`
+	Name        *string            `form:"name"`
+	TaxID       *string            `form:"tax_id"`
+	Token       *string            `form:"card"`
+	Type        *string            `form:"-"` // Doesn't seem to be used anywhere
 }
 
 // AppendTo implements some custom behavior around a recipient's bank account.
@@ -43,7 +43,7 @@ func (p *RecipientParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#list_recipients.
 type RecipientListParams struct {
 	ListParams `form:"*"`
-	Verified   bool `form:"verified"`
+	Verified   *bool `form:"verified"`
 }
 
 // Recipient is the resource representing a Stripe recipient.

--- a/recipient/client_test.go
+++ b/recipient/client_test.go
@@ -31,7 +31,7 @@ func TestRecipientList(t *testing.T) {
 
 func TestRecipientUpdate(t *testing.T) {
 	recipient, err := Update("rp_123", &stripe.RecipientParams{
-		Name: "Updated Name",
+		Name: stripe.String("Updated Name"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, recipient)

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -17,7 +17,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{Card: &CardParams{Name: "A Card"}}
+		params := &RecipientParams{Card: &CardParams{Name: String("A Card")}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -25,7 +25,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{BankAccount: &BankAccountParams{Token: "ba_123"}}
+		params := &RecipientParams{BankAccount: &BankAccountParams{Token: String("ba_123")}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -33,7 +33,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{BankAccount: &BankAccountParams{AccountNumber: "123"}}
+		params := &RecipientParams{BankAccount: &BankAccountParams{AccountNumber: String("123")}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRecipientParams_AppendTo(t *testing.T) {
 	{
-		params := &RecipientParams{Token: "card_123"}
+		params := &RecipientParams{Token: String("card_123")}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/refund.go
+++ b/refund.go
@@ -15,11 +15,11 @@ type RefundStatus string
 // For more details see https://stripe.com/docs/api#refund.
 type RefundParams struct {
 	Params               `form:"*"`
-	Amount               uint64       `form:"amount"`
-	Charge               string       `form:"charge"`
+	Amount               *uint64      `form:"amount"`
+	Charge               *string      `form:"charge"`
 	Reason               RefundReason `form:"reason"`
-	RefundApplicationFee bool         `form:"refund_application_fee"`
-	ReverseTransfer      bool         `form:"reverse_transfer"`
+	RefundApplicationFee *bool        `form:"refund_application_fee"`
+	ReverseTransfer      *bool        `form:"reverse_transfer"`
 }
 
 // RefundListParams is the set of parameters that can be used when listing refunds.

--- a/refund.go
+++ b/refund.go
@@ -15,11 +15,11 @@ type RefundStatus string
 // For more details see https://stripe.com/docs/api#refund.
 type RefundParams struct {
 	Params               `form:"*"`
-	Amount               *uint64      `form:"amount"`
-	Charge               *string      `form:"charge"`
-	Reason               RefundReason `form:"reason"`
-	RefundApplicationFee *bool        `form:"refund_application_fee"`
-	ReverseTransfer      *bool        `form:"reverse_transfer"`
+	Amount               *uint64 `form:"amount"`
+	Charge               *string `form:"charge"`
+	Reason               *string `form:"reason"`
+	RefundApplicationFee *bool   `form:"refund_application_fee"`
+	ReverseTransfer      *bool   `form:"reverse_transfer"`
 }
 
 // RefundListParams is the set of parameters that can be used when listing refunds.

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -25,7 +25,7 @@ func TestRefundList(t *testing.T) {
 
 func TestRefundNew(t *testing.T) {
 	refund, err := New(&stripe.RefundParams{
-		Charge: "ch_123",
+		Charge: stripe.String("ch_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -26,6 +26,7 @@ func TestRefundList(t *testing.T) {
 func TestRefundNew(t *testing.T) {
 	refund, err := New(&stripe.RefundParams{
 		Charge: stripe.String("ch_123"),
+		Reason: stripe.String(string(RefundDuplicate)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)

--- a/refund_test.go
+++ b/refund_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestRefundUnmarshal(t *testing.T) {
 	refundData := map[string]interface{}{
-		"id":     "re_1234",
-		"object": "refund",
-		"charge": "ch_1234",
+		"id":     String("re_1234"),
+		"object": String("refund"),
+		"charge": String("ch_1234"),
 	}
 
 	bytes, err := json.Marshal(&refundData)

--- a/reversal.go
+++ b/reversal.go
@@ -5,15 +5,15 @@ import "encoding/json"
 // ReversalParams is the set of parameters that can be used when reversing a transfer.
 type ReversalParams struct {
 	Params               `form:"*"`
-	Amount               uint64 `form:"amount"`
-	RefundApplicationFee bool   `form:"refund_application_fee"`
-	Transfer             string `form:"-"` // Included in URL
+	Amount               *uint64 `form:"amount"`
+	RefundApplicationFee *bool   `form:"refund_application_fee"`
+	Transfer             *string `form:"-"` // Included in URL
 }
 
 // ReversalListParams is the set of parameters that can be used when listing reversals.
 type ReversalListParams struct {
 	ListParams `form:"*"`
-	Transfer   string `form:"-"` // Included in URL
+	Transfer   *string `form:"-"` // Included in URL
 }
 
 // Reversal represents a transfer reversal.

--- a/reversal/client_test.go
+++ b/reversal/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestReversalGet(t *testing.T) {
 	reversal, err := Get("trr_123", &stripe.ReversalParams{
-		Transfer: "tr_123",
+		Transfer: stripe.String("tr_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, reversal)
@@ -18,7 +18,7 @@ func TestReversalGet(t *testing.T) {
 
 func TestReversalList(t *testing.T) {
 	i := List(&stripe.ReversalListParams{
-		Transfer: "tr_123",
+		Transfer: stripe.String("tr_123"),
 	})
 
 	// Verify that we can get at least one reversal
@@ -29,8 +29,8 @@ func TestReversalList(t *testing.T) {
 
 func TestReversalNew(t *testing.T) {
 	reversal, err := New(&stripe.ReversalParams{
-		Amount:   123,
-		Transfer: "tr_123",
+		Amount:   stripe.UInt64(123),
+		Transfer: stripe.String("tr_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, reversal)
@@ -43,7 +43,7 @@ func TestReversalUpdate(t *testing.T) {
 				"foo": "bar",
 			},
 		},
-		Transfer: "tr_123",
+		Transfer: stripe.String("tr_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, reversal)

--- a/sku.go
+++ b/sku.go
@@ -2,24 +2,30 @@ package stripe
 
 import "encoding/json"
 
+type InventoryParams struct {
+	Quantity *int64  `form:"quantity"`
+	Type     *string `form:"type"`
+	Value    *string `form:"value"`
+}
+
 type SKUParams struct {
 	Params            `form:"*"`
 	Active            *bool              `form:"active"`
 	Attributes        map[string]string  `form:"attributes"`
-	Currency          string             `form:"currency"`
-	Description       string             `form:"description"`
-	ID                string             `form:"id"`
-	Image             string             `form:"image"`
-	Inventory         Inventory          `form:"inventory"`
+	Currency          *string            `form:"currency"`
+	Description       *string            `form:"description"`
+	ID                *string            `form:"id"`
+	Image             *string            `form:"image"`
+	Inventory         *InventoryParams   `form:"inventory"`
 	PackageDimensions *PackageDimensions `form:"package_dimensions"`
-	Price             int64              `form:"price"`
-	Product           string             `form:"product"`
+	Price             *int64             `form:"price"`
+	Product           *string            `form:"product"`
 }
 
 type Inventory struct {
-	Quantity int64  `json:"quantity" form:"quantity"`
-	Type     string `json:"type" form:"type"`
-	Value    string `json:"value" form:"value"`
+	Quantity int64  `json:"quantity"`
+	Type     string `json:"type"`
+	Value    string `json:"value"`
 }
 
 type SKU struct {

--- a/sku.go
+++ b/sku.go
@@ -10,16 +10,16 @@ type InventoryParams struct {
 
 type SKUParams struct {
 	Params            `form:"*"`
-	Active            *bool              `form:"active"`
-	Attributes        map[string]string  `form:"attributes"`
-	Currency          *string            `form:"currency"`
-	Description       *string            `form:"description"`
-	ID                *string            `form:"id"`
-	Image             *string            `form:"image"`
-	Inventory         *InventoryParams   `form:"inventory"`
-	PackageDimensions *PackageDimensions `form:"package_dimensions"`
-	Price             *int64             `form:"price"`
-	Product           *string            `form:"product"`
+	Active            *bool                    `form:"active"`
+	Attributes        map[string]string        `form:"attributes"`
+	Currency          *string                  `form:"currency"`
+	Description       *string                  `form:"description"`
+	ID                *string                  `form:"id"`
+	Image             *string                  `form:"image"`
+	Inventory         *InventoryParams         `form:"inventory"`
+	PackageDimensions *PackageDimensionsParams `form:"package_dimensions"`
+	Price             *int64                   `form:"price"`
+	Product           *string                  `form:"product"`
 }
 
 type Inventory struct {

--- a/sku.go
+++ b/sku.go
@@ -32,7 +32,7 @@ type SKU struct {
 	Active            bool               `json:"active"`
 	Attributes        map[string]string  `json:"attributes"`
 	Created           int64              `json:"created"`
-	Currency          string             `json:"currency"`
+	Currency          Currency           `json:"currency"`
 	Description       string             `json:"description"`
 	ID                string             `json:"id"`
 	Image             string             `json:"image"`
@@ -56,7 +56,7 @@ type SKUListParams struct {
 	Attributes map[string]string `form:"attributes"`
 	IDs        []string          `form:"ids"`
 	InStock    *bool             `form:"in_stock"`
-	Product    string            `form:"product"`
+	Product    *string           `form:"product"`
 }
 
 func (s *SKU) UnmarshalJSON(data []byte) error {

--- a/sku/client_test.go
+++ b/sku/client_test.go
@@ -30,15 +30,17 @@ func TestSKUList(t *testing.T) {
 }
 
 func TestSKUNew(t *testing.T) {
-	active := true
 	sku, err := New(&stripe.SKUParams{
-		Active:     &active,
+		Active:     stripe.Bool(true),
 		Attributes: map[string]string{"attr1": "val1", "attr2": "val2"},
-		Price:      499,
-		Currency:   "usd",
-		Inventory:  stripe.Inventory{Type: "bucket", Value: "limited"},
-		Product:    "prod_123",
-		Image:      "http://example.com/foo.png",
+		Price:      stripe.Int64(499),
+		Currency:   stripe.String("usd"),
+		Inventory: &stripe.InventoryParams{
+			Type:  stripe.String("bucket"),
+			Value: stripe.String("limited"),
+		},
+		Product: stripe.String("prod_123"),
+		Image:   stripe.String("http://example.com/foo.png"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sku)
@@ -46,7 +48,10 @@ func TestSKUNew(t *testing.T) {
 
 func TestSKUUpdate(t *testing.T) {
 	sku, err := Update("sku_123", &stripe.SKUParams{
-		Inventory: stripe.Inventory{Type: "bucket", Value: "in_stock"},
+		Inventory: &stripe.InventoryParams{
+			Type:  stripe.String("bucket"),
+			Value: stripe.String("in_stock"),
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sku)

--- a/sku/client_test.go
+++ b/sku/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -34,7 +35,7 @@ func TestSKUNew(t *testing.T) {
 		Active:     stripe.Bool(true),
 		Attributes: map[string]string{"attr1": "val1", "attr2": "val2"},
 		Price:      stripe.Int64(499),
-		Currency:   stripe.String("usd"),
+		Currency:   stripe.String(string(currency.USD)),
 		Inventory: &stripe.InventoryParams{
 			Type:  stripe.String("bucket"),
 			Value: stripe.String("limited"),

--- a/source.go
+++ b/source.go
@@ -66,27 +66,27 @@ const (
 
 type SourceOwnerParams struct {
 	Address *AddressParams `form:"address"`
-	Email   string         `form:"email"`
-	Name    string         `form:"name"`
-	Phone   string         `form:"phone"`
+	Email   *string        `form:"email"`
+	Name    *string        `form:"name"`
+	Phone   *string        `form:"phone"`
 }
 
 type RedirectParams struct {
-	ReturnURL string `form:"return_url"`
+	ReturnURL *string `form:"return_url"`
 }
 
 type SourceObjectParams struct {
 	Params              `form:"*"`
-	Amount              uint64             `form:"amount"`
+	Amount              *uint64            `form:"amount"`
 	Currency            Currency           `form:"currency"`
-	Customer            string             `form:"customer"`
+	Customer            *string            `form:"customer"`
 	Flow                SourceFlow         `form:"flow"`
-	OriginalSource      string             `form:"original_source"`
+	OriginalSource      *string            `form:"original_source"`
 	Owner               *SourceOwnerParams `form:"owner"`
 	Redirect            *RedirectParams    `form:"redirect"`
-	StatementDescriptor string             `form:"statement_descriptor"`
-	Token               string             `form:"token"`
-	Type                string             `form:"type"`
+	StatementDescriptor *string            `form:"statement_descriptor"`
+	Token               *string            `form:"token"`
+	Type                *string            `form:"type"`
 	TypeData            map[string]string  `form:"-"`
 	Usage               SourceUsage        `form:"usage"`
 }
@@ -95,7 +95,7 @@ type SourceObjectParams struct {
 // a source from a customer.
 type SourceObjectDetachParams struct {
 	Params   `form:"*"`
-	Customer string `form:"-"`
+	Customer *string `form:"-"`
 }
 
 type SourceOwner struct {
@@ -211,12 +211,12 @@ type Source struct {
 // AppendTo implements custom encoding logic for SourceObjectParams so that the special
 // "TypeData" value for is sent as the correct parameter based on the Source type
 func (p *SourceObjectParams) AppendTo(body *form.Values, keyParts []string) {
-	if len(p.TypeData) > 0 && len(p.Type) == 0 {
+	if len(p.TypeData) > 0 && p.Type == nil {
 		panic("You can not fill TypeData if you don't explicitly set Type")
 	}
 
 	for k, vs := range p.TypeData {
-		body.Add(form.FormatKey(append(keyParts, p.Type, k)), vs)
+		body.Add(form.FormatKey(append(keyParts, StringValue(p.Type), k)), vs)
 	}
 }
 

--- a/source.go
+++ b/source.go
@@ -78,9 +78,9 @@ type RedirectParams struct {
 type SourceObjectParams struct {
 	Params              `form:"*"`
 	Amount              *uint64            `form:"amount"`
-	Currency            Currency           `form:"currency"`
+	Currency            *string            `form:"currency"`
 	Customer            *string            `form:"customer"`
-	Flow                SourceFlow         `form:"flow"`
+	Flow                *string            `form:"flow"`
 	OriginalSource      *string            `form:"original_source"`
 	Owner               *SourceOwnerParams `form:"owner"`
 	Redirect            *RedirectParams    `form:"redirect"`
@@ -88,7 +88,7 @@ type SourceObjectParams struct {
 	Token               *string            `form:"token"`
 	Type                *string            `form:"type"`
 	TypeData            map[string]string  `form:"-"`
-	Usage               SourceUsage        `form:"usage"`
+	Usage               *string            `form:"usage"`
 }
 
 // SourceObjectDetachParams is the set of parameters that can be used when detaching

--- a/source/client.go
+++ b/source/client.go
@@ -105,7 +105,7 @@ func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*str
 	source := &stripe.Source{}
 	var err error
 
-	if len(params.Customer) > 0 {
+	if params.Customer != nil {
 		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), c.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source detach params: Customer needs to be set")

--- a/source/client_test.go
+++ b/source/client_test.go
@@ -17,11 +17,11 @@ func TestSourceGet(t *testing.T) {
 
 func TestSourceNew(t *testing.T) {
 	source, err := New(&stripe.SourceObjectParams{
-		Type:     "bitcoin",
-		Amount:   1000,
+		Type:     stripe.String("bitcoin"),
+		Amount:   stripe.UInt64(1000),
 		Currency: currency.USD,
 		Owner: &stripe.SourceOwnerParams{
-			Email: "jenny.rosen@example.com",
+			Email: stripe.String("jenny.rosen@example.com"),
 		},
 	})
 	assert.Nil(t, err)
@@ -31,7 +31,7 @@ func TestSourceNew(t *testing.T) {
 func TestSourceUpdate(t *testing.T) {
 	source, err := Update("src_123", &stripe.SourceObjectParams{
 		Owner: &stripe.SourceOwnerParams{
-			Email: "jenny.rosen@example.com",
+			Email: stripe.String("jenny.rosen@example.com"),
 		},
 	})
 	assert.Nil(t, err)
@@ -40,7 +40,7 @@ func TestSourceUpdate(t *testing.T) {
 
 func TestSourceDetach(t *testing.T) {
 	source, err := Detach("src_123", &stripe.SourceObjectDetachParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, source)
@@ -48,9 +48,9 @@ func TestSourceDetach(t *testing.T) {
 
 func TestSourceSharing(t *testing.T) {
 	params := &stripe.SourceObjectParams{
-		Type:           "card",
-		Customer:       "cus_123",
-		OriginalSource: "src_123",
+		Type:           stripe.String("card"),
+		Customer:       stripe.String("cus_123"),
+		OriginalSource: stripe.String("src_123"),
 		Usage:          stripe.UsageReusable,
 	}
 	params.SetStripeAccount("acct_123")

--- a/source/client_test.go
+++ b/source/client_test.go
@@ -19,7 +19,8 @@ func TestSourceNew(t *testing.T) {
 	source, err := New(&stripe.SourceObjectParams{
 		Type:     stripe.String("bitcoin"),
 		Amount:   stripe.UInt64(1000),
-		Currency: currency.USD,
+		Currency: stripe.String(string(currency.USD)),
+		Flow:     stripe.String(string(stripe.FlowReceiver)),
 		Owner: &stripe.SourceOwnerParams{
 			Email: stripe.String("jenny.rosen@example.com"),
 		},
@@ -51,7 +52,7 @@ func TestSourceSharing(t *testing.T) {
 		Type:           stripe.String("card"),
 		Customer:       stripe.String("cus_123"),
 		OriginalSource: stripe.String("src_123"),
-		Usage:          stripe.UsageReusable,
+		Usage:          stripe.String(string(stripe.UsageReusable)),
 	}
 	params.SetStripeAccount("acct_123")
 	source, err := New(params)

--- a/source_test.go
+++ b/source_test.go
@@ -12,7 +12,7 @@ func TestSourceObjectParams_AppendTo(t *testing.T) {
 	// encoding
 	{
 		params := &SourceObjectParams{
-			Type: "source_type",
+			Type: String("source_type"),
 			TypeData: map[string]string{
 				"foo": "bar",
 			},

--- a/sourcetransaction.go
+++ b/sourcetransaction.go
@@ -5,7 +5,7 @@ import "encoding/json"
 // SourceTransactionListParams is the set of parameters that can be used when listing SourceTransactions.
 type SourceTransactionListParams struct {
 	ListParams `form:"*"`
-	Source     string `form:"-"` // Sent in with the URL
+	Source     *string `form:"-"` // Sent in with the URL
 }
 
 // SourceTransactionList is a list object for SourceTransactions.

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -34,7 +34,7 @@ func (c Client) List(params *stripe.SourceTransactionListParams) *Iter {
 		list := &stripe.SourceTransactionList{}
 		var err error
 
-		if params != nil && len(params.Source) > 0 {
+		if params != nil && params.Source != nil {
 			err = c.B.Call("GET", fmt.Sprintf("/sources/%v/source_transactions", params.Source), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid source transaction params: Source needs to be set")

--- a/sourcetransaction/client_test.go
+++ b/sourcetransaction/client_test.go
@@ -13,7 +13,7 @@ func TestSourceTransactionList(t *testing.T) {
 	t.Skip("not yet supported by stripe-mock")
 
 	i := List(&stripe.SourceTransactionListParams{
-		Source: "src_123",
+		Source: stripe.String("src_123"),
 	})
 
 	// Verify that we can get at least one transaction

--- a/stripe.go
+++ b/stripe.go
@@ -26,7 +26,7 @@ const (
 )
 
 // apiversion is the currently supported API version
-const apiversion = "2017-05-25"
+const apiversion = "2018-02-06"
 
 // clientversion is the binding version
 const clientversion = "29.0.1"

--- a/sub.go
+++ b/sub.go
@@ -20,43 +20,43 @@ type SubscriptionParams struct {
 	Params                      `form:"*"`
 	ApplicationFeePercent       *float64                   `form:"application_fee_percent"`
 	Billing                     SubscriptionBilling        `form:"billing"`
-	BillingCycleAnchor          int64                      `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow       bool                       `form:"-"` // See custom AppendTo
-	BillingCycleAnchorUnchanged bool                       `form:"-"` // See custom AppendTo
+	BillingCycleAnchor          *int64                     `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       *bool                      `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged *bool                      `form:"-"` // See custom AppendTo
 	Card                        *CardParams                `form:"card"`
 	Coupon                      *string                    `form:"coupon"`
-	Customer                    string                     `form:"customer"`
-	DaysUntilDue                uint64                     `form:"days_until_due"`
+	Customer                    *string                    `form:"customer"`
+	DaysUntilDue                *uint64                    `form:"days_until_due"`
 	Items                       []*SubscriptionItemsParams `form:"items,indexed"`
-	OnBehalfOf                  string                     `form:"on_behalf_of"`
-	Plan                        string                     `form:"plan"`
+	OnBehalfOf                  *string                    `form:"on_behalf_of"`
+	Plan                        *string                    `form:"plan"`
 	Prorate                     *bool                      `form:"prorate"`
-	ProrationDate               int64                      `form:"proration_date"`
+	ProrationDate               *int64                     `form:"proration_date"`
 	Quantity                    *uint64                    `form:"quantity"`
-	Source                      string                     `form:"source"`
+	Source                      *string                    `form:"source"`
 	TaxPercent                  *float64                   `form:"tax_percent"`
-	TrialEnd                    int64                      `form:"trial_end"`
-	TrialEndNow                 bool                       `form:"-"` // See custom AppendTo
-	TrialPeriodDays             int64                      `form:"trial_period_days"`
+	TrialEnd                    *int64                     `form:"trial_end"`
+	TrialEndNow                 *bool                      `form:"-"` // See custom AppendTo
+	TrialPeriodDays             *int64                     `form:"trial_period_days"`
 
 	// Used for Cancel
 
-	AtPeriodEnd bool `form:"at_period_end"`
+	AtPeriodEnd *bool `form:"at_period_end"`
 }
 
 // AppendTo implements custom encoding logic for SubscriptionParams so that the special
 // "now" value for billing_cycle_anchor and trial_end can be implemented
 // (they're otherwise timestamps rather than strings).
 func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
-	if p.BillingCycleAnchorNow {
+	if p.BillingCycleAnchorNow != nil {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "now")
 	}
 
-	if p.BillingCycleAnchorUnchanged {
+	if p.BillingCycleAnchorUnchanged != nil {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "unchanged")
 	}
 
-	if p.TrialEndNow {
+	if p.TrialEndNow != nil {
 		body.Add(form.FormatKey(append(keyParts, "trial_end")), "now")
 	}
 }

--- a/sub.go
+++ b/sub.go
@@ -19,7 +19,7 @@ type SubscriptionBilling string
 type SubscriptionParams struct {
 	Params                      `form:"*"`
 	ApplicationFeePercent       *float64                   `form:"application_fee_percent"`
-	Billing                     SubscriptionBilling        `form:"billing"`
+	Billing                     *string                    `form:"billing"`
 	BillingCycleAnchor          *int64                     `form:"billing_cycle_anchor"`
 	BillingCycleAnchorNow       *bool                      `form:"-"` // See custom AppendTo
 	BillingCycleAnchorUnchanged *bool                      `form:"-"` // See custom AppendTo

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -32,13 +32,13 @@ func TestSubscriptionList(t *testing.T) {
 
 func TestSubscriptionNew(t *testing.T) {
 	subscription, err := New(&stripe.SubscriptionParams{
-		Customer:           "cus_123",
-		Plan:               "plan_123",
+		Customer:           stripe.String("cus_123"),
+		Plan:               stripe.String("plan_123"),
 		Quantity:           stripe.UInt64(10),
 		TaxPercent:         stripe.Float64(20.0),
-		BillingCycleAnchor: time.Now().AddDate(0, 0, 12).Unix(),
+		BillingCycleAnchor: stripe.Int64(time.Now().AddDate(0, 0, 12).Unix()),
 		Billing:            "send_invoice",
-		DaysUntilDue:       30,
+		DaysUntilDue:       stripe.UInt64(30),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
@@ -46,7 +46,7 @@ func TestSubscriptionNew(t *testing.T) {
 
 func TestSubscriptionNew_WithItems(t *testing.T) {
 	subscription, err := New(&stripe.SubscriptionParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 		Items: []*stripe.SubscriptionItemsParams{
 			{
 				Plan:     "gold",

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -37,7 +37,7 @@ func TestSubscriptionNew(t *testing.T) {
 		Quantity:           stripe.UInt64(10),
 		TaxPercent:         stripe.Float64(20.0),
 		BillingCycleAnchor: stripe.Int64(time.Now().AddDate(0, 0, 12).Unix()),
-		Billing:            "send_invoice",
+		Billing:            stripe.String("send_invoice"),
 		DaysUntilDue:       stripe.UInt64(30),
 	})
 	assert.Nil(t, err)

--- a/sub_test.go
+++ b/sub_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSubscriptionParams_AppendTo(t *testing.T) {
 	{
-		params := &SubscriptionParams{BillingCycleAnchorNow: true}
+		params := &SubscriptionParams{BillingCycleAnchorNow: Bool(true)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -17,7 +17,7 @@ func TestSubscriptionParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SubscriptionParams{BillingCycleAnchorUnchanged: true}
+		params := &SubscriptionParams{BillingCycleAnchorUnchanged: Bool(true)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -25,7 +25,7 @@ func TestSubscriptionParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SubscriptionParams{TrialEndNow: true}
+		params := &SubscriptionParams{TrialEndNow: Bool(true)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/subitem.go
+++ b/subitem.go
@@ -4,19 +4,19 @@ package stripe
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
 type SubscriptionItemParams struct {
 	Params        `form:"*"`
-	ID            string  `form:"-"` // Handled in URL
-	Plan          string  `form:"plan"`
+	ID            *string `form:"-"` // Handled in URL
+	Plan          *string `form:"plan"`
 	Prorate       *bool   `form:"prorate"`
-	ProrationDate int64   `form:"proration_date"`
+	ProrationDate *int64  `form:"proration_date"`
 	Quantity      *uint64 `form:"quantity"`
-	Subscription  string  `form:"subscription"`
+	Subscription  *string `form:"subscription"`
 }
 
 // SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
 type SubscriptionItemListParams struct {
 	ListParams   `form:"*"`
-	Subscription string `form:"subscription"`
+	Subscription *string `form:"subscription"`
 }
 
 // SubscriptionItem is the resource representing a Stripe subscription item.

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -32,8 +32,8 @@ func TestSubscriptionItemList(t *testing.T) {
 func TestSubscriptionItemNew(t *testing.T) {
 	item, err := New(&stripe.SubscriptionItemParams{
 		Quantity:     stripe.UInt64(99),
-		Plan:         "plan_123",
-		Subscription: "sub_123",
+		Plan:         stripe.String("plan_123"),
+		Subscription: stripe.String("sub_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -6,11 +6,11 @@ type ThreeDSecureStatus string
 // For more details see https://stripe.com/docs/api#create_three_d_secure.
 type ThreeDSecureParams struct {
 	Params    `form:"*"`
-	Amount    uint64   `form:"amount"`
-	Card      string   `form:"card"`
+	Amount    *uint64  `form:"amount"`
+	Card      *string  `form:"card"`
 	Currency  Currency `form:"currency"`
-	Customer  string   `form:"customer"`
-	ReturnURL string   `form:"return_url"`
+	Customer  *string  `form:"customer"`
+	ReturnURL *string  `form:"return_url"`
 }
 
 // ThreeDSecure is the resource representing a Stripe 3DS object

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -6,11 +6,11 @@ type ThreeDSecureStatus string
 // For more details see https://stripe.com/docs/api#create_three_d_secure.
 type ThreeDSecureParams struct {
 	Params    `form:"*"`
-	Amount    *uint64  `form:"amount"`
-	Card      *string  `form:"card"`
-	Currency  Currency `form:"currency"`
-	Customer  *string  `form:"customer"`
-	ReturnURL *string  `form:"return_url"`
+	Amount    *uint64 `form:"amount"`
+	Card      *string `form:"card"`
+	Currency  *string `form:"currency"`
+	Customer  *string `form:"customer"`
+	ReturnURL *string `form:"return_url"`
 }
 
 // ThreeDSecure is the resource representing a Stripe 3DS object

--- a/threedsecure/client_test.go
+++ b/threedsecure/client_test.go
@@ -16,11 +16,11 @@ func TestThreeDSecureGet(t *testing.T) {
 
 func TestThreeDSecureNew(t *testing.T) {
 	threeDSecure, err := New(&stripe.ThreeDSecureParams{
-		Amount:    1000,
+		Amount:    stripe.UInt64(1000),
 		Currency:  "usd",
-		Customer:  "cus_123",
-		Card:      "card_123",
-		ReturnURL: "https://test.com",
+		Customer:  stripe.String("cus_123"),
+		Card:      stripe.String("card_123"),
+		ReturnURL: stripe.String("https://test.com"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, threeDSecure)

--- a/threedsecure/client_test.go
+++ b/threedsecure/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -17,7 +18,7 @@ func TestThreeDSecureGet(t *testing.T) {
 func TestThreeDSecureNew(t *testing.T) {
 	threeDSecure, err := New(&stripe.ThreeDSecureParams{
 		Amount:    stripe.UInt64(1000),
-		Currency:  "usd",
+		Currency:  stripe.String(string(currency.USD)),
 		Customer:  stripe.String("cus_123"),
 		Card:      stripe.String("card_123"),
 		ReturnURL: stripe.String("https://test.com"),

--- a/token.go
+++ b/token.go
@@ -10,11 +10,11 @@ type TokenParams struct {
 	Params      `form:"*"`
 	BankAccount *BankAccountParams `form:"bank_account"`
 	Card        *CardParams        `form:"card"`
-	Customer    string             `form:"customer"`
+	Customer    *string            `form:"customer"`
 
 	// Email is an undocumented parameter used by Stripe Checkout
 	// It may be removed from the API without notice.
-	Email string `form:"email"`
+	Email *string `form:"email"`
 
 	PII *PIIParams `form:"pii"`
 }
@@ -40,5 +40,5 @@ type Token struct {
 // PIIParams are parameters for personal identifiable information (PII).
 type PIIParams struct {
 	Params           `form:"*"`
-	PersonalIDNumber string `form:"personal_id_number"`
+	PersonalIDNumber *string `form:"personal_id_number"`
 }

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -41,7 +41,7 @@ func TestTokenNew_WithCard(t *testing.T) {
 func TestTokenNew_WithPII(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
 		PII: &stripe.PIIParams{
-			PersonalIDNumber: "000000000",
+			PersonalIDNumber: stripe.String("000000000"),
 		},
 	})
 	assert.Nil(t, err)
@@ -53,7 +53,7 @@ func TestTokenNew_SharedCustomerCard(t *testing.T) {
 		Card: &stripe.CardParams{
 			ID: "card_123",
 		},
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	}
 	params.SetStripeAccount("acct_123")
 	token, err := New(params)
@@ -66,7 +66,7 @@ func TestTokenNew_SharedCustomerBankAccount(t *testing.T) {
 		BankAccount: &stripe.BankAccountParams{
 			ID: "ba_123",
 		},
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	}
 	params.SetStripeAccount("acct_123")
 	token, err := New(params)

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -17,9 +17,9 @@ func TestTokenGet(t *testing.T) {
 func TestTokenNew_WithBankAccount(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
 		BankAccount: &stripe.BankAccountParams{
-			Country:       "US",
-			RoutingNumber: "110000000",
-			AccountNumber: "000123456789",
+			Country:       stripe.String("US"),
+			RoutingNumber: stripe.String("110000000"),
+			AccountNumber: stripe.String("000123456789"),
 		},
 	})
 	assert.Nil(t, err)
@@ -64,7 +64,7 @@ func TestTokenNew_SharedCustomerCard(t *testing.T) {
 func TestTokenNew_SharedCustomerBankAccount(t *testing.T) {
 	params := &stripe.TokenParams{
 		BankAccount: &stripe.BankAccountParams{
-			ID: "ba_123",
+			ID: stripe.String("ba_123"),
 		},
 		Customer: stripe.String("cus_123"),
 	}

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -29,9 +29,9 @@ func TestTokenNew_WithBankAccount(t *testing.T) {
 func TestTokenNew_WithCard(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
 		Card: &stripe.CardParams{
-			Number:   "4242424242424242", // raw PAN as we're testing token creation
-			ExpMonth: "10",
-			ExpYear:  "20",
+			Number:   stripe.String("4242424242424242"), // raw PAN as we're testing token creation
+			ExpMonth: stripe.String("10"),
+			ExpYear:  stripe.String("20"),
 		},
 	})
 	assert.Nil(t, err)

--- a/transfer.go
+++ b/transfer.go
@@ -18,22 +18,22 @@ type TransferDestination struct {
 // For more details see https://stripe.com/docs/api#create_transfer and https://stripe.com/docs/api#update_transfer.
 type TransferParams struct {
 	Params            `form:"*"`
-	Amount            int64              `form:"amount"`
-	Currency          Currency           `form:"currency"`
-	Destination       string             `form:"destination"`
-	SourceTransaction string             `form:"source_transaction"`
-	SourceType        TransferSourceType `form:"source_type"`
-	TransferGroup     string             `form:"transfer_group"`
+	Amount            *int64              `form:"amount"`
+	Currency          Currency            `form:"currency"`
+	Destination       *string             `form:"destination"`
+	SourceTransaction *string             `form:"source_transaction"`
+	SourceType        *TransferSourceType `form:"source_type"`
+	TransferGroup     *string             `form:"transfer_group"`
 }
 
 // TransferListParams is the set of parameters that can be used when listing transfers.
 // For more details see https://stripe.com/docs/api#list_transfers.
 type TransferListParams struct {
 	ListParams    `form:"*"`
-	Created       int64             `form:"created"`
+	Created       *int64            `form:"created"`
 	CreatedRange  *RangeQueryParams `form:"created"`
-	Destination   string            `form:"destination"`
-	TransferGroup string            `form:"transfer_group"`
+	Destination   *string           `form:"destination"`
+	TransferGroup *string           `form:"transfer_group"`
 }
 
 // Transfer is the resource representing a Stripe transfer.

--- a/transfer.go
+++ b/transfer.go
@@ -19,7 +19,7 @@ type TransferDestination struct {
 type TransferParams struct {
 	Params            `form:"*"`
 	Amount            *int64              `form:"amount"`
-	Currency          Currency            `form:"currency"`
+	Currency          *string             `form:"currency"`
 	Destination       *string             `form:"destination"`
 	SourceTransaction *string             `form:"source_transaction"`
 	SourceType        *TransferSourceType `form:"source_type"`

--- a/transfer.go
+++ b/transfer.go
@@ -18,12 +18,12 @@ type TransferDestination struct {
 // For more details see https://stripe.com/docs/api#create_transfer and https://stripe.com/docs/api#update_transfer.
 type TransferParams struct {
 	Params            `form:"*"`
-	Amount            *int64              `form:"amount"`
-	Currency          *string             `form:"currency"`
-	Destination       *string             `form:"destination"`
-	SourceTransaction *string             `form:"source_transaction"`
-	SourceType        *TransferSourceType `form:"source_type"`
-	TransferGroup     *string             `form:"transfer_group"`
+	Amount            *int64  `form:"amount"`
+	Currency          *string `form:"currency"`
+	Destination       *string `form:"destination"`
+	SourceTransaction *string `form:"source_transaction"`
+	SourceType        *string `form:"source_type"`
+	TransferGroup     *string `form:"transfer_group"`
 }
 
 // TransferListParams is the set of parameters that can be used when listing transfers.

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -25,10 +25,10 @@ func TestTransferList(t *testing.T) {
 
 func TestTransferNew(t *testing.T) {
 	transfer, err := New(&stripe.TransferParams{
-		Amount:            123,
+		Amount:            stripe.Int64(123),
 		Currency:          "usd",
-		Destination:       "acct_123",
-		SourceTransaction: "ch_123",
+		Destination:       stripe.String("acct_123"),
+		SourceTransaction: stripe.String("ch_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, transfer)

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -30,7 +30,7 @@ func TestTransferNew(t *testing.T) {
 		Currency:          stripe.String(string(currency.USD)),
 		Destination:       stripe.String("acct_123"),
 		SourceTransaction: stripe.String("ch_123"),
-		SourceType:        stripe.String("card"),
+		SourceType:        stripe.String(string(SourceCard)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, transfer)

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -26,7 +26,7 @@ func TestTransferList(t *testing.T) {
 func TestTransferNew(t *testing.T) {
 	transfer, err := New(&stripe.TransferParams{
 		Amount:            stripe.Int64(123),
-		Currency:          "usd",
+		Currency:          stripe.String("usd"),
 		Destination:       stripe.String("acct_123"),
 		SourceTransaction: stripe.String("ch_123"),
 	})

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -26,9 +27,10 @@ func TestTransferList(t *testing.T) {
 func TestTransferNew(t *testing.T) {
 	transfer, err := New(&stripe.TransferParams{
 		Amount:            stripe.Int64(123),
-		Currency:          stripe.String("usd"),
+		Currency:          stripe.String(string(currency.USD)),
 		Destination:       stripe.String("acct_123"),
 		SourceTransaction: stripe.String("ch_123"),
+		SourceType:        stripe.String("card"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, transfer)


### PR DESCRIPTION
This change will allow us to remove all the custom work we have around boolean as parameters in the library. Instead of having `Prorate` and `NoProrate` we will simply have `Prorate` as a boolean pointer that is explicitly set as needed. 

This will be merged as the same time as https://github.com/stripe/stripe-go/pull/459 to ensure that we only have one large breaking change for developers to work around.

cc @stripe/api-libraries 