### PR TITLE
Correct `Fprintf` format verb

### DIFF
--- a/webhook/client_handler_test.go
+++ b/webhook/client_handler_test.go
@@ -28,7 +28,7 @@ func Example() {
 		}
 
 		defer req.Body.Close()
-		fmt.Fprintf(w, "Received signed event: %t", event)
+		fmt.Fprintf(w, "Received signed event: %v", event)
 	})
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }


### PR DESCRIPTION
Go-tip is failing because it looks like `Fprintf` got a little more
picky about the use of inappropriate verbs.

`%t` is meant to be used for booleans (it prints the word "true" or
"false"). I think what we actually wanted here was `%v`.

cc @ob-stripe