### PR TITLE
Encode empty map values

### DIFF
--- a/form/form_test.go
+++ b/form/form_test.go
@@ -229,6 +229,15 @@ func TestAppendTo(t *testing.T) {
 			"bar",
 		},
 
+		// Tests map with an empty value
+		{
+			"map[empty]",
+			&testStruct{Map: map[string]interface{}{
+				"empty": int64(0),
+			}},
+			"0",
+		},
+
 		// Tests map nested inside of another map
 		{
 			"map[foo][bar]",

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -233,6 +233,11 @@ func TestAppendTo(t *testing.T) {
 		{
 			"map[empty]",
 			&testStruct{Map: map[string]interface{}{
+				// Note that we use an empty integer instead of an empty string
+				// here because `Value`''s `Get` implementation will return an
+				// empty string for an unset value which means that we can't
+				// differentiate between a missing and empty value. The empty
+				// value for int64 is 0, so we can.
 				"empty": int64(0),
 			}},
 			"0",


### PR DESCRIPTION
Because most parameter fields in stripe-go are non-pointers, we
generally require that a value be non-empty before we encode it, because
otherwise we can't tell whether or not it was explicitly set.

It recently came up in #511 that it's no longer possible to set an empty
value in a map, which is a direct result of this behavior.

This patch tweaks the implementation slightly so that we always encode
all values that we find in maps, even if they're zero values. This makes
sense because unlike a struct which has default fields, we can always
guarantee that anything present in a map *was* explicitly added. This
resolves the problem described above.

Fixes #511.

r? @remi-stripe
cc @ob-stripe