### PR TITLE
Add support for /v1/topups endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.7.0
+    - STRIPE_MOCK_VERSION=0.8.0
 
 go:
   - 1.7

--- a/topup.go
+++ b/topup.go
@@ -1,0 +1,53 @@
+package stripe
+
+// TopupParams is the set of parameters that can be used when creating or updating a top-up.
+// For more details see https://stripe.com/docs/api#create_topup and https://stripe.com/docs/api#update_topup.
+type TopupParams struct {
+	Params    `form:"*"`
+	Amount    uint64        `form:"amount"`
+	Currency  Currency      `form:"currency"`
+	Desc      string        `form:"description"`
+	Source    *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	Statement string        `form:"statement_descriptor"`
+}
+
+// SetSource adds valid sources to a TopupParams object,
+// returning an error for unsupported sources.
+func (p *TopupParams) SetSource(sp interface{}) error {
+	source, err := SourceParamsFor(sp)
+	p.Source = source
+	return err
+}
+
+// TopupListParams is the set of parameters that can be used when listing top-ups.
+// For more details see https://stripe.com/docs/api#list_topups.
+type TopupListParams struct {
+	ListParams   `form:"*"`
+	Created      int64             `form:"created"`
+	CreatedRange *RangeQueryParams `form:"created"`
+}
+
+// TopupList is a list of top-ups as retrieved from a list endpoint.
+type TopupList struct {
+	ListMeta
+	Values []*Topup `json:"data"`
+}
+
+// Topup is the resource representing a Stripe top-up.
+// For more details see https://stripe.com/docs/api#topups.
+type Topup struct {
+	Amount                   uint64         `json:"amount"`
+	ArrivalDate              int64          `json:"arrival_date"`
+	Created                  int64          `json:"created"`
+	Currency                 Currency       `json:"currency"`
+	Desc                     string         `json:"description"`
+	ExpectedAvailabilityDate int64          `json:"expected_availability_date"`
+	FailCode                 string         `json:"failure_code"`
+	FailMsg                  string         `json:"failure_message"`
+	ID                       string         `json:"id"`
+	Live                     bool           `json:"livemode"`
+	Source                   *PaymentSource `json:"source"`
+	Statement                string         `json:"statement_descriptor"`
+	Status                   string         `json:"status"`
+	Tx                       *Transaction   `json:"balance_transaction"`
+}

--- a/topup/client.go
+++ b/topup/client.go
@@ -1,0 +1,114 @@
+package topup
+
+import (
+	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
+)
+
+// Client is used to invoke /topups APIs.
+type Client struct {
+	B   stripe.Backend
+	Key string
+}
+
+// New POSTs new topups.
+// For more details see https://stripe.com/docs/api#create_topup.
+func New(params *stripe.TopupParams) (*stripe.Topup, error) {
+	return getC().New(params)
+}
+
+func (c Client) New(params *stripe.TopupParams) (*stripe.Topup, error) {
+	body := &form.Values{}
+	form.AppendTo(body, params)
+
+	topup := &stripe.Topup{}
+	err := c.B.Call("POST", "/topups", c.Key, body, &params.Params, topup)
+
+	return topup, err
+}
+
+// Get returns the details of a topup.
+// For more details see https://stripe.com/docs/api#retrieve_topup.
+func Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
+	return getC().Get(id, params)
+}
+
+func (c Client) Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
+	var body *form.Values
+	var commonParams *stripe.Params
+
+	if params != nil {
+		commonParams = &params.Params
+		body = &form.Values{}
+		form.AppendTo(body, params)
+	}
+
+	topup := &stripe.Topup{}
+	err := c.B.Call("GET", "/topups/"+id, c.Key, body, commonParams, topup)
+
+	return topup, err
+}
+
+// Update updates a topup's properties.
+// For more details see https://stripe.com/docs/api#update_topup.
+func Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
+	return getC().Update(id, params)
+}
+
+func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
+	var body *form.Values
+	var commonParams *stripe.Params
+
+	if params != nil {
+		commonParams = &params.Params
+		body = &form.Values{}
+		form.AppendTo(body, params)
+	}
+
+	topup := &stripe.Topup{}
+	err := c.B.Call("POST", "/topups/"+id, c.Key, body, commonParams, topup)
+
+	return topup, err
+}
+
+// List returns a list of topups.
+// For more details see https://stripe.com/docs/api#list_topups.
+func List(params *stripe.TopupListParams) *Iter {
+	return getC().List(params)
+}
+
+func (c Client) List(params *stripe.TopupListParams) *Iter {
+	var body *form.Values
+	var lp *stripe.ListParams
+	var p *stripe.Params
+
+	if params != nil {
+		body = &form.Values{}
+		form.AppendTo(body, params)
+		lp = &params.ListParams
+		p = params.ToParams()
+	}
+
+	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+		list := &stripe.TopupList{}
+		err := c.B.Call("GET", "/topups", c.Key, b, p, list)
+
+		ret := make([]interface{}, len(list.Values))
+		for i, v := range list.Values {
+			ret[i] = v
+		}
+
+		return ret, list.ListMeta, err
+	})}
+}
+
+// Iter is an iterator for lists of Topups.
+// The embedded Iter carries methods with it;
+// see its documentation for details.
+type Iter struct {
+	*stripe.Iter
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
+}

--- a/topup/client_test.go
+++ b/topup/client_test.go
@@ -1,0 +1,49 @@
+package topup
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go"
+	_ "github.com/stripe/stripe-go/testing"
+)
+
+func TestTopupGet(t *testing.T) {
+	topup, err := Get("tu_123", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, topup)
+}
+
+func TestTopupNew(t *testing.T) {
+	topup, err := New(&stripe.TopupParams{
+		Amount:    123,
+		Currency:  "usd",
+		Source:    &stripe.SourceParams{Token: "src_123"},
+		Desc:      "creating a topup",
+		Statement: "topup",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, topup)
+}
+
+func TestTopupNew_WithSetSource(t *testing.T) {
+	params := stripe.TopupParams{
+		Amount:    123,
+		Currency:  "usd",
+		Desc:      "creating a topup",
+		Statement: "topup",
+	}
+	params.SetSource("src_123")
+
+	topup, err := New(&params)
+	assert.Nil(t, err)
+	assert.NotNil(t, topup)
+}
+
+func TestTopupUpdate(t *testing.T) {
+	params := &stripe.TopupParams{}
+	params.AddMeta("key", "value")
+	topup, err := Update("tu_123", params)
+	assert.Nil(t, err)
+	assert.NotNil(t, topup)
+}


### PR DESCRIPTION
This add standard retrieve, create and update client support for the new `/v1/topups` endpoint.

r? @apakulov-stripe @ccontinanza-stripe @chellman-stripe @kenneth-stripe @miguel-stripe 