### PR TITLE
update PaymentSource.MarshalJSON to serialize bank accounts too

### DIFF
--- a/paymentsource.go
+++ b/paymentsource.go
@@ -191,6 +191,21 @@ func (s *PaymentSource) MarshalJSON() ([]byte, error) {
 			ID:   s.ID,
 			Type: s.Type,
 		}
+	case PaymentSourceBankAccount:
+		var customerID *string
+		if s.BankAccount.Customer != nil {
+			customerID = &s.BankAccount.Customer.ID
+		}
+
+		target = struct {
+			*BankAccount
+			Customer *string           `json:"customer"`
+			Type     PaymentSourceType `json:"object"`
+		}{
+			BankAccount: s.BankAccount,
+			Customer:    customerID,
+			Type:        s.Type,
+		}
 	case "":
 		target = s.ID
 	}

--- a/paymentsource_test.go
+++ b/paymentsource_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"encoding/json"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -23,5 +24,59 @@ func TestSourceParams_AppendTo(t *testing.T) {
 		t.Logf("body = %+v", body)
 		assert.Equal(t, []string{"4242424242424242"}, body.Get("source[number]"))
 		assert.Equal(t, []string{"card"}, body.Get("source[object]"))
+	}
+}
+
+func TestPaymentSource_MarshalJSON(t *testing.T) {
+	{
+		id := "card_123"
+		name := "alice cooper"
+		paymentSource := &PaymentSource{
+			Type: PaymentSourceCard,
+			ID:   id,
+			Card: &Card{
+				ID:   id,
+				Name: name,
+			},
+		}
+
+		d, err := json.Marshal(paymentSource)
+		assert.NoError(t, err)
+		assert.NotNil(t, d)
+
+		unmarshalled := &PaymentSource{}
+		err = json.Unmarshal(d, unmarshalled)
+		assert.NoError(t, err)
+
+		assert.Equal(t, unmarshalled.ID, id)
+		assert.NotNil(t, unmarshalled.Card)
+		assert.Equal(t, unmarshalled.Card.ID, id)
+		assert.Equal(t, unmarshalled.Card.Name, name)
+	}
+
+	{
+		id := "ba_123"
+		name := "big bank"
+		paymentSource := &PaymentSource{
+			Type: PaymentSourceBankAccount,
+			ID:   id,
+			BankAccount: &BankAccount{
+				ID:   id,
+				Name: name,
+			},
+		}
+
+		d, err := json.Marshal(paymentSource)
+		assert.NoError(t, err)
+		assert.NotNil(t, d)
+
+		unmarshalled := &PaymentSource{}
+		err = json.Unmarshal(d, unmarshalled)
+		assert.NoError(t, err)
+
+		assert.Equal(t, unmarshalled.ID, id)
+		assert.NotNil(t, unmarshalled.BankAccount)
+		assert.Equal(t, unmarshalled.BankAccount.ID, id)
+		assert.Equal(t, unmarshalled.BankAccount.Name, name)
 	}
 }


### PR DESCRIPTION
This pull request fixes serialization for `PaymentSourceBankAccount`.  `PaymentSource` has a  `MarshalJSON` implementation with custom behavior based on type but there was no implementation for type  `PaymentSourceBankAccount` so bank accounts were being serialized as `null`.