### PR TITLE
Fix latest version to properly support Product in plans

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -39,14 +39,24 @@ type PlanListParams struct {
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
 	Params        `form:"*"`
-	Amount        uint64         `form:"amount"`
-	AmountZero    bool           `form:"amount,zero"`
-	Currency      Currency       `form:"currency"`
-	ID            string         `form:"id"`
-	Interval      PlanInterval   `form:"interval"`
-	IntervalCount uint64         `form:"interval_count"`
-	Nickname      string         `form:"nickname"`
-	Product       *ProductParams `form:"product"`
-	ProductID     *string        `form:"product"`
-	TrialPeriod   uint64         `form:"trial_period_days"`
+	Amount        uint64             `form:"amount"`
+	AmountZero    bool               `form:"amount,zero"`
+	Currency      Currency           `form:"currency"`
+	ID            string             `form:"id"`
+	Interval      PlanInterval       `form:"interval"`
+	IntervalCount uint64             `form:"interval_count"`
+	Nickname      string             `form:"nickname"`
+	Product       *PlanProductParams `form:"product"`
+	ProductID     *string            `form:"product"`
+	TrialPeriod   uint64             `form:"trial_period_days"`
+}
+
+// PlanProductParams is the set of parameters that can be used when creating a product inside a plan
+// This can only be used on plan creation and won't work on plan update.
+// For more details see https://stripe.com/docs/api#create_plan-product and https://stripe.com/docs/api#update_plan-product
+type PlanProductParams struct {
+	ID                  string            `form:"id"`
+	Name                string            `form:"name"`
+	Meta                map[string]string `form:"metadata"`
+	StatementDescriptor string            `form:"statement_descriptor"`
 }

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -35,9 +35,10 @@ func TestPlanNew(t *testing.T) {
 		Currency: "usd",
 		ID:       "sapphire-elite",
 		Interval: "month",
-		Product: &stripe.ProductParams{
-			Name: "Sapphire Elite",
-			Type: stripe.ProductTypeService,
+		Product: &stripe.PlanProductParams{
+			ID:                  "plan_id",
+			Name:                "Sapphire Elite",
+			StatementDescriptor: "statement descriptor",
 		},
 	})
 	assert.Nil(t, err)

--- a/plan_test.go
+++ b/plan_test.go
@@ -39,10 +39,10 @@ func TestPlanListParams_AppendTo_Empty(t *testing.T) {
 }
 
 func TestPlanParams_AppendTo(t *testing.T) {
-	productParams := ProductParams{
+	productParams := PlanProductParams{
+		ID:                  "ID",
 		Name:                "Sapphire Elite",
 		StatementDescriptor: "SAPPHIRE",
-		Type:                ProductTypeService,
 	}
 	productId := "prod_123abc"
 	testCases := []struct {
@@ -55,6 +55,7 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		{"id", &PlanParams{ID: "sapphire-elite"}, "sapphire-elite"},
 		{"interval", &PlanParams{Interval: "month"}, "month"},
 		{"interval_count", &PlanParams{IntervalCount: 3}, strconv.FormatUint(3, 10)},
+		{"product[id]", &PlanParams{Product: &productParams}, "ID"},
 		{"product[name]", &PlanParams{Product: &productParams}, "Sapphire Elite"},
 		{"product[statement_descriptor]", &PlanParams{Product: &productParams}, "SAPPHIRE"},
 		{"product", &PlanParams{ProductID: &productId}, "prod_123abc"},

--- a/stripe.go
+++ b/stripe.go
@@ -26,7 +26,7 @@ const (
 )
 
 // apiversion is the currently supported API version
-const apiversion = "2017-05-25"
+const apiversion = "2018-02-06"
 
 // clientversion is the binding version
 const clientversion = "29.0.1"


### PR DESCRIPTION
This ensures that you can create plans with the latest API version. We had 2 separate bugs:
* re-using `ProductParams` meant that you could pass invalid parameters when creating a product inside a plan (such as Type which is unsupported).
* not properly enforcing the latest API version which means all requests are currently failing.

This is a breaking change **but** it fixes what we broke in 29.0 so it's likely a better fit for 29.0.2 but unsure.

r? @brandur-stripe 
cc @stripe/api-libraries 