### PR TITLE
allow AmountZero in InvoiceItemParams

### DIFF
--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -7,6 +7,7 @@ import "encoding/json"
 type InvoiceItemParams struct {
 	Params         `form:"*"`
 	Amount         int64    `form:"amount"`
+	AmountZero     bool     `form:"amount,zero"`
 	Currency       Currency `form:"currency"`
 	Customer       string   `form:"customer"`
 	Desc           string   `form:"description"`


### PR DESCRIPTION
After updating to recent version I can't make invoiceitems with zero amount (it was possible untill introducing `form` package in v26.0.0). This fix is similar to https://github.com/stripe/stripe-go/pull/516