### PR TITLE
Fix some parameters being sent in tests

### DIFF
--- a/account/client_test.go
+++ b/account/client_test.go
@@ -78,8 +78,6 @@ func TestAccountReject(t *testing.T) {
 
 func TestAccountUpdate(t *testing.T) {
 	account, err := Update("acct_123", &stripe.AccountParams{
-		Type:    stripe.AccountTypeCustom,
-		Country: "CA",
 		LegalEntity: &stripe.LegalEntity{
 			Address: stripe.Address{
 				Country: "CA",

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -67,7 +67,6 @@ func TestBankAccountNew_ByAccount(t *testing.T) {
 func TestBankAccountNew_ByCustomer(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
 		Customer: "cus_123",
-		Default:  true,
 		Token:    "tok_123",
 	})
 	assert.Nil(t, err)
@@ -85,8 +84,8 @@ func TestBankAccountUpdate_ByAccount(t *testing.T) {
 
 func TestBankAccountUpdate_ByCustomer(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
-		Customer: "cus_123",
-		Default:  true,
+		AccountHolderName: "New Name",
+		Customer:          "cus_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -66,7 +66,7 @@ func TestCardNew_RequiresParams(t *testing.T) {
 func TestCardUpdate(t *testing.T) {
 	card, err := Update("card_123", &stripe.CardParams{
 		Customer: "cus_123",
-		Default:  true,
+		Name:     "New Name",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -42,7 +42,11 @@ func TestCouponNew(t *testing.T) {
 
 func TestCouponUpdate(t *testing.T) {
 	coupon, err := Update("25OFF", &stripe.CouponParams{
-		Redemptions: 5,
+		Params: stripe.Params{
+			Meta: map[string]string{
+				"foo": "bar",
+			},
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -42,9 +42,6 @@ func TestSourceUpdate(t *testing.T) {
 	params := &stripe.CustomerSourceParams{
 		Customer: "cus_123",
 	}
-	params.SetSource(&stripe.CardParams{
-		Name: "Updated Name",
-	})
 
 	source, err := Update("card_123", params)
 	assert.Nil(t, err)

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -32,9 +32,10 @@ func TestSubList(t *testing.T) {
 
 func TestSubNew(t *testing.T) {
 	subscription, err := New(&stripe.SubParams{
-		Customer:           "cus_123",
-		Plan:               "plan_123",
-		Quantity:           10,
+		Customer: "cus_123",
+		Items: []*stripe.SubItemsParams{
+			{Plan: "plan_123", Quantity: 10},
+		},
 		TaxPercent:         20.0,
 		BillingCycleAnchor: time.Now().AddDate(0, 0, 12).Unix(),
 		Billing:            "send_invoice",
@@ -61,7 +62,6 @@ func TestSubNew_WithItems(t *testing.T) {
 func TestSubUpdate(t *testing.T) {
 	subscription, err := Update("sub_123", &stripe.SubParams{
 		NoProrate:      true,
-		QuantityZero:   true,
 		TaxPercentZero: true,
 	})
 	assert.Nil(t, err)


### PR DESCRIPTION
I found a bug recently in stripe-mock which causes it not to actually be
validating that parameters not in the spec are not being sent (the
actual Stripe API does check for this).

After applying a fix, I found that stripe-go's test suite no longer
passes against it, and the reason is that there are some subtle mistakes
throughout. This patch corrects them to be in line with what the API
actually expects.

cc @stripe/api-libraries