### PR TITLE
Product and plan support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.4.0
+    - STRIPE_MOCK_VERSION=0.7.0
 
 go:
   - 1.7

--- a/ephemeralkey/client_test.go
+++ b/ephemeralkey/client_test.go
@@ -17,7 +17,7 @@ func TestEphemeralKeyDel(t *testing.T) {
 func TestEphemeralKeyNew(t *testing.T) {
 	key, err := New(&stripe.EphemeralKeyParams{
 		Customer:      "cus_123",
-		StripeVersion: "2017-05-25",
+		StripeVersion: "2018-02-06",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, key)

--- a/example_test.go
+++ b/example_test.go
@@ -90,7 +90,7 @@ func ExamplePlan_list() {
 
 	it := plan.List(params)
 	for it.Next() {
-		log.Printf("%v ", it.Plan().Name)
+		log.Printf("%v ", it.Plan().Nickname)
 	}
 	if err := it.Err(); err != nil {
 		log.Fatal(err)

--- a/plan.go
+++ b/plan.go
@@ -16,8 +16,8 @@ type Plan struct {
 	IntervalCount uint64            `json:"interval_count"`
 	Live          bool              `json:"livemode"`
 	Meta          map[string]string `json:"metadata"`
-	Name          string            `json:"name"`
-	Statement     string            `json:"statement_descriptor"`
+	Nickname      string            `json:"nickname"`
+	Product       string            `json:"product"`
 	TrialPeriod   uint64            `json:"trial_period_days"`
 }
 
@@ -39,13 +39,14 @@ type PlanListParams struct {
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
 	Params        `form:"*"`
-	Amount        uint64       `form:"amount"`
-	AmountZero    bool         `form:"amount,zero"`
-	Currency      Currency     `form:"currency"`
-	ID            string       `form:"id"`
-	Interval      PlanInterval `form:"interval"`
-	IntervalCount uint64       `form:"interval_count"`
-	Name          string       `form:"name"`
-	Statement     string       `form:"statement_descriptor"`
-	TrialPeriod   uint64       `form:"trial_period_days"`
+	Amount        uint64       `  form:"amount"`
+	AmountZero    bool           `form:"amount,zero"`
+	Currency      Currency       `form:"currency"`
+	ID            string         `form:"id"`
+	Interval      PlanInterval   `form:"interval"`
+	IntervalCount uint64         `form:"interval_count"`
+	Nickname      string         `form:"nickname"`
+	Product       *ProductParams `form:"product"`
+	ProductID     *string        `form:"product"`
+	TrialPeriod   uint64         `form:"trial_period_days"`
 }

--- a/plan.go
+++ b/plan.go
@@ -39,7 +39,7 @@ type PlanListParams struct {
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
 	Params        `form:"*"`
-	Amount        uint64       `  form:"amount"`
+	Amount        uint64         `form:"amount"`
 	AmountZero    bool           `form:"amount,zero"`
 	Currency      Currency       `form:"currency"`
 	ID            string         `form:"id"`

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -35,7 +35,23 @@ func TestPlanNew(t *testing.T) {
 		Currency: "usd",
 		ID:       "sapphire-elite",
 		Interval: "month",
-		Name:     "Sapphire Elite",
+		Product: &stripe.ProductParams{
+			Name: "Sapphire Elite",
+			Type: "service",
+		},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, plan)
+}
+
+func TestPlanNewWithProductID(t *testing.T) {
+	productId := "prod_12345abc"
+	plan, err := New(&stripe.PlanParams{
+		Amount:    1,
+		Currency:  "usd",
+		ID:        "sapphire-elite",
+		Interval:  "month",
+		ProductID: &productId,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, plan)
@@ -43,7 +59,7 @@ func TestPlanNew(t *testing.T) {
 
 func TestPlanUpdate(t *testing.T) {
 	plan, err := Update("gold", &stripe.PlanParams{
-		Name: "Updated Name",
+		Nickname: "Updated nickame",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, plan)

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -37,7 +37,7 @@ func TestPlanNew(t *testing.T) {
 		Interval: "month",
 		Product: &stripe.ProductParams{
 			Name: "Sapphire Elite",
-			Type: "service",
+			Type: stripe.ProductTypeService,
 		},
 	})
 	assert.Nil(t, err)

--- a/plan_test.go
+++ b/plan_test.go
@@ -40,9 +40,9 @@ func TestPlanListParams_AppendTo_Empty(t *testing.T) {
 
 func TestPlanParams_AppendTo(t *testing.T) {
 	productParams := ProductParams{
-		Name:      "Sapphire Elite",
-		Statement: "SAPPHIRE",
-		Type:      "service",
+		Name:                "Sapphire Elite",
+		StatementDescriptor: "SAPPHIRE",
+		Type:                ProductTypeService,
 	}
 	productId := "prod_123abc"
 	testCases := []struct {

--- a/plan_test.go
+++ b/plan_test.go
@@ -39,6 +39,12 @@ func TestPlanListParams_AppendTo_Empty(t *testing.T) {
 }
 
 func TestPlanParams_AppendTo(t *testing.T) {
+	productParams := ProductParams{
+		Name:      "Sapphire Elite",
+		Statement: "SAPPHIRE",
+		Type:      "service",
+	}
+	productId := "prod_123abc"
 	testCases := []struct {
 		field  string
 		params *PlanParams
@@ -49,8 +55,9 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		{"id", &PlanParams{ID: "sapphire-elite"}, "sapphire-elite"},
 		{"interval", &PlanParams{Interval: "month"}, "month"},
 		{"interval_count", &PlanParams{IntervalCount: 3}, strconv.FormatUint(3, 10)},
-		{"name", &PlanParams{Name: "Sapphire Elite"}, "Sapphire Elite"},
-		{"statement_descriptor", &PlanParams{Statement: "Sapphire Elite"}, "Sapphire Elite"},
+		{"product[name]", &PlanParams{Product: &productParams}, "Sapphire Elite"},
+		{"product[statement_descriptor]", &PlanParams{Product: &productParams}, "SAPPHIRE"},
+		{"product", &PlanParams{ProductID: &productId}, "prod_123abc"},
 		{"trial_period_days", &PlanParams{TrialPeriod: 123}, strconv.FormatUint(123, 10)},
 	}
 	for _, tc := range testCases {

--- a/product.go
+++ b/product.go
@@ -27,6 +27,8 @@ type ProductParams struct {
 	Name              string             `form:"name"`
 	PackageDimensions *PackageDimensions `form:"package_dimensions"`
 	Shippable         *bool              `form:"shippable"`
+	Statement         string             `form:"statement_descriptor"`
+	Type              string             `form:"type"`
 	URL               string             `form:"url"`
 }
 
@@ -47,8 +49,10 @@ type Product struct {
 	PackageDimensions *PackageDimensions `json:"package_dimensions"`
 	Shippable         bool               `json:"shippable"`
 	Skus              *SKUList           `json:"skus"`
+	Statement         string             `json:"statement_descriptor"`
 	URL               string             `json:"url"`
 	Updated           int64              `json:"updated"`
+	Type              string             `json:"type"`
 }
 
 // ProductList is a list of products as retrieved from a list endpoint.

--- a/product.go
+++ b/product.go
@@ -2,6 +2,19 @@ package stripe
 
 import "encoding/json"
 
+// ProductType is the type of a product.
+type ProductType string
+
+const (
+	// ProductTypeGood is a constant that indicates a product represents a physical good,
+	// which may be sold through the Stripe Relay API.
+	ProductTypeGood ProductType = "good"
+
+	// ProductTypeService is a constant that indicates a product represents a service
+	// which is provided on a recurring basis and is priced with a Stripe plan.
+	ProductTypeService ProductType = "service"
+)
+
 // PackageDimensions represents the dimension of a product or a sku from the
 // perspective of shipping.
 type PackageDimensions struct {
@@ -16,43 +29,43 @@ type PackageDimensions struct {
 // For more details, see https://stripe.com/docs/api#create_product
 // and https://stripe.com/docs/api#update_product.
 type ProductParams struct {
-	Params            `form:"*"`
-	Active            *bool              `form:"active"`
-	Attrs             []string           `form:"attributes"`
-	Caption           string             `form:"caption"`
-	DeactivateOn      []string           `form:"deactivate_on"`
-	Desc              string             `form:"description"`
-	ID                string             `form:"id"`
-	Images            []string           `form:"images"`
-	Name              string             `form:"name"`
-	PackageDimensions *PackageDimensions `form:"package_dimensions"`
-	Shippable         *bool              `form:"shippable"`
-	Statement         string             `form:"statement_descriptor"`
-	Type              string             `form:"type"`
-	URL               string             `form:"url"`
+	Params              `form:"*"`
+	Active              *bool              `form:"active"`
+	Attrs               []string           `form:"attributes"`
+	Caption             string             `form:"caption"`
+	DeactivateOn        []string           `form:"deactivate_on"`
+	Desc                string             `form:"description"`
+	ID                  string             `form:"id"`
+	Images              []string           `form:"images"`
+	Name                string             `form:"name"`
+	PackageDimensions   *PackageDimensions `form:"package_dimensions"`
+	Shippable           *bool              `form:"shippable"`
+	StatementDescriptor string             `form:"statement_descriptor"`
+	Type                ProductType        `form:"type"`
+	URL                 string             `form:"url"`
 }
 
 // Product is the resource representing a Stripe product.
 // For more details see https://stripe.com/docs/api#products.
 type Product struct {
-	Active            bool               `json:"active"`
-	Attrs             []string           `json:"attributes"`
-	Caption           string             `json:"caption"`
-	Created           int64              `json:"created"`
-	DeactivateOn      []string           `json:"deactivate_on"`
-	Desc              string             `json:"description"`
-	ID                string             `json:"id"`
-	Images            []string           `json:"images"`
-	Live              bool               `json:"livemode"`
-	Meta              map[string]string  `json:"metadata"`
-	Name              string             `json:"name"`
-	PackageDimensions *PackageDimensions `json:"package_dimensions"`
-	Shippable         bool               `json:"shippable"`
-	Skus              *SKUList           `json:"skus"`
-	Statement         string             `json:"statement_descriptor"`
-	URL               string             `json:"url"`
-	Updated           int64              `json:"updated"`
-	Type              string             `json:"type"`
+	Active              bool               `json:"active"`
+	Attrs               []string           `json:"attributes"`
+	Caption             string             `json:"caption"`
+	Created             int64              `json:"created"`
+	DeactivateOn        []string           `json:"deactivate_on"`
+	Desc                string             `json:"description"`
+	ID                  string             `json:"id"`
+	Images              []string           `json:"images"`
+	Live                bool               `json:"livemode"`
+	Meta                map[string]string  `json:"metadata"`
+	Name                string             `json:"name"`
+	PackageDimensions   *PackageDimensions `json:"package_dimensions"`
+	Shippable           bool               `json:"shippable"`
+	Skus                *SKUList           `json:"skus"`
+	StatementDescriptor string             `json:"statement_descriptor"`
+	URL                 string             `json:"url"`
+	Updated             int64              `json:"updated"`
+	Type                ProductType        `json:"type"`
 }
 
 // ProductList is a list of products as retrieved from a list endpoint.

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -47,6 +47,7 @@ func TestProductNew(t *testing.T) {
 			Width:  6.50,
 			Weight: 10,
 		},
+		Type: "good",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, product)

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -47,7 +47,7 @@ func TestProductNew(t *testing.T) {
 			Width:  6.50,
 			Weight: 10,
 		},
-		Type: "good",
+		Type: stripe.ProductTypeGood,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, product)


### PR DESCRIPTION
All credit goes to @jhoon-stripe for the original PR: https://github.com/stripe/stripe-go/pull/496

I just rebased and resolved conflicts. From the original PR:

**Summary**
This PR implements upcoming changes to the way in which plan objects are created in the Stripe API. Specifically, it:

- Allows plans to be created with products (with a product ID)
- Allows plans to be created with inline product fields

r? @brandur-stripe @tmaxwell-stripe
cc @stripe/api-libraries