### PR TITLE
Handle all `json.Unmarshal` errors

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -158,21 +158,25 @@ func (s *TransactionSource) UnmarshalJSON(data []byte) error {
 
 		switch s.Type {
 		case TransactionSourceCharge:
-			json.Unmarshal(data, &s.Charge)
+			err = json.Unmarshal(data, &s.Charge)
 		case TransactionSourceDispute:
-			json.Unmarshal(data, &s.Dispute)
+			err = json.Unmarshal(data, &s.Dispute)
 		case TransactionSourceFee:
-			json.Unmarshal(data, &s.Fee)
+			err = json.Unmarshal(data, &s.Fee)
 		case TransactionSourcePayout:
-			json.Unmarshal(data, &s.Payout)
+			err = json.Unmarshal(data, &s.Payout)
 		case TransactionSourceRecipientTransfer:
-			json.Unmarshal(data, &s.RecipientTransfer)
+			err = json.Unmarshal(data, &s.RecipientTransfer)
 		case TransactionSourceRefund:
-			json.Unmarshal(data, &s.Refund)
+			err = json.Unmarshal(data, &s.Refund)
 		case TransactionSourceReversal:
-			json.Unmarshal(data, &s.Reversal)
+			err = json.Unmarshal(data, &s.Reversal)
 		case TransactionSourceTransfer:
-			json.Unmarshal(data, &s.Transfer)
+			err = json.Unmarshal(data, &s.Transfer)
+		}
+
+		if err != nil {
+			return err
 		}
 	} else {
 		// the id is surrounded by "\" characters, so strip them

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -133,13 +133,17 @@ func (s *PaymentSource) UnmarshalJSON(data []byte) error {
 
 		switch s.Type {
 		case PaymentSourceBankAccount:
-			json.Unmarshal(data, &s.BankAccount)
+			err = json.Unmarshal(data, &s.BankAccount)
 		case PaymentSourceBitcoinReceiver:
-			json.Unmarshal(data, &s.BitcoinReceiver)
+			err = json.Unmarshal(data, &s.BitcoinReceiver)
 		case PaymentSourceCard:
-			json.Unmarshal(data, &s.Card)
+			err = json.Unmarshal(data, &s.Card)
 		case PaymentSourceObject:
-			json.Unmarshal(data, &s.SourceObject)
+			err = json.Unmarshal(data, &s.SourceObject)
+		}
+
+		if err != nil {
+			return err
 		}
 	} else {
 		// the id is surrounded by "\" characters, so strip them

--- a/payout.go
+++ b/payout.go
@@ -138,9 +138,13 @@ func (d *PayoutDestination) UnmarshalJSON(data []byte) error {
 
 		switch d.Type {
 		case PayoutDestinationBankAccount:
-			json.Unmarshal(data, &d.BankAccount)
+			err = json.Unmarshal(data, &d.BankAccount)
 		case PayoutDestinationCard:
-			json.Unmarshal(data, &d.Card)
+			err = json.Unmarshal(data, &d.Card)
+		}
+
+		if err != nil {
+			return err
 		}
 	} else {
 		// the id is surrounded by "\" characters, so strip them

--- a/recipienttransfer.go
+++ b/recipienttransfer.go
@@ -112,9 +112,13 @@ func (d *RecipientTransferDestination) UnmarshalJSON(data []byte) error {
 
 		switch d.Type {
 		case RecipientTransferDestinationBankAccount:
-			json.Unmarshal(data, &d.BankAccount)
+			err = json.Unmarshal(data, &d.BankAccount)
 		case RecipientTransferDestinationCard:
-			json.Unmarshal(data, &d.Card)
+			err = json.Unmarshal(data, &d.Card)
+		}
+
+		if err != nil {
+			return err
 		}
 	} else {
 		// the id is surrounded by "\" characters, so strip them

--- a/stripe.go
+++ b/stripe.go
@@ -359,7 +359,11 @@ func (s *BackendConfiguration) ResponseToError(res *http.Response, resBody []byt
 	// so unmarshalling to a map for now and parsing the results manually
 	// but should investigate later
 	var errMap map[string]interface{}
-	json.Unmarshal(resBody, &errMap)
+
+	err := json.Unmarshal(resBody, &errMap)
+	if err != nil {
+		return err
+	}
 
 	e, ok := errMap["error"]
 	if !ok {

--- a/transfer.go
+++ b/transfer.go
@@ -90,7 +90,11 @@ func (d *TransferDestination) UnmarshalJSON(data []byte) error {
 	if err == nil {
 		*d = TransferDestination(dd)
 
-		json.Unmarshal(data, &d.Account)
+		err = json.Unmarshal(data, &d.Account)
+
+		if err != nil {
+			return err
+		}
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		d.ID = string(data[1 : len(data)-1])


### PR DESCRIPTION
We had a user over in #381 wondering why the errors from a
`json.Unmarshal` in `payout.go` wasn't being handled.

I believe the answer is that we've had a convention in here forever
whereby certain unmarshals from JSON blobs that are "low risk" are
assumed to succeed often enough that the error isn't worth handling. In
some of these `Unmarshal` implementations in particular, the `data` has
already been run through a previous `Unmarshal` so it's known that it
contains valid JSON and is unlikely to error on a second run.

Given that we've never had a complain about this before, it's probably
true that these `Unmarshals` are low risk and probably fine as is, but
nonetheless, it's still good practice to make sure that every error is
handled just in case. In this patch I've gone back through to any
`Unmarshal` invocations that were missing a check and added one.

r? @remi-stripe