### PR TITLE
Add `AmountZero` to `PlanParams`

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -40,6 +40,7 @@ type PlanListParams struct {
 type PlanParams struct {
 	Params        `form:"*"`
 	Amount        uint64       `form:"amount"`
+	AmountZero    bool         `form:"amount,zero"`
 	Currency      Currency     `form:"currency"`
 	ID            string       `form:"id"`
 	Interval      PlanInterval `form:"interval"`


### PR DESCRIPTION
Follows up #514 and adds `AmountZero` to `PlanParams` so that it's
possible to set amount to a zero value when creating or updating a plan.

Fixes #513.

r? @remi-stripe

---

For now this targets the branch in #515 until that's merged to master.