### PR TITLE
Add missing MaidenName, PersonalID, PersonalIDProvided fields to Owner

### DIFF
--- a/account.go
+++ b/account.go
@@ -342,11 +342,14 @@ type Gender string
 
 // Owner is the structure for an account owner.
 type Owner struct {
-	Address      Address              `json:"address" form:"address"`
-	DOB          DOB                  `json:"dob" form:"dob"`
-	First        string               `json:"first_name" form:"first_name"`
-	Last         string               `json:"last_name" form:"last_name"`
-	Verification IdentityVerification `json:"verification" form:"verification"`
+	Address            Address              `json:"address" form:"address"`
+	DOB                DOB                  `json:"dob" form:"dob"`
+	First              string               `json:"first_name" form:"first_name"`
+	Last               string               `json:"last_name" form:"last_name"`
+	MaidenName         string               `json:"maiden_name" form:"maiden_name"`
+	PersonalID         string               `json:"-" form:"personal_id_number"`
+	PersonalIDProvided bool                 `json:"personal_id_number_provided" form:"-"`
+	Verification       IdentityVerification `json:"verification" form:"verification"`
 }
 
 // IdentityVerification is the structure for an account's verification.

--- a/account.go
+++ b/account.go
@@ -342,14 +342,14 @@ type Gender string
 
 // Owner is the structure for an account owner.
 type Owner struct {
-	Address            Address              `json:"address" form:"address"`
-	DOB                DOB                  `json:"dob" form:"dob"`
-	First              string               `json:"first_name" form:"first_name"`
-	Last               string               `json:"last_name" form:"last_name"`
-	MaidenName         string               `json:"maiden_name" form:"maiden_name"`
-	PersonalID         string               `json:"-" form:"personal_id_number"`
-	PersonalIDProvided bool                 `json:"personal_id_number_provided" form:"-"`
-	Verification       IdentityVerification `json:"verification" form:"verification"`
+	Address                  Address              `json:"address" form:"address"`
+	DOB                      DOB                  `json:"dob" form:"dob"`
+	First                    string               `json:"first_name" form:"first_name"`
+	Last                     string               `json:"last_name" form:"last_name"`
+	MaidenName               string               `json:"maiden_name" form:"maiden_name"`
+	PersonalIDNumber         string               `json:"-" form:"personal_id_number"`
+	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided" form:"-"`
+	Verification             IdentityVerification `json:"verification" form:"verification"`
 }
 
 // IdentityVerification is the structure for an account's verification.


### PR DESCRIPTION
I noticed there are some fields missing on the [Owner type](https://github.com/stripe/stripe-go/blob/master/account.go#L344-L350) that are defined in the API documentation.

- maiden_name
- personal_id_number
- personal_id_number_provided

This PR adds those fields to the Owner type.