### PR TITLE
Run file upload tests against stripe-mock

### DIFF
--- a/fileupload/client_test.go
+++ b/fileupload/client_test.go
@@ -17,16 +17,13 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	_ "github.com/stripe/stripe-go/testing"
 )
 
 const (
 	expectedSize int64 = 734
 	expectedType       = "pdf"
 )
-
-func init() {
-	stripe.Key = "tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I"
-}
 
 func TestFileUploadNewThenGet(t *testing.T) {
 	t.Skip("File uploads are currently unreliable")

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -55,11 +55,17 @@ func init() {
 	}
 
 	stripe.Key = "sk_test_myTestKey"
-	stripe.SetBackend("api", &stripe.BackendConfiguration{
+
+	// Configure a backend for stripe-mock and set it for both the API and
+	// Uploads (unlike the real Stripe API, stripe-mock supports both these
+	// backends).
+	stripeMockBackend := &stripe.BackendConfiguration{
 		Type:       stripe.APIBackend,
 		URL:        "http://localhost:" + port + "/v1",
 		HTTPClient: &http.Client{},
-	})
+	}
+	stripe.SetBackend(stripe.APIBackend, stripeMockBackend)
+	stripe.SetBackend(stripe.UploadsBackend, stripeMockBackend)
 }
 
 // compareVersions compares two semantic version strings. We need this because


### PR DESCRIPTION
Stripe-mock now supports file uploads, so do the same thing that we did
for the rest of the API and set a backend for it that hits stripe-mock
instead of the live API.

cc @stripe/api-libraries 