### PR TITLE
Change Transfer.DestPayment from string to *Charge

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -45,7 +45,7 @@ type Transfer struct {
 	Created        int64               `json:"created"`
 	Currency       Currency            `json:"currency"`
 	Dest           TransferDestination `json:"destination"`
-	DestPayment    string              `json:"destination_payment"`
+	DestPayment    *Charge             `json:"destination_payment"`
 	ID             string              `json:"id"`
 	Live           bool                `json:"livemode"`
 	Meta           map[string]string   `json:"metadata"`


### PR DESCRIPTION
This change allows an expanded `transfer.destination_payment` to be accessed via the `DestPayment` field.

It is a small breaking change to the API.