### PR TITLE
Add subscription_item to InvoiceLine

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -125,6 +125,7 @@ type InvoiceLine struct {
 	Proration    bool              `json:"proration"`
 	Quantity     int64             `json:"quantity"`
 	Sub          string            `json:"subscription"`
+	SubItem      string            `json:"subscription_item"`
 	Type         InvoiceLineType   `json:"type"`
 }
 


### PR DESCRIPTION
My application has a function that can remove specific, metered items from a subscription before the end of a billing period, and since not all items were being removed, we had to set `ClearUsage: true` even though we need to bill the customer for their usage to-date. Thus we needed a way to calculate the costs of those items which are being removed (by previewing the invoice) so we can perform a one-time charge to cover their usage to-date. And creating the SubItemsParams to delete the specific items required knowing the subscription item ID, which _is_ returned with a call to invoice.GetNext, it just wasn't unmarshalled into a struct because there was no struct field for it.

Phew, anyway, here I present the one-line change that adds a missing field to the struct so we have the information we need to perform the task. 😅 