### PR TITLE
Update subscriptions with changes to `billing_cycle_anchor`

### DIFF
--- a/sub.go
+++ b/sub.go
@@ -17,30 +17,31 @@ type SubBilling string
 // SubParams is the set of parameters that can be used when creating or updating a subscription.
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubParams struct {
-	Params                `form:"*"`
-	Billing               SubBilling        `form:"billing"`
-	BillingCycleAnchor    int64             `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow bool              `form:"-"` // See custom AppendTo
-	Card                  *CardParams       `form:"card"`
-	Coupon                string            `form:"coupon"`
-	CouponEmpty           bool              `form:"coupon,empty"`
-	Customer              string            `form:"customer"`
-	DaysUntilDue          uint64            `form:"days_until_due"`
-	FeePercent            float64           `form:"application_fee_percent"`
-	FeePercentZero        bool              `form:"application_fee_percent,zero"`
-	Items                 []*SubItemsParams `form:"items,indexed"`
-	NoProrate             bool              `form:"prorate,invert"`
-	OnBehalfOf            string            `form:"on_behalf_of"`
-	Plan                  string            `form:"plan"`
-	ProrationDate         int64             `form:"proration_date"`
-	Quantity              uint64            `form:"quantity"`
-	QuantityZero          bool              `form:"quantity,zero"`
-	TaxPercent            float64           `form:"tax_percent"`
-	TaxPercentZero        bool              `form:"tax_percent,zero"`
-	Token                 string            `form:"card"`
-	TrialEnd              int64             `form:"trial_end"`
-	TrialEndNow           bool              `form:"-"` // See custom AppendTo
-	TrialPeriod           int64             `form:"trial_period_days"`
+	Params                      `form:"*"`
+	Billing                     SubBilling        `form:"billing"`
+	BillingCycleAnchor          int64             `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       bool              `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged bool              `form:"-"` // See custom AppendTo
+	Card                        *CardParams       `form:"card"`
+	Coupon                      string            `form:"coupon"`
+	CouponEmpty                 bool              `form:"coupon,empty"`
+	Customer                    string            `form:"customer"`
+	DaysUntilDue                uint64            `form:"days_until_due"`
+	FeePercent                  float64           `form:"application_fee_percent"`
+	FeePercentZero              bool              `form:"application_fee_percent,zero"`
+	Items                       []*SubItemsParams `form:"items,indexed"`
+	NoProrate                   bool              `form:"prorate,invert"`
+	OnBehalfOf                  string            `form:"on_behalf_of"`
+	Plan                        string            `form:"plan"`
+	ProrationDate               int64             `form:"proration_date"`
+	Quantity                    uint64            `form:"quantity"`
+	QuantityZero                bool              `form:"quantity,zero"`
+	TaxPercent                  float64           `form:"tax_percent"`
+	TaxPercentZero              bool              `form:"tax_percent,zero"`
+	Token                       string            `form:"card"`
+	TrialEnd                    int64             `form:"trial_end"`
+	TrialEndNow                 bool              `form:"-"` // See custom AppendTo
+	TrialPeriod                 int64             `form:"trial_period_days"`
 
 	// Used for Cancel
 
@@ -53,6 +54,10 @@ type SubParams struct {
 func (p *SubParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.BillingCycleAnchorNow {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "now")
+	}
+
+	if p.BillingCycleAnchorUnchanged {
+		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "unchanged")
 	}
 
 	if p.TrialEndNow {
@@ -86,27 +91,28 @@ type SubListParams struct {
 // Sub is the resource representing a Stripe subscription.
 // For more details see https://stripe.com/docs/api#subscriptions.
 type Sub struct {
-	Billing      SubBilling        `json:"billing"`
-	Canceled     int64             `json:"canceled_at"`
-	Created      int64             `json:"created"`
-	Customer     *Customer         `json:"customer"`
-	DaysUntilDue uint64            `json:"days_until_due"`
-	Discount     *Discount         `json:"discount"`
-	EndCancel    bool              `json:"cancel_at_period_end"`
-	Ended        int64             `json:"ended_at"`
-	FeePercent   float64           `json:"application_fee_percent"`
-	ID           string            `json:"id"`
-	Items        *SubItemList      `json:"items"`
-	Meta         map[string]string `json:"metadata"`
-	PeriodEnd    int64             `json:"current_period_end"`
-	PeriodStart  int64             `json:"current_period_start"`
-	Plan         *Plan             `json:"plan"`
-	Quantity     uint64            `json:"quantity"`
-	Start        int64             `json:"start"`
-	Status       SubStatus         `json:"status"`
-	TaxPercent   float64           `json:"tax_percent"`
-	TrialEnd     int64             `json:"trial_end"`
-	TrialStart   int64             `json:"trial_start"`
+	Billing            SubBilling        `json:"billing"`
+	BillingCycleAnchor int64             `json:"billing_cycle_anchor"`
+	Canceled           int64             `json:"canceled_at"`
+	Created            int64             `json:"created"`
+	Customer           *Customer         `json:"customer"`
+	DaysUntilDue       uint64            `json:"days_until_due"`
+	Discount           *Discount         `json:"discount"`
+	EndCancel          bool              `json:"cancel_at_period_end"`
+	Ended              int64             `json:"ended_at"`
+	FeePercent         float64           `json:"application_fee_percent"`
+	ID                 string            `json:"id"`
+	Items              *SubItemList      `json:"items"`
+	Meta               map[string]string `json:"metadata"`
+	PeriodEnd          int64             `json:"current_period_end"`
+	PeriodStart        int64             `json:"current_period_start"`
+	Plan               *Plan             `json:"plan"`
+	Quantity           uint64            `json:"quantity"`
+	Start              int64             `json:"start"`
+	Status             SubStatus         `json:"status"`
+	TaxPercent         float64           `json:"tax_percent"`
+	TrialEnd           int64             `json:"trial_end"`
+	TrialStart         int64             `json:"trial_start"`
 }
 
 // SubList is a list object for subscriptions.

--- a/sub_test.go
+++ b/sub_test.go
@@ -17,6 +17,14 @@ func TestSubParams_AppendTo(t *testing.T) {
 	}
 
 	{
+		params := &SubParams{BillingCycleAnchorUnchanged: true}
+		body := &form.Values{}
+		form.AppendTo(body, params)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"unchanged"}, body.Get("billing_cycle_anchor"))
+	}
+
+	{
 		params := &SubParams{TrialEndNow: true}
 		body := &form.Values{}
 		form.AppendTo(body, params)


### PR DESCRIPTION
Makes the following changes:

* Adds `BillingCycleAnchorUnchanged` to `SubParams` to support the new
  `unchanged` value for this field.
* Adds `BillingCycleAnchor` to the `Sub` response (which was previously
  not present).

Unfortunately the new fields were just a little bit longer in naming than anything
in there before, so `gofmt` made the diff a bit of a mess. It's much easier to 
view the changes using the "no whitespace" link:

https://github.com/stripe/stripe-go/pull/517/files?w=1

r? @ob-stripe (I'll also ask someone on the Subs team to review as well.)