### PR TITLE
Plan can now have zero amount via AmountZero

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -8,6 +8,7 @@ type PlanInterval string
 // For more details see https://stripe.com/docs/api#plans.
 type Plan struct {
 	Amount        uint64            `json:"amount"`
+	AmountZero    bool              `form:"amount,zero"`
 	Created       int64             `json:"created"`
 	Currency      Currency          `json:"currency"`
 	Deleted       bool              `json:"deleted"`


### PR DESCRIPTION
r? @brandur-stripe 

This fixes https://github.com/stripe/stripe-go/issues/513