### PR TITLE
Add const for redirect flow status "not_required"

### DIFF
--- a/source.go
+++ b/source.go
@@ -122,9 +122,10 @@ const (
 type RedirectFlowStatus string
 
 const (
-	RedirectFlowStatusFailed    RedirectFlowStatus = "failed"
-	RedirectFlowStatusPending   RedirectFlowStatus = "pending"
-	RedirectFlowStatusSucceeded RedirectFlowStatus = "succeeded"
+	RedirectFlowStatusFailed      RedirectFlowStatus = "failed"
+	RedirectFlowStatusNotRequired RedirectFlowStatus = "not_required"
+	RedirectFlowStatusPending     RedirectFlowStatus = "pending"
+	RedirectFlowStatusSucceeded   RedirectFlowStatus = "succeeded"
 )
 
 // ReceiverFlow informs of the state of a redirect authentication flow.


### PR DESCRIPTION
This PR adds the missing const definition for the "not_required" redirect flow status that was added in API version 2017-08-15.