### PR TITLE
Add support for mandate property on Source objects

### DIFF
--- a/source.go
+++ b/source.go
@@ -189,6 +189,20 @@ type CodeVerificationFlow struct {
 	Status            CodeVerificationFlowStatus `json:"status"`
 }
 
+type SourceMandateAcceptance struct {
+	Date      string `json:"date"`
+	IP        string `json:"ip"`
+	Status    string `json:"status"`
+	UserAgent string `json:"user_agent"`
+}
+
+type SourceMandate struct {
+	Acceptance         SourceMandateAcceptance `json:"acceptance"`
+	NotificationMethod string                  `json:"notification_method"`
+	Reference          string                  `json:"reference"`
+	URL                string                  `json:"url"`
+}
+
 type Source struct {
 	Amount              int64                 `json:"amount"`
 	ClientSecret        string                `json:"client_secret"`
@@ -198,6 +212,7 @@ type Source struct {
 	Flow                SourceFlow            `json:"flow"`
 	ID                  string                `json:"id"`
 	Live                bool                  `json:"livemode"`
+	Mandate             SourceMandate         `json:"mandate"`
 	Meta                map[string]string     `json:"metadata"`
 	Owner               SourceOwner           `json:"owner"`
 	Receiver            *ReceiverFlow         `json:"receiver,omitempty"`


### PR DESCRIPTION
Add support for the `mandate` property on the Source object. Currently only used for SEPA debits as far as I can tell. I could not add tests as stripe-mock does not return such a resource today.

This fixes https://github.com/stripe/stripe-go/issues/540

cc @stripe/api-libraries 
r? @ob-stripe 