### PR TITLE
Support shipping carrier and tracking number in orders

### DIFF
--- a/order.go
+++ b/order.go
@@ -46,9 +46,11 @@ type OrderReturnParams struct {
 }
 
 type Shipping struct {
-	Address Address `json:"address"`
-	Name    string  `json:"name"`
-	Phone   string  `json:"phone"`
+	Address        Address `json:"address"`
+	Name           string  `json:"name"`
+	Phone          string  `json:"phone"`
+	Carrier        string  `json:"carrier"`
+	TrackingNumber string  `json:"tracking_number"`
 }
 
 type ShippingMethod struct {

--- a/order.go
+++ b/order.go
@@ -35,8 +35,8 @@ type OrderUpdateParams struct {
 	Params                 `form:"*"`
 	Coupon                 string                     `form:"coupon"`
 	SelectedShippingMethod string                     `form:"selected_shipping_method"`
-	Status                 OrderStatus                `form:"status"`
 	Shipping               *OrderUpdateShippingParams `form:"shipping"`
+	Status                 OrderStatus                `form:"status"`
 }
 
 type OrderUpdateShippingParams struct {
@@ -53,9 +53,9 @@ type OrderReturnParams struct {
 
 type Shipping struct {
 	Address        Address `json:"address"`
+	Carrier        string  `json:"carrier"`
 	Name           string  `json:"name"`
 	Phone          string  `json:"phone"`
-	Carrier        string  `json:"carrier"`
 	TrackingNumber string  `json:"tracking_number"`
 }
 

--- a/order.go
+++ b/order.go
@@ -33,9 +33,15 @@ type ShippingParams struct {
 
 type OrderUpdateParams struct {
 	Params                 `form:"*"`
-	Coupon                 string      `form:"coupon"`
-	SelectedShippingMethod string      `form:"selected_shipping_method"`
-	Status                 OrderStatus `form:"status"`
+	Coupon                 string                     `form:"coupon"`
+	SelectedShippingMethod string                     `form:"selected_shipping_method"`
+	Status                 OrderStatus                `form:"status"`
+	Shipping               *OrderUpdateShippingParams `form:"shipping"`
+}
+
+type OrderUpdateShippingParams struct {
+	Carrier        string `form:"carrier"`
+	TrackingNumber string `form:"tracking_number"`
 }
 
 // OrderReturnParams is the set of parameters that can be used when returning

--- a/order_test.go
+++ b/order_test.go
@@ -1,0 +1,43 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestShipping_MarshalJSON(t *testing.T) {
+	{
+		shipping := &Shipping{
+			Name:           "name",
+			Phone:          "phone",
+			Carrier:        "USPS",
+			TrackingNumber: "tracking.123",
+			Address: Address{
+				Line1:   "123 Market Street",
+				City:    "San Francisco",
+				State:   "CA",
+				Country: "USA",
+			},
+		}
+
+		d, err := json.Marshal(shipping)
+		assert.NoError(t, err)
+		assert.NotNil(t, d)
+
+		unmarshalled := &Shipping{}
+		err = json.Unmarshal(d, unmarshalled)
+		assert.NoError(t, err)
+
+		assert.Equal(t, unmarshalled.Name, shipping.Name)
+		assert.Equal(t, unmarshalled.Phone, shipping.Phone)
+		assert.Equal(t, unmarshalled.Carrier, shipping.Carrier)
+		assert.Equal(t, unmarshalled.TrackingNumber, shipping.TrackingNumber)
+		assert.NotNil(t, unmarshalled.Address)
+		assert.Equal(t, unmarshalled.Address.Line1, shipping.Address.Line1)
+		assert.Equal(t, unmarshalled.Address.City, shipping.Address.City)
+		assert.Equal(t, unmarshalled.Address.State, shipping.Address.State)
+		assert.Equal(t, unmarshalled.Address.Country, shipping.Address.Country)
+	}
+}

--- a/order_test.go
+++ b/order_test.go
@@ -5,7 +5,20 @@ import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/form"
 )
+
+func TestOrderUpdateParams_AppendTo(t *testing.T) {
+	{
+		params := &OrderUpdateParams{Status: "fulfilled", Shipping: &OrderUpdateShippingParams{Carrier: "USPS", TrackingNumber: "123"}}
+		body := &form.Values{}
+		form.AppendTo(body, params)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"fulfilled"}, body.Get("status"))
+		assert.Equal(t, []string{"USPS"}, body.Get("shipping[carrier]"))
+		assert.Equal(t, []string{"123"}, body.Get("shipping[tracking_number]"))
+	}
+}
 
 func TestShipping_MarshalJSON(t *testing.T) {
 	{


### PR DESCRIPTION
This PR addresses missing functionality related to shipping attributes of an order.

* The `Shipping` struct was missing attributes for `carrier` and `tracking_number`.

* The `OrderUpdateParams` struct did not allow the shipping carrier or tracking number to be updated. You can workaround it using `AddExtra` but we might as well have typed support for these values.