### PR TITLE
Remi rename properties use pointers and strings on params types

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Below are a few simple examples:
 
 ```go
 params := &stripe.CustomerParams{
-	Balance: -123,
-	Desc:  "Stripe Developer",
-	Email: "gostripe@stripe.com",
+	Balance: stripe.Int64(-123),
+	Description:  stripe.String("Stripe Developer"),
+	Email: stripe.String("gostripe@stripe.com"),
 }
 params.SetSource("tok_1234")
 
@@ -62,7 +62,7 @@ customer, err := customer.New(params)
 ### Charges
 
 ```go
-params := &stripe.ChargeListParams{Customer: customer.ID}
+params := &stripe.ChargeListParams{Customer: stripe.String(customer.ID)}
 params.Filters.AddFilter("include[]", "", "total_count")
 
 // set this so you can easily retry your request in case of a timeout
@@ -103,17 +103,19 @@ of a connected account, one that uses the `Stripe-Account` header containing an
 account's ID, and one that uses the account's keys. Usually the former is the
 recommended approach. [See the documentation for more information][connect].
 
-To use the `Stripe-Account` approach, pass the `StripeAccount` field to a
-`ListParams` or `Params` class. For example:
+To use the `Stripe-Account` approach, use `SetStripeAccount()` on a `ListParams`
+or `Params` class. For example:
 
 ```go
 // For a list request
-listParams := &stripe.ChargeListParams{StripeAccount: merchantID}
+listParams := &stripe.ChargeListParams{}
+listParams.SetStripeAccount("acct_123")
 ```
 
 ```go
 // For any other kind of request
-params := &stripe.CustomerParams{StripeAccount: merchantID}
+params := &stripe.CustomerParams{}
+params.SetStripeAccount("acct_123")
 ```
 
 To use a key, pass it to `API`'s `Init` function:

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ i := event.List(nil)
 for i.Next() {
 	e := i.Event()
 
-	// access event data via e.GetObjValue("resource_name_based_on_type", "resource_property_name")
-	// alternatively you can access values via e.Data.Obj["resource_name_based_on_type"].(map[string]interface{})["resource_property_name"]
+	// access event data via e.GetObjectValue("resource_name_based_on_type", "resource_property_name")
+	// alternatively you can access values via e.Data.Object["resource_name_based_on_type"].(map[string]interface{})["resource_property_name"]
 
-	// access previous attributes via e.GetPrevValue("resource_name_based_on_type", "resource_property_name")
-	// alternatively you can access values via e.Data.Prev["resource_name_based_on_type"].(map[string]interface{})["resource_property_name"]
+	// access previous attributes via e.GetPreviousValue("resource_name_based_on_type", "resource_property_name")
+	// alternatively you can access values via e.Data.PrevPreviousAttributes["resource_name_based_on_type"].(map[string]interface{})["resource_property_name"]
 }
 ```
 

--- a/account.go
+++ b/account.go
@@ -66,13 +66,12 @@ type AccountParams struct {
 	BusinessPrimaryColor      string                        `form:"business_primary_color"`
 	BusinessURL               string                        `form:"business_url"`
 	Country                   string                        `form:"country"`
-	DebitNegativeBalances     bool                          `form:"debit_negative_balances"`
+	DebitNegativeBalances     *bool                         `form:"debit_negative_balances"`
 	DefaultCurrency           string                        `form:"default_currency"`
 	Email                     string                        `form:"email"`
 	ExternalAccount           *AccountExternalAccountParams `form:"external_account"`
 	FromRecipient             string                        `form:"from_recipient"`
 	LegalEntity               *LegalEntity                  `form:"legal_entity"`
-	NoDebitNegativeBalances   bool                          `form:"debit_negative_balances,invert"`
 	PayoutSchedule            *PayoutScheduleParams         `form:"payout_schedule"`
 	PayoutStatementDescriptor string                        `form:"payout_statement_descriptor"`
 	ProductDescription        string                        `form:"product_description"`
@@ -116,15 +115,15 @@ func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []st
 
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
-	DelayDays     uint64   `form:"delay_days"`
-	Interval      Interval `form:"interval"`
-	MinimumDelay  bool     `form:"-"` // See custom AppendTo
-	MonthlyAnchor uint64   `form:"monthly_anchor"`
-	WeeklyAnchor  string   `form:"weekly_anchor"`
+	DelayDays        uint64   `form:"delay_days"`
+	DelayDaysMinimum *bool    `form:"-"` // See custom AppendTo
+	Interval         Interval `form:"interval"`
+	MonthlyAnchor    uint64   `form:"monthly_anchor"`
+	WeeklyAnchor     string   `form:"weekly_anchor"`
 }
 
 func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
-	if p.MinimumDelay {
+	if BoolValue(p.DelayDaysMinimum) {
 		body.Add(form.FormatKey(append(keyParts, "delay_days")), "minimum")
 	}
 }

--- a/account.go
+++ b/account.go
@@ -400,9 +400,9 @@ type AccountAddress struct {
 
 // DOB is a structure for an account owner's date of birth.
 type DOB struct {
-	Day   int `json:"day"`
-	Month int `json:"month"`
-	Year  int `json:"year"`
+	Day   int64 `json:"day"`
+	Month int64 `json:"month"`
+	Year  int64 `json:"year"`
 }
 
 // Gender is the gender of an account owner. International regulations require

--- a/account.go
+++ b/account.go
@@ -6,57 +6,52 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
+// AccountType is the type of an account.
+type AccountType string
+
+const (
+	AccountTypeCustom   AccountType = "custom"
+	AccountTypeExpress  AccountType = "express"
+	AccountTypeStandard AccountType = "standard"
+)
+
+// ExternalAccountType is the type of an external account.
+type ExternalAccountType string
+
+const (
+	ExternalAccountTypeBankAccount ExternalAccountType = "bank_account"
+	ExternalAccountTypeCard        ExternalAccountType = "card"
+)
+
 // LegalEntityType describes the types for a legal entity.
-// Allowed values are "individual", "company".
 type LegalEntityType string
 
+const (
+	LegalEntityTypeCompany    LegalEntityType = "company"
+	LegalEntityTypeIndividual LegalEntityType = "individual"
+)
+
 // IdentityVerificationDetailsCode is a machine-readable code specifying the
-// verification state of a legal entity. Allowed values are
-// "failed_keyed_identity", "failed_other", "scan_corrupt",
-// "scan_failed_greyscale", "scan_failed_other",
-// "scan_id_country_not_supported", "scan_id_type_not_supported",
-// "scan_name_mismatch", "scan_not_readable", "scan_not_uploaded".
+// verification state of a legal entity
 type IdentityVerificationDetailsCode string
 
 // IdentityVerificationStatus describes the different statuses for identity verification.
-// Allowed values are "pending", "verified", "unverified".
 type IdentityVerificationStatus string
 
+const (
+	IdentityVerificationStatusPending    IdentityVerificationStatus = "pending"
+	IdentityVerificationStatusUnverified IdentityVerificationStatus = "unverified"
+	IdentityVerificationStatusVerified   IdentityVerificationStatus = "verified"
+)
+
 // Interval describes the payout interval.
-// Allowed values are "manual", "daily", "weekly", "monthly".
-type Interval string
+type PayoutInterval string
 
 const (
-	// Company is a constant value representing a company legal entity type.
-	Company LegalEntityType = "company"
-
-	// Day is a constant value representing a daily payout interval.
-	Day Interval = "daily"
-
-	// Individual is a constant value representing an individual legal entity
-	// type.
-	Individual LegalEntityType = "individual"
-
-	// IdentityVerificationPending is a constant value indicating that identity
-	// verification status is pending.
-	IdentityVerificationPending IdentityVerificationStatus = "pending"
-
-	// IdentityVerificationUnverified is a constant value indicating that
-	// identity verification status is unverified.
-	IdentityVerificationUnverified IdentityVerificationStatus = "unverified"
-
-	// IdentityVerificationVerified is a constant value indicating that
-	// identity verification status is verified.
-	IdentityVerificationVerified IdentityVerificationStatus = "verified"
-
-	// Manual is a constant value representing a manual payout interval.
-	Manual Interval = "manual"
-
-	// Monthly is a constant value representing a monthly payout interval.
-	Monthly Interval = "monthly"
-
-	// Weekly is a constant value representing a weekly payout interval.
-	Weekly Interval = "weekly"
+	PayoutIntervalDay     PayoutInterval = "daily"
+	PayoutIntervalManual  PayoutInterval = "manual"
+	PayoutIntervalMonthly PayoutInterval = "monthly"
+	PayoutIntervalWeekly  PayoutInterval = "weekly"
 )
 
 // AccountParams are the parameters allowed during account creation/updates.
@@ -274,33 +269,6 @@ func (a *Account) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// ExternalAccountType is the type of an external account.
-type ExternalAccountType string
-
-const (
-	// ExternalAccountTypeBankAccount is a constant value representing an external
-	// account which is a bank account.
-	ExternalAccountTypeBankAccount ExternalAccountType = "bank_account"
-
-	// ExternalAccountTypeCard is a constant value representing an external account
-	// which is a card.
-	ExternalAccountTypeCard ExternalAccountType = "card"
-)
-
-// AccountType is the type of an account.
-type AccountType string
-
-const (
-	// AccountTypeCustom is a constant value representing an account of type custom.
-	AccountTypeCustom AccountType = "custom"
-
-	// AccountTypeExpress is a constant value representing an account of type express.
-	AccountTypeExpress AccountType = "express"
-
-	// AccountTypeStandard is a constant value representing an account of type standard.
-	AccountTypeStandard AccountType = "standard"
-)
-
 // AccountList is a list of accounts as returned from a list endpoint.
 type AccountList struct {
 	ListMeta
@@ -329,7 +297,7 @@ type ExternalAccount struct {
 	// account is a card.
 	Card *Card
 
-	ID   string              `json:"id"`
+	ID   string `json:"id"`
 	Type ExternalAccountType `json:"object"`
 }
 
@@ -369,7 +337,7 @@ type LegalEntity struct {
 	FirstName                string               `json:"first_name"`
 	FirstNameKana            string               `json:"first_name_kana"`
 	FirstNameKanji           string               `json:"first_name_kanji"`
-	Gender                   Gender               `json:"gender"`
+	Gender                   string               `json:"gender"`
 	LastName                 string               `json:"last_name"`
 	LastNameKana             string               `json:"last_name_kana"`
 	LastNameKanji            string               `json:"last_name_kanji"`
@@ -405,19 +373,15 @@ type DOB struct {
 	Year  int64 `json:"year"`
 }
 
-// Gender is the gender of an account owner. International regulations require
-// either “male” or “female”.
-type Gender string
-
 // AdditionalOwner is the structure for an account owner.
 type AdditionalOwner struct {
-	Address                  AccountAddress       `json:"address"`
-	DOB                      DOB                  `json:"dob"`
-	FirstName                string               `json:"first_name"`
-	LastName                 string               `json:"last_name"`
-	MaidenName               string               `json:"maiden_name"`
-	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided"`
-	Verification             IdentityVerification `json:"verification"`
+	Address                  AccountAddress `json:"address"`
+	DOB                      DOB            `json:"dob"`
+	FirstName                string         `json:"first_name"`
+	LastName                 string         `json:"last_name"`
+	MaidenName               string         `json:"maiden_name"`
+	PersonalIDNumberProvided bool           `json:"personal_id_number_provided"`
+	Verification             string         `json:"verification"`
 }
 
 // IdentityVerification is the structure for an account's verification.
@@ -430,10 +394,10 @@ type IdentityVerification struct {
 
 // PayoutSchedule is the structure for an account's payout schedule.
 type PayoutSchedule struct {
-	DelayDays     int64    `json:"delay_days"`
-	Interval      Interval `json:"interval"`
-	MonthlyAnchor int64    `json:"monthly_anchor"`
-	WeeklyAnchor  string   `json:"weekly_anchor"`
+	DelayDays     int64          `json:"delay_days"`
+	Interval      PayoutInterval `json:"interval"`
+	MonthlyAnchor int64          `json:"monthly_anchor"`
+	WeeklyAnchor  string         `json:"weekly_anchor"`
 }
 
 // AccountRejectParams is the structure for the Reject function.

--- a/account.go
+++ b/account.go
@@ -134,9 +134,9 @@ type AccountAddressParams struct {
 
 // DOBParams represents a DOB during account creation/updates.
 type DOBParams struct {
-	Day   *int `form:"day"`
-	Month *int `form:"month"`
-	Year  *int `form:"year"`
+	Day   *int64 `form:"day"`
+	Month *int64 `form:"month"`
+	Year  *int64 `form:"year"`
 }
 
 // TOSAcceptanceParams represents tos_acceptance during account creation/updates.
@@ -194,10 +194,10 @@ func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []st
 
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
-	DelayDays        *uint64 `form:"delay_days"`
+	DelayDays        *int64  `form:"delay_days"`
 	DelayDaysMinimum *bool   `form:"-"` // See custom AppendTo
 	Interval         *string `form:"interval"`
-	MonthlyAnchor    *uint64 `form:"monthly_anchor"`
+	MonthlyAnchor    *int64  `form:"monthly_anchor"`
 	WeeklyAnchor     *string `form:"weekly_anchor"`
 }
 
@@ -454,9 +454,9 @@ func (d *IdentityDocument) AppendTo(body *form.Values, keyParts []string) {
 
 // PayoutSchedule is the structure for an account's payout schedule.
 type PayoutSchedule struct {
-	DelayDays     uint64   `json:"delay_days"`
+	DelayDays     int64    `json:"delay_days"`
 	Interval      Interval `json:"interval"`
-	MonthlyAnchor uint64   `json:"monthly_anchor"`
+	MonthlyAnchor int64    `json:"monthly_anchor"`
 	WeeklyAnchor  string   `json:"weekly_anchor"`
 }
 

--- a/account.go
+++ b/account.go
@@ -98,7 +98,7 @@ type LegalEntityParams struct {
 	BusinessNameKana     *string                     `form:"business_name_kana"`
 	BusinessNameKanji    *string                     `form:"business_name_kanji"`
 	BusinessTaxID        *string                     `form:"business_tax_id"`
-	BusinessVatID        *string                     `form:"business_vat_id"`
+	BusinessVATID        *string                     `form:"business_vat_id"`
 	DOB                  *DOBParams                  `form:"dob"`
 	FirstName            *string                     `form:"first_name"`
 	FirstNameKana        *string                     `form:"first_name_kana"`
@@ -364,7 +364,7 @@ type LegalEntity struct {
 	BusinessNameKana         string               `json:"business_name_kana"`
 	BusinessNameKanji        string               `json:"business_name_kanji"`
 	BusinessTaxIDProvided    bool                 `json:"business_tax_id_provided"`
-	BusinessVatIDProvided    bool                 `json:"business_vat_id_provided"`
+	BusinessVATIDProvided    bool                 `json:"business_vat_id_provided"`
 	DOB                      DOB                  `json:"dob"`
 	FirstName                string               `json:"first_name"`
 	FirstNameKana            string               `json:"first_name_kana"`

--- a/account.go
+++ b/account.go
@@ -62,25 +62,104 @@ const (
 // AccountParams are the parameters allowed during account creation/updates.
 type AccountParams struct {
 	Params                    `form:"*"`
-	BusinessName              string                        `form:"business_name"`
-	BusinessPrimaryColor      string                        `form:"business_primary_color"`
-	BusinessURL               string                        `form:"business_url"`
-	Country                   string                        `form:"country"`
+	BusinessName              *string                       `form:"business_name"`
+	BusinessPrimaryColor      *string                       `form:"business_primary_color"`
+	BusinessURL               *string                       `form:"business_url"`
+	Country                   *string                       `form:"country"`
 	DebitNegativeBalances     *bool                         `form:"debit_negative_balances"`
-	DefaultCurrency           string                        `form:"default_currency"`
-	Email                     string                        `form:"email"`
+	DefaultCurrency           *string                       `form:"default_currency"`
+	Email                     *string                       `form:"email"`
 	ExternalAccount           *AccountExternalAccountParams `form:"external_account"`
-	FromRecipient             string                        `form:"from_recipient"`
-	LegalEntity               *LegalEntity                  `form:"legal_entity"`
+	FromRecipient             *string                       `form:"from_recipient"`
+	LegalEntity               *LegalEntityParams            `form:"legal_entity"`
 	PayoutSchedule            *PayoutScheduleParams         `form:"payout_schedule"`
-	PayoutStatementDescriptor string                        `form:"payout_statement_descriptor"`
-	ProductDescription        string                        `form:"product_description"`
-	StatementDescriptor       string                        `form:"statement_descriptor"`
-	SupportEmail              string                        `form:"support_email"`
-	SupportPhone              string                        `form:"support_phone"`
-	SupportURL                string                        `form:"support_url"`
+	PayoutStatementDescriptor *string                       `form:"payout_statement_descriptor"`
+	ProductDescription        *string                       `form:"product_description"`
+	StatementDescriptor       *string                       `form:"statement_descriptor"`
+	SupportEmail              *string                       `form:"support_email"`
+	SupportPhone              *string                       `form:"support_phone"`
+	SupportURL                *string                       `form:"support_url"`
 	TOSAcceptance             *TOSAcceptanceParams          `form:"tos_acceptance"`
-	Type                      AccountType                   `form:"type"`
+	Type                      *string                       `form:"type"`
+}
+
+// LegalEntityParams represents a legal_entity during account creation/updates.
+type LegalEntityParams struct {
+	AdditionalOwners []AdditionalOwnerParams `form:"additional_owners,indexed"`
+
+	// AdditionalOwnersEmpty can be set to clear a legal entity's additional
+	// owners.
+	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
+
+	Address              *AccountAddressParams       `form:"address"`
+	AddressKana          *AccountAddressParams       `form:"address_kana"`
+	AddressKanji         *AccountAddressParams       `form:"address_kanji"`
+	BusinessName         *string                     `form:"business_name"`
+	BusinessNameKana     *string                     `form:"business_name_kana"`
+	BusinessNameKanji    *string                     `form:"business_name_kanji"`
+	BusinessTaxID        *string                     `form:"business_tax_id"`
+	BusinessVatID        *string                     `form:"business_vat_id"`
+	DOB                  *DOBParams                  `form:"dob"`
+	FirstName            *string                     `form:"first_name"`
+	FirstNameKana        *string                     `form:"first_name_kana"`
+	FirstNameKanji       *string                     `form:"first_name_kanji"`
+	Gender               *string                     `form:"gender"`
+	LastName             *string                     `form:"last_name"`
+	LastNameKana         *string                     `form:"last_name_kana"`
+	LastNameKanji        *string                     `form:"last_name_kanji"`
+	MaidenName           *string                     `form:"maiden_name"`
+	PersonalAddress      *AccountAddressParams       `form:"personal_address"`
+	PersonalAddressKana  *AccountAddressParams       `form:"personal_address_kana"`
+	PersonalAddressKanji *AccountAddressParams       `form:"personal_address_kanji"`
+	PersonalIDNumber     *string                     `form:"personal_id_number"`
+	PhoneNumber          *string                     `form:"phone_number"`
+	SSNLast4             *string                     `form:"ssn_last_4"`
+	Type                 *string                     `form:"type"`
+	Verification         *IdentityVerificationParams `form:"verification"`
+}
+
+// AccountAddressParams represents an address during account creation/updates.
+type AccountAddressParams struct {
+	City       *string `form:"city"`
+	Country    *string `form:"country"`
+	Line1      *string `form:"line1"`
+	Line2      *string `form:"line2"`
+	PostalCode *string `form:"postal_code"`
+	State      *string `form:"state"`
+
+	// Town/cho-me. Note that this is only used for Kana/Kanji representations
+	// of an address.
+	Town *string `form:"town"`
+}
+
+// DOBParams represents a DOB during account creation/updates.
+type DOBParams struct {
+	Day   *int `form:"day"`
+	Month *int `form:"month"`
+	Year  *int `form:"year"`
+}
+
+// TOSAcceptanceParams represents tos_acceptance during account creation/updates.
+type TOSAcceptanceParams struct {
+	Date      *int64  `form:"date"`
+	IP        *string `form:"ip"`
+	UserAgent *string `form:"user_agent"`
+}
+
+// AdditionalOwnerParams represents an additional owner during account creation/updates.
+type AdditionalOwnerParams struct {
+	Address          *AccountAddressParams       `form:"address"`
+	DOB              *DOBParams                  `form:"dob"`
+	FirstName        *string                     `form:"first_name"`
+	LastName         *string                     `form:"last_name"`
+	MaidenName       *string                     `form:"maiden_name"`
+	PersonalIDNumber *string                     `form:"personal_id_number"`
+	Verification     *IdentityVerificationParams `form:"verification"`
+}
+
+// IdentityVerification represents a verification during account creation/updates.
+type IdentityVerificationParams struct {
+	Document *IdentityDocument `form:"document"`
 }
 
 // AccountListParams are the parameters allowed during account listing.
@@ -93,21 +172,21 @@ type AccountListParams struct {
 // or everything else.
 type AccountExternalAccountParams struct {
 	Params            `form:"*"`
-	AccountNumber     string `form:"account_number"`
-	AccountHolderName string `form:"account_holder_name"`
-	AccountHolderType string `form:"account_holder_type"`
-	Country           string `form:"country"`
-	Currency          string `form:"currency"`
-	RoutingNumber     string `form:"routing_number"`
-	Token             string `form:"token"`
+	AccountNumber     *string `form:"account_number"`
+	AccountHolderName *string `form:"account_holder_name"`
+	AccountHolderType *string `form:"account_holder_type"`
+	Country           *string `form:"country"`
+	Currency          *string `form:"currency"`
+	RoutingNumber     *string `form:"routing_number"`
+	Token             *string `form:"token"`
 }
 
 // AppendTo implements custom encoding logic for AccountExternalAccountParams
 // so that we can send the special required `object` field up along with the
 // other specified parameters or the token value
 func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []string) {
-	if len(p.Token) > 0 {
-		body.Add(form.FormatKey(keyParts), p.Token)
+	if p.Token != nil {
+		body.Add(form.FormatKey(keyParts), StringValue(p.Token))
 	} else {
 		body.Add(form.FormatKey(append(keyParts, "object")), "bank_account")
 	}
@@ -115,11 +194,11 @@ func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []st
 
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
-	DelayDays        uint64   `form:"delay_days"`
-	DelayDaysMinimum *bool    `form:"-"` // See custom AppendTo
-	Interval         Interval `form:"interval"`
-	MonthlyAnchor    uint64   `form:"monthly_anchor"`
-	WeeklyAnchor     string   `form:"weekly_anchor"`
+	DelayDays        *uint64 `form:"delay_days"`
+	DelayDaysMinimum *bool   `form:"-"` // See custom AppendTo
+	Interval         *string `form:"interval"`
+	MonthlyAnchor    *uint64 `form:"monthly_anchor"`
+	WeeklyAnchor     *string `form:"weekly_anchor"`
 }
 
 func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
@@ -146,8 +225,8 @@ type Account struct {
 	ID                    string               `json:"id"`
 
 	Keys *struct {
-		Publish string `json:"publishable"`
-		Secret  string `json:"secret"`
+		Publishable string `json:"publishable"`
+		Secret      string `json:"secret"`
 	} `json:"keys"`
 
 	LegalEntity               *LegalEntity      `json:"legal_entity"`
@@ -170,7 +249,7 @@ type Account struct {
 		UserAgent string `json:"user_agent"`
 	} `json:"tos_acceptance"`
 
-	Type AccountType
+	Type AccountType `json:"type"`
 
 	Verification *struct {
 		DisabledReason string   `json:"disabled_reason"`
@@ -277,62 +356,53 @@ func (ea *ExternalAccount) UnmarshalJSON(b []byte) error {
 
 // LegalEntity is the structure for properties related to an account's legal state.
 type LegalEntity struct {
-	AdditionalOwners []AdditionalOwner `json:"additional_owners" form:"additional_owners,indexed"`
-
-	// AdditionalOwnersEmpty can be set to clear a legal entity's additional
-	// owners.
-	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
-
-	Address                  Address              `json:"address" form:"address"`
-	AddressKana              Address              `json:"address_kana" form:"address_kana"`
-	AddressKanji             Address              `json:"address_kanji" form:"address_kanji"`
-	BusinessName             string               `json:"business_name" form:"business_name"`
-	BusinessNameKana         string               `json:"business_name_kana" form:"business_name_kana"`
-	BusinessNameKanji        string               `json:"business_name_kanji" form:"business_name_kanji"`
-	BusinessTaxID            string               `json:"-" form:"business_tax_id"`
-	BusinessTaxIDProvided    bool                 `json:"business_tax_id_provided" form:"-"`
-	BusinessVatID            string               `json:"-" form:"business_vat_id"`
-	BusinessVatIDProvided    bool                 `json:"business_vat_id_provided" form:"-"`
-	DOB                      DOB                  `json:"dob" form:"dob"`
-	FirstName                string               `json:"first_name" form:"first_name"`
-	FirstNameKana            string               `json:"first_name_kana" form:"first_name_kana"`
-	FirstNameKanji           string               `json:"first_name_kanji" form:"first_name_kanji"`
-	Gender                   Gender               `json:"gender" form:"gender"`
-	LastName                 string               `json:"last_name" form:"last_name"`
-	LastNameKana             string               `json:"last_name_kana" form:"last_name_kana"`
-	LastNameKanji            string               `json:"last_name_kanji" form:"last_name_kanji"`
-	MaidenName               string               `json:"maiden_name" form:"maiden_name"`
-	PersonalAddress          Address              `json:"personal_address" form:"personal_address"`
-	PersonalAddressKana      Address              `json:"personal_address_kana" form:"personal_address_kana"`
-	PersonalAddressKanji     Address              `json:"personal_address_kanji" form:"personal_address_kanji"`
-	PersonalIDNumber         string               `json:"-" form:"personal_id_number"`
-	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided" form:"-"`
-	PhoneNumber              string               `json:"phone_number" form:"phone_number"`
-	SSNLast4                 string               `json:"-" form:"ssn_last_4"`
-	SSNLast4Provided         bool                 `json:"ssn_last_4_provided" form:"-"`
-	Type                     LegalEntityType      `json:"type" form:"type"`
-	Verification             IdentityVerification `json:"verification" form:"verification"`
+	AdditionalOwners         []AdditionalOwner    `json:"additional_owners"`
+	Address                  AccountAddress       `json:"address"`
+	AddressKana              AccountAddress       `json:"address_kana"`
+	AddressKanji             AccountAddress       `json:"address_kanji"`
+	BusinessName             string               `json:"business_name"`
+	BusinessNameKana         string               `json:"business_name_kana"`
+	BusinessNameKanji        string               `json:"business_name_kanji"`
+	BusinessTaxIDProvided    bool                 `json:"business_tax_id_provided"`
+	BusinessVatIDProvided    bool                 `json:"business_vat_id_provided"`
+	DOB                      DOB                  `json:"dob"`
+	FirstName                string               `json:"first_name"`
+	FirstNameKana            string               `json:"first_name_kana"`
+	FirstNameKanji           string               `json:"first_name_kanji"`
+	Gender                   Gender               `json:"gender"`
+	LastName                 string               `json:"last_name"`
+	LastNameKana             string               `json:"last_name_kana"`
+	LastNameKanji            string               `json:"last_name_kanji"`
+	MaidenName               string               `json:"maiden_name"`
+	PersonalAddress          AccountAddress       `json:"personal_address"`
+	PersonalAddressKana      AccountAddress       `json:"personal_address_kana"`
+	PersonalAddressKanji     AccountAddress       `json:"personal_address_kanji"`
+	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided"`
+	PhoneNumber              string               `json:"phone_number"`
+	SSNLast4Provided         bool                 `json:"ssn_last_4_provided"`
+	Type                     LegalEntityType      `json:"type"`
+	Verification             IdentityVerification `json:"verification"`
 }
 
 // Address is the structure for an account address.
-type Address struct {
-	City       string `json:"city" form:"city"`
-	Country    string `json:"country" form:"country"`
-	Line1      string `json:"line1" form:"line1"`
-	Line2      string `json:"line2" form:"line2"`
-	PostalCode string `json:"postal_code" form:"postal_code"`
-	State      string `json:"state" form:"state"`
+type AccountAddress struct {
+	City       string `json:"city"`
+	Country    string `json:"country"`
+	Line1      string `json:"line1"`
+	Line2      string `json:"line2"`
+	PostalCode string `json:"postal_code"`
+	State      string `json:"state"`
 
 	// Town/cho-me. Note that this is only used for Kana/Kanji representations
 	// of an address.
-	Town string `json:"town" form:"town"`
+	Town string `json:"town"`
 }
 
 // DOB is a structure for an account owner's date of birth.
 type DOB struct {
-	Day   int `json:"day" form:"day"`
-	Month int `json:"month" form:"month"`
-	Year  int `json:"year" form:"year"`
+	Day   int `json:"day"`
+	Month int `json:"month"`
+	Year  int `json:"year"`
 }
 
 // Gender is the gender of an account owner. International regulations require
@@ -341,22 +411,21 @@ type Gender string
 
 // AdditionalOwner is the structure for an account owner.
 type AdditionalOwner struct {
-	Address                  Address              `json:"address" form:"address"`
-	DOB                      DOB                  `json:"dob" form:"dob"`
-	FirstName                string               `json:"first_name" form:"first_name"`
-	LastName                 string               `json:"last_name" form:"last_name"`
-	MaidenName               string               `json:"maiden_name" form:"maiden_name"`
-	PersonalIDNumber         string               `json:"-" form:"personal_id_number"`
-	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided" form:"-"`
-	Verification             IdentityVerification `json:"verification" form:"verification"`
+	Address                  AccountAddress       `json:"address"`
+	DOB                      DOB                  `json:"dob"`
+	FirstName                string               `json:"first_name"`
+	LastName                 string               `json:"last_name"`
+	MaidenName               string               `json:"maiden_name"`
+	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided"`
+	Verification             IdentityVerification `json:"verification"`
 }
 
 // IdentityVerification is the structure for an account's verification.
 type IdentityVerification struct {
-	Details     *string                         `json:"details" form:"-"`
-	DetailsCode IdentityVerificationDetailsCode `json:"details_code" form:"-"`
-	Document    *IdentityDocument               `json:"document" form:"document"`
-	Status      IdentityVerificationStatus      `json:"status" form:"-"`
+	Details     *string                         `json:"details"`
+	DetailsCode IdentityVerificationDetailsCode `json:"details_code"`
+	Document    *IdentityDocument               `json:"document"`
+	Status      IdentityVerificationStatus      `json:"status"`
 }
 
 // IdentityDocument is the structure for an identity document.
@@ -385,24 +454,17 @@ func (d *IdentityDocument) AppendTo(body *form.Values, keyParts []string) {
 
 // PayoutSchedule is the structure for an account's payout schedule.
 type PayoutSchedule struct {
-	DelayDays     uint64   `json:"delay_days" form:"delay_days"`
-	Interval      Interval `json:"interval" form:"interval"`
-	MonthlyAnchor uint64   `json:"monthly_anchor" form:"monthly_anchor"`
-	WeeklyAnchor  string   `json:"weekly_anchor" form:"weekly_anchor"`
-}
-
-// TOSAcceptanceParams is the structure for TOS acceptance.
-type TOSAcceptanceParams struct {
-	Date      int64  `json:"date" form:"date"`
-	IP        string `json:"ip" form:"ip"`
-	UserAgent string `json:"user_agent" form:"user_agent"`
+	DelayDays     uint64   `json:"delay_days"`
+	Interval      Interval `json:"interval"`
+	MonthlyAnchor uint64   `json:"monthly_anchor"`
+	WeeklyAnchor  string   `json:"weekly_anchor"`
 }
 
 // AccountRejectParams is the structure for the Reject function.
 type AccountRejectParams struct {
 	// Reason is the reason that an account was rejected. It should be given a
 	// value of one of `fraud`, `terms_of_service`, or `other`.
-	Reason string `json:"reason" form:"reason"`
+	Reason *string `form:"reason"`
 }
 
 // UnmarshalJSON handles deserialization of an IdentityDocument.

--- a/account.go
+++ b/account.go
@@ -52,35 +52,36 @@ const (
 	// Manual is a constant value representing a manual payout interval.
 	Manual Interval = "manual"
 
-	// Month is a constant value representing a monthly payout interval.
-	Month Interval = "monthly"
+	// Monthly is a constant value representing a monthly payout interval.
+	Monthly Interval = "monthly"
 
-	// Week is a constant value representing a weekly payout interval.
-	Week Interval = "weekly"
+	// Weekly is a constant value representing a weekly payout interval.
+	Weekly Interval = "weekly"
 )
 
 // AccountParams are the parameters allowed during account creation/updates.
 type AccountParams struct {
-	Params               `form:"*"`
-	BusinessName         string                        `form:"business_name"`
-	BusinessPrimaryColor string                        `form:"business_primary_color"`
-	BusinessUrl          string                        `form:"business_url"`
-	Country              string                        `form:"country"`
-	DebitNegativeBal     bool                          `form:"debit_negative_balances"`
-	DefaultCurrency      string                        `form:"default_currency"`
-	Email                string                        `form:"email"`
-	ExternalAccount      *AccountExternalAccountParams `form:"external_account"`
-	FromRecipient        string                        `form:"from_recipient"`
-	LegalEntity          *LegalEntity                  `form:"legal_entity"`
-	NoDebitNegativeBal   bool                          `form:"debit_negative_balances,invert"`
-	PayoutSchedule       *PayoutScheduleParams         `form:"payout_schedule"`
-	PayoutStatement      string                        `form:"payout_statement_descriptor"`
-	Statement            string                        `form:"statement_descriptor"`
-	SupportEmail         string                        `form:"support_email"`
-	SupportPhone         string                        `form:"support_phone"`
-	SupportUrl           string                        `form:"support_url"`
-	TOSAcceptance        *TOSAcceptanceParams          `form:"tos_acceptance"`
-	Type                 AccountType                   `form:"type"`
+	Params                    `form:"*"`
+	BusinessName              string                        `form:"business_name"`
+	BusinessPrimaryColor      string                        `form:"business_primary_color"`
+	BusinessURL               string                        `form:"business_url"`
+	Country                   string                        `form:"country"`
+	DebitNegativeBalances     bool                          `form:"debit_negative_balances"`
+	DefaultCurrency           string                        `form:"default_currency"`
+	Email                     string                        `form:"email"`
+	ExternalAccount           *AccountExternalAccountParams `form:"external_account"`
+	FromRecipient             string                        `form:"from_recipient"`
+	LegalEntity               *LegalEntity                  `form:"legal_entity"`
+	NoDebitNegativeBalances   bool                          `form:"debit_negative_balances,invert"`
+	PayoutSchedule            *PayoutScheduleParams         `form:"payout_schedule"`
+	PayoutStatementDescriptor string                        `form:"payout_statement_descriptor"`
+	ProductDescription        string                        `form:"product_description"`
+	StatementDescriptor       string                        `form:"statement_descriptor"`
+	SupportEmail              string                        `form:"support_email"`
+	SupportPhone              string                        `form:"support_phone"`
+	SupportURL                string                        `form:"support_url"`
+	TOSAcceptance             *TOSAcceptanceParams          `form:"tos_acceptance"`
+	Type                      AccountType                   `form:"type"`
 }
 
 // AccountListParams are the parameters allowed during account listing.
@@ -93,12 +94,12 @@ type AccountListParams struct {
 // or everything else.
 type AccountExternalAccountParams struct {
 	Params            `form:"*"`
-	Account           string `form:"account_number"`
+	AccountNumber     string `form:"account_number"`
 	AccountHolderName string `form:"account_holder_name"`
 	AccountHolderType string `form:"account_holder_type"`
 	Country           string `form:"country"`
 	Currency          string `form:"currency"`
-	Routing           string `form:"routing_number"`
+	RoutingNumber     string `form:"routing_number"`
 	Token             string `form:"token"`
 }
 
@@ -115,11 +116,11 @@ func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []st
 
 // PayoutScheduleParams are the parameters allowed for payout schedules.
 type PayoutScheduleParams struct {
-	Delay        uint64   `form:"delay_days"`
-	Interval     Interval `form:"interval"`
-	MinimumDelay bool     `form:"-"` // See custom AppendTo
-	MonthAnchor  uint64   `form:"monthly_anchor"`
-	WeekAnchor   string   `form:"weekly_anchor"`
+	DelayDays     uint64   `form:"delay_days"`
+	Interval      Interval `form:"interval"`
+	MinimumDelay  bool     `form:"-"` // See custom AppendTo
+	MonthlyAnchor uint64   `form:"monthly_anchor"`
+	WeeklyAnchor  string   `form:"weekly_anchor"`
 }
 
 func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
@@ -131,38 +132,38 @@ func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
 // Account is the resource representing your Stripe account.
 // For more details see https://stripe.com/docs/api/#account.
 type Account struct {
-	BusinessLogo         string               `json:"business_logo"`
-	BusinessName         string               `json:"business_name"`
-	BusinessPrimaryColor string               `json:"business_primary_color"`
-	BusinessUrl          string               `json:"business_url"`
-	ChargesEnabled       bool                 `json:"charges_enabled"`
-	Country              string               `json:"country"`
-	DebitNegativeBal     bool                 `json:"debit_negative_balances"`
-	DefaultCurrency      string               `json:"default_currency"`
-	Deleted              bool                 `json:"deleted"`
-	DetailsSubmitted     bool                 `json:"details_submitted"`
-	Email                string               `json:"email"`
-	ExternalAccounts     *ExternalAccountList `json:"external_accounts"`
-	ID                   string               `json:"id"`
+	BusinessLogo          string               `json:"business_logo"`
+	BusinessName          string               `json:"business_name"`
+	BusinessPrimaryColor  string               `json:"business_primary_color"`
+	BusinessURL           string               `json:"business_url"`
+	ChargesEnabled        bool                 `json:"charges_enabled"`
+	Country               string               `json:"country"`
+	DebitNegativeBalances bool                 `json:"debit_negative_balances"`
+	DefaultCurrency       string               `json:"default_currency"`
+	Deleted               bool                 `json:"deleted"`
+	DetailsSubmitted      bool                 `json:"details_submitted"`
+	Email                 string               `json:"email"`
+	ExternalAccounts      *ExternalAccountList `json:"external_accounts"`
+	ID                    string               `json:"id"`
 
 	Keys *struct {
 		Publish string `json:"publishable"`
 		Secret  string `json:"secret"`
 	} `json:"keys"`
 
-	LegalEntity     *LegalEntity      `json:"legal_entity"`
-	Meta            map[string]string `json:"metadata"`
-	Name            string            `json:"display_name"`
-	PayoutSchedule  *PayoutSchedule   `json:"payout_schedule"`
-	PayoutStatement string            `json:"payout_statement_descriptor"`
-	PayoutsEnabled  bool              `json:"payouts_enabled"`
-	ProductDesc     string            `json:"product_description"`
-	Statement       string            `json:"statement_descriptor"`
-	SupportAddress  *Address          `json:"support_address"`
-	SupportEmail    string            `json:"support_email"`
-	SupportPhone    string            `json:"support_phone"`
-	SupportUrl      string            `json:"support_url"`
-	Timezone        string            `json:"timezone"`
+	LegalEntity               *LegalEntity      `json:"legal_entity"`
+	Metadata                  map[string]string `json:"metadata"`
+	DisplayName               string            `json:"display_name"`
+	PayoutSchedule            *PayoutSchedule   `json:"payout_schedule"`
+	PayoutStatementDescriptor string            `json:"payout_statement_descriptor"`
+	PayoutsEnabled            bool              `json:"payouts_enabled"`
+	ProductDescription        string            `json:"product_description"`
+	StatementDescriptor       string            `json:"statement_descriptor"`
+	SupportAddress            *Address          `json:"support_address"`
+	SupportEmail              string            `json:"support_email"`
+	SupportPhone              string            `json:"support_phone"`
+	SupportURL                string            `json:"support_url"`
+	Timezone                  string            `json:"timezone"`
 
 	TOSAcceptance *struct {
 		Date      int64  `json:"date"`
@@ -174,8 +175,8 @@ type Account struct {
 
 	Verification *struct {
 		DisabledReason string   `json:"disabled_reason"`
-		Due            *int64   `json:"due_by"`
-		Fields         []string `json:"fields_needed"`
+		DueBy          *int64   `json:"due_by"`
+		FieldsNeeded   []string `json:"fields_needed"`
 	} `json:"verification"`
 }
 
@@ -225,7 +226,7 @@ const (
 // AccountList is a list of accounts as returned from a list endpoint.
 type AccountList struct {
 	ListMeta
-	Values []*Account `json:"data"`
+	Data []*Account `json:"data"`
 }
 
 // ExternalAccountList is a list of external accounts that may be either bank
@@ -235,7 +236,7 @@ type ExternalAccountList struct {
 
 	// Values contains any external accounts (bank accounts and/or cards)
 	// currently attached to this account.
-	Values []*ExternalAccount `json:"data"`
+	Data []*ExternalAccount `json:"data"`
 }
 
 // ExternalAccount is an external account (a bank account or card) that's
@@ -277,56 +278,55 @@ func (ea *ExternalAccount) UnmarshalJSON(b []byte) error {
 
 // LegalEntity is the structure for properties related to an account's legal state.
 type LegalEntity struct {
-	AdditionalOwners []Owner `json:"additional_owners" form:"additional_owners,indexed"`
+	AdditionalOwners []AdditionalOwner `json:"additional_owners" form:"additional_owners,indexed"`
 
 	// AdditionalOwnersEmpty can be set to clear a legal entity's additional
 	// owners.
 	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
 
-	Address               Address              `json:"address" form:"address"`
-	AddressKana           Address              `json:"address_kana" form:"address_kana"`
-	AddressKanji          Address              `json:"address_kanji" form:"address_kanji"`
-	BusinessName          string               `json:"business_name" form:"business_name"`
-	BusinessNameKana      string               `json:"business_name_kana" form:"business_name_kana"`
-	BusinessNameKanji     string               `json:"business_name_kanji" form:"business_name_kanji"`
-	BusinessTaxID         string               `json:"-" form:"business_tax_id"`
-	BusinessTaxIDProvided bool                 `json:"business_tax_id_provided" form:"-"`
-	BusinessVatID         string               `json:"-" form:"business_vat_id"`
-	BusinessVatIDProvided bool                 `json:"business_vat_id_provided" form:"-"`
-	DOB                   DOB                  `json:"dob" form:"dob"`
-	First                 string               `json:"first_name" form:"first_name"`
-	FirstKana             string               `json:"first_name_kana" form:"first_name_kana"`
-	FirstKanji            string               `json:"first_name_kanji" form:"first_name_kanji"`
-	Gender                Gender               `json:"gender" form:"gender"`
-	Last                  string               `json:"last_name" form:"last_name"`
-	LastKana              string               `json:"last_name_kana" form:"last_name_kana"`
-	LastKanji             string               `json:"last_name_kanji" form:"last_name_kanji"`
-	MaidenName            string               `json:"maiden_name" form:"maiden_name"`
-	PersonalAddress       Address              `json:"personal_address" form:"personal_address"`
-	PersonalAddressKana   Address              `json:"personal_address_kana" form:"personal_address_kana"`
-	PersonalAddressKanji  Address              `json:"personal_address_kanji" form:"personal_address_kanji"`
-	PersonalID            string               `json:"-" form:"personal_id_number"`
-	PersonalIDProvided    bool                 `json:"personal_id_number_provided" form:"-"`
-	PhoneNumber           string               `json:"phone_number" form:"phone_number"`
-	SSN                   string               `json:"-" form:"ssn_last_4"`
-	SSNProvided           bool                 `json:"ssn_last_4_provided" form:"-"`
-	Type                  LegalEntityType      `json:"type" form:"type"`
-	Verification          IdentityVerification `json:"verification" form:"verification"`
+	Address                  Address              `json:"address" form:"address"`
+	AddressKana              Address              `json:"address_kana" form:"address_kana"`
+	AddressKanji             Address              `json:"address_kanji" form:"address_kanji"`
+	BusinessName             string               `json:"business_name" form:"business_name"`
+	BusinessNameKana         string               `json:"business_name_kana" form:"business_name_kana"`
+	BusinessNameKanji        string               `json:"business_name_kanji" form:"business_name_kanji"`
+	BusinessTaxID            string               `json:"-" form:"business_tax_id"`
+	BusinessTaxIDProvided    bool                 `json:"business_tax_id_provided" form:"-"`
+	BusinessVatID            string               `json:"-" form:"business_vat_id"`
+	BusinessVatIDProvided    bool                 `json:"business_vat_id_provided" form:"-"`
+	DOB                      DOB                  `json:"dob" form:"dob"`
+	FirstName                string               `json:"first_name" form:"first_name"`
+	FirstNameKana            string               `json:"first_name_kana" form:"first_name_kana"`
+	FirstNameKanji           string               `json:"first_name_kanji" form:"first_name_kanji"`
+	Gender                   Gender               `json:"gender" form:"gender"`
+	LastName                 string               `json:"last_name" form:"last_name"`
+	LastNameKana             string               `json:"last_name_kana" form:"last_name_kana"`
+	LastNameKanji            string               `json:"last_name_kanji" form:"last_name_kanji"`
+	MaidenName               string               `json:"maiden_name" form:"maiden_name"`
+	PersonalAddress          Address              `json:"personal_address" form:"personal_address"`
+	PersonalAddressKana      Address              `json:"personal_address_kana" form:"personal_address_kana"`
+	PersonalAddressKanji     Address              `json:"personal_address_kanji" form:"personal_address_kanji"`
+	PersonalIDNumber         string               `json:"-" form:"personal_id_number"`
+	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided" form:"-"`
+	PhoneNumber              string               `json:"phone_number" form:"phone_number"`
+	SSNLast4                 string               `json:"-" form:"ssn_last_4"`
+	SSNLast4Provided         bool                 `json:"ssn_last_4_provided" form:"-"`
+	Type                     LegalEntityType      `json:"type" form:"type"`
+	Verification             IdentityVerification `json:"verification" form:"verification"`
 }
 
 // Address is the structure for an account address.
 type Address struct {
-	City    string `json:"city" form:"city"`
-	Country string `json:"country" form:"country"`
-	Line1   string `json:"line1" form:"line1"`
-	Line2   string `json:"line2" form:"line2"`
-	State   string `json:"state" form:"state"`
+	City       string `json:"city" form:"city"`
+	Country    string `json:"country" form:"country"`
+	Line1      string `json:"line1" form:"line1"`
+	Line2      string `json:"line2" form:"line2"`
+	PostalCode string `json:"postal_code" form:"postal_code"`
+	State      string `json:"state" form:"state"`
 
 	// Town/cho-me. Note that this is only used for Kana/Kanji representations
 	// of an address.
 	Town string `json:"town" form:"town"`
-
-	Zip string `json:"postal_code" form:"postal_code"`
 }
 
 // DOB is a structure for an account owner's date of birth.
@@ -340,12 +340,12 @@ type DOB struct {
 // either “male” or “female”.
 type Gender string
 
-// Owner is the structure for an account owner.
-type Owner struct {
+// AdditionalOwner is the structure for an account owner.
+type AdditionalOwner struct {
 	Address                  Address              `json:"address" form:"address"`
 	DOB                      DOB                  `json:"dob" form:"dob"`
-	First                    string               `json:"first_name" form:"first_name"`
-	Last                     string               `json:"last_name" form:"last_name"`
+	FirstName                string               `json:"first_name" form:"first_name"`
+	LastName                 string               `json:"last_name" form:"last_name"`
 	MaidenName               string               `json:"maiden_name" form:"maiden_name"`
 	PersonalIDNumber         string               `json:"-" form:"personal_id_number"`
 	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided" form:"-"`
@@ -386,10 +386,10 @@ func (d *IdentityDocument) AppendTo(body *form.Values, keyParts []string) {
 
 // PayoutSchedule is the structure for an account's payout schedule.
 type PayoutSchedule struct {
-	Delay       uint64   `json:"delay_days" form:"delay_days"`
-	Interval    Interval `json:"interval" form:"interval"`
-	MonthAnchor uint64   `json:"monthly_anchor" form:"monthly_anchor"`
-	WeekAnchor  string   `json:"weekly_anchor" form:"weekly_anchor"`
+	DelayDays     uint64   `json:"delay_days" form:"delay_days"`
+	Interval      Interval `json:"interval" form:"interval"`
+	MonthlyAnchor uint64   `json:"monthly_anchor" form:"monthly_anchor"`
+	WeeklyAnchor  string   `json:"weekly_anchor" form:"weekly_anchor"`
 }
 
 // TOSAcceptanceParams is the structure for TOS acceptance.

--- a/account/client.go
+++ b/account/client.go
@@ -146,8 +146,8 @@ func (c Client) List(params *stripe.AccountListParams) *Iter {
 		list := &stripe.AccountList{}
 		err := c.B.Call("GET", "/accounts", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/account/client.go
+++ b/account/client.go
@@ -21,8 +21,8 @@ func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 
 	// Type is now required on creation and not allowed on update
 	// It can't be passed if you pass `from_recipient` though
-	if len(params.FromRecipient) == 0 {
-		body.Add("type", string(params.Type))
+	if params.FromRecipient != nil {
+		body.Add("type", stripe.StringValue(params.Type))
 	}
 
 	form.AppendTo(body, params)
@@ -115,8 +115,8 @@ func Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, err
 
 func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, error) {
 	body := &form.Values{}
-	if len(params.Reason) > 0 {
-		body.Add("reason", params.Reason)
+	if params.Reason != nil {
+		body.Add("reason", stripe.StringValue(params.Reason))
 	}
 	acct := &stripe.Account{}
 	err := c.B.Call("POST", "/accounts/"+id+"/reject", c.Key, body, nil, acct)

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -42,7 +42,7 @@ func TestAccountNew(t *testing.T) {
 		BusinessURL:           "www.stripe.com",
 		BusinessName:          "Stripe",
 		BusinessPrimaryColor:  "#ffffff",
-		DebitNegativeBalances: true,
+		DebitNegativeBalances: stripe.Bool(true),
 		SupportEmail:          "foo@bar.com",
 		SupportURL:            "www.stripe.com",
 		SupportPhone:          "4151234567",

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -37,20 +37,20 @@ func TestAccountList(t *testing.T) {
 
 func TestAccountNew(t *testing.T) {
 	account, err := New(&stripe.AccountParams{
-		Type:                 stripe.AccountTypeCustom,
-		Country:              "CA",
-		BusinessUrl:          "www.stripe.com",
-		BusinessName:         "Stripe",
-		BusinessPrimaryColor: "#ffffff",
-		DebitNegativeBal:     true,
-		SupportEmail:         "foo@bar.com",
-		SupportUrl:           "www.stripe.com",
-		SupportPhone:         "4151234567",
+		Type:                  stripe.AccountTypeCustom,
+		Country:               "CA",
+		BusinessURL:           "www.stripe.com",
+		BusinessName:          "Stripe",
+		BusinessPrimaryColor:  "#ffffff",
+		DebitNegativeBalances: true,
+		SupportEmail:          "foo@bar.com",
+		SupportURL:            "www.stripe.com",
+		SupportPhone:          "4151234567",
 		LegalEntity: &stripe.LegalEntity{
 			Type:         stripe.Individual,
 			BusinessName: "Stripe Go",
-			AdditionalOwners: []stripe.Owner{
-				{First: "Jane"},
+			AdditionalOwners: []stripe.AdditionalOwner{
+				{FirstName: "Jane"},
 			},
 			DOB: stripe.DOB{
 				Day:   1,
@@ -80,11 +80,11 @@ func TestAccountUpdate(t *testing.T) {
 	account, err := Update("acct_123", &stripe.AccountParams{
 		LegalEntity: &stripe.LegalEntity{
 			Address: stripe.Address{
-				Country: "CA",
-				City:    "Montreal",
-				Zip:     "H2Y 1C6",
-				Line1:   "275, rue Notre-Dame Est",
-				State:   "QC",
+				Country:    "CA",
+				City:       "Montreal",
+				PostalCode: "H2Y 1C6",
+				Line1:      "275, rue Notre-Dame Est",
+				State:      "QC",
 			},
 		},
 	})

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -37,31 +37,31 @@ func TestAccountList(t *testing.T) {
 
 func TestAccountNew(t *testing.T) {
 	account, err := New(&stripe.AccountParams{
-		Type:                  stripe.AccountTypeCustom,
-		Country:               "CA",
-		BusinessURL:           "www.stripe.com",
-		BusinessName:          "Stripe",
-		BusinessPrimaryColor:  "#ffffff",
+		Type:                  stripe.String(string(stripe.AccountTypeCustom)),
+		Country:               stripe.String("CA"),
+		BusinessURL:           stripe.String("www.stripe.com"),
+		BusinessName:          stripe.String("Stripe"),
+		BusinessPrimaryColor:  stripe.String("#ffffff"),
 		DebitNegativeBalances: stripe.Bool(true),
-		SupportEmail:          "foo@bar.com",
-		SupportURL:            "www.stripe.com",
-		SupportPhone:          "4151234567",
-		LegalEntity: &stripe.LegalEntity{
-			Type:         stripe.Individual,
-			BusinessName: "Stripe Go",
-			AdditionalOwners: []stripe.AdditionalOwner{
-				{FirstName: "Jane"},
+		SupportEmail:          stripe.String("foo@bar.com"),
+		SupportURL:            stripe.String("www.stripe.com"),
+		SupportPhone:          stripe.String("4151234567"),
+		LegalEntity: &stripe.LegalEntityParams{
+			Type:         stripe.String(string(stripe.Individual)),
+			BusinessName: stripe.String("Stripe Go"),
+			AdditionalOwners: []stripe.AdditionalOwnerParams{
+				{FirstName: stripe.String("Jane")},
 			},
-			DOB: stripe.DOB{
-				Day:   1,
-				Month: 2,
-				Year:  1990,
+			DOB: &stripe.DOBParams{
+				Day:   stripe.Int(1),
+				Month: stripe.Int(2),
+				Year:  stripe.Int(1990),
 			},
 		},
 		TOSAcceptance: &stripe.TOSAcceptanceParams{
-			IP:        "127.0.0.1",
-			Date:      1437578361,
-			UserAgent: "Mozilla/5.0",
+			IP:        stripe.String("127.0.0.1"),
+			Date:      stripe.Int64(1437578361),
+			UserAgent: stripe.String("Mozilla/5.0"),
 		},
 	})
 	assert.Nil(t, err)
@@ -70,7 +70,7 @@ func TestAccountNew(t *testing.T) {
 
 func TestAccountReject(t *testing.T) {
 	account, err := Reject("acct_123", &stripe.AccountRejectParams{
-		Reason: "fraud",
+		Reason: stripe.String("fraud"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, account)
@@ -78,13 +78,13 @@ func TestAccountReject(t *testing.T) {
 
 func TestAccountUpdate(t *testing.T) {
 	account, err := Update("acct_123", &stripe.AccountParams{
-		LegalEntity: &stripe.LegalEntity{
-			Address: stripe.Address{
-				Country:    "CA",
-				City:       "Montreal",
-				PostalCode: "H2Y 1C6",
-				Line1:      "275, rue Notre-Dame Est",
-				State:      "QC",
+		LegalEntity: &stripe.LegalEntityParams{
+			Address: &stripe.AccountAddressParams{
+				Country:    stripe.String("CA"),
+				City:       stripe.String("Montreal"),
+				PostalCode: stripe.String("H2Y 1C6"),
+				Line1:      stripe.String("275, rue Notre-Dame Est"),
+				State:      stripe.String("QC"),
 			},
 		},
 	})

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -50,12 +50,20 @@ func TestAccountNew(t *testing.T) {
 			Type:         stripe.String(string(stripe.Individual)),
 			BusinessName: stripe.String("Stripe Go"),
 			AdditionalOwners: []stripe.AdditionalOwnerParams{
-				{FirstName: stripe.String("Jane")},
+				{
+					FirstName: stripe.String("Jane"),
+					Verification: &stripe.IdentityVerificationParams{
+						Document: stripe.String("file_345"),
+					},
+				},
 			},
 			DOB: &stripe.DOBParams{
 				Day:   stripe.Int64(1),
 				Month: stripe.Int64(2),
 				Year:  stripe.Int64(1990),
+			},
+			Verification: &stripe.IdentityVerificationParams{
+				Document: stripe.String("file_123"),
 			},
 		},
 		TOSAcceptance: &stripe.TOSAcceptanceParams{

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -47,7 +47,7 @@ func TestAccountNew(t *testing.T) {
 		SupportURL:            stripe.String("www.stripe.com"),
 		SupportPhone:          stripe.String("4151234567"),
 		LegalEntity: &stripe.LegalEntityParams{
-			Type:         stripe.String(string(stripe.Individual)),
+			Type:         stripe.String(string(stripe.LegalEntityTypeIndividual)),
 			BusinessName: stripe.String("Stripe Go"),
 			AdditionalOwners: []stripe.AdditionalOwnerParams{
 				{

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -53,9 +53,9 @@ func TestAccountNew(t *testing.T) {
 				{FirstName: stripe.String("Jane")},
 			},
 			DOB: &stripe.DOBParams{
-				Day:   stripe.Int(1),
-				Month: stripe.Int(2),
-				Year:  stripe.Int(1990),
+				Day:   stripe.Int64(1),
+				Month: stripe.Int64(2),
+				Year:  stripe.Int64(1990),
 			},
 		},
 		TOSAcceptance: &stripe.TOSAcceptanceParams{

--- a/account_test.go
+++ b/account_test.go
@@ -80,7 +80,7 @@ func TestIdentityDocument_Appendto(t *testing.T) {
 
 func TestPayoutScheduleParams_AppendTo(t *testing.T) {
 	{
-		params := &PayoutScheduleParams{MinimumDelay: true}
+		params := &PayoutScheduleParams{DelayDaysMinimum: Bool(true)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/account_test.go
+++ b/account_test.go
@@ -57,11 +57,11 @@ func TestAccountUnmarshal(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "acct_123", account.ID)
-	assert.Equal(t, true, account.ExternalAccounts.More)
+	assert.Equal(t, true, account.ExternalAccounts.HasMore)
 
-	assert.Equal(t, 2, len(account.ExternalAccounts.Values))
-	assert.Equal(t, "ba_123", account.ExternalAccounts.Values[0].ID)
-	assert.Equal(t, "card_123", account.ExternalAccounts.Values[1].ID)
+	assert.Equal(t, 2, len(account.ExternalAccounts.Data))
+	assert.Equal(t, "ba_123", account.ExternalAccounts.Data[0].ID)
+	assert.Equal(t, "card_123", account.ExternalAccounts.Data[1].ID)
 }
 
 func TestIdentityDocument_Appendto(t *testing.T) {

--- a/account_test.go
+++ b/account_test.go
@@ -18,7 +18,7 @@ func TestAccountExternalAccountParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &AccountExternalAccountParams{Token: "tok_123"}
+		params := &AccountExternalAccountParams{Token: String("tok_123")}
 		body := &form.Values{}
 
 		// 0-length keyParts are not allowed, so call AppendTo directly (as
@@ -47,6 +47,7 @@ func TestAccountUnmarshal(t *testing.T) {
 				},
 			},
 		},
+		"type": "custom",
 	}
 
 	bytes, err := json.Marshal(&accountData)
@@ -56,6 +57,7 @@ func TestAccountUnmarshal(t *testing.T) {
 	err = json.Unmarshal(bytes, &account)
 	assert.NoError(t, err)
 
+	assert.Equal(t, AccountTypeCustom, account.Type)
 	assert.Equal(t, "acct_123", account.ID)
 	assert.Equal(t, true, account.ExternalAccounts.HasMore)
 

--- a/account_test.go
+++ b/account_test.go
@@ -66,20 +66,6 @@ func TestAccountUnmarshal(t *testing.T) {
 	assert.Equal(t, "card_123", account.ExternalAccounts.Data[1].ID)
 }
 
-func TestIdentityDocument_Appendto(t *testing.T) {
-	{
-		params := &IdentityDocument{ID: "file_123"}
-		body := &form.Values{}
-		params.AppendTo(body,
-			[]string{"legal_entity", "additional_owners", "0", "verification", "document"})
-		t.Logf("body = %+v", body)
-		assert.Equal(t,
-			[]string{"file_123"},
-			body.Get("legal_entity[additional_owners][0][verification][document]"),
-		)
-	}
-}
-
 func TestPayoutScheduleParams_AppendTo(t *testing.T) {
 	{
 		params := &PayoutScheduleParams{DelayDaysMinimum: Bool(true)}

--- a/address.go
+++ b/address.go
@@ -2,10 +2,20 @@ package stripe
 
 // Standard address parameters.
 type AddressParams struct {
-	City       string `form:"city"`
-	Country    string `form:"country"`
-	Line1      string `form:"line1"`
-	Line2      string `form:"line2"`
-	PostalCode string `form:"postal_code"`
-	State      string `form:"state"`
+	City       *string `form:"city"`
+	Country    *string `form:"country"`
+	Line1      *string `form:"line1"`
+	Line2      *string `form:"line2"`
+	PostalCode *string `form:"postal_code"`
+	State      *string `form:"state"`
+}
+
+// Standard address resource.
+type Address struct {
+	City       string `json:"city"`
+	Country    string `json:"country"`
+	Line1      string `json:"line1"`
+	Line2      string `json:"line2"`
+	PostalCode string `json:"postal_code"`
+	State      string `json:"state"`
 }

--- a/applepaydomain.go
+++ b/applepaydomain.go
@@ -12,7 +12,7 @@ type ApplePayDomain struct {
 	Deleted    bool   `json:"deleted"`
 	DomainName string `json:"domain_name"`
 	ID         string `json:"id"`
-	Live       bool   `json:"livemode"`
+	Livemode   bool   `json:"livemode"`
 }
 
 // ApplePayDomainListParams are the parameters allowed during ApplePayDomain listing.
@@ -23,5 +23,5 @@ type ApplePayDomainListParams struct {
 // ApplePayDomainList is a list of ApplePayDomains as returned from a list endpoint.
 type ApplePayDomainList struct {
 	ListMeta
-	Values []*ApplePayDomain `json:"data"`
+	Data []*ApplePayDomain `json:"data"`
 }

--- a/applepaydomain.go
+++ b/applepaydomain.go
@@ -3,7 +3,7 @@ package stripe
 // ApplePayDomainParams is the set of parameters that can be used when creating an ApplePayDomain object.
 type ApplePayDomainParams struct {
 	Params     `form:"*"`
-	DomainName string `form:"domain_name"`
+	DomainName *string `form:"domain_name"`
 }
 
 // ApplePayDomain is the resource representing a Stripe ApplePayDomain object

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -89,8 +89,8 @@ func (c Client) List(params *stripe.ApplePayDomainListParams) *Iter {
 		list := &stripe.ApplePayDomainList{}
 		err := c.B.Call("GET", "/apple_pay/domains", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/applepaydomain/client_test.go
+++ b/applepaydomain/client_test.go
@@ -31,7 +31,7 @@ func TestApplePayDomainList(t *testing.T) {
 
 func TestApplePayDomainNew(t *testing.T) {
 	domain, err := New(&stripe.ApplePayDomainParams{
-		DomainName: "example.com",
+		DomainName: stripe.String("example.com"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, domain)

--- a/balance.go
+++ b/balance.go
@@ -2,58 +2,58 @@ package stripe
 
 import "encoding/json"
 
-// TransactionStatus is the list of allowed values for the transaction's status.
+// BalanceTransactionStatus is the list of allowed values for the balance transaction's status.
 // Allowed values are "available", "pending".
-type TransactionStatus string
+type BalanceTransactionStatus string
 
-// TransactionType is the list of allowed values for the transaction's type.
+// BalanceTransactionType is the list of allowed values for the balance transaction's type.
 // Allowed values are "charge", "refund", "adjustment", "application_fee",
 // "application_fee_refund", "transfer", "transfer_cancel", "transfer_failure".
-type TransactionType string
+type BalanceTransactionType string
 
-// TransactionSourceType consts represent valid balance transaction sources.
-type TransactionSourceType string
+// BalanceTransactionSourceType consts represent valid balance transaction sources.
+type BalanceTransactionSourceType string
 
 const (
-	// TransactionSourceCharge is a constant representing a transaction source of charge
-	TransactionSourceCharge TransactionSourceType = "charge"
+	// BalanceTransactionSourceTypeCharge is a constant representing a transaction source of charge
+	BalanceTransactionSourceTypeCharge BalanceTransactionSourceType = "charge"
 
-	// TransactionSourceDispute is a constant representing a transaction source of dispute
-	TransactionSourceDispute TransactionSourceType = "dispute"
+	// BalanceTransactionSourceTypeDispute is a constant representing a transaction source of dispute
+	BalanceTransactionSourceTypeDispute BalanceTransactionSourceType = "dispute"
 
-	// TransactionSourceFee is a constant representing a transaction source of application_fee
-	TransactionSourceFee TransactionSourceType = "application_fee"
+	// BalanceTransactionSourceTypeApplicationFee is a constant representing a transaction source of application_fee
+	BalanceTransactionSourceTypeApplicationFee BalanceTransactionSourceType = "application_fee"
 
-	// TransactionSourcePayout is a constant representing a transaction source of payout
-	TransactionSourcePayout TransactionSourceType = "payout"
+	// BalanceTransactionSourceTypePayout is a constant representing a transaction source of payout
+	BalanceTransactionSourceTypePayout BalanceTransactionSourceType = "payout"
 
-	// TransactionSourceRecipientTransfer is a constant representing a transaction source of recipient_transfer
-	TransactionSourceRecipientTransfer TransactionSourceType = "recipient_transfer"
+	// BalanceTransactionSourceTypeRecipientTransfer is a constant representing a transaction source of recipient_transfer
+	BalanceTransactionSourceTypeRecipientTransfer BalanceTransactionSourceType = "recipient_transfer"
 
-	// TransactionSourceRefund is a constant representing a transaction source of refund
-	TransactionSourceRefund TransactionSourceType = "refund"
+	// BalanceTransactionSourceTypeRefund is a constant representing a transaction source of refund
+	BalanceTransactionSourceTypeRefund BalanceTransactionSourceType = "refund"
 
-	// TransactionSourceReversal is a constant representing a transaction source of reversal
-	TransactionSourceReversal TransactionSourceType = "reversal"
+	// BalanceTransactionSourceTypeReversal is a constant representing a transaction source of reversal
+	BalanceTransactionSourceTypeReversal BalanceTransactionSourceType = "reversal"
 
-	// TransactionSourceTransfer is a constant representing a transaction source of transfer
-	TransactionSourceTransfer TransactionSourceType = "transfer"
+	// BalanceTransactionSourceTypeTransfer is a constant representing a transaction source of transfer
+	BalanceTransactionSourceTypeTransfer BalanceTransactionSourceType = "transfer"
 )
 
-// TransactionSource describes the source of a balance Transaction.
+// BalanceTransactionSource describes the source of a balance Transaction.
 // The Type should indicate which object is fleshed out.
 // For more details see https://stripe.com/docs/api#retrieve_balance_transaction
-type TransactionSource struct {
-	Charge            *Charge               `json:"-"`
-	Dispute           *Dispute              `json:"-"`
-	Fee               *Fee                  `json:"-"`
-	ID                string                `json:"id"`
-	Payout            *Payout               `json:"-"`
-	RecipientTransfer *RecipientTransfer    `json:"-"`
-	Refund            *Refund               `json:"-"`
-	Reversal          *Reversal             `json:"-"`
-	Transfer          *Transfer             `json:"-"`
-	Type              TransactionSourceType `json:"object"`
+type BalanceTransactionSource struct {
+	ApplicationFee    *ApplicationFee              `json:"-"`
+	Charge            *Charge                      `json:"-"`
+	Dispute           *Dispute                     `json:"-"`
+	ID                string                       `json:"id"`
+	Payout            *Payout                      `json:"-"`
+	RecipientTransfer *RecipientTransfer           `json:"-"`
+	Refund            *Refund                      `json:"-"`
+	Reversal          *Reversal                    `json:"-"`
+	Transfer          *Transfer                    `json:"-"`
+	Type              BalanceTransactionSourceType `json:"object"`
 }
 
 // BalanceParams is the set of parameters that can be used when retrieving a balance.
@@ -62,56 +62,56 @@ type BalanceParams struct {
 	Params `form:"*"`
 }
 
-// TxParams is the set of parameters that can be used when retrieving a transaction.
+// BalanceTransactionParams is the set of parameters that can be used when retrieving a transaction.
 // For more details see https://stripe.com/docs/api#retrieve_balance_transaction.
-type TxParams struct {
+type BalanceTransactionParams struct {
 	Params `form:"*"`
 }
 
-// TxListParams is the set of parameters that can be used when listing balance transactions.
+// BalanceTransactionListParams is the set of parameters that can be used when listing balance transactions.
 // For more details see https://stripe.com/docs/api/#balance_history.
-type TxListParams struct {
-	ListParams     `form:"*"`
-	Available      int64             `form:"available_on"`
-	AvailableRange *RangeQueryParams `form:"available_on"`
-	Created        int64             `form:"created"`
-	CreatedRange   *RangeQueryParams `form:"created"`
-	Currency       string            `form:"currency"`
-	Payout         string            `form:"payout"`
-	Src            string            `form:"source"`
-	Type           TransactionType   `form:"type"`
+type BalanceTransactionListParams struct {
+	ListParams       `form:"*"`
+	AvailableOn      int64                  `form:"available_on"`
+	AvailableOnRange *RangeQueryParams      `form:"available_on"`
+	Created          int64                  `form:"created"`
+	CreatedRange     *RangeQueryParams      `form:"created"`
+	Currency         string                 `form:"currency"`
+	Payout           string                 `form:"payout"`
+	Source           string                 `form:"source"`
+	Type             BalanceTransactionType `form:"type"`
 }
 
 // Balance is the resource representing your Stripe balance.
 // For more details see https://stripe.com/docs/api/#balance.
 type Balance struct {
 	Available []Amount `json:"available"`
-	Live      bool     `json:"livemode"`
+	Livemode  bool     `json:"livemode"`
 	Pending   []Amount `json:"pending"`
 }
 
-// Transaction is the resource representing the balance transaction.
+// BalanceTransaction is the resource representing the balance transaction.
 // For more details see https://stripe.com/docs/api/#balance.
-type Transaction struct {
-	Amount     int64             `json:"amount"`
-	Available  int64             `json:"available_on"`
-	Created    int64             `json:"created"`
-	Currency   Currency          `json:"currency"`
-	Desc       string            `json:"description"`
-	ID         string            `json:"id"`
-	Fee        int64             `json:"fee"`
-	FeeDetails []TxFee           `json:"fee_details"`
-	Net        int64             `json:"net"`
-	Recipient  string            `json:"recipient"`
-	Src        TransactionSource `json:"source"`
-	Status     TransactionStatus `json:"status"`
-	Type       TransactionType   `json:"type"`
+type BalanceTransaction struct {
+	Amount      int64                    `json:"amount"`
+	AvailableOn int64                    `json:"available_on"`
+	Created     int64                    `json:"created"`
+	Currency    Currency                 `json:"currency"`
+	Description string                   `json:"description"`
+	ID          string                   `json:"id"`
+	Fee         int64                    `json:"fee"`
+	FeeDetails  []BalanceTransactionFee  `json:"fee_details"`
+	Net         int64                    `json:"net"`
+	Recipient   string                   `json:"recipient"`
+	Source      BalanceTransactionSource `json:"source"`
+	Status      BalanceTransactionStatus `json:"status"`
+	Type        BalanceTransactionType   `json:"type"`
 }
 
-// TransactionList is a list of transactions as returned from a list endpoint.
-type TransactionList struct {
+// BalanceTransactionList is a list of transactions as returned from a list endpoint.
+type BalanceTransactionList struct {
 	ListMeta
-	Values []*Transaction `json:"data"`
+	Data []*BalanceTransaction `json:"data"`
 }
 
 // Amount is a structure wrapping an amount value and its currency.
@@ -120,24 +120,24 @@ type Amount struct {
 	Currency Currency `json:"currency"`
 }
 
-// TxFee is a structure that breaks down the fees in a transaction.
-type TxFee struct {
-	Application string   `json:"application"`
+// BalanceTransactionFee is a structure that breaks down the fees in a transaction.
+type BalanceTransactionFee struct {
 	Amount      int64    `json:"amount"`
+	Application string   `json:"application"`
 	Currency    Currency `json:"currency"`
-	Desc        string   `json:"description"`
+	Description string   `json:"description"`
 	Type        string   `json:"type"`
 }
 
 // UnmarshalJSON handles deserialization of a Transaction.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (t *Transaction) UnmarshalJSON(data []byte) error {
-	type transaction Transaction
-	var tt transaction
+func (t *BalanceTransaction) UnmarshalJSON(data []byte) error {
+	type bt BalanceTransaction
+	var tt bt
 	err := json.Unmarshal(data, &tt)
 	if err == nil {
-		*t = Transaction(tt)
+		*t = BalanceTransaction(tt)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		t.ID = string(data[1 : len(data)-1])
@@ -146,32 +146,32 @@ func (t *Transaction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// UnmarshalJSON handles deserialization of a TransactionSource.
+// UnmarshalJSON handles deserialization of a BalanceTransactionSource.
 // This custom unmarshaling is needed because the specific
 // type of transaction source it refers to is specified in the JSON
-func (s *TransactionSource) UnmarshalJSON(data []byte) error {
-	type source TransactionSource
+func (s *BalanceTransactionSource) UnmarshalJSON(data []byte) error {
+	type source BalanceTransactionSource
 	var ss source
 	err := json.Unmarshal(data, &ss)
 	if err == nil {
-		*s = TransactionSource(ss)
+		*s = BalanceTransactionSource(ss)
 
 		switch s.Type {
-		case TransactionSourceCharge:
+		case BalanceTransactionSourceTypeApplicationFee:
+			err = json.Unmarshal(data, &s.ApplicationFee)
+		case BalanceTransactionSourceTypeCharge:
 			err = json.Unmarshal(data, &s.Charge)
-		case TransactionSourceDispute:
+		case BalanceTransactionSourceTypeDispute:
 			err = json.Unmarshal(data, &s.Dispute)
-		case TransactionSourceFee:
-			err = json.Unmarshal(data, &s.Fee)
-		case TransactionSourcePayout:
+		case BalanceTransactionSourceTypePayout:
 			err = json.Unmarshal(data, &s.Payout)
-		case TransactionSourceRecipientTransfer:
+		case BalanceTransactionSourceTypeRecipientTransfer:
 			err = json.Unmarshal(data, &s.RecipientTransfer)
-		case TransactionSourceRefund:
+		case BalanceTransactionSourceTypeRefund:
 			err = json.Unmarshal(data, &s.Refund)
-		case TransactionSourceReversal:
+		case BalanceTransactionSourceTypeReversal:
 			err = json.Unmarshal(data, &s.Reversal)
-		case TransactionSourceTransfer:
+		case BalanceTransactionSourceTypeTransfer:
 			err = json.Unmarshal(data, &s.Transfer)
 		}
 
@@ -186,7 +186,7 @@ func (s *TransactionSource) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON handles serialization of a TransactionSource.
-func (s *TransactionSource) MarshalJSON() ([]byte, error) {
+// MarshalJSON handles serialization of a BalanceTransactionSource.
+func (s *BalanceTransactionSource) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.ID)
 }

--- a/balance.go
+++ b/balance.go
@@ -72,14 +72,14 @@ type BalanceTransactionParams struct {
 // For more details see https://stripe.com/docs/api/#balance_history.
 type BalanceTransactionListParams struct {
 	ListParams       `form:"*"`
-	AvailableOn      int64                  `form:"available_on"`
-	AvailableOnRange *RangeQueryParams      `form:"available_on"`
-	Created          int64                  `form:"created"`
-	CreatedRange     *RangeQueryParams      `form:"created"`
-	Currency         string                 `form:"currency"`
-	Payout           string                 `form:"payout"`
-	Source           string                 `form:"source"`
-	Type             BalanceTransactionType `form:"type"`
+	AvailableOn      *int64            `form:"available_on"`
+	AvailableOnRange *RangeQueryParams `form:"available_on"`
+	Created          *int64            `form:"created"`
+	CreatedRange     *RangeQueryParams `form:"created"`
+	Currency         *string           `form:"currency"`
+	Payout           *string           `form:"payout"`
+	Source           *string           `form:"source"`
+	Type             *string           `form:"type"`
 }
 
 // Balance is the resource representing your Stripe balance.

--- a/balance/client.go
+++ b/balance/client.go
@@ -7,22 +7,22 @@ import (
 )
 
 const (
-	TxAvailable stripe.TransactionStatus = "available"
-	TxPending   stripe.TransactionStatus = "pending"
+	BalanceTransactionAvailable stripe.BalanceTransactionStatus = "available"
+	BalanceTransactionPending   stripe.BalanceTransactionStatus = "pending"
 
-	TxCharge                  stripe.TransactionType = "charge"
-	TxRefund                  stripe.TransactionType = "refund"
-	TxAdjust                  stripe.TransactionType = "adjustment"
-	TxAppFee                  stripe.TransactionType = "application_fee"
-	TxFeeRefund               stripe.TransactionType = "application_fee_refund"
-	TxRecipientTransfer       stripe.TransactionType = "recipient_transfer"
-	TxRecipientTransferCancel stripe.TransactionType = "recipient_transfer_cancel"
-	TxRecipientTransferFail   stripe.TransactionType = "recipient_transfer_failure"
-	TxPayout                  stripe.TransactionType = "payout"
-	TxPayoutCancel            stripe.TransactionType = "payout_cancel"
-	TxPayoutFail              stripe.TransactionType = "payout_failure"
-	TxTransfer                stripe.TransactionType = "transfer"
-	TxTransferCancel          stripe.TransactionType = "transfer_refund"
+	BalanceTransactionCharge                  stripe.BalanceTransactionType = "charge"
+	BalanceTransactionRefund                  stripe.BalanceTransactionType = "refund"
+	BalanceTransactionAdjust                  stripe.BalanceTransactionType = "adjustment"
+	BalanceTransactionAppFee                  stripe.BalanceTransactionType = "application_fee"
+	BalanceTransactionFeeRefund               stripe.BalanceTransactionType = "application_fee_refund"
+	BalanceTransactionRecipientTransfer       stripe.BalanceTransactionType = "recipient_transfer"
+	BalanceTransactionRecipientTransferCancel stripe.BalanceTransactionType = "recipient_transfer_cancel"
+	BalanceTransactionRecipientTransferFail   stripe.BalanceTransactionType = "recipient_transfer_failure"
+	BalanceTransactionPayout                  stripe.BalanceTransactionType = "payout"
+	BalanceTransactionPayoutCancel            stripe.BalanceTransactionType = "payout_cancel"
+	BalanceTransactionPayoutFail              stripe.BalanceTransactionType = "payout_failure"
+	BalanceTransactionTransfer                stripe.BalanceTransactionType = "transfer"
+	BalanceTransactionTransferCancel          stripe.BalanceTransactionType = "transfer_refund"
 )
 
 // Client is used to invoke /balance and transaction-related APIs.
@@ -53,13 +53,13 @@ func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 	return balance, err
 }
 
-// GetTx returns the details of a balance transaction.
+// GetBalanceTransaction returns the details of a balance transaction.
 // For more details see	https://stripe.com/docs/api#retrieve_balance_transaction.
-func GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, error) {
-	return getC().GetTx(id, params)
+func GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
+	return getC().GetBalanceTransaction(id, params)
 }
 
-func (c Client) GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, error) {
+func (c Client) GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -69,7 +69,7 @@ func (c Client) GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, 
 		form.AppendTo(body, params)
 	}
 
-	balance := &stripe.Transaction{}
+	balance := &stripe.BalanceTransaction{}
 	err := c.B.Call("GET", "/balance/history/"+id, c.Key, body, commonParams, balance)
 
 	return balance, err
@@ -77,11 +77,11 @@ func (c Client) GetTx(id string, params *stripe.TxParams) (*stripe.Transaction, 
 
 // List returns a list of balance transactions.
 // For more details see https://stripe.com/docs/api#balance_history.
-func List(params *stripe.TxListParams) *Iter {
+func List(params *stripe.BalanceTransactionListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.TxListParams) *Iter {
+func (c Client) List(params *stripe.BalanceTransactionListParams) *Iter {
 	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -94,11 +94,11 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.TransactionList{}
+		list := &stripe.BalanceTransactionList{}
 		err := c.B.Call("GET", "/balance/history", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -106,17 +106,17 @@ func (c Client) List(params *stripe.TxListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Transactions.
+// Iter is an iterator for lists of BalanceTransactions.
 // The embedded Iter carries methods with it;
 // see its documentation for details.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Charge returns the most recent Transaction
+// Charge returns the most recent BalanceTransaction
 // visited by a call to Next.
-func (i *Iter) Transaction() *stripe.Transaction {
-	return i.Current().(*stripe.Transaction)
+func (i *Iter) BalanceTransaction() *stripe.BalanceTransaction {
+	return i.Current().(*stripe.BalanceTransaction)
 }
 
 func getC() Client {

--- a/balance/client_test.go
+++ b/balance/client_test.go
@@ -14,17 +14,17 @@ func TestBalanceGet(t *testing.T) {
 	assert.NotNil(t, balance)
 }
 
-func TestBalanceList(t *testing.T) {
-	i := List(&stripe.TxListParams{})
+func TestBalanceTransactionList(t *testing.T) {
+	i := List(&stripe.BalanceTransactionListParams{})
 
 	// Verify that we can get at least one transaction
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.Transaction())
+	assert.NotNil(t, i.BalanceTransaction())
 }
 
-func TestBalanceTxGet(t *testing.T) {
-	transaction, err := GetTx("txn_123", nil)
+func TestBalanceBalanceTransactionGet(t *testing.T) {
+	transaction, err := GetBalanceTransaction("txn_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, transaction)
 }

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -30,7 +30,7 @@ type BankAccountParams struct {
 	Country            string `form:"country"`
 	Currency           string `form:"currency"`
 	Customer           string `form:"-"`
-	DefaultForCurrency bool   `form:"default_for_currency"`
+	DefaultForCurrency *bool  `form:"default_for_currency"`
 	RoutingNumber      string `form:"routing_number"`
 
 	// Token is a token referencing an external account like one returned from
@@ -67,8 +67,8 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 	if len(a.Token) > 0 {
 		body.Add(sourceType, a.Token)
 
-		if a.DefaultForCurrency {
-			body.Add("default_for_currency", strconv.FormatBool(a.DefaultForCurrency))
+		if a.DefaultForCurrency != nil {
+			body.Add("default_for_currency", strconv.FormatBool(BoolValue(a.DefaultForCurrency)))
 		}
 	} else {
 		body.Add(sourceType+"[object]", "bank_account")
@@ -91,8 +91,8 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 			body.Add(sourceType+"[routing_number]", a.RoutingNumber)
 		}
 
-		if a.DefaultForCurrency {
-			body.Add(sourceType+"[default_for_currency]", strconv.FormatBool(a.DefaultForCurrency))
+		if a.DefaultForCurrency != nil {
+			body.Add(sourceType+"[default_for_currency]", strconv.FormatBool(BoolValue(a.DefaultForCurrency)))
 		}
 	}
 }

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -8,7 +8,7 @@ import (
 )
 
 // BankAccountStatus is the list of allowed values for the bank account's status.
-// Allowed values are "new", "verified", "validated", "errored".
+// Allowed values are "new", "validated", "verified", "verification_failed", "errored".
 type BankAccountStatus string
 
 // BankAccountParams is the set of parameters that can be used when updating a
@@ -20,19 +20,18 @@ type BankAccountStatus string
 type BankAccountParams struct {
 	Params `form:"*"`
 
-	Account string `form:"account_number"`
-
-	// AccountID is the identifier of the parent account under which bank
+	// Account is the identifier of the parent account under which bank
 	// accounts are nested.
-	AccountID string `form:"-"`
+	Account string `form:"-"`
 
-	AccountHolderName string `form:"account_holder_name"`
-	AccountHolderType string `form:"account_holder_type"`
-	Country           string `form:"country"`
-	Currency          string `form:"currency"`
-	Customer          string `form:"-"`
-	Default           bool   `form:"default_for_currency"`
-	Routing           string `form:"routing_number"`
+	AccountHolderName  string `form:"account_holder_name"`
+	AccountHolderType  string `form:"account_holder_type"`
+	AccountNumber      string `form:"account_number"`
+	Country            string `form:"country"`
+	Currency           string `form:"currency"`
+	Customer           string `form:"-"`
+	DefaultForCurrency bool   `form:"default_for_currency"`
+	RoutingNumber      string `form:"routing_number"`
 
 	// Token is a token referencing an external account like one returned from
 	// Stripe.js.
@@ -68,13 +67,13 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 	if len(a.Token) > 0 {
 		body.Add(sourceType, a.Token)
 
-		if a.Default {
-			body.Add("default_for_currency", strconv.FormatBool(a.Default))
+		if a.DefaultForCurrency {
+			body.Add("default_for_currency", strconv.FormatBool(a.DefaultForCurrency))
 		}
 	} else {
 		body.Add(sourceType+"[object]", "bank_account")
 		body.Add(sourceType+"[country]", a.Country)
-		body.Add(sourceType+"[account_number]", a.Account)
+		body.Add(sourceType+"[account_number]", a.AccountNumber)
 		body.Add(sourceType+"[currency]", a.Currency)
 
 		// These are optional and the API will fail if we try to send empty
@@ -88,12 +87,12 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 			body.Add(sourceType+"[account_holder_type]", a.AccountHolderType)
 		}
 
-		if len(a.Routing) > 0 {
-			body.Add(sourceType+"[routing_number]", a.Routing)
+		if len(a.RoutingNumber) > 0 {
+			body.Add(sourceType+"[routing_number]", a.RoutingNumber)
 		}
 
-		if a.Default {
-			body.Add(sourceType+"[default_for_currency]", strconv.FormatBool(a.Default))
+		if a.DefaultForCurrency {
+			body.Add(sourceType+"[default_for_currency]", strconv.FormatBool(a.DefaultForCurrency))
 		}
 	}
 }
@@ -103,36 +102,36 @@ type BankAccountListParams struct {
 	ListParams `form:"*"`
 
 	// The identifier of the parent account under which the bank accounts are
-	// nested. Either AccountID or Customer should be populated.
-	AccountID string `form:"-"`
+	// nested. Either Account or Customer should be populated.
+	Account string `form:"-"`
 
 	// The identifier of the parent customer under which the bank accounts are
-	// nested. Either AccountID or Customer should be populated.
+	// nested. Either Account or Customer should be populated.
 	Customer string `form:"-"`
 }
 
 // BankAccount represents a Stripe bank account.
 type BankAccount struct {
-	AccountHolderName string            `json:"account_holder_name"`
-	AccountHolderType string            `json:"account_holder_type"`
-	Country           string            `json:"country"`
-	Currency          Currency          `json:"currency"`
-	Customer          *Customer         `json:"customer"`
-	Default           bool              `json:"default_for_currency"`
-	Deleted           bool              `json:"deleted"`
-	Fingerprint       string            `json:"fingerprint"`
-	ID                string            `json:"id"`
-	LastFour          string            `json:"last4"`
-	Meta              map[string]string `json:"metadata"`
-	Name              string            `json:"bank_name"`
-	Routing           string            `json:"routing_number"`
-	Status            BankAccountStatus `json:"status"`
+	AccountHolderName  string            `json:"account_holder_name"`
+	AccountHolderType  string            `json:"account_holder_type"`
+	BankName           string            `json:"bank_name"`
+	Country            string            `json:"country"`
+	Currency           Currency          `json:"currency"`
+	Customer           *Customer         `json:"customer"`
+	DefaultForCurrency bool              `json:"default_for_currency"`
+	Deleted            bool              `json:"deleted"`
+	Fingerprint        string            `json:"fingerprint"`
+	ID                 string            `json:"id"`
+	Last4              string            `json:"last4"`
+	Metadata           map[string]string `json:"metadata"`
+	RoutingNumber      string            `json:"routing_number"`
+	Status             BankAccountStatus `json:"status"`
 }
 
 // BankAccountList is a list object for bank accounts.
 type BankAccountList struct {
 	ListMeta
-	Values []*BankAccount `json:"data"`
+	Data []*BankAccount `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a BankAccount.

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -22,23 +22,23 @@ type BankAccountParams struct {
 
 	// Account is the identifier of the parent account under which bank
 	// accounts are nested.
-	Account string `form:"-"`
+	Account *string `form:"-"`
 
-	AccountHolderName  string `form:"account_holder_name"`
-	AccountHolderType  string `form:"account_holder_type"`
-	AccountNumber      string `form:"account_number"`
-	Country            string `form:"country"`
-	Currency           string `form:"currency"`
-	Customer           string `form:"-"`
-	DefaultForCurrency *bool  `form:"default_for_currency"`
-	RoutingNumber      string `form:"routing_number"`
+	AccountHolderName  *string `form:"account_holder_name"`
+	AccountHolderType  *string `form:"account_holder_type"`
+	AccountNumber      *string `form:"account_number"`
+	Country            *string `form:"country"`
+	Currency           *string `form:"currency"`
+	Customer           *string `form:"-"`
+	DefaultForCurrency *bool   `form:"default_for_currency"`
+	RoutingNumber      *string `form:"routing_number"`
 
 	// Token is a token referencing an external account like one returned from
 	// Stripe.js.
-	Token string `form:"-"`
+	Token *string `form:"-"`
 
 	// ID is used when tokenizing a bank account for shared customers
-	ID string `form:"*"`
+	ID *string `form:"*"`
 }
 
 // AppendToAsSourceOrExternalAccount appends the given BankAccountParams as
@@ -54,7 +54,7 @@ type BankAccountParams struct {
 // because the bank accounts endpoint is a little unusual. There is one other
 // resource like it, which is cards.
 func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values) {
-	isCustomer := len(a.Customer) > 0
+	isCustomer := a.Customer != nil
 
 	var sourceType string
 	if isCustomer {
@@ -64,31 +64,31 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 	}
 
 	// Use token (if exists) or a dictionary containing a user’s bank account details.
-	if len(a.Token) > 0 {
-		body.Add(sourceType, a.Token)
+	if a.Token != nil {
+		body.Add(sourceType, StringValue(a.Token))
 
 		if a.DefaultForCurrency != nil {
 			body.Add("default_for_currency", strconv.FormatBool(BoolValue(a.DefaultForCurrency)))
 		}
 	} else {
 		body.Add(sourceType+"[object]", "bank_account")
-		body.Add(sourceType+"[country]", a.Country)
-		body.Add(sourceType+"[account_number]", a.AccountNumber)
-		body.Add(sourceType+"[currency]", a.Currency)
+		body.Add(sourceType+"[country]", StringValue(a.Country))
+		body.Add(sourceType+"[account_number]", StringValue(a.AccountNumber))
+		body.Add(sourceType+"[currency]", StringValue(a.Currency))
 
 		// These are optional and the API will fail if we try to send empty
 		// values in for them, so make sure to check that they're actually set
 		// before encoding them.
-		if len(a.AccountHolderName) > 0 {
-			body.Add(sourceType+"[account_holder_name]", a.AccountHolderName)
+		if a.AccountHolderName != nil {
+			body.Add(sourceType+"[account_holder_name]", StringValue(a.AccountHolderName))
 		}
 
-		if len(a.AccountHolderType) > 0 {
-			body.Add(sourceType+"[account_holder_type]", a.AccountHolderType)
+		if a.AccountHolderType != nil {
+			body.Add(sourceType+"[account_holder_type]", StringValue(a.AccountHolderType))
 		}
 
-		if len(a.RoutingNumber) > 0 {
-			body.Add(sourceType+"[routing_number]", a.RoutingNumber)
+		if a.RoutingNumber != nil {
+			body.Add(sourceType+"[routing_number]", StringValue(a.RoutingNumber))
 		}
 
 		if a.DefaultForCurrency != nil {
@@ -103,11 +103,11 @@ type BankAccountListParams struct {
 
 	// The identifier of the parent account under which the bank accounts are
 	// nested. Either Account or Customer should be populated.
-	Account string `form:"-"`
+	Account *string `form:"-"`
 
 	// The identifier of the parent customer under which the bank accounts are
 	// nested. Either Account or Customer should be populated.
-	Customer string `form:"-"`
+	Customer *string `form:"-"`
 }
 
 // BankAccount represents a Stripe bank account.

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -16,10 +16,11 @@ type Client struct {
 }
 
 const (
-	NewAccount       stripe.BankAccountStatus = "new"
-	VerifiedAccount  stripe.BankAccountStatus = "verified"
-	ValidatedAccount stripe.BankAccountStatus = "validated"
-	ErroredAccount   stripe.BankAccountStatus = "errored"
+	NewAccount                stripe.BankAccountStatus = "new"
+	VerificationFAiledAccount stripe.BankAccountStatus = "verification_failed"
+	VerifiedAccount           stripe.BankAccountStatus = "verified"
+	ValidatedAccount          stripe.BankAccountStatus = "validated"
+	ErroredAccount            stripe.BankAccountStatus = "errored"
 )
 
 // New POSTs a new bank account.
@@ -40,7 +41,7 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 	if len(params.Customer) > 0 {
 		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", params.Customer), c.Key, body, &params.Params, ba)
 	} else {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, body, &params.Params, ba)
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts", params.Account), c.Key, body, &params.Params, ba)
 	}
 
 	return ba, err
@@ -66,10 +67,10 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 
 	if params != nil && len(params.Customer) > 0 {
 		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if params != nil && len(params.AccountID) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else if params != nil && len(params.Account) > 0 {
+		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
 	} else {
-		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
 
 	return ba, err
@@ -95,10 +96,10 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 
 	if len(params.Customer) > 0 {
 		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if len(params.AccountID) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else if len(params.Account) > 0 {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
 	} else {
-		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
 
 	return ba, err
@@ -124,10 +125,10 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 
 	if len(params.Customer) > 0 {
 		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if len(params.AccountID) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.AccountID, id), c.Key, body, commonParams, ba)
+	} else if len(params.Account) > 0 {
+		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
 	} else {
-		err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
 
 	return ba, err
@@ -153,14 +154,14 @@ func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 
 		if len(params.Customer) > 0 {
 			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts", params.Customer), c.Key, b, p, list)
-		} else if len(params.AccountID) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.AccountID), c.Key, b, p, list)
+		} else if len(params.Account) > 0 {
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.Account), c.Key, b, p, list)
 		} else {
-			err = errors.New("Invalid bank account params: either Customer or AccountID need to be set")
+			err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 		}
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -38,10 +38,10 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 
 	ba := &stripe.BankAccount{}
 	var err error
-	if len(params.Customer) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", params.Customer), c.Key, body, &params.Params, ba)
+	if params.Customer != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, ba)
 	} else {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts", params.Account), c.Key, body, &params.Params, ba)
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, ba)
 	}
 
 	return ba, err
@@ -65,10 +65,10 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	ba := &stripe.BankAccount{}
 	var err error
 
-	if params != nil && len(params.Customer) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if params != nil && len(params.Account) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
+	if params != nil && params.Customer != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+	} else if params != nil && params.Account != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -94,10 +94,10 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 	ba := &stripe.BankAccount{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if len(params.Account) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
+	if params.Customer != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/bank_accounts/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+	} else if params.Account != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/bank_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -123,10 +123,10 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	ba := &stripe.BankAccount{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/bank_accounts/%v", params.Customer, id), c.Key, body, commonParams, ba)
-	} else if len(params.Account) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", params.Account, id), c.Key, body, commonParams, ba)
+	if params.Customer != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/bank_accounts/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+	} else if params.Account != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/bank_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -152,10 +152,10 @@ func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 		list := &stripe.BankAccountList{}
 		var err error
 
-		if len(params.Customer) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts", params.Customer), c.Key, b, p, list)
-		} else if len(params.Account) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", params.Account), c.Key, b, p, list)
+		if params.Customer != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/bank_accounts", stripe.StringValue(params.Customer)), c.Key, b, p, list)
+		} else if params.Account != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/bank_accounts", stripe.StringValue(params.Account)), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 		}

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBankAccountDel_ByAccount(t *testing.T) {
 	bankAcount, err := Del("ba_123", &stripe.BankAccountParams{
-		Account: "acct_123",
+		Account: stripe.String("acct_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -18,26 +18,26 @@ func TestBankAccountDel_ByAccount(t *testing.T) {
 
 func TestBankAccountDel_ByCustomer(t *testing.T) {
 	bankAcount, err := Del("ba_123", &stripe.BankAccountParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
 }
 
 func TestBankAccountGet_ByAccount(t *testing.T) {
-	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Account: "acct_123"})
+	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Account: stripe.String("acct_123")})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
 }
 
 func TestBankAccountGet_ByCustomer(t *testing.T) {
-	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Customer: "cus_123"})
+	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Customer: stripe.String("cus_123")})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
 }
 
 func TestBankAccountList_ByAccount(t *testing.T) {
-	i := List(&stripe.BankAccountListParams{Customer: "acct_123"})
+	i := List(&stripe.BankAccountListParams{Customer: stripe.String("acct_123")})
 
 	// Verify that we can get at least one bank account
 	assert.True(t, i.Next())
@@ -46,7 +46,7 @@ func TestBankAccountList_ByAccount(t *testing.T) {
 }
 
 func TestBankAccountList_ByCustomer(t *testing.T) {
-	i := List(&stripe.BankAccountListParams{Customer: "cus_123"})
+	i := List(&stripe.BankAccountListParams{Customer: stripe.String("cus_123")})
 
 	// Verify that we can get at least one bank account
 	assert.True(t, i.Next())
@@ -56,9 +56,9 @@ func TestBankAccountList_ByCustomer(t *testing.T) {
 
 func TestBankAccountNew_ByAccount(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
-		Account:            "acct_123",
+		Account:            stripe.String("acct_123"),
 		DefaultForCurrency: stripe.Bool(true),
-		Token:              "tok_123",
+		Token:              stripe.String("tok_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -66,8 +66,8 @@ func TestBankAccountNew_ByAccount(t *testing.T) {
 
 func TestBankAccountNew_ByCustomer(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
-		Customer: "cus_123",
-		Token:    "tok_123",
+		Customer: stripe.String("cus_123"),
+		Token:    stripe.String("tok_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -75,7 +75,7 @@ func TestBankAccountNew_ByCustomer(t *testing.T) {
 
 func TestBankAccountUpdate_ByAccount(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
-		Account:            "acct_123",
+		Account:            stripe.String("acct_123"),
 		DefaultForCurrency: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
@@ -84,8 +84,8 @@ func TestBankAccountUpdate_ByAccount(t *testing.T) {
 
 func TestBankAccountUpdate_ByCustomer(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
-		AccountHolderName: "New Name",
-		Customer:          "cus_123",
+		AccountHolderName: stripe.String("New Name"),
+		Customer:          stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -57,7 +57,7 @@ func TestBankAccountList_ByCustomer(t *testing.T) {
 func TestBankAccountNew_ByAccount(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
 		Account:            "acct_123",
-		DefaultForCurrency: true,
+		DefaultForCurrency: stripe.Bool(true),
 		Token:              "tok_123",
 	})
 	assert.Nil(t, err)
@@ -76,7 +76,7 @@ func TestBankAccountNew_ByCustomer(t *testing.T) {
 func TestBankAccountUpdate_ByAccount(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
 		Account:            "acct_123",
-		DefaultForCurrency: true,
+		DefaultForCurrency: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBankAccountDel_ByAccount(t *testing.T) {
 	bankAcount, err := Del("ba_123", &stripe.BankAccountParams{
-		AccountID: "acct_123",
+		Account: "acct_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -25,7 +25,7 @@ func TestBankAccountDel_ByCustomer(t *testing.T) {
 }
 
 func TestBankAccountGet_ByAccount(t *testing.T) {
-	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{AccountID: "acct_123"})
+	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Account: "acct_123"})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
 }
@@ -56,9 +56,9 @@ func TestBankAccountList_ByCustomer(t *testing.T) {
 
 func TestBankAccountNew_ByAccount(t *testing.T) {
 	bankAcount, err := New(&stripe.BankAccountParams{
-		AccountID: "acct_123",
-		Default:   true,
-		Token:     "tok_123",
+		Account:            "acct_123",
+		DefaultForCurrency: true,
+		Token:              "tok_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)
@@ -75,8 +75,8 @@ func TestBankAccountNew_ByCustomer(t *testing.T) {
 
 func TestBankAccountUpdate_ByAccount(t *testing.T) {
 	bankAcount, err := Update("ba_123", &stripe.BankAccountParams{
-		AccountID: "acct_123",
-		Default:   true,
+		Account:            "acct_123",
+		DefaultForCurrency: true,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, bankAcount)

--- a/bankaccount_test.go
+++ b/bankaccount_test.go
@@ -30,7 +30,7 @@ func TestBankAccountParams_AppendToAsSourceOrExternalAccount(t *testing.T) {
 
 	// Includes account_holder_name
 	{
-		params := &BankAccountParams{AccountHolderType: String(string(Individual))}
+		params := &BankAccountParams{AccountHolderType: String("individual")}
 		body := &form.Values{}
 		params.AppendToAsSourceOrExternalAccount(body)
 		t.Logf("body = %+v", body)

--- a/bankaccount_test.go
+++ b/bankaccount_test.go
@@ -12,7 +12,7 @@ func TestBankAccountParams_AppendToAsSourceOrExternalAccount(t *testing.T) {
 
 	// Includes account_holder_name
 	{
-		params := &BankAccountParams{AccountHolderName: "Tyrion"}
+		params := &BankAccountParams{AccountHolderName: String("Tyrion")}
 		body := &form.Values{}
 		params.AppendToAsSourceOrExternalAccount(body)
 		t.Logf("body = %+v", body)
@@ -30,7 +30,7 @@ func TestBankAccountParams_AppendToAsSourceOrExternalAccount(t *testing.T) {
 
 	// Includes account_holder_name
 	{
-		params := &BankAccountParams{AccountHolderType: "individual"}
+		params := &BankAccountParams{AccountHolderType: String(string(Individual))}
 		body := &form.Values{}
 		params.AppendToAsSourceOrExternalAccount(body)
 		t.Logf("body = %+v", body)

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -8,9 +8,9 @@ import (
 // For more details see https://stripe.com/docs/api/#list_bitcoin_receivers.
 type BitcoinReceiverListParams struct {
 	ListParams `form:"*"`
-	NotActive  bool `form:"active,invert"`
-	NotFilled  bool `form:"filled,invert"`
-	Uncaptured bool `form:"uncaptured_funds"`
+	Active     *bool `form:"active"`
+	Filled     *bool `form:"filled"`
+	Uncaptured bool  `form:"uncaptured_funds"`
 }
 
 // BitcoinReceiverParams is the set of parameters that can be used when creating a BitcoinReceiver.

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -45,12 +45,12 @@ type BitcoinReceiver struct {
 	Created               int64                   `json:"created"`
 	Currency              Currency                `json:"currency"`
 	Customer              string                  `json:"customer"`
-	Desc                  string                  `json:"description"`
+	Description           string                  `json:"description"`
 	Email                 string                  `json:"email"`
 	Filled                bool                    `json:"filled"`
 	ID                    string                  `json:"id"`
 	InboundAddress        string                  `json:"inbound_address"`
-	Meta                  map[string]string       `json:"metadata"`
+	Metadata              map[string]string       `json:"metadata"`
 	Payment               string                  `json:"payment"`
 	RefundAddress         string                  `json:"refund_address"`
 	RejectTransactions    bool                    `json:"reject_transactions"`
@@ -60,7 +60,7 @@ type BitcoinReceiver struct {
 // BitcoinReceiverList is a list of bitcoin receivers as retrieved from a list endpoint.
 type BitcoinReceiverList struct {
 	ListMeta
-	Values []*BitcoinReceiver `json:"data"`
+	Data []*BitcoinReceiver `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a BitcoinReceiver.

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -17,7 +17,7 @@ type BitcoinReceiverListParams struct {
 // For more details see https://stripe.com/docs/api/#create_bitcoin_receiver.
 type BitcoinReceiverParams struct {
 	Params   `form:"*"`
-	Amount   *uint64 `form:"amount"`
+	Amount   *int64  `form:"amount"`
 	Currency *string `form:"currency"`
 	Desc     *string `form:"description"`
 	Email    *string `form:"email"`
@@ -37,10 +37,10 @@ type BitcoinReceiverUpdateParams struct {
 // For more details see https://stripe.com/docs/api/#bitcoin_receivers
 type BitcoinReceiver struct {
 	Active                bool                    `json:"active"`
-	Amount                uint64                  `json:"amount"`
-	AmountReceived        uint64                  `json:"amount_received"`
-	BitcoinAmount         uint64                  `json:"bitcoin_amount"`
-	BitcoinAmountReceived uint64                  `json:"bitcoin_amount_received"`
+	Amount                int64                   `json:"amount"`
+	AmountReceived        int64                   `json:"amount_received"`
+	BitcoinAmount         int64                   `json:"bitcoin_amount"`
+	BitcoinAmountReceived int64                   `json:"bitcoin_amount_received"`
 	BitcoinUri            string                  `json:"bitcoin_uri"`
 	Created               int64                   `json:"created"`
 	Currency              Currency                `json:"currency"`

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -7,30 +7,30 @@ import (
 // BitcoinReceiverListParams is the set of parameters that can be used when listing BitcoinReceivers.
 // For more details see https://stripe.com/docs/api/#list_bitcoin_receivers.
 type BitcoinReceiverListParams struct {
-	ListParams `form:"*"`
-	Active     *bool `form:"active"`
-	Filled     *bool `form:"filled"`
-	Uncaptured *bool `form:"uncaptured_funds"`
+	ListParams      `form:"*"`
+	Active          *bool `form:"active"`
+	Filled          *bool `form:"filled"`
+	UncapturedFunds *bool `form:"uncaptured_funds"`
 }
 
 // BitcoinReceiverParams is the set of parameters that can be used when creating a BitcoinReceiver.
 // For more details see https://stripe.com/docs/api/#create_bitcoin_receiver.
 type BitcoinReceiverParams struct {
-	Params   `form:"*"`
-	Amount   *int64  `form:"amount"`
-	Currency *string `form:"currency"`
-	Desc     *string `form:"description"`
-	Email    *string `form:"email"`
+	Params      `form:"*"`
+	Amount      *int64  `form:"amount"`
+	Currency    *string `form:"currency"`
+	Description *string `form:"description"`
+	Email       *string `form:"email"`
 }
 
 // BitcoinReceiverUpdateParams is the set of parameters that can be used when
 // updating a BitcoinReceiver. For more details see
 // https://stripe.com/docs/api/#update_bitcoin_receiver.
 type BitcoinReceiverUpdateParams struct {
-	Params     `form:"*"`
-	Desc       *string `form:"description"`
-	Email      *string `form:"email"`
-	RefundAddr *string `form:"refund_address"`
+	Params        `form:"*"`
+	Description   *string `form:"description"`
+	Email         *string `form:"email"`
+	RefundAddress *string `form:"refund_address"`
 }
 
 // BitcoinReceiver is the resource representing a Stripe bitcoin receiver.

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -10,17 +10,17 @@ type BitcoinReceiverListParams struct {
 	ListParams `form:"*"`
 	Active     *bool `form:"active"`
 	Filled     *bool `form:"filled"`
-	Uncaptured bool  `form:"uncaptured_funds"`
+	Uncaptured *bool `form:"uncaptured_funds"`
 }
 
 // BitcoinReceiverParams is the set of parameters that can be used when creating a BitcoinReceiver.
 // For more details see https://stripe.com/docs/api/#create_bitcoin_receiver.
 type BitcoinReceiverParams struct {
 	Params   `form:"*"`
-	Amount   uint64   `form:"amount"`
-	Currency Currency `form:"currency"`
-	Desc     string   `form:"description"`
-	Email    string   `form:"email"`
+	Amount   *uint64 `form:"amount"`
+	Currency *string `form:"currency"`
+	Desc     *string `form:"description"`
+	Email    *string `form:"email"`
 }
 
 // BitcoinReceiverUpdateParams is the set of parameters that can be used when
@@ -28,9 +28,9 @@ type BitcoinReceiverParams struct {
 // https://stripe.com/docs/api/#update_bitcoin_receiver.
 type BitcoinReceiverUpdateParams struct {
 	Params     `form:"*"`
-	Desc       string `form:"description"`
-	Email      string `form:"email"`
-	RefundAddr string `form:"refund_address"`
+	Desc       *string `form:"description"`
+	Email      *string `form:"email"`
+	RefundAddr *string `form:"refund_address"`
 }
 
 // BitcoinReceiver is the resource representing a Stripe bitcoin receiver.

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -90,8 +90,8 @@ func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
 		list := &stripe.BitcoinReceiverList{}
 		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/bitcointransaction.go
+++ b/bitcointransaction.go
@@ -14,7 +14,7 @@ type BitcoinTransactionListParams struct {
 // For more details see https://stripe.com/docs/api/#retrieve_bitcoin_receiver
 type BitcoinTransactionList struct {
 	ListMeta
-	Values []*BitcoinTransaction `json:"data"`
+	Data []*BitcoinTransaction `json:"data"`
 }
 
 // BitcoinTransaction is the resource representing a Stripe bitcoin transaction.

--- a/bitcointransaction.go
+++ b/bitcointransaction.go
@@ -20,8 +20,8 @@ type BitcoinTransactionList struct {
 // BitcoinTransaction is the resource representing a Stripe bitcoin transaction.
 // For more details see https://stripe.com/docs/api/#bitcoin_receivers
 type BitcoinTransaction struct {
-	Amount        uint64   `json:"amount"`
-	BitcoinAmount uint64   `json:"bitcoin_amount"`
+	Amount        int64    `json:"amount"`
+	BitcoinAmount int64    `json:"bitcoin_amount"`
 	Created       int64    `json:"created"`
 	Currency      Currency `json:"currency"`
 	Customer      string   `json:"customer"`

--- a/bitcointransaction.go
+++ b/bitcointransaction.go
@@ -5,8 +5,8 @@ import "encoding/json"
 // BitcoinTransactionListParams is the set of parameters that can be used when listing BitcoinTransactions.
 type BitcoinTransactionListParams struct {
 	ListParams `form:"*"`
-	Customer   string `form:"customer"`
-	Receiver   string `form:"-"` // Sent in with the URL
+	Customer   *string `form:"customer"`
+	Receiver   *string `form:"-"` // Sent in with the URL
 }
 
 // BitcoinTransactionList is a list object for BitcoinTransactions.

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -36,8 +36,8 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 		list := &stripe.BitcoinTransactionList{}
 		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -34,7 +34,7 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinTransactionList{}
-		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", params.Receiver), c.Key, b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", stripe.StringValue(params.Receiver)), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/bitcointransaction/client_test.go
+++ b/bitcointransaction/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBitcoinTransactionList(t *testing.T) {
 	i := List(&stripe.BitcoinTransactionListParams{
-		Receiver: "btcrcv_123",
+		Receiver: stripe.String("btcrcv_123"),
 	})
 
 	// Verify that we can get at least one transaction

--- a/card.go
+++ b/card.go
@@ -36,23 +36,23 @@ type Verification string
 // of all parameters. See AppendToAsCardSourceOrExternalAccount.
 type CardParams struct {
 	Params             `form:"*"`
-	Account            string `form:"-"`
-	AddressCity        string `form:"address_city"`
-	AddressCountry     string `form:"address_country"`
-	AddressLine1       string `form:"address_line1"`
-	AddressLine2       string `form:"address_line2"`
-	AddressState       string `form:"address_state"`
-	AddressZip         string `form:"address_zip"`
-	CVC                string `form:"cvc"`
-	Currency           string `form:"currency"`
-	Customer           string `form:"-"`
-	DefaultForCurrency bool   `form:"default_for_currency"`
-	ExpMonth           string `form:"exp_month"`
-	ExpYear            string `form:"exp_year"`
-	Name               string `form:"name"`
-	Number             string `form:"number"`
-	Recipient          string `form:"-"`
-	Token              string `form:"-"`
+	Account            *string `form:"-"`
+	AddressCity        *string `form:"address_city"`
+	AddressCountry     *string `form:"address_country"`
+	AddressLine1       *string `form:"address_line1"`
+	AddressLine2       *string `form:"address_line2"`
+	AddressState       *string `form:"address_state"`
+	AddressZip         *string `form:"address_zip"`
+	CVC                *string `form:"cvc"`
+	Currency           *string `form:"currency"`
+	Customer           *string `form:"-"`
+	DefaultForCurrency *bool   `form:"default_for_currency"`
+	ExpMonth           *string `form:"exp_month"`
+	ExpYear            *string `form:"exp_year"`
+	Name               *string `form:"name"`
+	Number             *string `form:"number"`
+	Recipient          *string `form:"-"`
+	Token              *string `form:"-"`
 
 	// ID is used when tokenizing a card for shared customers
 	ID string `form:"*"`
@@ -73,65 +73,65 @@ type CardParams struct {
 func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, keyParts []string) {
 	form.AppendToPrefixed(body, c.Params, keyParts)
 
-	if c.DefaultForCurrency {
-		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(c.DefaultForCurrency))
+	if c.DefaultForCurrency != nil {
+		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(BoolValue(c.DefaultForCurrency)))
 	}
 
-	if len(c.Token) > 0 {
-		if len(c.Account) > 0 {
-			body.Add(form.FormatKey(append(keyParts, "external_account")), c.Token)
+	if c.Token != nil {
+		if c.Account != nil {
+			body.Add(form.FormatKey(append(keyParts, "external_account")), StringValue(c.Token))
 		} else {
-			body.Add(form.FormatKey(append(keyParts, cardSource)), c.Token)
+			body.Add(form.FormatKey(append(keyParts, cardSource)), StringValue(c.Token))
 		}
 	}
 
-	if len(c.Number) > 0 {
+	if c.Number != nil {
 		body.Add(form.FormatKey(append(keyParts, cardSource, "object")), "card")
-		body.Add(form.FormatKey(append(keyParts, cardSource, "number")), c.Number)
+		body.Add(form.FormatKey(append(keyParts, cardSource, "number")), StringValue(c.Number))
 	}
 
-	if len(c.CVC) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "cvc")), c.CVC)
+	if c.CVC != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "cvc")), StringValue(c.CVC))
 	}
 
-	if len(c.Currency) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "currency")), c.Currency)
+	if c.Currency != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "currency")), StringValue(c.Currency))
 	}
 
-	if len(c.ExpMonth) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), c.ExpMonth)
+	if c.ExpMonth != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), StringValue(c.ExpMonth))
 	}
 
-	if len(c.ExpYear) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), c.ExpYear)
+	if c.ExpYear != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), StringValue(c.ExpYear))
 	}
 
-	if len(c.Name) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "name")), c.Name)
+	if c.Name != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "name")), StringValue(c.Name))
 	}
 
-	if len(c.AddressCity) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), c.AddressCity)
+	if c.AddressCity != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), StringValue(c.AddressCity))
 	}
 
-	if len(c.AddressCountry) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), c.AddressCountry)
+	if c.AddressCountry != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), StringValue(c.AddressCountry))
 	}
 
-	if len(c.AddressLine1) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), c.AddressLine1)
+	if c.AddressLine1 != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), StringValue(c.AddressLine1))
 	}
 
-	if len(c.AddressLine2) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), c.AddressLine2)
+	if c.AddressLine2 != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), StringValue(c.AddressLine2))
 	}
 
-	if len(c.AddressState) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), c.AddressState)
+	if c.AddressState != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), StringValue(c.AddressState))
 	}
 
-	if len(c.AddressZip) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), c.AddressZip)
+	if c.AddressZip != nil {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), StringValue(c.AddressZip))
 	}
 }
 
@@ -139,9 +139,9 @@ func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, ke
 // For more details see https://stripe.com/docs/api#list_cards.
 type CardListParams struct {
 	ListParams `form:"*"`
-	Account    string `form:"-"`
-	Customer   string `form:"-"`
-	Recipient  string `form:"-"`
+	Account    *string `form:"-"`
+	Customer   *string `form:"-"`
+	Recipient  *string `form:"-"`
 }
 
 // Card is the resource representing a Stripe credit/debit card.

--- a/card.go
+++ b/card.go
@@ -35,24 +35,24 @@ type Verification string
 // cards have some unusual logic on creates that necessitates manual handling
 // of all parameters. See AppendToAsCardSourceOrExternalAccount.
 type CardParams struct {
-	Params    `form:"*"`
-	Account   string `form:"-"`
-	Address1  string `form:"address_line1"`
-	Address2  string `form:"address_line2"`
-	CVC       string `form:"cvc"`
-	City      string `form:"address_city"`
-	Country   string `form:"address_country"`
-	Currency  string `form:"currency"`
-	Customer  string `form:"-"`
-	Default   bool   `form:"default_for_currency"`
-	Month     string `form:"exp_month"`
-	Name      string `form:"name"`
-	Number    string `form:"number"`
-	Recipient string `form:"-"`
-	State     string `form:"address_state"`
-	Token     string `form:"-"`
-	Year      string `form:"exp_year"`
-	Zip       string `form:"address_zip"`
+	Params             `form:"*"`
+	Account            string `form:"-"`
+	AddressCity        string `form:"address_city"`
+	AddressCountry     string `form:"address_country"`
+	AddressLine1       string `form:"address_line1"`
+	AddressLine2       string `form:"address_line2"`
+	AddressState       string `form:"address_state"`
+	AddressZip         string `form:"address_zip"`
+	CVC                string `form:"cvc"`
+	Currency           string `form:"currency"`
+	Customer           string `form:"-"`
+	DefaultForCurrency bool   `form:"default_for_currency"`
+	ExpMonth           string `form:"exp_month"`
+	ExpYear            string `form:"exp_year"`
+	Name               string `form:"name"`
+	Number             string `form:"number"`
+	Recipient          string `form:"-"`
+	Token              string `form:"-"`
 
 	// ID is used when tokenizing a card for shared customers
 	ID string `form:"*"`
@@ -73,8 +73,8 @@ type CardParams struct {
 func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, keyParts []string) {
 	form.AppendToPrefixed(body, c.Params, keyParts)
 
-	if c.Default {
-		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(c.Default))
+	if c.DefaultForCurrency {
+		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(c.DefaultForCurrency))
 	}
 
 	if len(c.Token) > 0 {
@@ -98,44 +98,40 @@ func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, ke
 		body.Add(form.FormatKey(append(keyParts, cardSource, "currency")), c.Currency)
 	}
 
-	if c.Default {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "default_for_currency")), strconv.FormatBool(c.Default))
+	if len(c.ExpMonth) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), c.ExpMonth)
 	}
 
-	if len(c.Month) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), c.Month)
-	}
-
-	if len(c.Year) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), c.Year)
+	if len(c.ExpYear) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), c.ExpYear)
 	}
 
 	if len(c.Name) > 0 {
 		body.Add(form.FormatKey(append(keyParts, cardSource, "name")), c.Name)
 	}
 
-	if len(c.Address1) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), c.Address1)
+	if len(c.AddressCity) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), c.AddressCity)
 	}
 
-	if len(c.Address2) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), c.Address2)
+	if len(c.AddressCountry) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), c.AddressCountry)
 	}
 
-	if len(c.City) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), c.City)
+	if len(c.AddressLine1) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), c.AddressLine1)
 	}
 
-	if len(c.State) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), c.State)
+	if len(c.AddressLine2) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), c.AddressLine2)
 	}
 
-	if len(c.Zip) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), c.Zip)
+	if len(c.AddressState) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), c.AddressState)
 	}
 
-	if len(c.Country) > 0 {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), c.Country)
+	if len(c.AddressZip) > 0 {
+		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), c.AddressZip)
 	}
 }
 
@@ -151,18 +147,21 @@ type CardListParams struct {
 // Card is the resource representing a Stripe credit/debit card.
 // For more details see https://stripe.com/docs/api#cards.
 type Card struct {
-	Address1      string       `json:"address_line1"`
-	Address1Check Verification `json:"address_line1_check"`
-	Address2      string       `json:"address_line2"`
-	Brand         CardBrand    `json:"brand"`
-	CVCCheck      Verification `json:"cvc_check"`
-	CardCountry   string       `json:"country"`
-	City          string       `json:"address_city"`
-	Country       string       `json:"address_country"`
-	Currency      Currency     `json:"currency"`
-	Customer      *Customer    `json:"customer"`
-	Default       bool         `json:"default_for_currency"`
-	Deleted       bool         `json:"deleted"`
+	AddressCity        string       `json:"address_city"`
+	AddressCountry     string       `json:"address_country"`
+	AddressLine1       string       `json:"address_line1"`
+	AddressLine1Check  Verification `json:"address_line1_check"`
+	AddressLine2       string       `json:"address_line2"`
+	AddressState       string       `json:"address_state"`
+	AddressZip         string       `json:"address_zip"`
+	AddressZipCheck    Verification `json:"address_zip_check"`
+	Brand              CardBrand    `json:"brand"`
+	CVCCheck           Verification `json:"cvc_check"`
+	Country            string       `json:"country"`
+	Currency           Currency     `json:"currency"`
+	Customer           *Customer    `json:"customer"`
+	DefaultForCurrency bool         `json:"default_for_currency"`
+	Deleted            bool         `json:"deleted"`
 
 	// Description is a succinct summary of the card's information.
 	//
@@ -170,10 +169,12 @@ type Card struct {
 	// as part of standard API requests.
 	Description string `json:"description"`
 
-	DynLastFour string      `json:"dynamic_last4"`
-	Fingerprint string      `json:"fingerprint"`
-	Funding     CardFunding `json:"funding"`
-	ID          string      `json:"id"`
+	DynamicLast4 string      `json:"dynamic_last4"`
+	ExpMonth     uint8       `json:"exp_month"`
+	ExpYear      uint16      `json:"exp_year"`
+	Fingerprint  string      `json:"fingerprint"`
+	Funding      CardFunding `json:"funding"`
+	ID           string      `json:"id"`
 
 	// IIN is the card's "Issuer Identification Number".
 	//
@@ -187,23 +188,18 @@ type Card struct {
 	// as part of standard API requests.
 	Issuer string `json:"issuer"`
 
-	LastFour           string             `json:"last4"`
-	Meta               map[string]string  `json:"metadata"`
-	Month              uint8              `json:"exp_month"`
+	Last4              string             `json:"last4"`
+	Metadata           map[string]string  `json:"metadata"`
 	Name               string             `json:"name"`
 	Recipient          *Recipient         `json:"recipient"`
-	State              string             `json:"address_state"`
 	ThreeDSecure       *ThreeDSecure      `json:"three_d_secure"`
 	TokenizationMethod TokenizationMethod `json:"tokenization_method"`
-	Year               uint16             `json:"exp_year"`
-	Zip                string             `json:"address_zip"`
-	ZipCheck           Verification       `json:"address_zip_check"`
 }
 
 // CardList is a list object for cards.
 type CardList struct {
 	ListMeta
-	Values []*Card `json:"data"`
+	Data []*Card `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Card.

--- a/card/client.go
+++ b/card/client.go
@@ -203,8 +203,8 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 			err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 		}
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/card/client.go
+++ b/card/client.go
@@ -55,12 +55,12 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	card := &stripe.Card{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, body, &params.Params, card)
-	} else if len(params.Customer) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/cards", params.Customer), c.Key, body, &params.Params, card)
-	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards", params.Recipient), c.Key, body, &params.Params, card)
+	if params.Account != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, card)
+	} else if params.Customer != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/cards", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, card)
+	} else if params.Recipient != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards", stripe.StringValue(params.Recipient)), c.Key, body, &params.Params, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -91,12 +91,12 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	card := &stripe.Card{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts/%v", params.Account, id), c.Key, body, commonParams, card)
-	} else if len(params.Customer) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards/%v", params.Customer, id), c.Key, body, commonParams, card)
-	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards/%v", params.Recipient, id), c.Key, body, commonParams, card)
+	if params.Account != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
+	} else if params.Customer != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
+	} else if params.Recipient != nil {
+		err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -121,12 +121,12 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 	card := &stripe.Card{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts/%v", params.Account, id), c.Key, body, &params.Params, card)
-	} else if len(params.Customer) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/cards/%v", params.Customer, id), c.Key, body, &params.Params, card)
-	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards/%v", params.Recipient, id), c.Key, body, &params.Params, card)
+	if params.Account != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, &params.Params, card)
+	} else if params.Customer != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/cards/%v", stripe.StringValue(params.Customer), id), c.Key, body, &params.Params, card)
+	} else if params.Recipient != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, &params.Params, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -155,12 +155,12 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	card := &stripe.Card{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/external_accounts/%v", params.Account, id), c.Key, body, commonParams, card)
-	} else if len(params.Customer) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/cards/%v", params.Customer, id), c.Key, body, commonParams, card)
-	} else if len(params.Recipient) > 0 {
-		err = c.B.Call("DELETE", fmt.Sprintf("/recipients/%v/cards/%v", params.Recipient, id), c.Key, body, commonParams, card)
+	if params.Account != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
+	} else if params.Customer != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/cards/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
+	} else if params.Recipient != nil {
+		err = c.B.Call("DELETE", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -193,12 +193,12 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 			return nil, list.ListMeta, errors.New("params should not be nil")
 		}
 
-		if len(params.Account) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", params.Account), c.Key, b, p, list)
-		} else if len(params.Customer) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards", params.Customer), c.Key, b, p, list)
-		} else if len(params.Recipient) > 0 {
-			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", params.Recipient), c.Key, b, p, list)
+		if params.Account != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts", stripe.StringValue(params.Account)), c.Key, b, p, list)
+		} else if params.Customer != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/cards", stripe.StringValue(params.Customer)), c.Key, b, p, list)
+		} else if params.Recipient != nil {
+			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", stripe.StringValue(params.Recipient)), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 		}

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCardDel(t *testing.T) {
 	card, err := Del("card_123", &stripe.CardParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)
@@ -23,7 +23,7 @@ func TestCardDel_RequiresParams(t *testing.T) {
 
 func TestCardGet(t *testing.T) {
 	card, err := Get("card_123", &stripe.CardParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)
@@ -35,7 +35,7 @@ func TestCardGet_RequiresParams(t *testing.T) {
 }
 
 func TestCardList_ByCustomer(t *testing.T) {
-	i := List(&stripe.CardListParams{Customer: "cus_123"})
+	i := List(&stripe.CardListParams{Customer: stripe.String("cus_123")})
 
 	// Verify that we can get at least one card
 	assert.True(t, i.Next())
@@ -51,8 +51,8 @@ func TestCardList_RequiresParams(t *testing.T) {
 
 func TestCardNew(t *testing.T) {
 	card, err := New(&stripe.CardParams{
-		Customer: "cus_123",
-		Token:    "tok_123",
+		Customer: stripe.String("cus_123"),
+		Token:    stripe.String("tok_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)
@@ -65,8 +65,8 @@ func TestCardNew_RequiresParams(t *testing.T) {
 
 func TestCardUpdate(t *testing.T) {
 	card, err := Update("card_123", &stripe.CardParams{
-		Customer: "cus_123",
-		Name:     "New Name",
+		Customer: stripe.String("cus_123"),
+		Name:     stripe.String("New Name"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, card)

--- a/charge.go
+++ b/charge.go
@@ -15,22 +15,22 @@ type FraudReport string
 // ChargeParams is the set of parameters that can be used when creating or updating a charge.
 // For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
-	Params        `form:"*"`
-	Amount        uint64              `form:"amount"`
-	Currency      Currency            `form:"currency"`
-	Customer      string              `form:"customer"`
-	Desc          string              `form:"description"`
-	Destination   *DestinationParams  `form:"destination"`
-	Email         string              `form:"receipt_email"`
-	ExchangeRate  float64             `form:"exchange_rate"`
-	Fee           uint64              `form:"application_fee"`
-	FraudDetails  *FraudDetailsParams `form:"fraud_details"`
-	NoCapture     bool                `form:"capture,invert"`
-	OnBehalfOf    string              `form:"on_behalf_of"`
-	Shipping      *ShippingDetails    `form:"shipping"`
-	Source        *SourceParams       `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	Statement     string              `form:"statement_descriptor"`
-	TransferGroup string              `form:"transfer_group"`
+	Params              `form:"*"`
+	Amount              uint64              `form:"amount"`
+	ApplicationFee      uint64              `form:"application_fee"`
+	Currency            Currency            `form:"currency"`
+	Customer            string              `form:"customer"`
+	Description         string              `form:"description"`
+	Destination         *DestinationParams  `form:"destination"`
+	ExchangeRate        float64             `form:"exchange_rate"`
+	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
+	NoCapture           bool                `form:"capture,invert"`
+	OnBehalfOf          string              `form:"on_behalf_of"`
+	ReceiptEmail        string              `form:"receipt_email"`
+	Shipping            *ShippingDetails    `form:"shipping"`
+	Source              *SourceParams       `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	StatementDescriptor string              `form:"statement_descriptor"`
+	TransferGroup       string              `form:"transfer_group"`
 }
 
 // SetSource adds valid sources to a ChargeParams object,
@@ -64,50 +64,50 @@ type ChargeListParams struct {
 // CaptureParams is the set of parameters that can be used when capturing a charge.
 // For more details see https://stripe.com/docs/api#charge_capture.
 type CaptureParams struct {
-	Params       `form:"*"`
-	Amount       uint64  `form:"amount"`
-	Email        string  `form:"receipt_email"`
-	ExchangeRate float64 `form:"exchange_rate"`
-	Fee          uint64  `form:"application_fee"`
-	Statement    string  `form:"statement_descriptor"`
+	Params              `form:"*"`
+	Amount              uint64  `form:"amount"`
+	ApplicationFee      uint64  `form:"application_fee"`
+	ExchangeRate        float64 `form:"exchange_rate"`
+	ReceiptEmail        string  `form:"receipt_email"`
+	StatementDescriptor string  `form:"statement_descriptor"`
 }
 
 // Charge is the resource representing a Stripe charge.
 // For more details see https://stripe.com/docs/api#charges.
 type Charge struct {
-	Amount         uint64            `json:"amount"`
-	AmountRefunded uint64            `json:"amount_refunded"`
-	Application    *Application      `json:"application"`
-	Captured       bool              `json:"captured"`
-	Created        int64             `json:"created"`
-	Currency       Currency          `json:"currency"`
-	Customer       *Customer         `json:"customer"`
-	Desc           string            `json:"description"`
-	Dest           *Account          `json:"destination"`
-	Dispute        *Dispute          `json:"dispute"`
-	Email          string            `json:"receipt_email"`
-	FailCode       string            `json:"failure_code"`
-	FailMsg        string            `json:"failure_message"`
-	Fee            *Fee              `json:"application_fee"`
-	FraudDetails   *FraudDetails     `json:"fraud_details"`
-	ID             string            `json:"id"`
-	Invoice        *Invoice          `json:"invoice"`
-	Live           bool              `json:"livemode"`
-	Meta           map[string]string `json:"metadata"`
-	Outcome        *ChargeOutcome    `json:"outcome"`
-	Paid           bool              `json:"paid"`
-	ReceiptNumber  string            `json:"receipt_number"`
-	Refunded       bool              `json:"refunded"`
-	Refunds        *RefundList       `json:"refunds"`
-	Review         *Review           `json:"review"`
-	Shipping       *ShippingDetails  `json:"shipping"`
-	Source         *PaymentSource    `json:"source"`
-	SourceTransfer *Transfer         `json:"source_transfer"`
-	Statement      string            `json:"statement_descriptor"`
-	Status         string            `json:"status"`
-	Transfer       *Transfer         `json:"transfer"`
-	TransferGroup  string            `json:"transfer_group"`
-	Tx             *Transaction      `json:"balance_transaction"`
+	Amount              uint64              `json:"amount"`
+	AmountRefunded      uint64              `json:"amount_refunded"`
+	Application         *Application        `json:"application"`
+	ApplicationFee      *ApplicationFee     `json:"application_fee"`
+	BalanceTransaction  *BalanceTransaction `json:"balance_transaction"`
+	Captured            bool                `json:"captured"`
+	Created             int64               `json:"created"`
+	Currency            Currency            `json:"currency"`
+	Customer            *Customer           `json:"customer"`
+	Description         string              `json:"description"`
+	Destination         *Account            `json:"destination"`
+	Dispute             *Dispute            `json:"dispute"`
+	FailureCode         string              `json:"failure_code"`
+	FailureMessage      string              `json:"failure_message"`
+	FraudDetails        *FraudDetails       `json:"fraud_details"`
+	ID                  string              `json:"id"`
+	Invoice             *Invoice            `json:"invoice"`
+	Livemode            bool                `json:"livemode"`
+	Metadata            map[string]string   `json:"metadata"`
+	Outcome             *ChargeOutcome      `json:"outcome"`
+	Paid                bool                `json:"paid"`
+	ReceiptEmail        string              `json:"receipt_email"`
+	ReceiptNumber       string              `json:"receipt_number"`
+	Refunded            bool                `json:"refunded"`
+	Refunds             *RefundList         `json:"refunds"`
+	Review              *Review             `json:"review"`
+	Shipping            *ShippingDetails    `json:"shipping"`
+	Source              *PaymentSource      `json:"source"`
+	SourceTransfer      *Transfer           `json:"source_transfer"`
+	StatementDescriptor string              `json:"statement_descriptor"`
+	Status              string              `json:"status"`
+	Transfer            *Transfer           `json:"transfer"`
+	TransferGroup       string              `json:"transfer_group"`
 }
 
 // UnmarshalJSON handles deserialization of a charge.
@@ -129,7 +129,7 @@ func (c *Charge) UnmarshalJSON(data []byte) error {
 // ChargeList is a list of charges as retrieved from a list endpoint.
 type ChargeList struct {
 	ListMeta
-	Values []*Charge `json:"data"`
+	Data []*Charge `json:"data"`
 }
 
 // FraudDetails is the structure detailing fraud status.
@@ -158,11 +158,11 @@ type ChargeOutcome struct {
 
 // ShippingDetails is the structure containing shipping information.
 type ShippingDetails struct {
-	Address  Address `json:"address" form:"address"`
-	Carrier  string  `json:"carrier" form:"carrier"`
-	Name     string  `json:"name" form:"name"`
-	Phone    string  `json:"phone" form:"phone"`
-	Tracking string  `json:"tracking_number" form:"tracking_number"`
+	Address        Address `json:"address" form:"address"`
+	Carrier        string  `json:"carrier" form:"carrier"`
+	Name           string  `json:"name" form:"name"`
+	Phone          string  `json:"phone" form:"phone"`
+	TrackingNumber string  `json:"tracking_number" form:"tracking_number"`
 }
 
 var depth int = -1

--- a/charge.go
+++ b/charge.go
@@ -18,13 +18,13 @@ type ChargeParams struct {
 	Params              `form:"*"`
 	Amount              uint64              `form:"amount"`
 	ApplicationFee      uint64              `form:"application_fee"`
+	Capture             *bool               `form:"capture"`
 	Currency            Currency            `form:"currency"`
 	Customer            string              `form:"customer"`
 	Description         string              `form:"description"`
 	Destination         *DestinationParams  `form:"destination"`
 	ExchangeRate        float64             `form:"exchange_rate"`
 	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
-	NoCapture           bool                `form:"capture,invert"`
 	OnBehalfOf          string              `form:"on_behalf_of"`
 	ReceiptEmail        string              `form:"receipt_email"`
 	Shipping            *ShippingDetails    `form:"shipping"`

--- a/charge.go
+++ b/charge.go
@@ -16,8 +16,8 @@ type FraudReport string
 // For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
 	Params              `form:"*"`
-	Amount              *uint64                `form:"amount"`
-	ApplicationFee      *uint64                `form:"application_fee"`
+	Amount              *int64                 `form:"amount"`
+	ApplicationFee      *int64                 `form:"application_fee"`
 	Capture             *bool                  `form:"capture"`
 	Currency            *string                `form:"currency"`
 	Customer            *string                `form:"customer"`
@@ -52,7 +52,7 @@ func (p *ChargeParams) SetSource(sp interface{}) error {
 
 type DestinationParams struct {
 	Account *string `form:"account"`
-	Amount  *uint64 `form:"amount"`
+	Amount  *int64  `form:"amount"`
 }
 
 // FraudDetailsParams provides information on the fraud details for a charge.
@@ -74,8 +74,8 @@ type ChargeListParams struct {
 // For more details see https://stripe.com/docs/api#charge_capture.
 type CaptureParams struct {
 	Params              `form:"*"`
-	Amount              *uint64  `form:"amount"`
-	ApplicationFee      *uint64  `form:"application_fee"`
+	Amount              *int64   `form:"amount"`
+	ApplicationFee      *int64   `form:"application_fee"`
 	ExchangeRate        *float64 `form:"exchange_rate"`
 	ReceiptEmail        *string  `form:"receipt_email"`
 	StatementDescriptor *string  `form:"statement_descriptor"`
@@ -84,8 +84,8 @@ type CaptureParams struct {
 // Charge is the resource representing a Stripe charge.
 // For more details see https://stripe.com/docs/api#charges.
 type Charge struct {
-	Amount              uint64              `json:"amount"`
-	AmountRefunded      uint64              `json:"amount_refunded"`
+	Amount              int64               `json:"amount"`
+	AmountRefunded      int64               `json:"amount_refunded"`
 	Application         *Application        `json:"application"`
 	ApplicationFee      *ApplicationFee     `json:"application_fee"`
 	BalanceTransaction  *BalanceTransaction `json:"balance_transaction"`

--- a/charge.go
+++ b/charge.go
@@ -16,21 +16,30 @@ type FraudReport string
 // For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
 	Params              `form:"*"`
-	Amount              uint64              `form:"amount"`
-	ApplicationFee      uint64              `form:"application_fee"`
-	Capture             *bool               `form:"capture"`
-	Currency            Currency            `form:"currency"`
-	Customer            string              `form:"customer"`
-	Description         string              `form:"description"`
-	Destination         *DestinationParams  `form:"destination"`
-	ExchangeRate        float64             `form:"exchange_rate"`
-	FraudDetails        *FraudDetailsParams `form:"fraud_details"`
-	OnBehalfOf          string              `form:"on_behalf_of"`
-	ReceiptEmail        string              `form:"receipt_email"`
-	Shipping            *ShippingDetails    `form:"shipping"`
-	Source              *SourceParams       `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	StatementDescriptor string              `form:"statement_descriptor"`
-	TransferGroup       string              `form:"transfer_group"`
+	Amount              *uint64                `form:"amount"`
+	ApplicationFee      *uint64                `form:"application_fee"`
+	Capture             *bool                  `form:"capture"`
+	Currency            *string                `form:"currency"`
+	Customer            *string                `form:"customer"`
+	Description         *string                `form:"description"`
+	Destination         *DestinationParams     `form:"destination"`
+	ExchangeRate        *float64               `form:"exchange_rate"`
+	FraudDetails        *FraudDetailsParams    `form:"fraud_details"`
+	OnBehalfOf          *string                `form:"on_behalf_of"`
+	ReceiptEmail        *string                `form:"receipt_email"`
+	Shipping            *ShippingDetailsParams `form:"shipping"`
+	Source              *SourceParams          `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	StatementDescriptor *string                `form:"statement_descriptor"`
+	TransferGroup       *string                `form:"transfer_group"`
+}
+
+// ShippingDetailsParams is the structure containing shipping information as parameters
+type ShippingDetailsParams struct {
+	Address        *AddressParams `form:"address"`
+	Carrier        *string        `form:"carrier"`
+	Name           *string        `form:"name"`
+	Phone          *string        `form:"phone"`
+	TrackingNumber *string        `form:"tracking_number"`
 }
 
 // SetSource adds valid sources to a ChargeParams object,
@@ -42,34 +51,34 @@ func (p *ChargeParams) SetSource(sp interface{}) error {
 }
 
 type DestinationParams struct {
-	Account string `form:"account"`
-	Amount  uint64 `form:"amount"`
+	Account *string `form:"account"`
+	Amount  *uint64 `form:"amount"`
 }
 
 // FraudDetailsParams provides information on the fraud details for a charge.
 type FraudDetailsParams struct {
-	UserReport FraudReport `form:"user_report"`
+	UserReport *string `form:"user_report"`
 }
 
 // ChargeListParams is the set of parameters that can be used when listing charges.
 // For more details see https://stripe.com/docs/api#list_charges.
 type ChargeListParams struct {
 	ListParams    `form:"*"`
-	Created       int64             `form:"created"`
+	Created       *int64            `form:"created"`
 	CreatedRange  *RangeQueryParams `form:"created"`
-	Customer      string            `form:"customer"`
-	TransferGroup string            `form:"transfer_group"`
+	Customer      *string           `form:"customer"`
+	TransferGroup *string           `form:"transfer_group"`
 }
 
 // CaptureParams is the set of parameters that can be used when capturing a charge.
 // For more details see https://stripe.com/docs/api#charge_capture.
 type CaptureParams struct {
 	Params              `form:"*"`
-	Amount              uint64  `form:"amount"`
-	ApplicationFee      uint64  `form:"application_fee"`
-	ExchangeRate        float64 `form:"exchange_rate"`
-	ReceiptEmail        string  `form:"receipt_email"`
-	StatementDescriptor string  `form:"statement_descriptor"`
+	Amount              *uint64  `form:"amount"`
+	ApplicationFee      *uint64  `form:"application_fee"`
+	ExchangeRate        *float64 `form:"exchange_rate"`
+	ReceiptEmail        *string  `form:"receipt_email"`
+	StatementDescriptor *string  `form:"statement_descriptor"`
 }
 
 // Charge is the resource representing a Stripe charge.
@@ -158,11 +167,11 @@ type ChargeOutcome struct {
 
 // ShippingDetails is the structure containing shipping information.
 type ShippingDetails struct {
-	Address        Address `json:"address" form:"address"`
-	Carrier        string  `json:"carrier" form:"carrier"`
-	Name           string  `json:"name" form:"name"`
-	Phone          string  `json:"phone" form:"phone"`
-	TrackingNumber string  `json:"tracking_number" form:"tracking_number"`
+	Address        Address `json:"address"`
+	Carrier        string  `json:"carrier"`
+	Name           string  `json:"name"`
+	Phone          string  `json:"phone"`
+	TrackingNumber string  `json:"tracking_number"`
 }
 
 var depth int = -1

--- a/charge/client.go
+++ b/charge/client.go
@@ -124,8 +124,8 @@ func (c Client) List(params *stripe.ChargeListParams) *Iter {
 		list := &stripe.ChargeList{}
 		err := c.B.Call("GET", "/charges", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/charge/client.go
+++ b/charge/client.go
@@ -79,7 +79,7 @@ func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, 
 	return charge, err
 }
 
-// Capture captures a previously created charge with NoCapture set to true.
+// Capture captures a charge not yet captured.
 // For more details see https://stripe.com/docs/api#charge_capture.
 func Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 	return getC().Capture(id, params)

--- a/charge/client.go
+++ b/charge/client.go
@@ -143,7 +143,7 @@ func (c Client) MarkFraudulent(id string) (*stripe.Charge, error) {
 		id,
 		&stripe.ChargeParams{
 			FraudDetails: &stripe.FraudDetailsParams{
-				UserReport: ReportFraudulent,
+				UserReport: stripe.String(string(ReportFraudulent)),
 			},
 		},
 	)
@@ -159,7 +159,7 @@ func (c Client) MarkSafe(id string) (*stripe.Charge, error) {
 		id,
 		&stripe.ChargeParams{
 			FraudDetails: &stripe.FraudDetailsParams{
-				UserReport: ReportSafe,
+				UserReport: stripe.String(string(ReportSafe)),
 			},
 		},
 	)

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -71,7 +71,7 @@ func TestChargeMarkSafe(t *testing.T) {
 
 func TestChargeUpdate(t *testing.T) {
 	charge, err := Update("ch_123", &stripe.ChargeParams{
-		Desc: "Updated description",
+		Description: "Updated description",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)
@@ -80,7 +80,7 @@ func TestChargeUpdate(t *testing.T) {
 func TestChargeUpdateDispute(t *testing.T) {
 	charge, err := UpdateDispute("ch_123", &stripe.DisputeParams{
 		Evidence: &stripe.DisputeEvidenceParams{
-			ProductDesc: "original description",
+			ProductDescription: "original description",
 		},
 	})
 	assert.Nil(t, err)

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -43,9 +44,17 @@ func TestChargeMarkFraudulent(t *testing.T) {
 
 func TestChargeNew(t *testing.T) {
 	charge, err := New(&stripe.ChargeParams{
-		Amount:   123,
-		Currency: "usd",
-		Source:   &stripe.SourceParams{Token: "src_123"},
+		Amount:   stripe.UInt64(123),
+		Currency: stripe.String(string(currency.USD)),
+		Source:   &stripe.SourceParams{Token: stripe.String("src_123")},
+		Shipping: &stripe.ShippingDetailsParams{
+			Address: &stripe.AddressParams{
+				Line1: stripe.String("line1"),
+				City:  stripe.String("city"),
+			},
+			Carrier: stripe.String("carrier"),
+			Name:    stripe.String("name"),
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)
@@ -53,8 +62,8 @@ func TestChargeNew(t *testing.T) {
 
 func TestChargeNew_WithSetSource(t *testing.T) {
 	params := stripe.ChargeParams{
-		Amount:   123,
-		Currency: "usd",
+		Amount:   stripe.UInt64(123),
+		Currency: stripe.String(string(currency.USD)),
 	}
 	params.SetSource("tok_123")
 
@@ -71,7 +80,7 @@ func TestChargeMarkSafe(t *testing.T) {
 
 func TestChargeUpdate(t *testing.T) {
 	charge, err := Update("ch_123", &stripe.ChargeParams{
-		Description: "Updated description",
+		Description: stripe.String("Updated description"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)
@@ -80,7 +89,7 @@ func TestChargeUpdate(t *testing.T) {
 func TestChargeUpdateDispute(t *testing.T) {
 	charge, err := UpdateDispute("ch_123", &stripe.DisputeParams{
 		Evidence: &stripe.DisputeEvidenceParams{
-			ProductDescription: "original description",
+			ProductDescription: stripe.String("original description"),
 		},
 	})
 	assert.Nil(t, err)

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -44,7 +44,7 @@ func TestChargeMarkFraudulent(t *testing.T) {
 
 func TestChargeNew(t *testing.T) {
 	charge, err := New(&stripe.ChargeParams{
-		Amount:   stripe.UInt64(123),
+		Amount:   stripe.Int64(123),
 		Currency: stripe.String(string(currency.USD)),
 		Source:   &stripe.SourceParams{Token: stripe.String("src_123")},
 		Shipping: &stripe.ShippingDetailsParams{
@@ -62,7 +62,7 @@ func TestChargeNew(t *testing.T) {
 
 func TestChargeNew_WithSetSource(t *testing.T) {
 	params := stripe.ChargeParams{
-		Amount:   stripe.UInt64(123),
+		Amount:   stripe.Int64(123),
 		Currency: stripe.String(string(currency.USD)),
 	}
 	params.SetSource("tok_123")

--- a/charge_test.go
+++ b/charge_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestChargeParams_AppendTo(t *testing.T) {
 	{
-		params := &ChargeParams{Amount: UInt64(123)}
+		params := &ChargeParams{Amount: Int64(123)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/charge_test.go
+++ b/charge_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestChargeParams_AppendTo(t *testing.T) {
 	{
-		params := &ChargeParams{Amount: 123}
+		params := &ChargeParams{Amount: UInt64(123)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -17,7 +17,7 @@ func TestChargeParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &ChargeParams{Source: &SourceParams{Card: &CardParams{Number: "4242424242424242"}}}
+		params := &ChargeParams{Source: &SourceParams{Card: &CardParams{Number: String("4242424242424242")}}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/client/api.go
+++ b/client/api.go
@@ -52,12 +52,12 @@ type API struct {
 	// Cards is the client used to invoke /cards APIs.
 	// For more details see https://stripe.com/docs/api#cards.
 	Cards *card.Client
-	// Subs is the client used to invoke /subscriptions APIs.
+	// Subscriptions is the client used to invoke /subscriptions APIs.
 	// For more details see https://stripe.com/docs/api#subscriptions.
-	Subs *sub.Client
-	// SubItems is the client used to invoke subscription's items-related APIs.
+	Subscriptions *sub.Client
+	// SubscriptionItems is the client used to invoke subscription's items-related APIs.
 	// For more details see https://stripe.com/docs/api#subscription_items.
-	SubItems *subitem.Client
+	SubscriptionItems *subitem.Client
 	// Plans is the client used to invoke /plans APIs.
 	// For more details see https://stripe.com/docs/api#plans.
 	Plans *plan.Client
@@ -160,8 +160,8 @@ func (a *API) Init(key string, backends *Backends) {
 	a.Charges = &charge.Client{B: backends.API, Key: key}
 	a.Customers = &customer.Client{B: backends.API, Key: key}
 	a.Cards = &card.Client{B: backends.API, Key: key}
-	a.Subs = &sub.Client{B: backends.API, Key: key}
-	a.SubItems = &subitem.Client{B: backends.API, Key: key}
+	a.Subscriptions = &sub.Client{B: backends.API, Key: key}
+	a.SubscriptionItems = &subitem.Client{B: backends.API, Key: key}
 	a.Plans = &plan.Client{B: backends.API, Key: key}
 	a.Coupons = &coupon.Client{B: backends.API, Key: key}
 	a.Discounts = &discount.Client{B: backends.API, Key: key}

--- a/countryspec.go
+++ b/countryspec.go
@@ -7,7 +7,7 @@ type Country string
 // For more details see https://stripe.com/docs/api#country_spec_object-verification_fields.
 type VerificationFieldsList struct {
 	AdditionalFields []string `json:"additional"`
-	MinimumFields    []string `json:"minimum"`
+	Minimum          []string `json:"minimum"`
 }
 
 // CountrySpec is the resource representing the rules required for a Stripe account.
@@ -24,7 +24,7 @@ type CountrySpec struct {
 // CountrySpecList is a list of country specs as retrieved from a list endpoint.
 type CountrySpecList struct {
 	ListMeta
-	Values []*CountrySpec `json:"data"`
+	Data []*CountrySpec `json:"data"`
 }
 
 // CountrySpecListParams are the parameters allowed during CountrySpec listing.

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -46,8 +46,8 @@ func (c Client) List(params *stripe.CountrySpecListParams) *Iter {
 		list := &stripe.CountrySpecList{}
 		err := c.B.Call("GET", "/country_specs", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/coupon.go
+++ b/coupon.go
@@ -9,15 +9,15 @@ type CouponDuration string
 // CouponParams is the set of parameters that can be used when creating a coupon.
 // For more details see https://stripe.com/docs/api#create_coupon.
 type CouponParams struct {
-	Params         `form:"*"`
-	Amount         uint64         `form:"amount_off"`
-	Currency       Currency       `form:"currency"`
-	Duration       CouponDuration `form:"duration"`
-	DurationPeriod uint64         `form:"duration_in_months"`
-	ID             string         `form:"id"`
-	Percent        uint64         `form:"percent_off"`
-	RedeemBy       int64          `form:"redeem_by"`
-	Redemptions    uint64         `form:"max_redemptions"`
+	Params           `form:"*"`
+	AmountOff        uint64         `form:"amount_off"`
+	Currency         Currency       `form:"currency"`
+	Duration         CouponDuration `form:"duration"`
+	DurationInMonths uint64         `form:"duration_in_months"`
+	ID               string         `form:"id"`
+	MaxRedemptions   uint64         `form:"max_redemptions"`
+	PercentOff       uint64         `form:"percent_off"`
+	RedeemBy         int64          `form:"redeem_by"`
 }
 
 // CouponListParams is the set of parameters that can be used when listing coupons.
@@ -31,26 +31,26 @@ type CouponListParams struct {
 // Coupon is the resource representing a Stripe coupon.
 // For more details see https://stripe.com/docs/api#coupons.
 type Coupon struct {
-	Amount         uint64            `json:"amount_off"`
-	Created        int64             `json:"created"`
-	Currency       Currency          `json:"currency"`
-	Deleted        bool              `json:"deleted"`
-	Duration       CouponDuration    `json:"duration"`
-	DurationPeriod uint64            `json:"duration_in_months"`
-	ID             string            `json:"id"`
-	Live           bool              `json:"livemode"`
-	Meta           map[string]string `json:"metadata"`
-	Percent        uint64            `json:"percent_off"`
-	RedeemBy       int64             `json:"redeem_by"`
-	Redeemed       uint64            `json:"times_redeemed"`
-	Redemptions    uint64            `json:"max_redemptions"`
-	Valid          bool              `json:"valid"`
+	AmountOff        uint64            `json:"amount_off"`
+	Created          int64             `json:"created"`
+	Currency         Currency          `json:"currency"`
+	Deleted          bool              `json:"deleted"`
+	Duration         CouponDuration    `json:"duration"`
+	DurationInMonths uint64            `json:"duration_in_months"`
+	ID               string            `json:"id"`
+	Livemode         bool              `json:"livemode"`
+	MaxRedemptions   uint64            `json:"max_redemptions"`
+	Metadata         map[string]string `json:"metadata"`
+	PercentOff       uint64            `json:"percent_off"`
+	RedeemBy         int64             `json:"redeem_by"`
+	TimesRedeemed    uint64            `json:"times_redeemed"`
+	Valid            bool              `json:"valid"`
 }
 
 // CouponList is a list of coupons as retrieved from a list endpoint.
 type CouponList struct {
 	ListMeta
-	Values []*Coupon `json:"data"`
+	Data []*Coupon `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Coupon.

--- a/coupon.go
+++ b/coupon.go
@@ -10,21 +10,21 @@ type CouponDuration string
 // For more details see https://stripe.com/docs/api#create_coupon.
 type CouponParams struct {
 	Params           `form:"*"`
-	AmountOff        uint64         `form:"amount_off"`
-	Currency         Currency       `form:"currency"`
-	Duration         CouponDuration `form:"duration"`
-	DurationInMonths uint64         `form:"duration_in_months"`
-	ID               string         `form:"id"`
-	MaxRedemptions   uint64         `form:"max_redemptions"`
-	PercentOff       uint64         `form:"percent_off"`
-	RedeemBy         int64          `form:"redeem_by"`
+	AmountOff        *uint64 `form:"amount_off"`
+	Currency         *string `form:"currency"`
+	Duration         *string `form:"duration"`
+	DurationInMonths *uint64 `form:"duration_in_months"`
+	ID               *string `form:"id"`
+	MaxRedemptions   *uint64 `form:"max_redemptions"`
+	PercentOff       *uint64 `form:"percent_off"`
+	RedeemBy         *int64  `form:"redeem_by"`
 }
 
 // CouponListParams is the set of parameters that can be used when listing coupons.
 // For more detail see https://stripe.com/docs/api#list_coupons.
 type CouponListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 

--- a/coupon.go
+++ b/coupon.go
@@ -10,13 +10,13 @@ type CouponDuration string
 // For more details see https://stripe.com/docs/api#create_coupon.
 type CouponParams struct {
 	Params           `form:"*"`
-	AmountOff        *uint64 `form:"amount_off"`
+	AmountOff        *int64  `form:"amount_off"`
 	Currency         *string `form:"currency"`
 	Duration         *string `form:"duration"`
-	DurationInMonths *uint64 `form:"duration_in_months"`
+	DurationInMonths *int64  `form:"duration_in_months"`
 	ID               *string `form:"id"`
-	MaxRedemptions   *uint64 `form:"max_redemptions"`
-	PercentOff       *uint64 `form:"percent_off"`
+	MaxRedemptions   *int64  `form:"max_redemptions"`
+	PercentOff       *int64  `form:"percent_off"`
 	RedeemBy         *int64  `form:"redeem_by"`
 }
 
@@ -31,19 +31,19 @@ type CouponListParams struct {
 // Coupon is the resource representing a Stripe coupon.
 // For more details see https://stripe.com/docs/api#coupons.
 type Coupon struct {
-	AmountOff        uint64            `json:"amount_off"`
+	AmountOff        int64             `json:"amount_off"`
 	Created          int64             `json:"created"`
 	Currency         Currency          `json:"currency"`
 	Deleted          bool              `json:"deleted"`
 	Duration         CouponDuration    `json:"duration"`
-	DurationInMonths uint64            `json:"duration_in_months"`
+	DurationInMonths int64             `json:"duration_in_months"`
 	ID               string            `json:"id"`
 	Livemode         bool              `json:"livemode"`
-	MaxRedemptions   uint64            `json:"max_redemptions"`
+	MaxRedemptions   int64             `json:"max_redemptions"`
 	Metadata         map[string]string `json:"metadata"`
-	PercentOff       uint64            `json:"percent_off"`
+	PercentOff       int64             `json:"percent_off"`
 	RedeemBy         int64             `json:"redeem_by"`
-	TimesRedeemed    uint64            `json:"times_redeemed"`
+	TimesRedeemed    int64             `json:"times_redeemed"`
 	Valid            bool              `json:"valid"`
 }
 

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -119,8 +119,8 @@ func (c Client) List(params *stripe.CouponListParams) *Iter {
 		list := &stripe.CouponList{}
 		err := c.B.Call("GET", "/coupons", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -31,10 +31,10 @@ func TestCouponList(t *testing.T) {
 
 func TestCouponNew(t *testing.T) {
 	coupon, err := New(&stripe.CouponParams{
-		Duration:       "repeating",
-		DurationPeriod: 3,
-		ID:             "25OFF",
-		Percent:        25,
+		Duration:         "repeating",
+		DurationInMonths: 3,
+		ID:               "25OFF",
+		PercentOff:       25,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)
@@ -43,7 +43,7 @@ func TestCouponNew(t *testing.T) {
 func TestCouponUpdate(t *testing.T) {
 	coupon, err := Update("25OFF", &stripe.CouponParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -31,10 +32,11 @@ func TestCouponList(t *testing.T) {
 
 func TestCouponNew(t *testing.T) {
 	coupon, err := New(&stripe.CouponParams{
-		Duration:         "repeating",
-		DurationInMonths: 3,
-		ID:               "25OFF",
-		PercentOff:       25,
+		Currency:         stripe.String(string(currency.USD)),
+		Duration:         stripe.String(string(Repeating)),
+		DurationInMonths: stripe.UInt64(3),
+		ID:               stripe.String("25OFF"),
+		PercentOff:       stripe.UInt64(25),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -34,9 +34,9 @@ func TestCouponNew(t *testing.T) {
 	coupon, err := New(&stripe.CouponParams{
 		Currency:         stripe.String(string(currency.USD)),
 		Duration:         stripe.String(string(Repeating)),
-		DurationInMonths: stripe.UInt64(3),
+		DurationInMonths: stripe.Int64(3),
 		ID:               stripe.String("25OFF"),
-		PercentOff:       stripe.UInt64(25),
+		PercentOff:       stripe.Int64(25),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)

--- a/customer.go
+++ b/customer.go
@@ -7,23 +7,20 @@ import (
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
-	Params             `form:"*"`
-	AccountBalance     int64                    `form:"account_balance"`
-	AccountBalanceZero bool                     `form:"account_balance,zero"`
-	BusinessVatID      string                   `form:"business_vat_id"`
-	Coupon             string                   `form:"coupon"`
-	CouponEmpty        bool                     `form:"coupon,empty"`
-	DefaultSource      string                   `form:"default_source"`
-	Description        string                   `form:"description"`
-	Email              string                   `form:"email"`
-	Plan               string                   `form:"plan"`
-	Quantity           uint64                   `form:"quantity"`
-	Shipping           *CustomerShippingDetails `form:"shipping"`
-	Source             *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	TaxPercent         float64                  `form:"tax_percent"`
-	TaxPercentZero     bool                     `form:"tax_percent,zero"`
-	Token              string                   `form:"-"` // This doesn't seem to be used?
-	TrialEnd           int64                    `form:"trial_end"`
+	Params         `form:"*"`
+	AccountBalance *int64                   `form:"account_balance"`
+	BusinessVatID  string                   `form:"business_vat_id"`
+	Coupon         *string                  `form:"coupon"`
+	DefaultSource  string                   `form:"default_source"`
+	Description    string                   `form:"description"`
+	Email          string                   `form:"email"`
+	Plan           string                   `form:"plan"`
+	Quantity       uint64                   `form:"quantity"`
+	Shipping       *CustomerShippingDetails `form:"shipping"`
+	Source         *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxPercent     *float64                 `form:"tax_percent"`
+	Token          string                   `form:"-"` // This doesn't seem to be used?
+	TrialEnd       int64                    `form:"trial_end"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,

--- a/customer.go
+++ b/customer.go
@@ -7,23 +7,23 @@ import (
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
-	Params         `form:"*"`
-	Balance        int64                    `form:"account_balance"`
-	BalanceZero    bool                     `form:"account_balance,zero"`
-	BusinessVatID  string                   `form:"business_vat_id"`
-	Coupon         string                   `form:"coupon"`
-	CouponEmpty    bool                     `form:"coupon,empty"`
-	DefaultSource  string                   `form:"default_source"`
-	Desc           string                   `form:"description"`
-	Email          string                   `form:"email"`
-	Plan           string                   `form:"plan"`
-	Quantity       uint64                   `form:"quantity"`
-	Shipping       *CustomerShippingDetails `form:"shipping"`
-	Source         *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	TaxPercent     float64                  `form:"tax_percent"`
-	TaxPercentZero bool                     `form:"tax_percent,zero"`
-	Token          string                   `form:"-"` // This doesn't seem to be used?
-	TrialEnd       int64                    `form:"trial_end"`
+	Params             `form:"*"`
+	AccountBalance     int64                    `form:"account_balance"`
+	AccountBalanceZero bool                     `form:"account_balance,zero"`
+	BusinessVatID      string                   `form:"business_vat_id"`
+	Coupon             string                   `form:"coupon"`
+	CouponEmpty        bool                     `form:"coupon,empty"`
+	DefaultSource      string                   `form:"default_source"`
+	Description        string                   `form:"description"`
+	Email              string                   `form:"email"`
+	Plan               string                   `form:"plan"`
+	Quantity           uint64                   `form:"quantity"`
+	Shipping           *CustomerShippingDetails `form:"shipping"`
+	Source             *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxPercent         float64                  `form:"tax_percent"`
+	TaxPercentZero     bool                     `form:"tax_percent,zero"`
+	Token              string                   `form:"-"` // This doesn't seem to be used?
+	TrialEnd           int64                    `form:"trial_end"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,
@@ -45,28 +45,28 @@ type CustomerListParams struct {
 // Customer is the resource representing a Stripe customer.
 // For more details see https://stripe.com/docs/api#customers.
 type Customer struct {
-	Balance       int64                    `json:"account_balance"`
-	BusinessVatID string                   `json:"business_vat_id"`
-	Currency      Currency                 `json:"currency"`
-	Created       int64                    `json:"created"`
-	DefaultSource *PaymentSource           `json:"default_source"`
-	Deleted       bool                     `json:"deleted"`
-	Delinquent    bool                     `json:"delinquent"`
-	Desc          string                   `json:"description"`
-	Discount      *Discount                `json:"discount"`
-	Email         string                   `json:"email"`
-	ID            string                   `json:"id"`
-	Live          bool                     `json:"livemode"`
-	Meta          map[string]string        `json:"metadata"`
-	Shipping      *CustomerShippingDetails `json:"shipping"`
-	Sources       *SourceList              `json:"sources"`
-	Subs          *SubList                 `json:"subscriptions"`
+	AccountBalance int64                    `json:"account_balance"`
+	BusinessVatID  string                   `json:"business_vat_id"`
+	Created        int64                    `json:"created"`
+	Currency       Currency                 `json:"currency"`
+	DefaultSource  *PaymentSource           `json:"default_source"`
+	Deleted        bool                     `json:"deleted"`
+	Delinquent     bool                     `json:"delinquent"`
+	Description    string                   `json:"description"`
+	Discount       *Discount                `json:"discount"`
+	Email          string                   `json:"email"`
+	ID             string                   `json:"id"`
+	Livemode       bool                     `json:"livemode"`
+	Metadata       map[string]string        `json:"metadata"`
+	Shipping       *CustomerShippingDetails `json:"shipping"`
+	Sources        *SourceList              `json:"sources"`
+	Subscriptions  *SubscriptionList        `json:"subscriptions"`
 }
 
 // CustomerList is a list of customers as retrieved from a list endpoint.
 type CustomerList struct {
 	ListMeta
-	Values []*Customer `json:"data"`
+	Data []*Customer `json:"data"`
 }
 
 // CustomerShippingDetails is the structure containing shipping information.

--- a/customer.go
+++ b/customer.go
@@ -8,19 +8,26 @@ import (
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
 	Params         `form:"*"`
-	AccountBalance *int64                   `form:"account_balance"`
-	BusinessVatID  string                   `form:"business_vat_id"`
-	Coupon         *string                  `form:"coupon"`
-	DefaultSource  string                   `form:"default_source"`
-	Description    string                   `form:"description"`
-	Email          string                   `form:"email"`
-	Plan           string                   `form:"plan"`
-	Quantity       uint64                   `form:"quantity"`
-	Shipping       *CustomerShippingDetails `form:"shipping"`
-	Source         *SourceParams            `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	TaxPercent     *float64                 `form:"tax_percent"`
-	Token          string                   `form:"-"` // This doesn't seem to be used?
-	TrialEnd       int64                    `form:"trial_end"`
+	AccountBalance *int64                         `form:"account_balance"`
+	BusinessVatID  *string                        `form:"business_vat_id"`
+	Coupon         *string                        `form:"coupon"`
+	DefaultSource  *string                        `form:"default_source"`
+	Description    *string                        `form:"description"`
+	Email          *string                        `form:"email"`
+	Plan           *string                        `form:"plan"`
+	Quantity       *uint64                        `form:"quantity"`
+	Shipping       *CustomerShippingDetailsParams `form:"shipping"`
+	Source         *SourceParams                  `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxPercent     *float64                       `form:"tax_percent"`
+	Token          *string                        `form:"-"` // This doesn't seem to be used?
+	TrialEnd       *int64                         `form:"trial_end"`
+}
+
+// CustomerShippingDetailsParams is the structure containing shipping information.
+type CustomerShippingDetailsParams struct {
+	Address *AddressParams `form:"address"`
+	Name    *string        `form:"name"`
+	Phone   *string        `form:"phone"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,
@@ -35,7 +42,7 @@ func (cp *CustomerParams) SetSource(sp interface{}) error {
 // For more details see https://stripe.com/docs/api#list_customers.
 type CustomerListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 
@@ -68,9 +75,9 @@ type CustomerList struct {
 
 // CustomerShippingDetails is the structure containing shipping information.
 type CustomerShippingDetails struct {
-	Address Address `json:"address" form:"address"`
-	Name    string  `json:"name" form:"name"`
-	Phone   string  `json:"phone" form:"phone"`
+	Address Address `json:"address"`
+	Name    string  `json:"name"`
+	Phone   string  `json:"phone"`
 }
 
 // UnmarshalJSON handles deserialization of a Customer.

--- a/customer.go
+++ b/customer.go
@@ -9,7 +9,7 @@ import (
 type CustomerParams struct {
 	Params         `form:"*"`
 	AccountBalance *int64                         `form:"account_balance"`
-	BusinessVatID  *string                        `form:"business_vat_id"`
+	BusinessVATID  *string                        `form:"business_vat_id"`
 	Coupon         *string                        `form:"coupon"`
 	DefaultSource  *string                        `form:"default_source"`
 	Description    *string                        `form:"description"`
@@ -50,7 +50,7 @@ type CustomerListParams struct {
 // For more details see https://stripe.com/docs/api#customers.
 type Customer struct {
 	AccountBalance int64                    `json:"account_balance"`
-	BusinessVatID  string                   `json:"business_vat_id"`
+	BusinessVATID  string                   `json:"business_vat_id"`
 	Created        int64                    `json:"created"`
 	Currency       Currency                 `json:"currency"`
 	DefaultSource  *PaymentSource           `json:"default_source"`

--- a/customer.go
+++ b/customer.go
@@ -15,7 +15,7 @@ type CustomerParams struct {
 	Description    *string                        `form:"description"`
 	Email          *string                        `form:"email"`
 	Plan           *string                        `form:"plan"`
-	Quantity       *uint64                        `form:"quantity"`
+	Quantity       *int64                         `form:"quantity"`
 	Shipping       *CustomerShippingDetailsParams `form:"shipping"`
 	Source         *SourceParams                  `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 	TaxPercent     *float64                       `form:"tax_percent"`

--- a/customer/client.go
+++ b/customer/client.go
@@ -122,8 +122,8 @@ func (c Client) List(params *stripe.CustomerListParams) *Iter {
 		list := &stripe.CustomerList{}
 		err := c.B.Call("GET", "/customers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -31,7 +31,14 @@ func TestCustomerList(t *testing.T) {
 
 func TestCustomerNew(t *testing.T) {
 	customer, err := New(&stripe.CustomerParams{
-		Email: "foo@example.com",
+		Email: stripe.String("foo@example.com"),
+		Shipping: &stripe.CustomerShippingDetailsParams{
+			Address: &stripe.AddressParams{
+				Line1: stripe.String("line1"),
+				City:  stripe.String("city"),
+			},
+			Name: stripe.String("name"),
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, customer)
@@ -45,7 +52,7 @@ func TestCustomerNew_NilParams(t *testing.T) {
 
 func TestCustomerUpdate(t *testing.T) {
 	customer, err := Update("cus_123", &stripe.CustomerParams{
-		Email: "foo@example.com",
+		Email: stripe.String("foo@example.com"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, customer)

--- a/discount.go
+++ b/discount.go
@@ -8,10 +8,10 @@ type DiscountParams struct {
 // Discount is the resource representing a Stripe discount.
 // For more details see https://stripe.com/docs/api#discounts.
 type Discount struct {
-	Coupon   *Coupon `json:"coupon"`
-	Customer string  `json:"customer"`
-	Deleted  bool    `json:"deleted"`
-	End      int64   `json:"end"`
-	Start    int64   `json:"start"`
-	Sub      string  `json:"subscription"`
+	Coupon       *Coupon `json:"coupon"`
+	Customer     string  `json:"customer"`
+	Deleted      bool    `json:"deleted"`
+	End          int64   `json:"end"`
+	Start        int64   `json:"start"`
+	Subscription string  `json:"subscription"`
 }

--- a/dispute.go
+++ b/dispute.go
@@ -27,31 +27,31 @@ type DisputeParams struct {
 // DisputeEvidenceParams is the set of parameters that can be used when submitting
 // evidence for disputes.
 type DisputeEvidenceParams struct {
-	ActivityLog                  string `form:"access_activity_log"`
+	AccessActivityLog            string `form:"access_activity_log"`
 	BillingAddress               string `form:"billing_address"`
 	CancellationPolicy           string `form:"cancellation_policy"`
-	CancellationPolicyDisclsoure string `form:"cancellation_policy_disclosure"`
+	CancellationPolicyDisclosure string `form:"cancellation_policy_disclosure"`
 	CancellationRebuttal         string `form:"cancellation_rebuttal"`
-	CustomerComm                 string `form:"customer_communication"`
-	CustomerEmail                string `form:"customer_email_address"`
-	CustomerIP                   string `form:"customer_purchase_ip"`
+	CustomerCommunication        string `form:"customer_communication"`
+	CustomerEmailAddress         string `form:"customer_email_address"`
 	CustomerName                 string `form:"customer_name"`
-	CustomerSig                  string `form:"customer_signature"`
-	DuplicateCharge              string `form:"duplicate_charge_id"`
-	DuplicateChargeDoc           string `form:"duplicate_charge_documentation"`
-	DuplicateChargeReason        string `form:"duplicate_charge_explanation"`
-	ProductDesc                  string `form:"product_description"`
+	CustomerPurchaseIP           string `form:"customer_purchase_ip"`
+	CustomerSignature            string `form:"customer_signature"`
+	DuplicateChargeDocumentation string `form:"duplicate_charge_documentation"`
+	DuplicateChargeExplanation   string `form:"duplicate_charge_explanation"`
+	DuplicateChargeID            string `form:"duplicate_charge_id"`
+	ProductDescription           string `form:"product_description"`
 	Receipt                      string `form:"receipt"`
 	RefundPolicy                 string `form:"refund_policy"`
 	RefundPolicyDisclosure       string `form:"refund_policy_disclosure"`
-	RefundRefusalReason          string `form:"refund_refusal_explanation"`
+	RefundRefusalExplanation     string `form:"refund_refusal_explanation"`
 	ServiceDate                  string `form:"service_date"`
-	ServiceDoc                   string `form:"service_documentation"`
+	ServiceDocumentation         string `form:"service_documentation"`
 	ShippingAddress              string `form:"shipping_address"`
 	ShippingCarrier              string `form:"shipping_carrier"`
 	ShippingDate                 string `form:"shipping_date"`
-	ShippingDoc                  string `form:"shipping_documentation"`
-	ShippingTracking             string `form:"shipping_tracking_number"`
+	ShippingDocumentation        string `form:"shipping_documentation"`
+	ShippingTrackingNumber       string `form:"shipping_tracking_number"`
 	UncategorizedFile            string `form:"uncategorized_file"`
 	UncategorizedText            string `form:"uncategorized_text"`
 }
@@ -67,34 +67,34 @@ type DisputeListParams struct {
 // Dispute is the resource representing a Stripe dispute.
 // For more details see https://stripe.com/docs/api#disputes.
 type Dispute struct {
-	Amount          uint64            `json:"amount"`
-	Charge          string            `json:"charge"`
-	Created         int64             `json:"created"`
-	Currency        Currency          `json:"currency"`
-	Evidence        *DisputeEvidence  `json:"evidence"`
-	EvidenceDetails *EvidenceDetails  `json:"evidence_details"`
-	ID              string            `json:"id"`
-	Live            bool              `json:"livemode"`
-	Meta            map[string]string `json:"metadata"`
-	Reason          DisputeReason     `json:"reason"`
-	Refundable      bool              `json:"is_charge_refundable"`
-	Status          DisputeStatus     `json:"status"`
-	Transactions    []*Transaction    `json:"balance_transactions"`
+	Amount              uint64                `json:"amount"`
+	BalanceTransactions []*BalanceTransaction `json:"balance_transactions"`
+	Charge              *Charge               `json:"charge"`
+	Created             int64                 `json:"created"`
+	Currency            Currency              `json:"currency"`
+	Evidence            *DisputeEvidence      `json:"evidence"`
+	EvidenceDetails     *EvidenceDetails      `json:"evidence_details"`
+	ID                  string                `json:"id"`
+	IsChargeRefundable  bool                  `json:"is_charge_refundable"`
+	Livemode            bool                  `json:"livemode"`
+	Metadata            map[string]string     `json:"metadata"`
+	Reason              DisputeReason         `json:"reason"`
+	Status              DisputeStatus         `json:"status"`
 }
 
 // DisputeList is a list of disputes as retrieved from a list endpoint.
 type DisputeList struct {
 	ListMeta
-	Values []*Dispute `json:"data"`
+	Data []*Dispute `json:"data"`
 }
 
 // EvidenceDetails is the structure representing more details about
 // the dispute.
 type EvidenceDetails struct {
-	Count       int   `json:"submission_count"`
-	DueDate     int64 `json:"due_by"`
-	HasEvidence bool  `json:"has_evidence"`
-	PastDue     bool  `json:"past_due"`
+	DueBy           int64 `json:"due_by"`
+	HasEvidence     bool  `json:"has_evidence"`
+	PastDue         bool  `json:"past_due"`
+	SubmissionCount int   `json:"submission_count"`
 }
 
 // DisputeEvidence is the structure that contains various details about
@@ -102,43 +102,43 @@ type EvidenceDetails struct {
 // Almost all fields are strings since there structures (i.e. address)
 // do not typically get parsed by anyone and are thus presented as-received.
 type DisputeEvidence struct {
-	ActivityLog                  string `json:"access_activity_log"`
+	AccessActivityLog            string `json:"access_activity_log"`
 	BillingAddress               string `json:"billing_address"`
 	CancellationPolicy           *File  `json:"cancellation_policy"`
 	CancellationPolicyDisclosure string `json:"cancellation_policy_disclosure"`
 	CancellationRebuttal         string `json:"cancellation_rebuttal"`
-	CustomerComm                 *File  `json:"customer_communication"`
-	CustomerEmail                string `json:"customer_email_address"`
-	CustomerIP                   string `json:"customer_purchase_ip"`
+	CustomerCommunication        *File  `json:"customer_communication"`
+	CustomerEmailAddress         string `json:"customer_email_address"`
 	CustomerName                 string `json:"customer_name"`
-	CustomerSig                  *File  `json:"customer_signature"`
-	DuplicateCharge              string `json:"duplicate_charge_id"`
-	DuplicateChargeDoc           *File  `json:"duplicate_charge_documentation"`
-	DuplicateChargeReason        string `json:"duplicate_charge_explanation"`
-	ProductDesc                  string `json:"product_description"`
+	CustomerPurchaseIP           string `json:"customer_purchase_ip"`
+	CustomerSignature            *File  `json:"customer_signature"`
+	DuplicateChargeDocumentation *File  `json:"duplicate_charge_documentation"`
+	DuplicateChargeExplanation   string `json:"duplicate_charge_explanation"`
+	DuplicateChargeID            string `json:"duplicate_charge_id"`
+	ProductDescription           string `json:"product_description"`
 	Receipt                      *File  `json:"receipt"`
 	RefundPolicy                 *File  `json:"refund_policy"`
 	RefundPolicyDisclosure       string `json:"refund_policy_disclosure"`
-	RefundRefusalReason          string `json:"refund_refusal_explanation"`
+	RefundRefusalExplanation     string `json:"refund_refusal_explanation"`
 	ServiceDate                  string `json:"service_date"`
-	ServiceDoc                   *File  `json:"service_documentation"`
+	ServiceDocumentation         *File  `json:"service_documentation"`
 	ShippingAddress              string `json:"shipping_address"`
 	ShippingCarrier              string `json:"shipping_carrier"`
 	ShippingDate                 string `json:"shipping_date"`
-	ShippingDoc                  *File  `json:"shipping_documentation"`
-	ShippingTracking             string `json:"shipping_tracking_number"`
+	ShippingDocumentation        *File  `json:"shipping_documentation"`
+	ShippingTrackingNumber       string `json:"shipping_tracking_number"`
 	UncategorizedFile            *File  `json:"uncategorized_file"`
 	UncategorizedText            string `json:"uncategorized_text"`
 }
 
 // File represents a link to downloadable content.
 type File struct {
-	Created int64  `json:"created"`
-	ID      string `json:"id"`
-	Mime    string `json:"mime_type"`
-	Purpose string `json:"purpose"`
-	Size    int    `json:"size"`
-	URL     string `json:"url"`
+	Created  int64  `json:"created"`
+	ID       string `json:"id"`
+	MIMEType string `json:"mime_type"`
+	Purpose  string `json:"purpose"`
+	Size     int    `json:"size"`
+	URL      string `json:"url"`
 }
 
 // UnmarshalJSON handles deserialization of a Dispute.

--- a/dispute.go
+++ b/dispute.go
@@ -21,7 +21,7 @@ type DisputeStatus string
 type DisputeParams struct {
 	Params   `form:"*"`
 	Evidence *DisputeEvidenceParams `form:"evidence"`
-	NoSubmit bool                   `form:"submit,invert"`
+	Submit   *bool                  `form:"submit"`
 }
 
 // DisputeEvidenceParams is the set of parameters that can be used when submitting

--- a/dispute.go
+++ b/dispute.go
@@ -94,7 +94,7 @@ type EvidenceDetails struct {
 	DueBy           int64 `json:"due_by"`
 	HasEvidence     bool  `json:"has_evidence"`
 	PastDue         bool  `json:"past_due"`
-	SubmissionCount int   `json:"submission_count"`
+	SubmissionCount int64 `json:"submission_count"`
 }
 
 // DisputeEvidence is the structure that contains various details about
@@ -137,7 +137,7 @@ type File struct {
 	ID       string `json:"id"`
 	MIMEType string `json:"mime_type"`
 	Purpose  string `json:"purpose"`
-	Size     int    `json:"size"`
+	Size     int64  `json:"size"`
 	URL      string `json:"url"`
 }
 

--- a/dispute.go
+++ b/dispute.go
@@ -67,7 +67,7 @@ type DisputeListParams struct {
 // Dispute is the resource representing a Stripe dispute.
 // For more details see https://stripe.com/docs/api#disputes.
 type Dispute struct {
-	Amount              uint64                `json:"amount"`
+	Amount              int64                 `json:"amount"`
 	BalanceTransactions []*BalanceTransaction `json:"balance_transactions"`
 	Charge              *Charge               `json:"charge"`
 	Created             int64                 `json:"created"`

--- a/dispute.go
+++ b/dispute.go
@@ -27,40 +27,40 @@ type DisputeParams struct {
 // DisputeEvidenceParams is the set of parameters that can be used when submitting
 // evidence for disputes.
 type DisputeEvidenceParams struct {
-	AccessActivityLog            string `form:"access_activity_log"`
-	BillingAddress               string `form:"billing_address"`
-	CancellationPolicy           string `form:"cancellation_policy"`
-	CancellationPolicyDisclosure string `form:"cancellation_policy_disclosure"`
-	CancellationRebuttal         string `form:"cancellation_rebuttal"`
-	CustomerCommunication        string `form:"customer_communication"`
-	CustomerEmailAddress         string `form:"customer_email_address"`
-	CustomerName                 string `form:"customer_name"`
-	CustomerPurchaseIP           string `form:"customer_purchase_ip"`
-	CustomerSignature            string `form:"customer_signature"`
-	DuplicateChargeDocumentation string `form:"duplicate_charge_documentation"`
-	DuplicateChargeExplanation   string `form:"duplicate_charge_explanation"`
-	DuplicateChargeID            string `form:"duplicate_charge_id"`
-	ProductDescription           string `form:"product_description"`
-	Receipt                      string `form:"receipt"`
-	RefundPolicy                 string `form:"refund_policy"`
-	RefundPolicyDisclosure       string `form:"refund_policy_disclosure"`
-	RefundRefusalExplanation     string `form:"refund_refusal_explanation"`
-	ServiceDate                  string `form:"service_date"`
-	ServiceDocumentation         string `form:"service_documentation"`
-	ShippingAddress              string `form:"shipping_address"`
-	ShippingCarrier              string `form:"shipping_carrier"`
-	ShippingDate                 string `form:"shipping_date"`
-	ShippingDocumentation        string `form:"shipping_documentation"`
-	ShippingTrackingNumber       string `form:"shipping_tracking_number"`
-	UncategorizedFile            string `form:"uncategorized_file"`
-	UncategorizedText            string `form:"uncategorized_text"`
+	AccessActivityLog            *string `form:"access_activity_log"`
+	BillingAddress               *string `form:"billing_address"`
+	CancellationPolicy           *string `form:"cancellation_policy"`
+	CancellationPolicyDisclosure *string `form:"cancellation_policy_disclosure"`
+	CancellationRebuttal         *string `form:"cancellation_rebuttal"`
+	CustomerCommunication        *string `form:"customer_communication"`
+	CustomerEmailAddress         *string `form:"customer_email_address"`
+	CustomerName                 *string `form:"customer_name"`
+	CustomerPurchaseIP           *string `form:"customer_purchase_ip"`
+	CustomerSignature            *string `form:"customer_signature"`
+	DuplicateChargeDocumentation *string `form:"duplicate_charge_documentation"`
+	DuplicateChargeExplanation   *string `form:"duplicate_charge_explanation"`
+	DuplicateChargeID            *string `form:"duplicate_charge_id"`
+	ProductDescription           *string `form:"product_description"`
+	Receipt                      *string `form:"receipt"`
+	RefundPolicy                 *string `form:"refund_policy"`
+	RefundPolicyDisclosure       *string `form:"refund_policy_disclosure"`
+	RefundRefusalExplanation     *string `form:"refund_refusal_explanation"`
+	ServiceDate                  *string `form:"service_date"`
+	ServiceDocumentation         *string `form:"service_documentation"`
+	ShippingAddress              *string `form:"shipping_address"`
+	ShippingCarrier              *string `form:"shipping_carrier"`
+	ShippingDate                 *string `form:"shipping_date"`
+	ShippingDocumentation        *string `form:"shipping_documentation"`
+	ShippingTrackingNumber       *string `form:"shipping_tracking_number"`
+	UncategorizedFile            *string `form:"uncategorized_file"`
+	UncategorizedText            *string `form:"uncategorized_text"`
 }
 
 // DisputeListParams is the set of parameters that can be used when listing disputes.
 // For more details see https://stripe.com/docs/api#list_disputes.
 type DisputeListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -8,23 +8,23 @@ import (
 )
 
 const (
-	Duplicate    stripe.DisputeReason = "duplicate"
-	Fraudulent   stripe.DisputeReason = "fraudulent"
-	SubCanceled  stripe.DisputeReason = "subscription_canceled"
-	Unacceptable stripe.DisputeReason = "product_unacceptable"
-	NotReceived  stripe.DisputeReason = "product_not_received"
-	Unrecognized stripe.DisputeReason = "unrecognized"
-	Credit       stripe.DisputeReason = "credit_not_processed"
-	General      stripe.DisputeReason = "general"
+	CreditNotProcessed   stripe.DisputeReason = "credit_not_processed"
+	Duplicate            stripe.DisputeReason = "duplicate"
+	Fraudulent           stripe.DisputeReason = "fraudulent"
+	General              stripe.DisputeReason = "general"
+	ProductNotReceived   stripe.DisputeReason = "product_not_received"
+	ProductUnacceptable  stripe.DisputeReason = "product_unacceptable"
+	SubscriptionCanceled stripe.DisputeReason = "subscription_canceled"
+	Unrecognized         stripe.DisputeReason = "unrecognized"
 
-	Won             stripe.DisputeStatus = "won"
-	Lost            stripe.DisputeStatus = "lost"
-	Response        stripe.DisputeStatus = "needs_response"
-	Review          stripe.DisputeStatus = "under_review"
-	WarningResponse stripe.DisputeStatus = "warning_needs_response"
-	WarningReview   stripe.DisputeStatus = "warning_under_review"
-	ChargeRefunded  stripe.DisputeStatus = "charge_refunded"
-	WarningClosed   stripe.DisputeStatus = "warning_closed"
+	Lost                 stripe.DisputeStatus = "lost"
+	NeedsResponse        stripe.DisputeStatus = "needs_response"
+	ChargeRefunded       stripe.DisputeStatus = "charge_refunded"
+	UnderReview          stripe.DisputeStatus = "under_review"
+	WarningClosed        stripe.DisputeStatus = "warning_closed"
+	WarningNeedsResponse stripe.DisputeStatus = "warning_needs_response"
+	WarningUnderReview   stripe.DisputeStatus = "warning_under_review"
+	Won                  stripe.DisputeStatus = "won"
 )
 
 // Client is used to invoke dispute-related APIs.
@@ -77,8 +77,8 @@ func (c Client) List(params *stripe.DisputeListParams) *Iter {
 		list := &stripe.DisputeList{}
 		err := c.B.Call("GET", "/disputes", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/dispute/client_test.go
+++ b/dispute/client_test.go
@@ -32,7 +32,7 @@ func TestDisputeList(t *testing.T) {
 func TestDisputeUpdate(t *testing.T) {
 	dispute, err := Update("dp_123", &stripe.DisputeParams{
 		Evidence: &stripe.DisputeEvidenceParams{
-			CustomerName: "A Name",
+			CustomerName: stripe.String("A Name"),
 		},
 	})
 	assert.Nil(t, err)

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -19,10 +19,10 @@ type EphemeralKey struct {
 		Type string `json:"type"`
 	} `json:"associated_objects"`
 
-	Created int64  `json:"created"`
-	Expires int64  `json:"expires"`
-	ID      string `json:"id"`
-	Live    bool   `json:"livemode"`
+	Created  int64  `json:"created"`
+	Expires  int64  `json:"expires"`
+	ID       string `json:"id"`
+	Livemode bool   `json:"livemode"`
 
 	// RawJSON is provided so that it may be passed back to the frontend
 	// unchanged.  Ephemeral keys are issued on behalf of another client which

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -7,8 +7,8 @@ import "encoding/json"
 // For more details see https://stripe.com/docs/api#ephemeral_keys.
 type EphemeralKeyParams struct {
 	Params        `form:"*"`
-	Customer      string `form:"customer"`
-	StripeVersion string `form:"-"` // This goes in the `Stripe-Version` header
+	Customer      *string `form:"customer"`
+	StripeVersion *string `form:"-"` // This goes in the `Stripe-Version` header
 }
 
 // EphemeralKey is the resource representing a Stripe ephemeral key.

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -24,19 +24,17 @@ func New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
 // New POSTs new ephemeral keys.
 // For more details see https://stripe.com/docs/api#create_ephemeral_key.
 func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
-	if params.StripeVersion == "" {
+	if params.StripeVersion == nil || len(stripe.StringValue(params.StripeVersion)) == 0 {
 		return nil, fmt.Errorf("params.StripeVersion must be specified")
 	}
 
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	if len(params.StripeVersion) > 0 {
-		if params.Headers == nil {
-			params.Headers = make(http.Header)
-		}
-		params.Headers.Add("Stripe-Version", params.StripeVersion)
+	if params.Headers == nil {
+		params.Headers = make(http.Header)
 	}
+	params.Headers.Add("Stripe-Version", stripe.StringValue(params.StripeVersion))
 
 	ephemeralKey := &stripe.EphemeralKey{}
 	err := c.B.Call("POST", "ephemeral_keys", c.Key, body, &params.Params, ephemeralKey)

--- a/ephemeralkey/client_test.go
+++ b/ephemeralkey/client_test.go
@@ -16,8 +16,8 @@ func TestEphemeralKeyDel(t *testing.T) {
 
 func TestEphemeralKeyNew(t *testing.T) {
 	key, err := New(&stripe.EphemeralKeyParams{
-		Customer:      "cus_123",
-		StripeVersion: "2018-02-06",
+		Customer:      stripe.String("cus_123"),
+		StripeVersion: stripe.String("2018-02-06"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, key)

--- a/error.go
+++ b/error.go
@@ -17,26 +17,19 @@ const (
 	ErrorTypePermission     ErrorType = "more_permissions_required"
 	ErrorTypeRateLimit      ErrorType = "rate_limit_error"
 
-	CardDeclined  ErrorCode = "card_declined"
-	ExpiredCard   ErrorCode = "expired_card"
-	IncorrectNum  ErrorCode = "incorrect_number"
-	InvalidCvc    ErrorCode = "invalid_cvc"
-	InvalidExpM   ErrorCode = "invalid_expiry_month"
-	InvalidExpY   ErrorCode = "invalid_expiry_year"
-	InvalidNum    ErrorCode = "invalid_number"
-	IncorrectCvc  ErrorCode = "incorrect_cvc"
-	IncorrectZip  ErrorCode = "incorrect_zip"
-	Missing       ErrorCode = "missing"
-	ProcessingErr ErrorCode = "processing_error"
-	RateLimit     ErrorCode = "rate_limit"
-
-	// These additional types are written purely for backward compatibility
-	// (the originals were given quite unsuitable names) and should be
-	// considered deprecated. Remove them on the next major version revision.
-
-	APIErr         ErrorType = ErrorTypeAPI
-	CardErr        ErrorType = ErrorTypeCard
-	InvalidRequest ErrorType = ErrorTypeInvalidRequest
+	ErrorCodeCardDeclined       ErrorCode = "card_declined"
+	ErrorCodeExpiredCard        ErrorCode = "expired_card"
+	ErrorCodeIncorrectCvc       ErrorCode = "incorrect_cvc"
+	ErrorCodeIncorrectZip       ErrorCode = "incorrect_zip"
+	ErrorCodeIncorrectNumber    ErrorCode = "incorrect_number"
+	ErrorCodeInvalidCvc         ErrorCode = "invalid_cvc"
+	ErrorCodeInvalidExpiryMonth ErrorCode = "invalid_expiry_month"
+	ErrorCodeInvalidExpiryYear  ErrorCode = "invalid_expiry_year"
+	ErrorCodeInvalidNumber      ErrorCode = "invalid_number"
+	ErrorCodeInvalidSwipeData   ErrorCode = "invalid_swipe_data"
+	ErrorCodeMissing            ErrorCode = "missing"
+	ErrorCodeProcessingError    ErrorCode = "processing_error"
+	ErrorCodeRateLimit          ErrorCode = "rate_limit"
 )
 
 // Error is the response returned when a call is unsuccessful.

--- a/error.go
+++ b/error.go
@@ -19,10 +19,10 @@ const (
 
 	ErrorCodeCardDeclined       ErrorCode = "card_declined"
 	ErrorCodeExpiredCard        ErrorCode = "expired_card"
-	ErrorCodeIncorrectCvc       ErrorCode = "incorrect_cvc"
+	ErrorCodeIncorrectCVC       ErrorCode = "incorrect_cvc"
 	ErrorCodeIncorrectZip       ErrorCode = "incorrect_zip"
 	ErrorCodeIncorrectNumber    ErrorCode = "incorrect_number"
-	ErrorCodeInvalidCvc         ErrorCode = "invalid_cvc"
+	ErrorCodeInvalidCVC         ErrorCode = "invalid_cvc"
 	ErrorCodeInvalidExpiryMonth ErrorCode = "invalid_expiry_month"
 	ErrorCodeInvalidExpiryYear  ErrorCode = "invalid_expiry_year"
 	ErrorCodeInvalidNumber      ErrorCode = "invalid_number"

--- a/error_test.go
+++ b/error_test.go
@@ -18,7 +18,7 @@ func TestErrorResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Request-Id", "req_123")
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, `{"error":{"message":"bar","type":"`+InvalidRequest+`"}}`)
+		fmt.Fprintln(w, `{"error":{"message":"bar","type":"`+ErrorTypeInvalidRequest+`"}}`)
 	}))
 	defer ts.Close()
 
@@ -32,7 +32,7 @@ func TestErrorResponse(t *testing.T) {
 	assert.Error(t, err)
 
 	stripeErr := err.(*Error)
-	assert.Equal(t, InvalidRequest, stripeErr.Type)
+	assert.Equal(t, ErrorTypeInvalidRequest, stripeErr.Type)
 	assert.Equal(t, "req_123", stripeErr.RequestID)
 	assert.Equal(t, 401, stripeErr.HTTPStatusCode)
 }

--- a/event.go
+++ b/event.go
@@ -9,14 +9,14 @@ import (
 // Event is the resource representing a Stripe event.
 // For more details see https://stripe.com/docs/api#events.
 type Event struct {
-	Account  string        `json:"account"`
-	Created  int64         `json:"created"`
-	Data     *EventData    `json:"data"`
-	ID       string        `json:"id"`
-	Live     bool          `json:"livemode"`
-	Request  *EventRequest `json:"request"`
-	Type     string        `json:"type"`
-	Webhooks uint64        `json:"pending_webhooks"`
+	Account         string        `json:"account"`
+	Created         int64         `json:"created"`
+	Data            *EventData    `json:"data"`
+	ID              string        `json:"id"`
+	Livemode        bool          `json:"livemode"`
+	PendingWebhooks uint64        `json:"pending_webhooks"`
+	Request         *EventRequest `json:"request"`
+	Type            string        `json:"type"`
 }
 
 // EventRequest contains information on a request that created an event.
@@ -33,15 +33,15 @@ type EventRequest struct {
 
 // EventData is the unmarshalled object as a map.
 type EventData struct {
-	Obj  map[string]interface{}
-	Prev map[string]interface{} `json:"previous_attributes"`
-	Raw  json.RawMessage        `json:"object"`
+	Object             map[string]interface{}
+	PreviousAttributes map[string]interface{} `json:"previous_attributes"`
+	Raw                json.RawMessage        `json:"object"`
 }
 
 // EventList is a list of events as retrieved from a list endpoint.
 type EventList struct {
 	ListMeta
-	Values []*Event `json:"data"`
+	Data []*Event `json:"data"`
 }
 
 // EventListParams is the set of parameters that can be used when listing events.
@@ -54,14 +54,14 @@ type EventListParams struct {
 	Types        []string          `form:"types"`
 }
 
-// GetObjValue returns the value from the e.Data.Obj bag based on the keys hierarchy.
-func (e *Event) GetObjValue(keys ...string) string {
-	return getValue(e.Data.Obj, keys)
+// GetObjectValue returns the value from the e.Data.Object bag based on the keys hierarchy.
+func (e *Event) GetObjectValue(keys ...string) string {
+	return getValue(e.Data.Object, keys)
 }
 
-// GetPrevValue returns the value from the e.Data.Prev bag based on the keys hierarchy.
-func (e *Event) GetPrevValue(keys ...string) string {
-	return getValue(e.Data.Prev, keys)
+// GetPreviousValue returns the value from the e.Data.Prev bag based on the keys hierarchy.
+func (e *Event) GetPreviousValue(keys ...string) string {
+	return getValue(e.Data.PreviousAttributes, keys)
 }
 
 // UnmarshalJSON handles deserialization of the EventData.
@@ -75,7 +75,7 @@ func (e *EventData) UnmarshalJSON(data []byte) error {
 	}
 
 	*e = EventData(ee)
-	return json.Unmarshal(e.Raw, &e.Obj)
+	return json.Unmarshal(e.Raw, &e.Object)
 }
 
 // getValue returns the value from the m map based on the keys.

--- a/event.go
+++ b/event.go
@@ -14,7 +14,7 @@ type Event struct {
 	Data            *EventData    `json:"data"`
 	ID              string        `json:"id"`
 	Livemode        bool          `json:"livemode"`
-	PendingWebhooks uint64        `json:"pending_webhooks"`
+	PendingWebhooks int64         `json:"pending_webhooks"`
 	Request         *EventRequest `json:"request"`
 	Type            string        `json:"type"`
 }

--- a/event.go
+++ b/event.go
@@ -48,9 +48,9 @@ type EventList struct {
 // For more details see https://stripe.com/docs/api#list_events.
 type EventListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Type         string            `form:"type"`
+	Type         *string           `form:"type"`
 	Types        []string          `form:"types"`
 }
 

--- a/event/client.go
+++ b/event/client.go
@@ -46,8 +46,8 @@ func (c Client) List(params *stripe.EventListParams) *Iter {
 		list := &stripe.EventList{}
 		err := c.B.Call("GET", "/events", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/event_test.go
+++ b/event_test.go
@@ -6,10 +6,10 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestGetObjValue(t *testing.T) {
+func TestGetObjectValue(t *testing.T) {
 	event := &Event{
 		Data: &EventData{
-			Obj: map[string]interface{}{
+			Object: map[string]interface{}{
 				"top_level_key": "top_level",
 				"integer_key":   123,
 				"map": map[string]interface{}{
@@ -29,27 +29,27 @@ func TestGetObjValue(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "top_level", event.GetObjValue("top_level_key"))
+	assert.Equal(t, "top_level", event.GetObjectValue("top_level_key"))
 
 	// Check that it coerces non-string values into strings (this behavior is
 	// somewhat questionable, but I'm going with how it already works)
-	assert.Equal(t, "123", event.GetObjValue("integer_key"))
+	assert.Equal(t, "123", event.GetObjectValue("integer_key"))
 
-	assert.Equal(t, "nested", event.GetObjValue("map", "nested_key"))
-	assert.Equal(t, "index-1", event.GetObjValue("slice", "1"))
+	assert.Equal(t, "nested", event.GetObjectValue("map", "nested_key"))
+	assert.Equal(t, "index-1", event.GetObjectValue("slice", "1"))
 	assert.Equal(t, "slice_nested",
-		event.GetObjValue("slice_of_maps", "0", "slice_nested_key"))
+		event.GetObjectValue("slice_of_maps", "0", "slice_nested_key"))
 
 	// By design a `nil` just returns an empty string
-	assert.Equal(t, "", event.GetObjValue("bad_key"))
+	assert.Equal(t, "", event.GetObjectValue("bad_key"))
 
 	// Panic conditions. Usually the function tries to just return a value is
 	// fairly forgiving, but it does panic under certain obviously impossible
 	// cases.
 	assert.PanicsWithValue(t, "Cannot access nested slice element with non-integer key: string_key", func() {
-		event.GetObjValue("slice", "string_key")
+		event.GetObjectValue("slice", "string_key")
 	})
 	assert.PanicsWithValue(t, "Cannot descend into non-map non-slice object with key: bad_key", func() {
-		event.GetObjValue("top_level_key", "bad_key")
+		event.GetObjectValue("top_level_key", "bad_key")
 	})
 }

--- a/example_test.go
+++ b/example_test.go
@@ -19,7 +19,7 @@ func ExampleCharge_new() {
 		Currency: currency.USD,
 	}
 	params.SetSource("tok_visa")
-	params.AddMeta("key", "value")
+	params.AddMetadata("key", "value")
 
 	ch, err := charge.New(params)
 
@@ -34,9 +34,9 @@ func ExampleCharge_get() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.ChargeParams{}
-	params.Expand("customer")
-	params.Expand("application")
-	params.Expand("balance_transaction")
+	params.AddExpand("customer")
+	params.AddExpand("application")
+	params.AddExpand("balance_transaction")
 
 	ch, err := charge.Get("ch_example_id", params)
 
@@ -55,7 +55,7 @@ func ExampleInvoice_update() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.InvoiceParams{
-		Desc: "updated description",
+		Description: "updated description",
 	}
 
 	inv, err := invoice.Update("sub_example_id", params)
@@ -64,7 +64,7 @@ func ExampleInvoice_update() {
 		log.Fatal(err)
 	}
 
-	log.Printf("%v\n", inv.Desc)
+	log.Printf("%v\n", inv.Description)
 }
 
 func ExampleCustomer_delete() {

--- a/example_test.go
+++ b/example_test.go
@@ -15,8 +15,8 @@ func ExampleCharge_new() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.ChargeParams{
-		Amount:   1000,
-		Currency: currency.USD,
+		Amount:   stripe.UInt64(1000),
+		Currency: stripe.String(string(currency.USD)),
 	}
 	params.SetSource("tok_visa")
 	params.AddMetadata("key", "value")
@@ -55,7 +55,7 @@ func ExampleInvoice_update() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.InvoiceParams{
-		Description: "updated description",
+		Description: stripe.String("updated description"),
 	}
 
 	inv, err := invoice.Update("sub_example_id", params)

--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@ func ExampleCharge_new() {
 	stripe.Key = "sk_key"
 
 	params := &stripe.ChargeParams{
-		Amount:   stripe.UInt64(1000),
+		Amount:   stripe.Int64(1000),
 		Currency: stripe.String(string(currency.USD)),
 	}
 	params.SetSource("tok_visa")

--- a/exchangerate.go
+++ b/exchangerate.go
@@ -10,7 +10,7 @@ type ExchangeRate struct {
 // ExchangeRateList is a list of exchange rates as retrieved from a list endpoint.
 type ExchangeRateList struct {
 	ListMeta
-	Values []*ExchangeRate `json:"data"`
+	Data []*ExchangeRate `json:"data"`
 }
 
 // ExchangeRateListParams are the parameters allowed during ExchangeRate listing.

--- a/exchangerate/client.go
+++ b/exchangerate/client.go
@@ -45,8 +45,8 @@ func (c Client) List(params *stripe.ExchangeRateListParams) *Iter {
 		list := &stripe.ExchangeRateList{}
 		err := c.B.Call("GET", "/exchange_rates", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/exchangerate/client_test.go
+++ b/exchangerate/client_test.go
@@ -5,11 +5,12 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
 func TestExchangeRateGet(t *testing.T) {
-	rates, err := Get("usd")
+	rates, err := Get(string(currency.USD))
 	assert.Nil(t, err)
 	assert.NotNil(t, rates)
 }

--- a/fee.go
+++ b/fee.go
@@ -2,55 +2,54 @@ package stripe
 
 import "encoding/json"
 
-// FeeParams is the set of parameters that can be used when refunding an application fee.
+// ApplicationFeeParams is the set of parameters that can be used when refunding an application fee.
 // For more details see https://stripe.com/docs/api#refund_application_fee.
-type FeeParams struct {
+type ApplicationFeeParams struct {
 	Params `form:"*"`
-	Amount uint64
 }
 
-// FeeListParams is the set of parameters that can be used when listing application fees.
+// ApplicationFeeListParams is the set of parameters that can be used when listing application fees.
 // For more details see https://stripe.com/docs/api#list_application_fees.
-type FeeListParams struct {
+type ApplicationFeeListParams struct {
 	ListParams   `form:"*"`
 	Charge       string            `form:"charge"`
 	Created      int64             `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 
-// Fee is the resource representing a Stripe application fee.
+// ApplicationFee is the resource representing a Stripe application fee.
 // For more details see https://stripe.com/docs/api#application_fees.
-type Fee struct {
-	Account                *Account       `json:"account"`
-	Amount                 uint64         `json:"amount"`
-	AmountRefunded         uint64         `json:"amount_refunded"`
-	App                    string         `json:"application"`
-	Charge                 *Charge        `json:"charge"`
-	Created                int64          `json:"created"`
-	Currency               Currency       `json:"currency"`
-	ID                     string         `json:"id"`
-	Live                   bool           `json:"livemode"`
-	OriginatingTransaction *Charge        `json:"originating_transaction"`
-	Refunded               bool           `json:"refunded"`
-	Refunds                *FeeRefundList `json:"refunds"`
-	Tx                     *Transaction   `json:"balance_transaction"`
+type ApplicationFee struct {
+	Account                *Account                  `json:"account"`
+	Amount                 uint64                    `json:"amount"`
+	AmountRefunded         uint64                    `json:"amount_refunded"`
+	Application            string                    `json:"application"`
+	BalanceTransaction     *BalanceTransaction       `json:"balance_transaction"`
+	Charge                 *Charge                   `json:"charge"`
+	Created                int64                     `json:"created"`
+	Currency               Currency                  `json:"currency"`
+	ID                     string                    `json:"id"`
+	Livemode               bool                      `json:"livemode"`
+	OriginatingTransaction *Charge                   `json:"originating_transaction"`
+	Refunded               bool                      `json:"refunded"`
+	Refunds                *ApplicationFeeRefundList `json:"refunds"`
 }
 
-// FeeList is a list of fees as retrieved from a list endpoint.
-type FeeList struct {
+//ApplicationFeeList is a list of application fees as retrieved from a list endpoint.
+type ApplicationFeeList struct {
 	ListMeta
-	Values []*Fee `json:"data"`
+	Data []*ApplicationFee `json:"data"`
 }
 
-// UnmarshalJSON handles deserialization of a Fee.
+// UnmarshalJSON handles deserialization of an ApplicationFee.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (f *Fee) UnmarshalJSON(data []byte) error {
-	type appfee Fee
+func (f *ApplicationFee) UnmarshalJSON(data []byte) error {
+	type appfee ApplicationFee
 	var ff appfee
 	err := json.Unmarshal(data, &ff)
 	if err == nil {
-		*f = Fee(ff)
+		*f = ApplicationFee(ff)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		f.ID = string(data[1 : len(data)-1])

--- a/fee.go
+++ b/fee.go
@@ -12,8 +12,8 @@ type ApplicationFeeParams struct {
 // For more details see https://stripe.com/docs/api#list_application_fees.
 type ApplicationFeeListParams struct {
 	ListParams   `form:"*"`
-	Charge       string            `form:"charge"`
-	Created      int64             `form:"created"`
+	Charge       *string           `form:"charge"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 

--- a/fee.go
+++ b/fee.go
@@ -21,8 +21,8 @@ type ApplicationFeeListParams struct {
 // For more details see https://stripe.com/docs/api#application_fees.
 type ApplicationFee struct {
 	Account                *Account                  `json:"account"`
-	Amount                 uint64                    `json:"amount"`
-	AmountRefunded         uint64                    `json:"amount_refunded"`
+	Amount                 int64                     `json:"amount"`
+	AmountRefunded         int64                     `json:"amount_refunded"`
 	Application            string                    `json:"application"`
 	BalanceTransaction     *BalanceTransaction       `json:"balance_transaction"`
 	Charge                 *Charge                   `json:"charge"`

--- a/fee/client.go
+++ b/fee/client.go
@@ -16,11 +16,11 @@ type Client struct {
 
 // Get returns the details of an application fee.
 // For more details see https://stripe.com/docs/api#retrieve_application_fee.
-func Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
+func Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
+func (c Client) Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -30,7 +30,7 @@ func (c Client) Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
 		form.AppendTo(body, params)
 	}
 
-	fee := &stripe.Fee{}
+	fee := &stripe.ApplicationFee{}
 	err := c.B.Call("GET", fmt.Sprintf("application_fees/%v", id), c.Key, body, commonParams, fee)
 
 	return fee, err
@@ -38,11 +38,11 @@ func (c Client) Get(id string, params *stripe.FeeParams) (*stripe.Fee, error) {
 
 // List returns a list of application fees.
 // For more details see https://stripe.com/docs/api#list_application_fees.
-func List(params *stripe.FeeListParams) *Iter {
+func List(params *stripe.ApplicationFeeListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.FeeListParams) *Iter {
+func (c Client) List(params *stripe.ApplicationFeeListParams) *Iter {
 	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -55,11 +55,11 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.FeeList{}
+		list := &stripe.ApplicationFeeList{}
 		err := c.B.Call("GET", "/application_fees", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -67,17 +67,17 @@ func (c Client) List(params *stripe.FeeListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Fees.
+// Iter is an iterator for lists of ApplicationFees.
 // The embedded Iter carries methods with it;
 // see its documentation for details.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Fee returns the most recent Fee
+// ApplicationFee returns the most recent ApplicationFee
 // visited by a call to Next.
-func (i *Iter) Fee() *stripe.Fee {
-	return i.Current().(*stripe.Fee)
+func (i *Iter) ApplicationFee() *stripe.ApplicationFee {
+	return i.Current().(*stripe.ApplicationFee)
 }
 
 func getC() Client {

--- a/fee/client_test.go
+++ b/fee/client_test.go
@@ -8,17 +8,17 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestFeeGet(t *testing.T) {
+func TestApplicationFeeGet(t *testing.T) {
 	fee, err := Get("fee_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, fee)
 }
 
-func TestFeeList(t *testing.T) {
-	i := List(&stripe.FeeListParams{})
+func TestApplicationFeeList(t *testing.T) {
+	i := List(&stripe.ApplicationFeeListParams{})
 
 	// Verify that we can get at least one fee
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.Fee())
+	assert.NotNil(t, i.ApplicationFee())
 }

--- a/feerefund.go
+++ b/feerefund.go
@@ -4,48 +4,48 @@ import (
 	"encoding/json"
 )
 
-// FeeRefundParams is the set of parameters that can be used when refunding a fee.
+// ApplicationFeeRefundParams is the set of parameters that can be used when refunding an application fee.
 // For more details see https://stripe.com/docs/api#fee_refund.
-type FeeRefundParams struct {
-	Params `form:"*"`
-	Amount uint64 `form:"amount"`
-	Fee    string `form:"-"` // Included in the URL
+type ApplicationFeeRefundParams struct {
+	Params         `form:"*"`
+	Amount         uint64 `form:"amount"`
+	ApplicationFee string `form:"-"` // Included in the URL
 }
 
-// FeeRefundListParams is the set of parameters that can be used when listing fee refunds.
+// ApplicationFeeRefundListParams is the set of parameters that can be used when listing application fee refunds.
 // For more details see https://stripe.com/docs/api#list_fee_refunds.
-type FeeRefundListParams struct {
-	ListParams `form:"*"`
-	Fee        string `form:"-"` // Included in the URL
+type ApplicationFeeRefundListParams struct {
+	ListParams     `form:"*"`
+	ApplicationFee string `form:"-"` // Included in the URL
 }
 
-// FeeRefund is the resource representing a Stripe fee refund.
+// ApplicationFeeRefund is the resource representing a Stripe application fee refund.
 // For more details see https://stripe.com/docs/api#fee_refunds.
-type FeeRefund struct {
-	Amount   uint64            `json:"amount"`
-	Created  int64             `json:"created"`
-	Currency Currency          `json:"currency"`
-	Fee      string            `json:"fee"`
-	ID       string            `json:"id"`
-	Meta     map[string]string `json:"metadata"`
-	Tx       *Transaction      `json:"balance_transaction"`
+type ApplicationFeeRefund struct {
+	Amount             uint64              `json:"amount"`
+	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
+	Created            int64               `json:"created"`
+	Currency           Currency            `json:"currency"`
+	Fee                string              `json:"fee"`
+	ID                 string              `json:"id"`
+	Metadata           map[string]string   `json:"metadata"`
 }
 
-// FeeRefundList is a list object for fee refunds.
-type FeeRefundList struct {
+// ApplicationFeeRefundList is a list object for application fee refunds.
+type ApplicationFeeRefundList struct {
 	ListMeta
-	Values []*FeeRefund `json:"data"`
+	Data []*ApplicationFeeRefund `json:"data"`
 }
 
-// UnmarshalJSON handles deserialization of a FeeRefund.
+// UnmarshalJSON handles deserialization of a ApplicationFeeRefund.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (f *FeeRefund) UnmarshalJSON(data []byte) error {
-	type feerefund FeeRefund
+func (f *ApplicationFeeRefund) UnmarshalJSON(data []byte) error {
+	type feerefund ApplicationFeeRefund
 	var ff feerefund
 	err := json.Unmarshal(data, &ff)
 	if err == nil {
-		*f = FeeRefund(ff)
+		*f = ApplicationFeeRefund(ff)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		f.ID = string(data[1 : len(data)-1])

--- a/feerefund.go
+++ b/feerefund.go
@@ -8,15 +8,15 @@ import (
 // For more details see https://stripe.com/docs/api#fee_refund.
 type ApplicationFeeRefundParams struct {
 	Params         `form:"*"`
-	Amount         uint64 `form:"amount"`
-	ApplicationFee string `form:"-"` // Included in the URL
+	Amount         *uint64 `form:"amount"`
+	ApplicationFee *string `form:"-"` // Included in the URL
 }
 
 // ApplicationFeeRefundListParams is the set of parameters that can be used when listing application fee refunds.
 // For more details see https://stripe.com/docs/api#list_fee_refunds.
 type ApplicationFeeRefundListParams struct {
 	ListParams     `form:"*"`
-	ApplicationFee string `form:"-"` // Included in the URL
+	ApplicationFee *string `form:"-"` // Included in the URL
 }
 
 // ApplicationFeeRefund is the resource representing a Stripe application fee refund.

--- a/feerefund.go
+++ b/feerefund.go
@@ -8,7 +8,7 @@ import (
 // For more details see https://stripe.com/docs/api#fee_refund.
 type ApplicationFeeRefundParams struct {
 	Params         `form:"*"`
-	Amount         *uint64 `form:"amount"`
+	Amount         *int64  `form:"amount"`
 	ApplicationFee *string `form:"-"` // Included in the URL
 }
 
@@ -22,7 +22,7 @@ type ApplicationFeeRefundListParams struct {
 // ApplicationFeeRefund is the resource representing a Stripe application fee refund.
 // For more details see https://stripe.com/docs/api#fee_refunds.
 type ApplicationFeeRefund struct {
-	Amount             uint64              `json:"amount"`
+	Amount             int64               `json:"amount"`
 	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
 	Created            int64               `json:"created"`
 	Currency           Currency            `json:"currency"`

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -16,80 +16,80 @@ type Client struct {
 
 // New refunds the application fee collected.
 // For more details see https://stripe.com/docs/api#refund_application_fee.
-func New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func New(params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	return getC().New(params)
 }
 
-func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func (c Client) New(params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.Fee == "" {
-		return nil, fmt.Errorf("params.Fee must be set")
+	if params.ApplicationFee == "" {
+		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", params.Fee), c.Key, body, &params.Params, refund)
+	refund := &stripe.ApplicationFeeRefund{}
+	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", params.ApplicationFee), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
 
 // Get returns the details of a fee refund.
 // For more details see https://stripe.com/docs/api#retrieve_fee_refund.
-func Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func Get(id string, params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func (c Client) Get(id string, params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.Fee == "" {
-		return nil, fmt.Errorf("params.Fee must be set")
+	if params.ApplicationFee == "" {
+		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", params.Fee, id), c.Key, body, &params.Params, refund)
+	refund := &stripe.ApplicationFeeRefund{}
+	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", params.ApplicationFee, id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
 
 // Update updates a refund's properties.
 // For more details see https://stripe.com/docs/api#update_refund.
-func Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func Update(id string, params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	return getC().Update(id, params)
 }
 
-func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
+func (c Client) Update(id string, params *stripe.ApplicationFeeRefundParams) (*stripe.ApplicationFeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.Fee == "" {
-		return nil, fmt.Errorf("params.Fee must be set")
+	if params.ApplicationFee == "" {
+		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", params.Fee, id), c.Key, body, &params.Params, refund)
+	refund := &stripe.ApplicationFeeRefund{}
+	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", params.ApplicationFee, id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
 
 // List returns a list of fee refunds.
 // For more details see https://stripe.com/docs/api#list_fee_refunds.
-func List(params *stripe.FeeRefundListParams) *Iter {
+func List(params *stripe.ApplicationFeeRefundListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
+func (c Client) List(params *stripe.ApplicationFeeRefundListParams) *Iter {
 	body := &form.Values{}
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -99,11 +99,11 @@ func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 	p = params.ToParams()
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.FeeRefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.Fee), c.Key, b, p, list)
+		list := &stripe.ApplicationFeeRefundList{}
+		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.ApplicationFee), c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -111,17 +111,17 @@ func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of FeeRefunds.
+// Iter is an iterator for lists of ApplicationFeeRefunds.
 // The embedded Iter carries methods with it;
 // see its documentation for details.
 type Iter struct {
 	*stripe.Iter
 }
 
-// FeeRefund returns the most recent FeeRefund
+// ApplicationFeeRefund returns the most recent ApplicationFeeRefund
 // visited by a call to Next.
-func (i *Iter) FeeRefund() *stripe.FeeRefund {
-	return i.Current().(*stripe.FeeRefund)
+func (i *Iter) ApplicationFeeRefund() *stripe.ApplicationFeeRefund {
+	return i.Current().(*stripe.ApplicationFeeRefund)
 }
 
 func getC() Client {

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -24,7 +24,7 @@ func (c Client) New(params *stripe.ApplicationFeeRefundParams) (*stripe.Applicat
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ApplicationFee == "" {
+	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
@@ -32,7 +32,7 @@ func (c Client) New(params *stripe.ApplicationFeeRefundParams) (*stripe.Applicat
 	form.AppendTo(body, params)
 
 	refund := &stripe.ApplicationFeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", params.ApplicationFee), c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -47,7 +47,7 @@ func (c Client) Get(id string, params *stripe.ApplicationFeeRefundParams) (*stri
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ApplicationFee == "" {
+	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
@@ -55,7 +55,7 @@ func (c Client) Get(id string, params *stripe.ApplicationFeeRefundParams) (*stri
 	form.AppendTo(body, params)
 
 	refund := &stripe.ApplicationFeeRefund{}
-	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", params.ApplicationFee, id), c.Key, body, &params.Params, refund)
+	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -70,7 +70,7 @@ func (c Client) Update(id string, params *stripe.ApplicationFeeRefundParams) (*s
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ApplicationFee == "" {
+	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
@@ -78,7 +78,7 @@ func (c Client) Update(id string, params *stripe.ApplicationFeeRefundParams) (*s
 	form.AppendTo(body, params)
 
 	refund := &stripe.ApplicationFeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", params.ApplicationFee, id), c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -100,7 +100,7 @@ func (c Client) List(params *stripe.ApplicationFeeRefundListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplicationFeeRefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", params.ApplicationFee), c.Key, b, p, list)
+		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/feerefund/client_test.go
+++ b/feerefund/client_test.go
@@ -8,38 +8,38 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestFeeRefundGet(t *testing.T) {
-	refund, err := Get("fr_123", &stripe.FeeRefundParams{
-		Fee: "fee_123",
+func TestApplicationFeeRefundGet(t *testing.T) {
+	refund, err := Get("fr_123", &stripe.ApplicationFeeRefundParams{
+		ApplicationFee: "fee_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)
 }
 
-func TestFeeRefundList(t *testing.T) {
-	i := List(&stripe.FeeRefundListParams{
-		Fee: "fee_123",
+func TestApplicationFeeRefundList(t *testing.T) {
+	i := List(&stripe.ApplicationFeeRefundListParams{
+		ApplicationFee: "fee_123",
 	})
 
 	// Verify that we can get at least one refund
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.FeeRefund())
+	assert.NotNil(t, i.ApplicationFeeRefund())
 }
 
-func TestFeeRefundNew(t *testing.T) {
-	refund, err := New(&stripe.FeeRefundParams{
-		Fee: "fee_123",
+func TestApplicationFeeRefundNew(t *testing.T) {
+	refund, err := New(&stripe.ApplicationFeeRefundParams{
+		ApplicationFee: "fee_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)
 }
 
-func TestFeeRefundUpdate(t *testing.T) {
-	refund, err := Update("fr_123", &stripe.FeeRefundParams{
-		Fee: "fee_123",
+func TestApplicationFeeRefundUpdate(t *testing.T) {
+	refund, err := Update("fr_123", &stripe.ApplicationFeeRefundParams{
+		ApplicationFee: "fee_123",
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/feerefund/client_test.go
+++ b/feerefund/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestApplicationFeeRefundGet(t *testing.T) {
 	refund, err := Get("fr_123", &stripe.ApplicationFeeRefundParams{
-		ApplicationFee: "fee_123",
+		ApplicationFee: stripe.String("fee_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)
@@ -18,7 +18,7 @@ func TestApplicationFeeRefundGet(t *testing.T) {
 
 func TestApplicationFeeRefundList(t *testing.T) {
 	i := List(&stripe.ApplicationFeeRefundListParams{
-		ApplicationFee: "fee_123",
+		ApplicationFee: stripe.String("fee_123"),
 	})
 
 	// Verify that we can get at least one refund
@@ -29,7 +29,7 @@ func TestApplicationFeeRefundList(t *testing.T) {
 
 func TestApplicationFeeRefundNew(t *testing.T) {
 	refund, err := New(&stripe.ApplicationFeeRefundParams{
-		ApplicationFee: "fee_123",
+		ApplicationFee: stripe.String("fee_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)
@@ -37,7 +37,7 @@ func TestApplicationFeeRefundNew(t *testing.T) {
 
 func TestApplicationFeeRefundUpdate(t *testing.T) {
 	refund, err := Update("fr_123", &stripe.ApplicationFeeRefundParams{
-		ApplicationFee: "fee_123",
+		ApplicationFee: stripe.String("fee_123"),
 		Params: stripe.Params{
 			Metadata: map[string]string{
 				"foo": "bar",

--- a/fileupload.go
+++ b/fileupload.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"mime/multipart"
-	"os"
 	"path/filepath"
 )
 
@@ -13,10 +12,6 @@ import (
 // For more details see https://stripe.com/docs/api#create_file_upload.
 type FileUploadParams struct {
 	Params `form:"*"`
-
-	// File is a deprecated form of FileReader and Filename that will do the same thing, but
-	// allows referencing a file directly. Please prefer the use of FileReader and Filename instead.
-	File *os.File
 
 	// FileReader is a reader with the contents of the file that should be uploaded.
 	FileReader io.Reader
@@ -54,7 +49,7 @@ type FileUpload struct {
 // FileUploadList is a list of file uploads as retrieved from a list endpoint.
 type FileUploadList struct {
 	ListMeta
-	Values []*FileUpload `json:"data"`
+	Data []*FileUpload `json:"data"`
 }
 
 // AppendDetails adds the file upload details to an io.ReadWriter. It returns
@@ -80,16 +75,6 @@ func (f *FileUploadParams) AppendDetails(body io.ReadWriter) (string, error) {
 		}
 
 		_, err = io.Copy(part, f.FileReader)
-		if err != nil {
-			return "", err
-		}
-	} else if f.File != nil {
-		part, err := writer.CreateFormFile("file", filepath.Base(f.File.Name()))
-		if err != nil {
-			return "", err
-		}
-
-		_, err = io.Copy(part, f.File)
 		if err != nil {
 			return "", err
 		}

--- a/fileupload.go
+++ b/fileupload.go
@@ -17,18 +17,18 @@ type FileUploadParams struct {
 	FileReader io.Reader
 
 	// Filename is just the name of the file without path information.
-	Filename string
+	Filename *string
 
-	Purpose FileUploadPurpose
+	Purpose *string
 }
 
 // FileUploadListParams is the set of parameters that can be used when listing
 // file uploads. For more details see https://stripe.com/docs/api#list_file_uploads.
 type FileUploadListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Purpose      FileUploadPurpose `form:"purpose"`
+	Purpose      *string           `form:"purpose"`
 }
 
 // FileUploadPurpose is the purpose of a particular file upload. Allowed values
@@ -59,8 +59,8 @@ func (f *FileUploadParams) AppendDetails(body io.ReadWriter) (string, error) {
 	writer := multipart.NewWriter(body)
 	var err error
 
-	if len(f.Purpose) > 0 {
-		err = writer.WriteField("purpose", string(f.Purpose))
+	if f.Purpose != nil {
+		err = writer.WriteField("purpose", StringValue(f.Purpose))
 		if err != nil {
 			return "", err
 		}
@@ -68,8 +68,8 @@ func (f *FileUploadParams) AppendDetails(body io.ReadWriter) (string, error) {
 
 	// Support both FileReader/Filename and File with
 	// the former being the newer preferred version
-	if f.FileReader != nil && f.Filename != "" {
-		part, err := writer.CreateFormFile("file", filepath.Base(f.Filename))
+	if f.FileReader != nil && f.Filename != nil {
+		part, err := writer.CreateFormFile("file", filepath.Base(StringValue(f.Filename)))
 		if err != nil {
 			return "", err
 		}

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -88,8 +88,8 @@ func (c Client) List(params *stripe.FileUploadListParams) *Iter {
 		list := &stripe.FileUploadList{}
 		err := c.B.Call("GET", "/files", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/fileupload/client_test.go
+++ b/fileupload/client_test.go
@@ -34,9 +34,9 @@ func TestFileUploadNewThenGet(t *testing.T) {
 	}
 
 	uploadParams := &stripe.FileUploadParams{
-		Purpose:    "dispute_evidence",
+		Purpose:    stripe.String(string(DisputeEvidenceFile)),
 		FileReader: f,
-		Filename:   f.Name(),
+		Filename:   stripe.String(f.Name()),
 	}
 
 	target, err := New(uploadParams)
@@ -59,9 +59,9 @@ func TestFileUploadList(t *testing.T) {
 	}
 
 	uploadParams := &stripe.FileUploadParams{
-		Purpose:    "dispute_evidence",
+		Purpose:    stripe.String(string(DisputeEvidenceFile)),
 		FileReader: f,
-		Filename:   f.Name(),
+		Filename:   stripe.String(f.Name()),
 	}
 
 	_, err = New(uploadParams)

--- a/fileupload/client_test.go
+++ b/fileupload/client_test.go
@@ -59,8 +59,9 @@ func TestFileUploadList(t *testing.T) {
 	}
 
 	uploadParams := &stripe.FileUploadParams{
-		Purpose: "dispute_evidence",
-		File:    f,
+		Purpose:    "dispute_evidence",
+		FileReader: f,
+		Filename:   f.Name(),
 	}
 
 	_, err = New(uploadParams)

--- a/form/form.go
+++ b/form/form.go
@@ -59,12 +59,6 @@ type formOptions struct {
 	// empty string is a string's zero value and wouldn't normally be encoded.
 	Empty bool
 
-	// Invert indicates that a boolean field's value should be inverted. False
-	// is the zero value for a boolean so it's convention in the library to
-	// specify a `No*` field to allow a false to be passed to the API. These
-	// fields should be annotated with `invert`.
-	Invert bool
-
 	// Zero indicates a field that's specifically defined to workaround the
 	// fact because 0 is the "zero value" of all int/float types, we can't
 	// properly encode an explicit 0. It indicates that an explicit zero should
@@ -159,8 +153,6 @@ func boolEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero 
 		switch {
 		case options.Empty:
 			values.Add(FormatKey(keyParts), "")
-		case options.Invert:
-			values.Add(FormatKey(keyParts), strconv.FormatBool(false))
 		case options.Zero:
 			values.Add(FormatKey(keyParts), "0")
 		}
@@ -387,11 +379,11 @@ func makeStructEncoder(t reflect.Type) *structEncoder {
 		fldKind := fldTyp.Kind()
 
 		if Strict && options != nil &&
-			(options.Empty || options.Invert || options.Zero) &&
+			(options.Empty || options.Zero) &&
 			fldKind != reflect.Bool {
 
 			panic(fmt.Sprintf(
-				"Cannot specify `empty`, `invert`, or `zero` for non-boolean field; on: %s/%s",
+				"Cannot specify `empty`, or `zero` for non-boolean field; on: %s/%s",
 				t.Name(), reflectField.Name,
 			))
 		}
@@ -467,12 +459,6 @@ func parseTag(tag string) (string, *formOptions) {
 				options = &formOptions{}
 			}
 			options.IndexedArray = true
-
-		case "invert":
-			if options == nil {
-				options = &formOptions{}
-			}
-			options.Invert = true
 
 		case "zero":
 			if options == nil {

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -51,8 +51,6 @@ type testStruct struct {
 	Int64    int64  `form:"int64"`
 	Int64Ptr *int64 `form:"int64_ptr"`
 
-	Inverted bool `form:"inverted,invert"`
-
 	Map map[string]interface{} `form:"map"`
 
 	Slice    []string  `form:"slice"`
@@ -217,8 +215,6 @@ func TestAppendTo(t *testing.T) {
 		{"int64_ptr", &testStruct{Int64Ptr: &int64Val}, "123"},
 		{"int64_ptr", &testStruct{Int64Ptr: &int64Val0}, "0"},
 		{"int64_ptr", &testStruct{}, ""},
-
-		{"inverted", &testStruct{Inverted: true}, "false"},
 
 		// Tests map
 		{

--- a/invoice.go
+++ b/invoice.go
@@ -14,30 +14,26 @@ type InvoiceBilling string
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
 	Params              `form:"*"`
-	ApplicationFee      uint64         `form:"application_fee"`
-	ApplicationFeeZero  bool           `form:"application_fee,zero"`
+	ApplicationFee      *uint64        `form:"application_fee"`
 	Billing             InvoiceBilling `form:"billing"`
-	Closed              bool           `form:"closed"`
+	Closed              *bool          `form:"closed"`
 	Customer            string         `form:"customer"`
 	DaysUntilDue        uint64         `form:"days_until_due"`
 	Description         string         `form:"description"`
 	DueDate             int64          `form:"due_date"`
 	Forgiven            bool           `form:"forgiven"`
-	NoClosed            bool           `form:"closed,invert"`
 	Paid                bool           `form:"paid"`
 	StatementDescriptor string         `form:"statement_descriptor"`
 	Subscription        string         `form:"subscription"`
-	TaxPercent          float64        `form:"tax_percent"`
-	TaxPercentZero      bool           `form:"tax_percent,zero"`
+	TaxPercent          *float64       `form:"tax_percent"`
 
 	// These are all for exclusive use by GetNext.
 
 	SubscriptionItems         []*SubscriptionItemsParams `form:"subscription_items,indexed"`
-	SubscriptionNoProrate     bool                       `form:"subscription_prorate,invert"`
 	SubscriptionPlan          string                     `form:"subscription_plan"`
+	SubscriptionProrate       *bool                      `form:"subscription_prorate"`
 	SubscriptionProrationDate int64                      `form:"subscription_proration_date"`
-	SubscriptionQuantity      uint64                     `form:"subscription_quantity"`
-	SubscriptionQuantityZero  bool                       `form:"subscription_quantity,zero"`
+	SubscriptionQuantity      *uint64                    `form:"subscription_quantity"`
 	SubscriptionTrialEnd      int64                      `form:"subscription_trial_end"`
 }
 

--- a/invoice.go
+++ b/invoice.go
@@ -14,39 +14,39 @@ type InvoiceBilling string
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
 	Params              `form:"*"`
-	ApplicationFee      *uint64        `form:"application_fee"`
-	Billing             InvoiceBilling `form:"billing"`
-	Closed              *bool          `form:"closed"`
-	Customer            string         `form:"customer"`
-	DaysUntilDue        uint64         `form:"days_until_due"`
-	Description         string         `form:"description"`
-	DueDate             int64          `form:"due_date"`
-	Forgiven            bool           `form:"forgiven"`
-	Paid                bool           `form:"paid"`
-	StatementDescriptor string         `form:"statement_descriptor"`
-	Subscription        string         `form:"subscription"`
-	TaxPercent          *float64       `form:"tax_percent"`
+	ApplicationFee      *uint64  `form:"application_fee"`
+	Billing             *string  `form:"billing"`
+	Closed              *bool    `form:"closed"`
+	Customer            *string  `form:"customer"`
+	DaysUntilDue        *uint64  `form:"days_until_due"`
+	Description         *string  `form:"description"`
+	DueDate             *int64   `form:"due_date"`
+	Forgiven            *bool    `form:"forgiven"`
+	Paid                *bool    `form:"paid"`
+	StatementDescriptor *string  `form:"statement_descriptor"`
+	Subscription        *string  `form:"subscription"`
+	TaxPercent          *float64 `form:"tax_percent"`
 
 	// These are all for exclusive use by GetNext.
 
 	SubscriptionItems         []*SubscriptionItemsParams `form:"subscription_items,indexed"`
-	SubscriptionPlan          string                     `form:"subscription_plan"`
+	SubscriptionPlan          *string                    `form:"subscription_plan"`
 	SubscriptionProrate       *bool                      `form:"subscription_prorate"`
-	SubscriptionProrationDate int64                      `form:"subscription_proration_date"`
+	SubscriptionProrationDate *int64                     `form:"subscription_proration_date"`
 	SubscriptionQuantity      *uint64                    `form:"subscription_quantity"`
-	SubscriptionTrialEnd      int64                      `form:"subscription_trial_end"`
+	SubscriptionTrialEnd      *int64                     `form:"subscription_trial_end"`
 }
 
 // InvoiceListParams is the set of parameters that can be used when listing invoices.
 // For more details see https://stripe.com/docs/api#list_customer_invoices.
 type InvoiceListParams struct {
 	ListParams   `form:"*"`
-	Billing      InvoiceBilling    `form:"billing"`
-	Customer     string            `form:"customer"`
-	Date         int64             `form:"date"`
+	Billing      *string           `form:"billing"`
+	Customer     *string           `form:"customer"`
+	Date         *int64            `form:"date"`
 	DateRange    *RangeQueryParams `form:"date"`
-	DueDate      int64             `form:"due_date"`
-	Subscription string            `form:"subscription"`
+	DueDate      *int64            `form:"due_date"`
+	Subscription *string           `form:"subscription"`
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.
@@ -54,12 +54,12 @@ type InvoiceListParams struct {
 type InvoiceLineListParams struct {
 	ListParams `form:"*"`
 
-	Customer string `form:"customer"`
+	Customer *string `form:"customer"`
 
 	// ID is the invoice ID to list invoice lines for.
-	ID string `form:"-"` // Goes in the URL
+	ID *string `form:"-"` // Goes in the URL
 
-	Subscription string `form:"subscription"`
+	Subscription *string `form:"subscription"`
 }
 
 // Invoice is the resource representing a Stripe invoice.
@@ -142,7 +142,7 @@ type InvoiceLineList struct {
 // https://stripe.com/docs/api#pay_invoice.
 type InvoicePayParams struct {
 	Params `form:"*"`
-	Source string `form:"source"`
+	Source *string `form:"source"`
 }
 
 // UnmarshalJSON handles deserialization of an Invoice.

--- a/invoice.go
+++ b/invoice.go
@@ -14,11 +14,11 @@ type InvoiceBilling string
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
 	Params              `form:"*"`
-	ApplicationFee      *uint64  `form:"application_fee"`
+	ApplicationFee      *int64   `form:"application_fee"`
 	Billing             *string  `form:"billing"`
 	Closed              *bool    `form:"closed"`
 	Customer            *string  `form:"customer"`
-	DaysUntilDue        *uint64  `form:"days_until_due"`
+	DaysUntilDue        *int64   `form:"days_until_due"`
 	Description         *string  `form:"description"`
 	DueDate             *int64   `form:"due_date"`
 	Forgiven            *bool    `form:"forgiven"`
@@ -33,7 +33,7 @@ type InvoiceParams struct {
 	SubscriptionPlan          *string                    `form:"subscription_plan"`
 	SubscriptionProrate       *bool                      `form:"subscription_prorate"`
 	SubscriptionProrationDate *int64                     `form:"subscription_proration_date"`
-	SubscriptionQuantity      *uint64                    `form:"subscription_quantity"`
+	SubscriptionQuantity      *int64                     `form:"subscription_quantity"`
 	SubscriptionTrialEnd      *int64                     `form:"subscription_trial_end"`
 }
 
@@ -66,8 +66,8 @@ type InvoiceLineListParams struct {
 // For more details see https://stripe.com/docs/api#invoice_object.
 type Invoice struct {
 	AmountDue           int64             `json:"amount_due"`
-	ApplicationFee      uint64            `json:"application_fee"`
-	AttemptCount        uint64            `json:"attempt_count"`
+	ApplicationFee      int64             `json:"application_fee"`
+	AttemptCount        int64             `json:"attempt_count"`
 	Attempted           bool              `json:"attempted"`
 	Billing             InvoiceBilling    `json:"billing"`
 	Charge              *Charge           `json:"charge"`

--- a/invoice.go
+++ b/invoice.go
@@ -13,44 +13,44 @@ type InvoiceBilling string
 // InvoiceParams is the set of parameters that can be used when creating or updating an invoice.
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
-	Params         `form:"*"`
-	Billing        InvoiceBilling `form:"billing"`
-	Closed         bool           `form:"closed"`
-	Customer       string         `form:"customer"`
-	DaysUntilDue   uint64         `form:"days_until_due"`
-	Desc           string         `form:"description"`
-	DueDate        int64          `form:"due_date"`
-	Fee            uint64         `form:"application_fee"`
-	FeeZero        bool           `form:"application_fee,zero"`
-	Forgive        bool           `form:"forgiven"`
-	NoClosed       bool           `form:"closed,invert"`
-	Paid           bool           `form:"paid"`
-	Statement      string         `form:"statement_descriptor"`
-	Sub            string         `form:"subscription"`
-	TaxPercent     float64        `form:"tax_percent"`
-	TaxPercentZero bool           `form:"tax_percent,zero"`
+	Params              `form:"*"`
+	ApplicationFee      uint64         `form:"application_fee"`
+	ApplicationFeeZero  bool           `form:"application_fee,zero"`
+	Billing             InvoiceBilling `form:"billing"`
+	Closed              bool           `form:"closed"`
+	Customer            string         `form:"customer"`
+	DaysUntilDue        uint64         `form:"days_until_due"`
+	Description         string         `form:"description"`
+	DueDate             int64          `form:"due_date"`
+	Forgiven            bool           `form:"forgiven"`
+	NoClosed            bool           `form:"closed,invert"`
+	Paid                bool           `form:"paid"`
+	StatementDescriptor string         `form:"statement_descriptor"`
+	Subscription        string         `form:"subscription"`
+	TaxPercent          float64        `form:"tax_percent"`
+	TaxPercentZero      bool           `form:"tax_percent,zero"`
 
 	// These are all for exclusive use by GetNext.
 
-	SubItems         []*SubItemsParams `form:"subscription_items,indexed"`
-	SubNoProrate     bool              `form:"subscription_prorate,invert"`
-	SubPlan          string            `form:"subscription_plan"`
-	SubProrationDate int64             `form:"subscription_proration_date"`
-	SubQuantity      uint64            `form:"subscription_quantity"`
-	SubQuantityZero  bool              `form:"subscription_quantity,zero"`
-	SubTrialEnd      int64             `form:"subscription_trial_end"`
+	SubscriptionItems         []*SubscriptionItemsParams `form:"subscription_items,indexed"`
+	SubscriptionNoProrate     bool                       `form:"subscription_prorate,invert"`
+	SubscriptionPlan          string                     `form:"subscription_plan"`
+	SubscriptionProrationDate int64                      `form:"subscription_proration_date"`
+	SubscriptionQuantity      uint64                     `form:"subscription_quantity"`
+	SubscriptionQuantityZero  bool                       `form:"subscription_quantity,zero"`
+	SubscriptionTrialEnd      int64                      `form:"subscription_trial_end"`
 }
 
 // InvoiceListParams is the set of parameters that can be used when listing invoices.
 // For more details see https://stripe.com/docs/api#list_customer_invoices.
 type InvoiceListParams struct {
-	ListParams `form:"*"`
-	Billing    InvoiceBilling    `form:"billing"`
-	Customer   string            `form:"customer"`
-	Date       int64             `form:"date"`
-	DateRange  *RangeQueryParams `form:"date"`
-	DueDate    int64             `form:"due_date"`
-	Sub        string            `form:"subscription"`
+	ListParams   `form:"*"`
+	Billing      InvoiceBilling    `form:"billing"`
+	Customer     string            `form:"customer"`
+	Date         int64             `form:"date"`
+	DateRange    *RangeQueryParams `form:"date"`
+	DueDate      int64             `form:"due_date"`
+	Subscription string            `form:"subscription"`
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.
@@ -63,51 +63,51 @@ type InvoiceLineListParams struct {
 	// ID is the invoice ID to list invoice lines for.
 	ID string `form:"-"` // Goes in the URL
 
-	Sub string `form:"subscription"`
+	Subscription string `form:"subscription"`
 }
 
 // Invoice is the resource representing a Stripe invoice.
 // For more details see https://stripe.com/docs/api#invoice_object.
 type Invoice struct {
-	Amount        int64             `json:"amount_due"`
-	Attempted     bool              `json:"attempted"`
-	Attempts      uint64            `json:"attempt_count"`
-	Billing       InvoiceBilling    `json:"billing"`
-	Charge        *Charge           `json:"charge"`
-	Closed        bool              `json:"closed"`
-	Currency      Currency          `json:"currency"`
-	Customer      *Customer         `json:"customer"`
-	Date          int64             `json:"date"`
-	Desc          string            `json:"description"`
-	Discount      *Discount         `json:"discount"`
-	DueDate       int64             `json:"due_date"`
-	End           int64             `json:"period_end"`
-	EndBalance    int64             `json:"ending_balance"`
-	Fee           uint64            `json:"application_fee"`
-	Forgive       bool              `json:"forgiven"`
-	ID            string            `json:"id"`
-	Lines         *InvoiceLineList  `json:"lines"`
-	Live          bool              `json:"livemode"`
-	Meta          map[string]string `json:"metadata"`
-	NextAttempt   int64             `json:"next_payment_attempt"`
-	Number        string            `json:"number"`
-	Paid          bool              `json:"paid"`
-	ReceiptNumber string            `json:"receipt_number"`
-	Start         int64             `json:"period_start"`
-	StartBalance  int64             `json:"starting_balance"`
-	Statement     string            `json:"statement_descriptor"`
-	Sub           string            `json:"subscription"`
-	Subtotal      int64             `json:"subtotal"`
-	Tax           int64             `json:"tax"`
-	TaxPercent    float64           `json:"tax_percent"`
-	Total         int64             `json:"total"`
-	Webhook       int64             `json:"webhooks_delivered_at"`
+	AmountDue           int64             `json:"amount_due"`
+	ApplicationFee      uint64            `json:"application_fee"`
+	AttemptCount        uint64            `json:"attempt_count"`
+	Attempted           bool              `json:"attempted"`
+	Billing             InvoiceBilling    `json:"billing"`
+	Charge              *Charge           `json:"charge"`
+	Closed              bool              `json:"closed"`
+	Currency            Currency          `json:"currency"`
+	Customer            *Customer         `json:"customer"`
+	Date                int64             `json:"date"`
+	Description         string            `json:"description"`
+	Discount            *Discount         `json:"discount"`
+	DueDate             int64             `json:"due_date"`
+	EndingBalance       int64             `json:"ending_balance"`
+	Forgiven            bool              `json:"forgiven"`
+	ID                  string            `json:"id"`
+	Lines               *InvoiceLineList  `json:"lines"`
+	Livemode            bool              `json:"livemode"`
+	Metadata            map[string]string `json:"metadata"`
+	NextPaymentAttempt  int64             `json:"next_payment_attempt"`
+	Number              string            `json:"number"`
+	Paid                bool              `json:"paid"`
+	PeriodEnd           int64             `json:"period_end"`
+	PeriodStart         int64             `json:"period_start"`
+	ReceiptNumber       string            `json:"receipt_number"`
+	StartingBalance     int64             `json:"starting_balance"`
+	StatementDescriptor string            `json:"statement_descriptor"`
+	Subscription        string            `json:"subscription"`
+	Subtotal            int64             `json:"subtotal"`
+	Tax                 int64             `json:"tax"`
+	TaxPercent          float64           `json:"tax_percent"`
+	Total               int64             `json:"total"`
+	WebhooksDeliveredAt int64             `json:"webhooks_delivered_at"`
 }
 
 // InvoiceList is a list of invoices as retrieved from a list endpoint.
 type InvoiceList struct {
 	ListMeta
-	Values []*Invoice `json:"data"`
+	Data []*Invoice `json:"data"`
 }
 
 // InvoiceLine is the resource representing a Stripe invoice line item.
@@ -115,16 +115,16 @@ type InvoiceList struct {
 type InvoiceLine struct {
 	Amount           int64             `json:"amount"`
 	Currency         Currency          `json:"currency"`
-	Desc             string            `json:"description"`
+	Description      string            `json:"description"`
 	Discountable     bool              `json:"discountable"`
 	ID               string            `json:"id"`
-	Live             bool              `json:"live_mode"`
-	Meta             map[string]string `json:"metadata"`
+	Livemode         bool              `json:"live_mode"`
+	Metadata         map[string]string `json:"metadata"`
 	Period           *Period           `json:"period"`
 	Plan             *Plan             `json:"plan"`
 	Proration        bool              `json:"proration"`
 	Quantity         int64             `json:"quantity"`
-	Sub              string            `json:"subscription"`
+	Subscription     string            `json:"subscription"`
 	SubscriptionItem string            `json:"subscription_item"`
 	Type             InvoiceLineType   `json:"type"`
 }
@@ -138,7 +138,7 @@ type Period struct {
 // InvoiceLineList is a list object for invoice line items.
 type InvoiceLineList struct {
 	ListMeta
-	Values []*InvoiceLine `json:"data"`
+	Data []*InvoiceLine `json:"data"`
 }
 
 // InvoicePayParams is the set of parameters that can be used when

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -139,8 +139,8 @@ func (c Client) List(params *stripe.InvoiceListParams) *Iter {
 		list := &stripe.InvoiceList{}
 		err := c.B.Call("GET", "/invoices", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -164,8 +164,8 @@ func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 		list := &stripe.InvoiceLineList{}
 		err := c.B.Call("GET", fmt.Sprintf("/invoices/%v/lines", params.ID), c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -52,7 +52,7 @@ func TestInvoicePay(t *testing.T) {
 
 func TestInvoiceUpdate(t *testing.T) {
 	invoice, err := Update("in_123", &stripe.InvoiceParams{
-		Closed: true,
+		Closed: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -25,7 +25,7 @@ func TestInvoiceList(t *testing.T) {
 
 func TestInvoiceListLines(t *testing.T) {
 	i := ListLines(&stripe.InvoiceLineListParams{
-		ID: "in_123",
+		ID: stripe.String("in_123"),
 	})
 
 	// Verify that we can get at least one invoice
@@ -36,7 +36,8 @@ func TestInvoiceListLines(t *testing.T) {
 
 func TestInvoiceNew(t *testing.T) {
 	invoice, err := New(&stripe.InvoiceParams{
-		Customer: "cus_123",
+		Billing:  stripe.String("charge_automatically"),
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)
@@ -44,7 +45,7 @@ func TestInvoiceNew(t *testing.T) {
 
 func TestInvoicePay(t *testing.T) {
 	invoice, err := Pay("in_123", &stripe.InvoicePayParams{
-		Source: "src_123",
+		Source: stripe.String("src_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)
@@ -52,7 +53,8 @@ func TestInvoicePay(t *testing.T) {
 
 func TestInvoiceUpdate(t *testing.T) {
 	invoice, err := Update("in_123", &stripe.InvoiceParams{
-		Closed: stripe.Bool(true),
+		Forgiven: stripe.Bool(true),
+		Closed:   stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -6,22 +6,22 @@ import "encoding/json"
 // For more details see https://stripe.com/docs/api#create_invoiceitem and https://stripe.com/docs/api#update_invoiceitem.
 type InvoiceItemParams struct {
 	Params       `form:"*"`
-	Amount       int64    `form:"amount"`
-	Currency     Currency `form:"currency"`
-	Customer     string   `form:"customer"`
-	Description  string   `form:"description"`
-	Discountable *bool    `form:"discountable"`
-	Invoice      string   `form:"invoice"`
-	Subscription string   `form:"subscription"`
+	Amount       *int64  `form:"amount"`
+	Currency     *string `form:"currency"`
+	Customer     *string `form:"customer"`
+	Description  *string `form:"description"`
+	Discountable *bool   `form:"discountable"`
+	Invoice      *string `form:"invoice"`
+	Subscription *string `form:"subscription"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
 type InvoiceItemListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Customer     string            `form:"customer"`
+	Customer     *string           `form:"customer"`
 }
 
 // InvoiceItem is the resource represneting a Stripe invoice item.

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -10,11 +10,11 @@ type InvoiceItemParams struct {
 	AmountZero     bool     `form:"amount,zero"`
 	Currency       Currency `form:"currency"`
 	Customer       string   `form:"customer"`
-	Desc           string   `form:"description"`
+	Description    string   `form:"description"`
 	Discountable   bool     `form:"discountable"`
 	Invoice        string   `form:"invoice"`
 	NoDiscountable bool     `form:"discountable,invert"`
-	Sub            string   `form:"subscription"`
+	Subscription   string   `form:"subscription"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.
@@ -34,23 +34,23 @@ type InvoiceItem struct {
 	Customer     *Customer         `json:"customer"`
 	Date         int64             `json:"date"`
 	Deleted      bool              `json:"deleted"`
-	Desc         string            `json:"description"`
+	Description  string            `json:"description"`
 	Discountable bool              `json:"discountable"`
 	ID           string            `json:"id"`
 	Invoice      *Invoice          `json:"invoice"`
-	Live         bool              `json:"livemode"`
-	Meta         map[string]string `json:"metadata"`
+	Livemode     bool              `json:"livemode"`
+	Metadata     map[string]string `json:"metadata"`
 	Period       *Period           `json:"period"`
 	Plan         *Plan             `json:"plan"`
 	Proration    bool              `json:"proration"`
 	Quantity     int64             `json:"quantity"`
-	Sub          string            `json:"subscription"`
+	Subscription *Subscription     `json:"subscription"`
 }
 
 // InvoiceItemList is a list of invoice items as retrieved from a list endpoint.
 type InvoiceItemList struct {
 	ListMeta
-	Values []*InvoiceItem `json:"data"`
+	Data []*InvoiceItem `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of an InvoiceItem.

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -5,16 +5,14 @@ import "encoding/json"
 // InvoiceItemParams is the set of parameters that can be used when creating or updating an invoice item.
 // For more details see https://stripe.com/docs/api#create_invoiceitem and https://stripe.com/docs/api#update_invoiceitem.
 type InvoiceItemParams struct {
-	Params         `form:"*"`
-	Amount         int64    `form:"amount"`
-	AmountZero     bool     `form:"amount,zero"`
-	Currency       Currency `form:"currency"`
-	Customer       string   `form:"customer"`
-	Description    string   `form:"description"`
-	Discountable   bool     `form:"discountable"`
-	Invoice        string   `form:"invoice"`
-	NoDiscountable bool     `form:"discountable,invert"`
-	Subscription   string   `form:"subscription"`
+	Params       `form:"*"`
+	Amount       int64    `form:"amount"`
+	Currency     Currency `form:"currency"`
+	Customer     string   `form:"customer"`
+	Description  string   `form:"description"`
+	Discountable *bool    `form:"discountable"`
+	Invoice      string   `form:"invoice"`
+	Subscription string   `form:"subscription"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -116,8 +116,8 @@ func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
 		list := &stripe.InvoiceItemList{}
 		err := c.B.Call("GET", "/invoiceitems", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/invoiceitem/client_test.go
+++ b/invoiceitem/client_test.go
@@ -42,7 +42,7 @@ func TestInvoiceItemNew(t *testing.T) {
 
 func TestInvoiceItemUpdate(t *testing.T) {
 	item, err := Update("ii_123", &stripe.InvoiceItemParams{
-		Desc: "Updated description",
+		Description: "Updated description",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/invoiceitem/client_test.go
+++ b/invoiceitem/client_test.go
@@ -32,9 +32,9 @@ func TestInvoiceItemList(t *testing.T) {
 
 func TestInvoiceItemNew(t *testing.T) {
 	item, err := New(&stripe.InvoiceItemParams{
-		Amount:   123,
-		Currency: currency.USD,
-		Customer: "cus_123",
+		Amount:   stripe.Int64(123),
+		Currency: stripe.String(string(currency.USD)),
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)
@@ -42,7 +42,7 @@ func TestInvoiceItemNew(t *testing.T) {
 
 func TestInvoiceItemUpdate(t *testing.T) {
 	item, err := Update("ii_123", &stripe.InvoiceItemParams{
-		Description: "Updated description",
+		Description: stripe.String("Updated description"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/iter.go
+++ b/iter.go
@@ -50,7 +50,7 @@ func GetIter(params *ListParams, qs *form.Values, query Query) *Iter {
 
 func (it *Iter) getPage() {
 	it.values, it.meta, it.err = it.query(it.qs)
-	if it.params.End != "" {
+	if it.params.EndingBefore != "" {
 		// We are moving backward,
 		// but items arrive in forward order.
 		reverse(it.values)
@@ -63,14 +63,14 @@ func (it *Iter) getPage() {
 // It returns false when the iterator stops
 // at the end of the list.
 func (it *Iter) Next() bool {
-	if len(it.values) == 0 && it.meta.More && !it.params.Single {
+	if len(it.values) == 0 && it.meta.HasMore && !it.params.Single {
 		// determine if we're moving forward or backwards in paging
-		if it.params.End != "" {
-			it.params.End = listItemID(it.cur)
-			it.qs.Set(endbefore, it.params.End)
+		if it.params.EndingBefore != "" {
+			it.params.EndingBefore = listItemID(it.cur)
+			it.qs.Set(EndingBefore, it.params.EndingBefore)
 		} else {
-			it.params.Start = listItemID(it.cur)
-			it.qs.Set(startafter, it.params.Start)
+			it.params.StartingAfter = listItemID(it.cur)
+			it.qs.Set(StartingAfter, it.params.StartingAfter)
 		}
 		it.getPage()
 	}

--- a/iter_test.go
+++ b/iter_test.go
@@ -44,7 +44,7 @@ func TestIterOneErr(t *testing.T) {
 
 func TestIterPage2Empty(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{&item{"x"}}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
 		{nil, ListMeta{}, nil},
 	}
 	want := []interface{}{&item{"x"}}
@@ -56,7 +56,7 @@ func TestIterPage2Empty(t *testing.T) {
 
 func TestIterPage2EmptyErr(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{&item{"x"}}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
 		{nil, ListMeta{}, errTest},
 	}
 	want := []interface{}{&item{"x"}}
@@ -68,8 +68,8 @@ func TestIterPage2EmptyErr(t *testing.T) {
 
 func TestIterTwoPages(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
-		{[]interface{}{2}, ListMeta{0, false, ""}, nil},
+		{[]interface{}{&item{"x"}}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{[]interface{}{2}, ListMeta{HasMore: false, TotalCount: 0, URL: ""}, nil},
 	}
 	want := []interface{}{&item{"x"}, 2}
 	g, gerr := collect(GetIter(nil, nil, tq.query))
@@ -80,8 +80,8 @@ func TestIterTwoPages(t *testing.T) {
 
 func TestIterTwoPagesErr(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"x"}}, ListMeta{0, true, ""}, nil},
-		{[]interface{}{2}, ListMeta{0, false, ""}, errTest},
+		{[]interface{}{&item{"x"}}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{[]interface{}{2}, ListMeta{HasMore: false, TotalCount: 0, URL: ""}, errTest},
 	}
 	want := []interface{}{&item{"x"}, 2}
 	g, gerr := collect(GetIter(nil, nil, tq.query))
@@ -93,7 +93,7 @@ func TestIterTwoPagesErr(t *testing.T) {
 func TestIterReversed(t *testing.T) {
 	tq := testQuery{{[]interface{}{1, 2}, ListMeta{}, nil}}
 	want := []interface{}{2, 1}
-	g, gerr := collect(GetIter(&ListParams{End: "x"}, nil, tq.query))
+	g, gerr := collect(GetIter(&ListParams{EndingBefore: "x"}, nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -101,11 +101,11 @@ func TestIterReversed(t *testing.T) {
 
 func TestIterReversedTwoPages(t *testing.T) {
 	tq := testQuery{
-		{[]interface{}{&item{"3"}, 4}, ListMeta{0, true, ""}, nil},
+		{[]interface{}{&item{"3"}, 4}, ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
 		{[]interface{}{1, 2}, ListMeta{}, nil},
 	}
 	want := []interface{}{4, &item{"3"}, 2, 1}
-	g, gerr := collect(GetIter(&ListParams{End: "x"}, nil, tq.query))
+	g, gerr := collect(GetIter(&ListParams{EndingBefore: "x"}, nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)

--- a/loginlink.go
+++ b/loginlink.go
@@ -10,5 +10,5 @@ type LoginLinkParams struct {
 // For more details see https://stripe.com/docs/api#login_link_object
 type LoginLink struct {
 	Created int64  `json:"created"`
-	Url     string `json:"url"`
+	URL     string `json:"url"`
 }

--- a/loginlink.go
+++ b/loginlink.go
@@ -3,7 +3,7 @@ package stripe
 // LoginLinkParams is the set of parameters that can be used when creating a login_link.
 // For more details see https://stripe.com/docs/api#create_login_link.
 type LoginLinkParams struct {
-	Account string `form:"-"` // Included in URL
+	Account *string `form:"-"` // Included in URL
 }
 
 // LoginLink is the resource representing a login link for Express accounts.

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -27,8 +27,8 @@ func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 	loginLink := &stripe.LoginLink{}
 	var err error
 
-	if len(params.Account) > 0 {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/login_links", params.Account), c.Key, body, nil, loginLink)
+	if params.Account != nil {
+		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/login_links", stripe.StringValue(params.Account)), c.Key, body, nil, loginLink)
 	} else {
 		err = errors.New("Invalid login link params: Account must be set")
 	}

--- a/loginlink/client_test.go
+++ b/loginlink/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestLoginLinkNew(t *testing.T) {
 	link, err := New(&stripe.LoginLinkParams{
-		Account: "acct_EXPRESS",
+		Account: stripe.String("acct_EXPRESS"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, link)

--- a/order.go
+++ b/order.go
@@ -75,12 +75,12 @@ const (
 )
 
 type DeliveryEstimate struct {
-	Type EstimateType `json:"type"`
-	// If Type == Range
-	Earliest string `json:"earliest"`
-	Latest   string `json:"latest"`
 	// If Type == Exact
 	Date string `json:"date"`
+	// If Type == Range
+	Earliest string       `json:"earliest"`
+	Latest   string       `json:"latest"`
+	Type     EstimateType `json:"type"`
 }
 
 type Order struct {
@@ -95,8 +95,8 @@ type Order struct {
 	Email                  string            `json:"email"`
 	ID                     string            `json:"id"`
 	Items                  []OrderItem       `json:"items"`
-	Live                   bool              `json:"livemode"`
-	Meta                   map[string]string `json:"metadata"`
+	Livemode               bool              `json:"livemode"`
+	Metadata               map[string]string `json:"metadata"`
 	Returns                *OrderReturnList  `json:"returns"`
 	SelectedShippingMethod *string           `json:"selected_shipping_method"`
 	Shipping               Shipping          `json:"shipping"`
@@ -109,7 +109,7 @@ type Order struct {
 // OrderList is a list of orders as retrieved from a list endpoint.
 type OrderList struct {
 	ListMeta
-	Values []*Order `json:"data"`
+	Data []*Order `json:"data"`
 }
 
 // OrderListParams is the set of parameters that can be used when
@@ -127,10 +127,10 @@ type OrderListParams struct {
 // StatusTransitions are the timestamps at which the order status was updated
 // https://stripe.com/docs/api#order_object
 type StatusTransitions struct {
-	Canceled  int64 `json:"canceled"`
-	Fulfilled int64 `json:"fulfiled"`
-	Paid      int64 `json:"paid"`
-	Returned  int64 `json:"returned"`
+	Canceled int64 `json:"canceled"`
+	Fulfiled int64 `json:"fulfiled"`
+	Paid     int64 `json:"paid"`
+	Returned int64 `json:"returned"`
 }
 
 // OrderPayParams is the set of parameters that can be used when

--- a/order.go
+++ b/order.go
@@ -127,10 +127,10 @@ type OrderListParams struct {
 // StatusTransitions are the timestamps at which the order status was updated
 // https://stripe.com/docs/api#order_object
 type StatusTransitions struct {
-	Canceled int64 `json:"canceled"`
-	Fulfiled int64 `json:"fulfiled"`
-	Paid     int64 `json:"paid"`
-	Returned int64 `json:"returned"`
+	Canceled  int64 `json:"canceled"`
+	Fulfilled int64 `json:"fulfiled"`
+	Paid      int64 `json:"paid"`
+	Returned  int64 `json:"returned"`
 }
 
 // OrderPayParams is the set of parameters that can be used when

--- a/order.go
+++ b/order.go
@@ -119,7 +119,7 @@ type OrderListParams struct {
 	ListParams   `form:"*"`
 	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Customer     string            `form:"customer"`
+	Customer     *string           `form:"customer"`
 	IDs          []string          `form:"ids"`
 	Status       *string           `form:"status"`
 }

--- a/order.go
+++ b/order.go
@@ -17,31 +17,31 @@ const (
 
 type OrderParams struct {
 	Params   `form:"*"`
-	Coupon   string             `form:"coupon"`
-	Currency Currency           `form:"currency"`
-	Customer string             `form:"customer"`
-	Email    string             `form:"email"`
+	Coupon   *string            `form:"coupon"`
+	Currency *string            `form:"currency"`
+	Customer *string            `form:"customer"`
+	Email    *string            `form:"email"`
 	Items    []*OrderItemParams `form:"items,indexed"`
 	Shipping *ShippingParams    `form:"shipping"`
 }
 
 type ShippingParams struct {
 	Address *AddressParams `form:"address"`
-	Name    string         `form:"name"`
-	Phone   string         `form:"phone"`
+	Name    *string        `form:"name"`
+	Phone   *string        `form:"phone"`
 }
 
 type OrderUpdateParams struct {
 	Params                 `form:"*"`
-	Coupon                 string                     `form:"coupon"`
-	SelectedShippingMethod string                     `form:"selected_shipping_method"`
+	Coupon                 *string                    `form:"coupon"`
+	SelectedShippingMethod *string                    `form:"selected_shipping_method"`
 	Shipping               *OrderUpdateShippingParams `form:"shipping"`
-	Status                 OrderStatus                `form:"status"`
+	Status                 *string                    `form:"status"`
 }
 
 type OrderUpdateShippingParams struct {
-	Carrier        string `form:"carrier"`
-	TrackingNumber string `form:"tracking_number"`
+	Carrier        *string `form:"carrier"`
+	TrackingNumber *string `form:"tracking_number"`
 }
 
 // OrderReturnParams is the set of parameters that can be used when returning
@@ -117,11 +117,11 @@ type OrderList struct {
 // https://stripe.com/docs/api#list_orders.
 type OrderListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 	Customer     string            `form:"customer"`
 	IDs          []string          `form:"ids"`
-	Status       OrderStatus       `form:"status"`
+	Status       *string           `form:"status"`
 }
 
 // StatusTransitions are the timestamps at which the order status was updated
@@ -138,9 +138,9 @@ type StatusTransitions struct {
 // https://stripe.com/docs/api#pay_order.
 type OrderPayParams struct {
 	Params         `form:"*"`
-	ApplicationFee int64         `form:"application_fee"`
-	Customer       string        `form:"customer"`
-	Email          string        `form:"email"`
+	ApplicationFee *int64        `form:"application_fee"`
+	Customer       *string       `form:"customer"`
+	Email          *string       `form:"email"`
 	Source         *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 

--- a/order/client.go
+++ b/order/client.go
@@ -134,8 +134,8 @@ func (c Client) List(params *stripe.OrderListParams) *Iter {
 		list := &stripe.OrderList{}
 		err := c.B.Call("GET", "/orders", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/order/client.go
+++ b/order/client.go
@@ -75,7 +75,7 @@ func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, er
 	var commonParams *stripe.Params
 
 	if params != nil {
-		if params.Source == nil && len(params.Customer) == 0 {
+		if params.Source == nil && params.Customer == nil {
 			err := errors.New("Invalid order pay params: either customer or a source must be set")
 			return nil, err
 		}

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -29,7 +30,7 @@ func TestOrderList(t *testing.T) {
 
 func TestOrderNew(t *testing.T) {
 	order, err := New(&stripe.OrderParams{
-		Currency: "usd",
+		Currency: stripe.String(string(currency.USD)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, order)
@@ -37,7 +38,7 @@ func TestOrderNew(t *testing.T) {
 
 func TestOrderPay(t *testing.T) {
 	order, err := Pay("or_123", &stripe.OrderPayParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, order)
@@ -82,7 +83,7 @@ func TestOrderReturn_RequestParams(t *testing.T) {
 
 func TestOrderUpdate(t *testing.T) {
 	order, err := Update("or_123", &stripe.OrderUpdateParams{
-		Status: "fulfilled",
+		Status: stripe.String(string(stripe.StatusFulfilled)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, order)

--- a/order_test.go
+++ b/order_test.go
@@ -10,7 +10,13 @@ import (
 
 func TestOrderUpdateParams_AppendTo(t *testing.T) {
 	{
-		params := &OrderUpdateParams{Status: "fulfilled", Shipping: &OrderUpdateShippingParams{Carrier: "USPS", TrackingNumber: "123"}}
+		params := &OrderUpdateParams{
+			Status: String("fulfilled"),
+			Shipping: &OrderUpdateShippingParams{
+				Carrier:        String("USPS"),
+				TrackingNumber: String("123"),
+			},
+		}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/orderitem.go
+++ b/orderitem.go
@@ -8,12 +8,12 @@ import (
 )
 
 type OrderItemParams struct {
-	Amount      int64              `form:"amount"`
-	Currency    Currency           `form:"currency"`
-	Description string             `form:"description"`
-	Parent      string             `form:"parent"`
-	Quantity    *int64             `form:"quantity"`
-	Type        orderitem.ItemType `form:"type"`
+	Amount      *int64  `form:"amount"`
+	Currency    *string `form:"currency"`
+	Description *string `form:"description"`
+	Parent      *string `form:"parent"`
+	Quantity    *int64  `form:"quantity"`
+	Type        *string `form:"type"`
 }
 
 type OrderItem struct {

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -8,15 +8,15 @@ type OrderReturn struct {
 	Currency Currency    `json:"currency"`
 	ID       string      `json:"id"`
 	Items    []OrderItem `json:"items"`
+	Livemode bool        `json:"livemode"`
 	Order    Order       `json:"order"`
-	Live     bool        `json:"livemode"`
 	Refund   *Refund     `json:"refund"`
 }
 
 // OrderReturnList is a list of returns as retrieved from a list endpoint.
 type OrderReturnList struct {
 	ListMeta
-	Values []*OrderReturn `json:"data"`
+	Data []*OrderReturn `json:"data"`
 }
 
 // OrderReturnListParams is the set of parameters that can be used when listing

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -23,9 +23,9 @@ type OrderReturnList struct {
 // returns. For more details, see: https://stripe.com/docs/api#list_order_returns.
 type OrderReturnListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Order        string            `form:"order"`
+	Order        *string           `form:"order"`
 }
 
 // UnmarshalJSON handles deserialization of an OrderReturn.

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -32,8 +32,8 @@ func (c Client) List(params *stripe.OrderReturnListParams) *Iter {
 		list := &stripe.OrderReturnList{}
 		err := c.B.Call("GET", "/order_returns", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/params.go
+++ b/params.go
@@ -13,17 +13,13 @@ import (
 )
 
 const (
-	endbefore  = "ending_before"
-	startafter = "starting_after"
+	EndingBefore  = "ending_before"
+	StartingAfter = "starting_after"
 )
 
 // Params is the structure that contains the common properties
 // of any *Params structure.
 type Params struct {
-	// Account is deprecated form of StripeAccount that will do the same thing.
-	// Please use StripeAccount instead.
-	Account string `form:"-"` // Passed as header
-
 	// Context used for request. It may carry deadlines, cancelation signals,
 	// and other request-scoped values across API boundaries and between
 	// processes.
@@ -34,14 +30,14 @@ type Params struct {
 	// key or query the state of the API.
 	Context context.Context `form:"-"`
 
-	Exp   []string     `form:"expand"`
-	Extra *ExtraValues `form:"*"`
+	Expand []string     `form:"expand"`
+	Extra  *ExtraValues `form:"*"`
 
 	// Headers may be used to provide extra header lines on the HTTP request.
 	Headers http.Header `form:"-"`
 
 	IdempotencyKey string            `form:"-"` // Passed as header
-	Meta           map[string]string `form:"metadata"`
+	Metadata       map[string]string `form:"metadata"`
 
 	// StripeAccount may contain the ID of a connected account. By including
 	// this field, the request is made as if it originated from the connected
@@ -79,10 +75,10 @@ type ListParams struct {
 	// key or query the state of the API.
 	Context context.Context `form:"-"`
 
-	End     string   `form:"ending_before"`
-	Exp     []string `form:"expand"`
-	Filters Filters  `form:"*"`
-	Limit   int      `form:"limit"`
+	EndingBefore string   `form:"ending_before"`
+	Expand       []string `form:"expand"`
+	Filters      Filters  `form:"*"`
+	Limit        int      `form:"limit"`
 
 	// Single specifies whether this is a single page iterator. By default,
 	// listing through an iterator will automatically grab additional pages as
@@ -90,7 +86,7 @@ type ListParams struct {
 	// page, set this to true.
 	Single bool `form:"-"` // Not an API parameter
 
-	Start string `form:"starting_after"`
+	StartingAfter string `form:"starting_after"`
 
 	// StripeAccount may contain the ID of a connected account. By including
 	// this field, the request is made as if it originated from the connected
@@ -103,9 +99,9 @@ type ListParams struct {
 // of List iterators. The Count property is only populated if the
 // total_count include option is passed in (see tests for example).
 type ListMeta struct {
-	Count uint32 `json:"total_count"`
-	More  bool   `json:"has_more"`
-	URL   string `json:"url"`
+	HasMore    bool   `json:"has_more"`
+	TotalCount uint32 `json:"total_count"`
+	URL        string `json:"url"`
 }
 
 // RangeQueryParams are a set of generic request parameters that are used on
@@ -166,29 +162,23 @@ func NewIdempotencyKey() string {
 	return fmt.Sprintf("%v_%v", now, base64.URLEncoding.EncodeToString(buf)[:6])
 }
 
-// SetAccount sets a value for the Stripe-Account header.
-func (p *Params) SetAccount(val string) {
-	p.Account = val
-	p.StripeAccount = val
-}
-
 // SetStripeAccount sets a value for the Stripe-Account header.
 func (p *Params) SetStripeAccount(val string) {
 	p.StripeAccount = val
 }
 
-// Expand appends a new field to expand.
-func (p *Params) Expand(f string) {
-	p.Exp = append(p.Exp, f)
+// AddExpand appends a new field to expand.
+func (p *Params) AddExpand(f string) {
+	p.Expand = append(p.Expand, f)
 }
 
-// AddMeta adds a new key-value pair to the Metadata.
-func (p *Params) AddMeta(key, value string) {
-	if p.Meta == nil {
-		p.Meta = make(map[string]string)
+// AddMetadata adds a new key-value pair to the Metadata.
+func (p *Params) AddMetadata(key, value string) {
+	if p.Metadata == nil {
+		p.Metadata = make(map[string]string)
 	}
 
-	p.Meta[key] = value
+	p.Metadata[key] = value
 }
 
 // AddExtra adds a new arbitrary key-value pair to the request data
@@ -200,9 +190,9 @@ func (p *Params) AddExtra(key, value string) {
 	p.Extra.Add(key, value)
 }
 
-// Expand appends a new field to expand.
-func (p *ListParams) Expand(f string) {
-	p.Exp = append(p.Exp, f)
+// AddExpand appends a new field to expand.
+func (p *ListParams) AddExpand(f string) {
+	p.Expand = append(p.Expand, f)
 }
 
 // ToParams converts a ListParams to a Params by moving over any fields that

--- a/params.go
+++ b/params.go
@@ -78,7 +78,7 @@ type ListParams struct {
 	EndingBefore string   `form:"ending_before"`
 	Expand       []string `form:"expand"`
 	Filters      Filters  `form:"*"`
-	Limit        int      `form:"limit"`
+	Limit        int64    `form:"limit"`
 
 	// Single specifies whether this is a single page iterator. By default,
 	// listing through an iterator will automatically grab additional pages as

--- a/params_test.go
+++ b/params_test.go
@@ -76,9 +76,9 @@ func TestListParams_Nested(t *testing.T) {
 	params := &testListParams{
 		Field: "field_value",
 		ListParams: stripe.ListParams{
-			End:   "acct_123",
-			Limit: 100,
-			Start: "acct_123",
+			EndingBefore:  "acct_123",
+			Limit:         100,
+			StartingAfter: "acct_123",
 		},
 	}
 
@@ -145,13 +145,13 @@ func TestParams_AppendTo_Nested(t *testing.T) {
 	params := &testParams{
 		Field: "field_value",
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},
 		SubParams: &testSubParams{
 			Params: stripe.Params{
-				Meta: map[string]string{
+				Metadata: map[string]string{
 					"sub_foo": "bar",
 				},
 			},
@@ -204,7 +204,7 @@ func TestListParams_Expand(t *testing.T) {
 		p := stripe.ListParams{}
 
 		for _, exp := range testCase.Expand {
-			p.Expand(exp)
+			p.AddExpand(exp)
 		}
 
 		body := valuesFromArray(testCase.InitialBody)
@@ -223,30 +223,12 @@ func TestListParams_ToParams(t *testing.T) {
 	assert.Equal(t, listParams.StripeAccount, params.StripeAccount)
 }
 
-func TestParams_SetAccount(t *testing.T) {
-	p := &stripe.Params{}
-	p.SetAccount(TestMerchantID)
-
-	if p.Account != TestMerchantID {
-		t.Fatalf("Expected Account of %v but got %v.", TestMerchantID, p.Account)
-	}
-
-	if p.StripeAccount != TestMerchantID {
-		t.Fatalf("Expected StripeAccount of %v but got %v.", TestMerchantID, p.StripeAccount)
-	}
-}
-
 func TestParams_SetStripeAccount(t *testing.T) {
 	p := &stripe.Params{}
 	p.SetStripeAccount(TestMerchantID)
 
 	if p.StripeAccount != TestMerchantID {
 		t.Fatalf("Expected Account of %v but got %v.", TestMerchantID, p.StripeAccount)
-	}
-
-	// Check that we don't set the deprecated parameter.
-	if p.Account != "" {
-		t.Fatalf("Expected empty Account but got %v.", TestMerchantID)
 	}
 }
 

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -111,7 +111,7 @@ type PaymentSource struct {
 // SourceList is a list object for cards.
 type SourceList struct {
 	ListMeta
-	Values []*PaymentSource `json:"data"`
+	Data []*PaymentSource `json:"data"`
 }
 
 // SourceListParams are used to enumerate the payment sources that are attached

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -11,7 +11,7 @@ import (
 // arbitrary payment source.
 type SourceParams struct {
 	Card  *CardParams `form:"-"`
-	Token string      `form:"source"`
+	Token *string     `form:"source"`
 }
 
 func (p *SourceParams) AppendTo(body *form.Values, keyParts []string) {
@@ -25,7 +25,7 @@ func (p *SourceParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#sources
 type CustomerSourceParams struct {
 	Params   `form:"*"`
-	Customer string        `form:"-"` // Goes in the URL
+	Customer *string       `form:"-"` // Goes in the URL
 	Source   *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 
@@ -34,7 +34,7 @@ type CustomerSourceParams struct {
 type SourceVerifyParams struct {
 	Params   `form:"*"`
 	Amounts  [2]int64 `form:"amounts"` // Amounts is used when verifying bank accounts
-	Customer string   `form:"-"`       // Goes in the URL
+	Customer *string  `form:"-"`       // Goes in the URL
 	Values   []string `form:"values"`  // Values is used when verifying sources
 }
 
@@ -62,7 +62,7 @@ func SourceParamsFor(obj interface{}) (*SourceParams, error) {
 		}
 	case string:
 		sp = &SourceParams{
-			Token: p,
+			Token: &p,
 		}
 	default:
 		err = fmt.Errorf("Unsupported source type %s", p)
@@ -118,7 +118,7 @@ type SourceList struct {
 // to a Customer.
 type SourceListParams struct {
 	ListParams `form:"*"`
-	Customer   string `form:"-"` // Handled in URL
+	Customer   *string `form:"-"` // Handled in URL
 }
 
 // UnmarshalJSON handles deserialization of a PaymentSource.

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -137,8 +137,8 @@ func (s Client) List(params *stripe.SourceListParams) *Iter {
 			err = errors.New("Invalid source params: customer needs to be set")
 		}
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -28,8 +28,8 @@ func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources", params.Customer), s.Key, body, &params.Params, source)
+	if params.Customer != nil {
+		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), s.Key, body, &params.Params, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -56,8 +56,8 @@ func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), s.Key, body, commonParams, source)
+	if params.Customer != nil {
+		err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -78,8 +78,8 @@ func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), s.Key, body, &params.Params, source)
+	if params.Customer != nil {
+		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -106,8 +106,8 @@ func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), s.Key, body, commonParams, source)
+	if params.Customer != nil {
+		err = s.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -131,8 +131,8 @@ func (s Client) List(params *stripe.SourceListParams) *Iter {
 		list := &stripe.SourceList{}
 		var err error
 
-		if len(params.Customer) > 0 {
-			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", params.Customer), s.Key, b, p, list)
+		if params.Customer != nil {
+			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), s.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid source params: customer needs to be set")
 		}
@@ -159,8 +159,8 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 	source := &stripe.PaymentSource{}
 	var err error
 
-	if len(params.Customer) > 0 {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v/verify", params.Customer, id), s.Key, body, &params.Params, source)
+	if params.Customer != nil {
+		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v/verify", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
 	} else if len(params.Values) > 0 {
 		err = s.B.Call("POST", fmt.Sprintf("/sources/%v/verify", id), s.Key, body, &params.Params, source)
 	} else {

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSourceGet(t *testing.T) {
 	source, err := Get("card_123", &stripe.CustomerSourceParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, source)
@@ -18,7 +18,7 @@ func TestSourceGet(t *testing.T) {
 
 func TestSourceList(t *testing.T) {
 	i := List(&stripe.SourceListParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 
 	// Verify that we can get at least one source
@@ -29,7 +29,7 @@ func TestSourceList(t *testing.T) {
 
 func TestSourceNew(t *testing.T) {
 	params := &stripe.CustomerSourceParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	}
 	params.SetSource("tok_123")
 
@@ -40,8 +40,11 @@ func TestSourceNew(t *testing.T) {
 
 func TestSourceUpdate(t *testing.T) {
 	params := &stripe.CustomerSourceParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	}
+	params.SetSource(&stripe.CardParams{
+		Name: stripe.String("Updated Name"),
+	})
 
 	source, err := Update("card_123", params)
 	assert.Nil(t, err)
@@ -50,7 +53,7 @@ func TestSourceUpdate(t *testing.T) {
 
 func TestSourceVerify(t *testing.T) {
 	source, err := Verify("ba_123", &stripe.SourceVerifyParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 		Amounts:  [2]int64{32, 45},
 	})
 	assert.Nil(t, err)

--- a/paymentsource_test.go
+++ b/paymentsource_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSourceParams_AppendTo(t *testing.T) {
 	{
-		params := &SourceParams{Token: "tok_123"}
+		params := &SourceParams{Token: String("tok_123")}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -18,7 +18,7 @@ func TestSourceParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SourceParams{Card: &CardParams{Number: "4242424242424242"}}
+		params := &SourceParams{Card: &CardParams{Number: String("4242424242424242")}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/paymentsource_test.go
+++ b/paymentsource_test.go
@@ -61,8 +61,8 @@ func TestPaymentSource_MarshalJSON(t *testing.T) {
 			Type: PaymentSourceBankAccount,
 			ID:   id,
 			BankAccount: &BankAccount{
-				ID:   id,
-				Name: name,
+				ID:                id,
+				AccountHolderName: name,
 			},
 		}
 
@@ -77,6 +77,6 @@ func TestPaymentSource_MarshalJSON(t *testing.T) {
 		assert.Equal(t, unmarshalled.ID, id)
 		assert.NotNil(t, unmarshalled.BankAccount)
 		assert.Equal(t, unmarshalled.BankAccount.ID, id)
-		assert.Equal(t, unmarshalled.BankAccount.Name, name)
+		assert.Equal(t, unmarshalled.BankAccount.AccountHolderName, name)
 	}
 }

--- a/payout.go
+++ b/payout.go
@@ -81,32 +81,32 @@ type PayoutListParams struct {
 // Payout is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payouts.
 type Payout struct {
-	Amount                    int64             `json:"amount"`
-	ArrivalDate               int64             `json:"arrival_date"`
-	Automatic                 bool              `json:"automatic"`
-	BalanceTransaction        *Transaction      `json:"balance_transaction"`
-	Bank                      *BankAccount      `json:"bank_account"`
-	Card                      *Card             `json:"card"`
-	Created                   int64             `json:"created"`
-	Currency                  Currency          `json:"currency"`
-	Destination               PayoutDestination `json:"destination"`
-	FailCode                  PayoutFailureCode `json:"failure_code"`
-	FailMessage               string            `json:"failure_message"`
-	FailureBalanceTransaction *Transaction      `json:"failure_balance_transaction"`
-	ID                        string            `json:"id"`
-	Live                      bool              `json:"livemode"`
-	Meta                      map[string]string `json:"metadata"`
-	Method                    PayoutMethodType  `json:"method"`
-	SourceType                PayoutSourceType  `json:"source_type"`
-	StatementDescriptor       string            `json:"statement_descriptor"`
-	Status                    PayoutStatus      `json:"status"`
-	Type                      PayoutType        `json:"type"`
+	Amount                    int64               `json:"amount"`
+	ArrivalDate               int64               `json:"arrival_date"`
+	Automatic                 bool                `json:"automatic"`
+	BalanceTransaction        *BalanceTransaction `json:"balance_transaction"`
+	BankAccount               *BankAccount        `json:"bank_account"`
+	Card                      *Card               `json:"card"`
+	Created                   int64               `json:"created"`
+	Currency                  Currency            `json:"currency"`
+	Destination               PayoutDestination   `json:"destination"`
+	FailureBalanceTransaction *BalanceTransaction `json:"failure_balance_transaction"`
+	FailureCode               PayoutFailureCode   `json:"failure_code"`
+	FailureMessage            string              `json:"failure_message"`
+	ID                        string              `json:"id"`
+	Livemode                  bool                `json:"livemode"`
+	Metadata                  map[string]string   `json:"metadata"`
+	Method                    PayoutMethodType    `json:"method"`
+	SourceType                PayoutSourceType    `json:"source_type"`
+	StatementDescriptor       string              `json:"statement_descriptor"`
+	Status                    PayoutStatus        `json:"status"`
+	Type                      PayoutType          `json:"type"`
 }
 
 // PayoutList is a list of payouts as retrieved from a list endpoint.
 type PayoutList struct {
 	ListMeta
-	Values []*Payout `json:"data"`
+	Data []*Payout `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Payout.

--- a/payout.go
+++ b/payout.go
@@ -58,24 +58,24 @@ type PayoutDestination struct {
 // For more details see https://stripe.com/docs/api#create_payout and https://stripe.com/docs/api#update_payout.
 type PayoutParams struct {
 	Params              `form:"*"`
-	Amount              int64            `form:"amount"`
-	Currency            Currency         `form:"currency"`
-	Destination         string           `form:"destination"`
-	Method              PayoutMethodType `form:"method"`
-	SourceType          PayoutSourceType `form:"source_type"`
-	StatementDescriptor string           `form:"statement_descriptor"`
+	Amount              *int64  `form:"amount"`
+	Currency            *string `form:"currency"`
+	Destination         *string `form:"destination"`
+	Method              *string `form:"method"`
+	SourceType          *string `form:"source_type"`
+	StatementDescriptor *string `form:"statement_descriptor"`
 }
 
 // PayoutListParams is the set of parameters that can be used when listing payouts.
 // For more details see https://stripe.com/docs/api#list_payouts.
 type PayoutListParams struct {
 	ListParams       `form:"*"`
-	ArrivalDate      int64             `form:"arrival_date"`
+	ArrivalDate      *int64            `form:"arrival_date"`
 	ArrivalDateRange *RangeQueryParams `form:"arrival_date"`
-	Created          int64             `form:"created"`
+	Created          *int64            `form:"created"`
 	CreatedRange     *RangeQueryParams `form:"created"`
-	Destination      string            `form:"destination"`
-	Status           PayoutStatus      `form:"status"`
+	Destination      *string           `form:"destination"`
+	Status           *string           `form:"status"`
 }
 
 // Payout is the resource representing a Stripe payout.

--- a/payout/client.go
+++ b/payout/client.go
@@ -145,8 +145,8 @@ func (c Client) List(params *stripe.PayoutListParams) *Iter {
 		list := &stripe.PayoutList{}
 		err := c.B.Call("GET", "/payouts", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/payout/client_test.go
+++ b/payout/client_test.go
@@ -41,7 +41,7 @@ func TestPayoutNew(t *testing.T) {
 func TestPayoutUpdate(t *testing.T) {
 	payout, err := Update("tr_123", &stripe.PayoutParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/payout/client_test.go
+++ b/payout/client_test.go
@@ -5,17 +5,18 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
 func TestPayoutCancel(t *testing.T) {
-	payout, err := Cancel("tr_123", nil)
+	payout, err := Cancel("po_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, payout)
 }
 
 func TestPayoutGet(t *testing.T) {
-	payout, err := Get("tr_123", nil)
+	payout, err := Get("po_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, payout)
 }
@@ -31,8 +32,8 @@ func TestPayoutList(t *testing.T) {
 
 func TestPayoutNew(t *testing.T) {
 	payout, err := New(&stripe.PayoutParams{
-		Amount:   123,
-		Currency: "usd",
+		Amount:   stripe.Int64(123),
+		Currency: stripe.String(string(currency.USD)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, payout)

--- a/plan.go
+++ b/plan.go
@@ -107,8 +107,8 @@ type PlanTransformUsage struct {
 
 // PlanTransformUsageParams represents the bucket billing configuration.
 type PlanTransformUsageParams struct {
-	DivideBy int64  `form:"bucket_size"`
-	Round    string `form:"round"`
+	DivideBy *int64  `form:"bucket_size"`
+	Round    *string `form:"round"`
 }
 
 // PlanTierParams configures tiered pricing

--- a/plan.go
+++ b/plan.go
@@ -40,14 +40,14 @@ const (
 // Plan is the resource representing a Stripe plan.
 // For more details see https://stripe.com/docs/api#plans.
 type Plan struct {
-	Amount          uint64              `json:"amount"`
+	Amount          int64               `json:"amount"`
 	BillingScheme   string              `json:"billing_scheme"`
 	Created         int64               `json:"created"`
 	Currency        Currency            `json:"currency"`
 	Deleted         bool                `json:"deleted"`
 	ID              string              `json:"id"`
 	Interval        PlanInterval        `json:"interval"`
-	IntervalCount   uint64              `json:"interval_count"`
+	IntervalCount   int64               `json:"interval_count"`
 	Livemode        bool                `json:"livemode"`
 	Metadata        map[string]string   `json:"metadata"`
 	Nickname        string              `json:"nickname"`
@@ -55,7 +55,7 @@ type Plan struct {
 	Tiers           []*PlanTier         `json:"tiers"`
 	TiersMode       string              `json:"tiers_mode"`
 	TransformUsage  *PlanTransformUsage `json:"transform_usage"`
-	TrialPeriodDays uint64              `json:"trial_period_days"`
+	TrialPeriodDays int64               `json:"trial_period_days"`
 	UsageType       string              `json:"usage_type"`
 }
 
@@ -77,26 +77,26 @@ type PlanListParams struct {
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
 	Params          `form:"*"`
-	Amount          *uint64                   `form:"amount"`
+	Amount          *int64                    `form:"amount"`
 	BillingScheme   *string                   `form:"billing_scheme"`
 	Currency        *string                   `form:"currency"`
 	ID              *string                   `form:"id"`
 	Interval        *string                   `form:"interval"`
-	IntervalCount   *uint64                   `form:"interval_count"`
+	IntervalCount   *int64                    `form:"interval_count"`
 	Nickname        *string                   `form:"nickname"`
 	Product         *ProductParams            `form:"product"`
 	ProductID       *string                   `form:"product"`
 	Tiers           []*PlanTierParams         `form:"tiers,indexed"`
 	TiersMode       *string                   `form:"tiers_mode"`
 	TransformUsage  *PlanTransformUsageParams `form:"transform_usage"`
-	TrialPeriodDays *uint64                   `form:"trial_period_days"`
+	TrialPeriodDays *int64                    `form:"trial_period_days"`
 	UsageType       *string                   `form:"usage_type"`
 }
 
 // PlanTier configures tiered pricing
 type PlanTier struct {
-	Amount uint64 `json:"amount"`
-	UpTo   uint64 `json:"up_to"`
+	Amount int64 `json:"amount"`
+	UpTo   int64 `json:"up_to"`
 }
 
 // PlanTransformUsage represents the bucket billing configuration.
@@ -114,9 +114,9 @@ type PlanTransformUsageParams struct {
 // PlanTierParams configures tiered pricing
 type PlanTierParams struct {
 	Params  `form:"*"`
-	Amount  *uint64 `form:"amount"`
-	UpTo    *uint64 `form:"-"` // handled in custom AppendTo
-	UpToInf *bool   `form:"-"` // handled in custom AppendTo
+	Amount  *int64 `form:"amount"`
+	UpTo    *int64 `form:"-"` // handled in custom AppendTo
+	UpToInf *bool  `form:"-"` // handled in custom AppendTo
 }
 
 // AppendTo implements custom up_to serialisation logic for tiers configuration
@@ -124,7 +124,7 @@ func (p *PlanTierParams) AppendTo(body *form.Values, keyParts []string) {
 	if BoolValue(p.UpToInf) {
 		body.Add(form.FormatKey(append(keyParts, "up_to")), "inf")
 	} else {
-		body.Add(form.FormatKey(append(keyParts, "up_to")), strconv.FormatUint(UInt64Value(p.UpTo), 10))
+		body.Add(form.FormatKey(append(keyParts, "up_to")), strconv.FormatInt(Int64Value(p.UpTo), 10))
 	}
 }
 

--- a/plan.go
+++ b/plan.go
@@ -69,7 +69,7 @@ type PlanList struct {
 // For more details see https://stripe.com/docs/api#list_plans.
 type PlanListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 
@@ -77,21 +77,20 @@ type PlanListParams struct {
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
 	Params          `form:"*"`
-	Amount          uint64                    `form:"amount"`
-	AmountZero      bool                      `form:"amount,zero"`
-	BillingScheme   string                    `form:"billing_scheme"`
-	Currency        Currency                  `form:"currency"`
-	ID              string                    `form:"id"`
-	Interval        PlanInterval              `form:"interval"`
-	IntervalCount   uint64                    `form:"interval_count"`
-	Nickname        string                    `form:"nickname"`
-	Product         *PlanProductParams        `form:"product"`
+	Amount          *uint64                   `form:"amount"`
+	BillingScheme   *string                   `form:"billing_scheme"`
+	Currency        *string                   `form:"currency"`
+	ID              *string                   `form:"id"`
+	Interval        *string                   `form:"interval"`
+	IntervalCount   *uint64                   `form:"interval_count"`
+	Nickname        *string                   `form:"nickname"`
+	Product         *ProductParams            `form:"product"`
 	ProductID       *string                   `form:"product"`
 	Tiers           []*PlanTierParams         `form:"tiers,indexed"`
-	TiersMode       string                    `form:"tiers_mode"`
+	TiersMode       *string                   `form:"tiers_mode"`
 	TransformUsage  *PlanTransformUsageParams `form:"transform_usage"`
-	TrialPeriodDays uint64                    `form:"trial_period_days"`
-	UsageType       string                    `form:"usage_type"`
+	TrialPeriodDays *uint64                   `form:"trial_period_days"`
+	UsageType       *string                   `form:"usage_type"`
 }
 
 // PlanTier configures tiered pricing
@@ -115,17 +114,17 @@ type PlanTransformUsageParams struct {
 // PlanTierParams configures tiered pricing
 type PlanTierParams struct {
 	Params  `form:"*"`
-	Amount  uint64 `form:"amount"`
-	UpTo    uint64 `form:"-"` // handled in custom AppendTo
-	UpToInf bool   `form:"-"` // handled in custom AppendTo
+	Amount  *uint64 `form:"amount"`
+	UpTo    *uint64 `form:"-"` // handled in custom AppendTo
+	UpToInf *bool   `form:"-"` // handled in custom AppendTo
 }
 
 // AppendTo implements custom up_to serialisation logic for tiers configuration
 func (p *PlanTierParams) AppendTo(body *form.Values, keyParts []string) {
-	if p.UpToInf {
+	if BoolValue(p.UpToInf) {
 		body.Add(form.FormatKey(append(keyParts, "up_to")), "inf")
 	} else {
-		body.Add(form.FormatKey(append(keyParts, "up_to")), strconv.FormatUint(p.UpTo, 10))
+		body.Add(form.FormatKey(append(keyParts, "up_to")), strconv.FormatUint(UInt64Value(p.UpTo), 10))
 	}
 }
 
@@ -133,8 +132,8 @@ func (p *PlanTierParams) AppendTo(body *form.Values, keyParts []string) {
 // This can only be used on plan creation and won't work on plan update.
 // For more details see https://stripe.com/docs/api#create_plan-product and https://stripe.com/docs/api#update_plan-product
 type PlanProductParams struct {
-	ID                  string            `form:"id"`
-	Name                string            `form:"name"`
-	Meta                map[string]string `form:"metadata"`
-	StatementDescriptor string            `form:"statement_descriptor"`
+	ID                  *string           `form:"id"`
+	Name                *string           `form:"name"`
+	Metadata            map[string]string `form:"metadata"`
+	StatementDescriptor *string           `form:"statement_descriptor"`
 }

--- a/plan.go
+++ b/plan.go
@@ -40,29 +40,29 @@ const (
 // Plan is the resource representing a Stripe plan.
 // For more details see https://stripe.com/docs/api#plans.
 type Plan struct {
-	Amount         uint64              `json:"amount"`
-	BillingScheme  string              `json:"billing_scheme"`
-	Created        int64               `json:"created"`
-	Currency       Currency            `json:"currency"`
-	Deleted        bool                `json:"deleted"`
-	ID             string              `json:"id"`
-	Interval       PlanInterval        `json:"interval"`
-	IntervalCount  uint64              `json:"interval_count"`
-	Live           bool                `json:"livemode"`
-	Meta           map[string]string   `json:"metadata"`
-	Nickname       string              `json:"nickname"`
-	Product        string              `json:"product"`
-	Tiers          []*PlanTier         `json:"tiers"`
-	TiersMode      string              `json:"tiers_mode"`
-	TransformUsage *PlanTransformUsage `json:"transform_usage"`
-	TrialPeriod    uint64              `json:"trial_period_days"`
-	UsageType      string              `json:"usage_type"`
+	Amount          uint64              `json:"amount"`
+	BillingScheme   string              `json:"billing_scheme"`
+	Created         int64               `json:"created"`
+	Currency        Currency            `json:"currency"`
+	Deleted         bool                `json:"deleted"`
+	ID              string              `json:"id"`
+	Interval        PlanInterval        `json:"interval"`
+	IntervalCount   uint64              `json:"interval_count"`
+	Livemode        bool                `json:"livemode"`
+	Metadata        map[string]string   `json:"metadata"`
+	Nickname        string              `json:"nickname"`
+	Product         string              `json:"product"`
+	Tiers           []*PlanTier         `json:"tiers"`
+	TiersMode       string              `json:"tiers_mode"`
+	TransformUsage  *PlanTransformUsage `json:"transform_usage"`
+	TrialPeriodDays uint64              `json:"trial_period_days"`
+	UsageType       string              `json:"usage_type"`
 }
 
 // PlanList is a list of plans as returned from a list endpoint.
 type PlanList struct {
 	ListMeta
-	Values []*Plan `json:"data"`
+	Data []*Plan `json:"data"`
 }
 
 // PlanListParams is the set of parameters that can be used when listing plans.
@@ -76,22 +76,22 @@ type PlanListParams struct {
 // PlanParams is the set of parameters that can be used when creating or updating a plan.
 // For more details see https://stripe.com/docs/api#create_plan and https://stripe.com/docs/api#update_plan.
 type PlanParams struct {
-	Params         `form:"*"`
-	Amount         uint64                    `form:"amount"`
-	AmountZero     bool                      `form:"amount,zero"`
-	BillingScheme  string                    `form:"billing_scheme"`
-	Currency       Currency                  `form:"currency"`
-	ID             string                    `form:"id"`
-	Interval       PlanInterval              `form:"interval"`
-	IntervalCount  uint64                    `form:"interval_count"`
-	Nickname       string                    `form:"nickname"`
-	Product        *PlanProductParams        `form:"product"`
-	ProductID      *string                   `form:"product"`
-	Tiers          []*PlanTierParams         `form:"tiers,indexed"`
-	TiersMode      string                    `form:"tiers_mode"`
-	TransformUsage *PlanTransformUsageParams `form:"transform_usage"`
-	TrialPeriod    uint64                    `form:"trial_period_days"`
-	UsageType      string                    `form:"usage_type"`
+	Params          `form:"*"`
+	Amount          uint64                    `form:"amount"`
+	AmountZero      bool                      `form:"amount,zero"`
+	BillingScheme   string                    `form:"billing_scheme"`
+	Currency        Currency                  `form:"currency"`
+	ID              string                    `form:"id"`
+	Interval        PlanInterval              `form:"interval"`
+	IntervalCount   uint64                    `form:"interval_count"`
+	Nickname        string                    `form:"nickname"`
+	Product         *PlanProductParams        `form:"product"`
+	ProductID       *string                   `form:"product"`
+	Tiers           []*PlanTierParams         `form:"tiers,indexed"`
+	TiersMode       string                    `form:"tiers_mode"`
+	TransformUsage  *PlanTransformUsageParams `form:"transform_usage"`
+	TrialPeriodDays uint64                    `form:"trial_period_days"`
+	UsageType       string                    `form:"usage_type"`
 }
 
 // PlanTier configures tiered pricing

--- a/plan/client.go
+++ b/plan/client.go
@@ -126,8 +126,8 @@ func (c Client) List(params *stripe.PlanListParams) *Iter {
 		list := &stripe.PlanList{}
 		err := c.B.Call("GET", "/plans", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -31,14 +32,15 @@ func TestPlanList(t *testing.T) {
 
 func TestPlanNew(t *testing.T) {
 	plan, err := New(&stripe.PlanParams{
-		Amount:   1,
-		Currency: "usd",
-		ID:       "sapphire-elite",
-		Interval: "month",
-		Product: &stripe.PlanProductParams{
-			ID:                  "plan_id",
-			Name:                "Sapphire Elite",
-			StatementDescriptor: "statement descriptor",
+		Amount:   stripe.UInt64(1),
+		Currency: stripe.String(string(currency.USD)),
+		ID:       stripe.String("sapphire-elite"),
+		Interval: stripe.String(string(Month)),
+		Product: &stripe.ProductParams{
+			ID:                  stripe.String("plan_id"),
+			Name:                stripe.String("Sapphire Elite"),
+			StatementDescriptor: stripe.String("statement descriptor"),
+			Type:                stripe.String(string(stripe.ProductTypeService)),
 		},
 	})
 	assert.Nil(t, err)
@@ -46,13 +48,12 @@ func TestPlanNew(t *testing.T) {
 }
 
 func TestPlanNewWithProductID(t *testing.T) {
-	productId := "prod_12345abc"
 	plan, err := New(&stripe.PlanParams{
-		Amount:    1,
-		Currency:  "usd",
-		ID:        "sapphire-elite",
-		Interval:  "month",
-		ProductID: &productId,
+		Amount:    stripe.UInt64(1),
+		Currency:  stripe.String(string(currency.USD)),
+		ID:        stripe.String("sapphire-elite"),
+		Interval:  stripe.String(string(Month)),
+		ProductID: stripe.String("prod_12345abc"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, plan)
@@ -60,7 +61,7 @@ func TestPlanNewWithProductID(t *testing.T) {
 
 func TestPlanUpdate(t *testing.T) {
 	plan, err := Update("gold", &stripe.PlanParams{
-		Nickname: "Updated nickame",
+		Nickname: stripe.String("Updated nickame"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, plan)

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -32,7 +32,7 @@ func TestPlanList(t *testing.T) {
 
 func TestPlanNew(t *testing.T) {
 	plan, err := New(&stripe.PlanParams{
-		Amount:   stripe.UInt64(1),
+		Amount:   stripe.Int64(1),
 		Currency: stripe.String(string(currency.USD)),
 		ID:       stripe.String("sapphire-elite"),
 		Interval: stripe.String(string(Month)),
@@ -49,7 +49,7 @@ func TestPlanNew(t *testing.T) {
 
 func TestPlanNewWithProductID(t *testing.T) {
 	plan, err := New(&stripe.PlanParams{
-		Amount:    stripe.UInt64(1),
+		Amount:    stripe.Int64(1),
 		Currency:  stripe.String(string(currency.USD)),
 		ID:        stripe.String("sapphire-elite"),
 		Interval:  stripe.String(string(Month)),

--- a/plan_test.go
+++ b/plan_test.go
@@ -67,8 +67,8 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		{"tiers[0][up_to]", &PlanParams{Tiers: tiers}, strconv.FormatUint(321, 10)},
 		{"tiers[1][amount]", &PlanParams{Tiers: tiers}, strconv.FormatUint(123, 10)},
 		{"tiers[1][up_to]", &PlanParams{Tiers: tiers}, "inf"},
-		{"transform_usage[bucket_size]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: 123, Round: "round_up"}}, strconv.FormatUint(123, 10)},
-		{"transform_usage[round]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: 123, Round: "round_up"}}, "round_up"},
+		{"transform_usage[bucket_size]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: Int64(123), Round: String("round_up")}}, strconv.FormatUint(123, 10)},
+		{"transform_usage[round]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: Int64(123), Round: String("round_up")}}, "round_up"},
 		{"trial_period_days", &PlanParams{TrialPeriodDays: Int64(123)}, strconv.FormatUint(123, 10)},
 		{"usage_type", &PlanParams{UsageType: String("metered")}, "metered"},
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -14,7 +14,7 @@ func TestPlanListParams_AppendTo(t *testing.T) {
 		params *PlanListParams
 		want   interface{}
 	}{
-		{"created", &PlanListParams{Created: 123}, strconv.FormatInt(123, 10)},
+		{"created", &PlanListParams{Created: Int64(123)}, strconv.FormatInt(123, 10)},
 		{
 			"created[gt]",
 			&PlanListParams{CreatedRange: &RangeQueryParams{GreaterThan: 123}},
@@ -39,39 +39,38 @@ func TestPlanListParams_AppendTo_Empty(t *testing.T) {
 }
 
 func TestPlanParams_AppendTo(t *testing.T) {
-	productParams := PlanProductParams{
-		ID:                  "ID",
-		Name:                "Sapphire Elite",
-		StatementDescriptor: "SAPPHIRE",
+	productParams := ProductParams{
+		ID:                  String("ID"),
+		Name:                String("Sapphire Elite"),
+		StatementDescriptor: String("SAPPHIRE"),
+		Type:                String(string(ProductTypeService)),
 	}
-	productID := "prod_123abc"
-	tiers := []*PlanTierParams{{Amount: 123, UpTo: 321}, {Amount: 123, UpToInf: true}}
+	tiers := []*PlanTierParams{
+		{Amount: UInt64(123), UpTo: UInt64(321)},
+		{Amount: UInt64(123), UpToInf: Bool(true)}}
 	testCases := []struct {
 		field  string
 		params *PlanParams
 		want   interface{}
 	}{
-		{"amount", &PlanParams{}, ""},
-		{"amount", &PlanParams{Amount: 0, AmountZero: false}, ""},
-		{"amount", &PlanParams{Amount: 0, AmountZero: true}, strconv.FormatUint(0, 10)},
-		{"amount", &PlanParams{Amount: 123}, strconv.FormatUint(123, 10)},
-		{"currency", &PlanParams{Currency: "USD"}, "USD"},
-		{"id", &PlanParams{ID: "sapphire-elite"}, "sapphire-elite"},
-		{"interval_count", &PlanParams{IntervalCount: 3}, strconv.FormatUint(3, 10)},
-		{"interval", &PlanParams{Interval: "month"}, "month"},
-		{"product", &PlanParams{ProductID: &productID}, "prod_123abc"},
+		{"amount", &PlanParams{Amount: UInt64(123)}, strconv.FormatUint(123, 10)},
+		{"currency", &PlanParams{Currency: String("usd")}, "usd"},
+		{"id", &PlanParams{ID: String("sapphire-elite")}, "sapphire-elite"},
+		{"interval", &PlanParams{Interval: String("month")}, "month"},
+		{"interval_count", &PlanParams{IntervalCount: UInt64(3)}, strconv.FormatUint(3, 10)},
+		{"product", &PlanParams{ProductID: String("prod_123abc")}, "prod_123abc"},
 		{"product[id]", &PlanParams{Product: &productParams}, "ID"},
 		{"product[name]", &PlanParams{Product: &productParams}, "Sapphire Elite"},
 		{"product[statement_descriptor]", &PlanParams{Product: &productParams}, "SAPPHIRE"},
-		{"tiers_mode", &PlanParams{TiersMode: "volume"}, "volume"},
+		{"product", &PlanParams{ProductID: String("prod_123abc")}, "prod_123abc"}, {"tiers_mode", &PlanParams{TiersMode: String("volume")}, "volume"},
 		{"tiers[0][amount]", &PlanParams{Tiers: tiers}, strconv.FormatUint(123, 10)},
 		{"tiers[0][up_to]", &PlanParams{Tiers: tiers}, strconv.FormatUint(321, 10)},
 		{"tiers[1][amount]", &PlanParams{Tiers: tiers}, strconv.FormatUint(123, 10)},
 		{"tiers[1][up_to]", &PlanParams{Tiers: tiers}, "inf"},
 		{"transform_usage[bucket_size]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: 123, Round: "round_up"}}, strconv.FormatUint(123, 10)},
 		{"transform_usage[round]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: 123, Round: "round_up"}}, "round_up"},
-		{"trial_period_days", &PlanParams{TrialPeriodDays: 123}, strconv.FormatUint(123, 10)},
-		{"usage_type", &PlanParams{UsageType: "metered"}, "metered"},
+		{"trial_period_days", &PlanParams{TrialPeriodDays: UInt64(123)}, strconv.FormatUint(123, 10)},
+		{"usage_type", &PlanParams{UsageType: String("metered")}, "metered"},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {

--- a/plan_test.go
+++ b/plan_test.go
@@ -70,7 +70,7 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		{"tiers[1][up_to]", &PlanParams{Tiers: tiers}, "inf"},
 		{"transform_usage[bucket_size]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: 123, Round: "round_up"}}, strconv.FormatUint(123, 10)},
 		{"transform_usage[round]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: 123, Round: "round_up"}}, "round_up"},
-		{"trial_period_days", &PlanParams{TrialPeriod: 123}, strconv.FormatUint(123, 10)},
+		{"trial_period_days", &PlanParams{TrialPeriodDays: 123}, strconv.FormatUint(123, 10)},
 		{"usage_type", &PlanParams{UsageType: "metered"}, "metered"},
 	}
 	for _, tc := range testCases {

--- a/plan_test.go
+++ b/plan_test.go
@@ -46,18 +46,18 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		Type:                String(string(ProductTypeService)),
 	}
 	tiers := []*PlanTierParams{
-		{Amount: UInt64(123), UpTo: UInt64(321)},
-		{Amount: UInt64(123), UpToInf: Bool(true)}}
+		{Amount: Int64(123), UpTo: Int64(321)},
+		{Amount: Int64(123), UpToInf: Bool(true)}}
 	testCases := []struct {
 		field  string
 		params *PlanParams
 		want   interface{}
 	}{
-		{"amount", &PlanParams{Amount: UInt64(123)}, strconv.FormatUint(123, 10)},
+		{"amount", &PlanParams{Amount: Int64(123)}, strconv.FormatUint(123, 10)},
 		{"currency", &PlanParams{Currency: String("usd")}, "usd"},
 		{"id", &PlanParams{ID: String("sapphire-elite")}, "sapphire-elite"},
 		{"interval", &PlanParams{Interval: String("month")}, "month"},
-		{"interval_count", &PlanParams{IntervalCount: UInt64(3)}, strconv.FormatUint(3, 10)},
+		{"interval_count", &PlanParams{IntervalCount: Int64(3)}, strconv.FormatUint(3, 10)},
 		{"product", &PlanParams{ProductID: String("prod_123abc")}, "prod_123abc"},
 		{"product[id]", &PlanParams{Product: &productParams}, "ID"},
 		{"product[name]", &PlanParams{Product: &productParams}, "Sapphire Elite"},
@@ -69,7 +69,7 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		{"tiers[1][up_to]", &PlanParams{Tiers: tiers}, "inf"},
 		{"transform_usage[bucket_size]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: 123, Round: "round_up"}}, strconv.FormatUint(123, 10)},
 		{"transform_usage[round]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: 123, Round: "round_up"}}, "round_up"},
-		{"trial_period_days", &PlanParams{TrialPeriodDays: UInt64(123)}, strconv.FormatUint(123, 10)},
+		{"trial_period_days", &PlanParams{TrialPeriodDays: Int64(123)}, strconv.FormatUint(123, 10)},
 		{"usage_type", &PlanParams{UsageType: String("metered")}, "metered"},
 	}
 	for _, tc := range testCases {

--- a/product.go
+++ b/product.go
@@ -91,7 +91,7 @@ type ProductListParams struct {
 	Active     *bool    `form:"active"`
 	IDs        []string `form:"ids"`
 	Shippable  *bool    `form:"shippable"`
-	URL        string   `form:"url"`
+	URL        *string  `form:"url"`
 }
 
 // UnmarshalJSON handles deserialization of a Product.

--- a/product.go
+++ b/product.go
@@ -17,11 +17,11 @@ const (
 
 // PackageDimensions represents the dimension of a product or a sku from the
 // perspective of shipping.
-type PackageDimensions struct {
-	Height float64 `json:"height" form:"height"`
-	Length float64 `json:"length" form:"length"`
-	Weight float64 `json:"weight" form:"weight"`
-	Width  float64 `json:"width" form:"width"`
+type PackageDimensionsParams struct {
+	Height *float64 `form:"height"`
+	Length *float64 `form:"length"`
+	Weight *float64 `form:"weight"`
+	Width  *float64 `form:"width"`
 }
 
 // ProductParams is the set of parameters that can be used
@@ -30,19 +30,28 @@ type PackageDimensions struct {
 // and https://stripe.com/docs/api#update_product.
 type ProductParams struct {
 	Params              `form:"*"`
-	Active              *bool              `form:"active"`
-	Attributes          []string           `form:"attributes"`
-	Caption             string             `form:"caption"`
-	DeactivateOn        []string           `form:"deactivate_on"`
-	Description         string             `form:"description"`
-	ID                  string             `form:"id"`
-	Images              []string           `form:"images"`
-	Name                string             `form:"name"`
-	PackageDimensions   *PackageDimensions `form:"package_dimensions"`
-	Shippable           *bool              `form:"shippable"`
-	StatementDescriptor string             `form:"statement_descriptor"`
-	Type                ProductType        `form:"type"`
-	URL                 string             `form:"url"`
+	Active              *bool                    `form:"active"`
+	Attributes          []string                 `form:"attributes"`
+	Caption             *string                  `form:"caption"`
+	DeactivateOn        []string                 `form:"deactivate_on"`
+	Description         *string                  `form:"description"`
+	ID                  *string                  `form:"id"`
+	Images              []string                 `form:"images"`
+	Name                *string                  `form:"name"`
+	PackageDimensions   *PackageDimensionsParams `form:"package_dimensions"`
+	Shippable           *bool                    `form:"shippable"`
+	StatementDescriptor *string                  `form:"statement_descriptor"`
+	Type                *string                  `form:"type"`
+	URL                 *string                  `form:"url"`
+}
+
+// PackageDimensions represents the dimension of a product or a sku from the
+// perspective of shipping.
+type PackageDimensions struct {
+	Height float64 `json:"height"`
+	Length float64 `json:"length"`
+	Weight float64 `json:"weight"`
+	Width  float64 `json:"width"`
 }
 
 // Product is the resource representing a Stripe product.
@@ -61,8 +70,8 @@ type Product struct {
 	Name                string             `json:"name"`
 	PackageDimensions   *PackageDimensions `json:"package_dimensions"`
 	Shippable           bool               `json:"shippable"`
-	StatementDescriptor string             `json:"statement_descriptor"`
 	Skus                *SKUList           `json:"skus"`
+	StatementDescriptor string             `json:"statement_descriptor"`
 	Type                ProductType        `json:"type"`
 	URL                 string             `json:"url"`
 	Updated             int64              `json:"updated"`

--- a/product.go
+++ b/product.go
@@ -31,10 +31,10 @@ type PackageDimensions struct {
 type ProductParams struct {
 	Params              `form:"*"`
 	Active              *bool              `form:"active"`
-	Attrs               []string           `form:"attributes"`
+	Attributes          []string           `form:"attributes"`
 	Caption             string             `form:"caption"`
 	DeactivateOn        []string           `form:"deactivate_on"`
-	Desc                string             `form:"description"`
+	Description         string             `form:"description"`
 	ID                  string             `form:"id"`
 	Images              []string           `form:"images"`
 	Name                string             `form:"name"`
@@ -49,29 +49,29 @@ type ProductParams struct {
 // For more details see https://stripe.com/docs/api#products.
 type Product struct {
 	Active              bool               `json:"active"`
-	Attrs               []string           `json:"attributes"`
+	Attributes          []string           `json:"attributes"`
 	Caption             string             `json:"caption"`
 	Created             int64              `json:"created"`
 	DeactivateOn        []string           `json:"deactivate_on"`
-	Desc                string             `json:"description"`
+	Description         string             `json:"description"`
 	ID                  string             `json:"id"`
 	Images              []string           `json:"images"`
-	Live                bool               `json:"livemode"`
-	Meta                map[string]string  `json:"metadata"`
+	Livemode            bool               `json:"livemode"`
+	Metadata            map[string]string  `json:"metadata"`
 	Name                string             `json:"name"`
 	PackageDimensions   *PackageDimensions `json:"package_dimensions"`
 	Shippable           bool               `json:"shippable"`
-	Skus                *SKUList           `json:"skus"`
 	StatementDescriptor string             `json:"statement_descriptor"`
+	Skus                *SKUList           `json:"skus"`
+	Type                ProductType        `json:"type"`
 	URL                 string             `json:"url"`
 	Updated             int64              `json:"updated"`
-	Type                ProductType        `json:"type"`
 }
 
 // ProductList is a list of products as retrieved from a list endpoint.
 type ProductList struct {
 	ListMeta
-	Values []*Product `json:"data"`
+	Data []*Product `json:"data"`
 }
 
 // ProductListParams is the set of parameters that can be used when

--- a/product/client.go
+++ b/product/client.go
@@ -103,8 +103,8 @@ func (c Client) List(params *stripe.ProductListParams) *Iter {
 		list := &stripe.ProductList{}
 		err := c.B.Call("GET", "/products", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -34,13 +34,13 @@ func TestProductNew(t *testing.T) {
 	shippable := true
 
 	product, err := New(&stripe.ProductParams{
-		Active:    &active,
-		Name:      "Test Name",
-		Desc:      "This is a description",
-		Caption:   "This is a caption",
-		Attrs:     []string{"attr1", "attr2"},
-		URL:       "http://example.com",
-		Shippable: &shippable,
+		Active:      &active,
+		Name:        "Test Name",
+		Description: "This is a description",
+		Caption:     "This is a caption",
+		Attributes:  []string{"attr1", "attr2"},
+		URL:         "http://example.com",
+		Shippable:   &shippable,
 		PackageDimensions: &stripe.PackageDimensions{
 			Height: 2.234,
 			Length: 5.10,

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -30,24 +30,21 @@ func TestProductList(t *testing.T) {
 }
 
 func TestProductNew(t *testing.T) {
-	active := true
-	shippable := true
-
 	product, err := New(&stripe.ProductParams{
-		Active:      &active,
-		Name:        "Test Name",
-		Description: "This is a description",
-		Caption:     "This is a caption",
+		Active:      stripe.Bool(true),
+		Name:        stripe.String("Test Name"),
+		Description: stripe.String("This is a description"),
+		Caption:     stripe.String("This is a caption"),
 		Attributes:  []string{"attr1", "attr2"},
-		URL:         "http://example.com",
-		Shippable:   &shippable,
-		PackageDimensions: &stripe.PackageDimensions{
-			Height: 2.234,
-			Length: 5.10,
-			Width:  6.50,
-			Weight: 10,
+		URL:         stripe.String("http://example.com"),
+		Shippable:   stripe.Bool(true),
+		PackageDimensions: &stripe.PackageDimensionsParams{
+			Height: stripe.Float64(2.234),
+			Length: stripe.Float64(5.10),
+			Width:  stripe.Float64(6.50),
+			Weight: stripe.Float64(10),
 		},
-		Type: stripe.ProductTypeGood,
+		Type: stripe.String(string(stripe.ProductTypeGood)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, product)
@@ -55,7 +52,7 @@ func TestProductNew(t *testing.T) {
 
 func TestProductUpdate(t *testing.T) {
 	product, err := Update("prod_123", &stripe.ProductParams{
-		Name: "Updated Name",
+		Name: stripe.String("Updated Name"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, product)

--- a/recipient.go
+++ b/recipient.go
@@ -15,10 +15,10 @@ type RecipientType string
 type RecipientParams struct {
 	Params `form:"*"`
 
-	Bank        *BankAccountParams `form:"-"` // Kind of an abberation because a bank account's token will be replace the rest of its data. Keep this in a custom AppendTo for now.
+	BankAccount *BankAccountParams `form:"-"` // Kind of an abberation because a bank account's token will be replace the rest of its data. Keep this in a custom AppendTo for now.
 	Card        *CardParams        `form:"card"`
 	DefaultCard string             `form:"default_card"`
-	Desc        string             `form:"description"`
+	Description string             `form:"description"`
 	Email       string             `form:"email"`
 	Name        string             `form:"name"`
 	TaxID       string             `form:"tax_id"`
@@ -30,11 +30,11 @@ type RecipientParams struct {
 // This was probably the wrong way to go about this, but grandfather the
 // behavior for the time being.
 func (p *RecipientParams) AppendTo(body *form.Values, keyParts []string) {
-	if p.Bank != nil {
-		if len(p.Bank.Token) > 0 {
-			body.Add("bank_account", p.Bank.Token)
+	if p.BankAccount != nil {
+		if len(p.BankAccount.Token) > 0 {
+			body.Add("bank_account", p.BankAccount.Token)
 		} else {
-			form.AppendToPrefixed(body, p.Bank, append(keyParts, "bank_account"))
+			form.AppendToPrefixed(body, p.BankAccount, append(keyParts, "bank_account"))
 		}
 	}
 }
@@ -49,25 +49,25 @@ type RecipientListParams struct {
 // Recipient is the resource representing a Stripe recipient.
 // For more details see https://stripe.com/docs/api#recipients.
 type Recipient struct {
-	Bank        *BankAccount      `json:"active_account"`
-	Cards       *CardList         `json:"cards"`
-	Created     int64             `json:"created"`
-	DefaultCard *Card             `json:"default_card"`
-	Deleted     bool              `json:"deleted"`
-	Desc        string            `json:"description"`
-	Email       string            `json:"email"`
-	ID          string            `json:"id"`
-	Live        bool              `json:"livemode"`
-	Meta        map[string]string `json:"metadata"`
-	MigratedTo  *Account          `json:"migrated_to"`
-	Name        string            `json:"name"`
-	Type        RecipientType     `json:"type"`
+	ActiveAccount *BankAccount      `json:"active_account"`
+	Cards         *CardList         `json:"cards"`
+	Created       int64             `json:"created"`
+	DefaultCard   *Card             `json:"default_card"`
+	Deleted       bool              `json:"deleted"`
+	Description   string            `json:"description"`
+	Email         string            `json:"email"`
+	ID            string            `json:"id"`
+	Livemode      bool              `json:"livemode"`
+	Metadata      map[string]string `json:"metadata"`
+	MigratedTo    *Account          `json:"migrated_to"`
+	Name          string            `json:"name"`
+	Type          RecipientType     `json:"type"`
 }
 
 // RecipientList is a list of recipients as retrieved from a list endpoint.
 type RecipientList struct {
 	ListMeta
-	Values []*Recipient `json:"data"`
+	Data []*Recipient `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Recipient.

--- a/recipient.go
+++ b/recipient.go
@@ -17,13 +17,13 @@ type RecipientParams struct {
 
 	BankAccount *BankAccountParams `form:"-"` // Kind of an abberation because a bank account's token will be replace the rest of its data. Keep this in a custom AppendTo for now.
 	Card        *CardParams        `form:"card"`
-	DefaultCard string             `form:"default_card"`
-	Description string             `form:"description"`
-	Email       string             `form:"email"`
-	Name        string             `form:"name"`
-	TaxID       string             `form:"tax_id"`
-	Token       string             `form:"card"`
-	Type        RecipientType      `form:"-"` // Doesn't seem to be used anywhere
+	DefaultCard *string            `form:"default_card"`
+	Description *string            `form:"description"`
+	Email       *string            `form:"email"`
+	Name        *string            `form:"name"`
+	TaxID       *string            `form:"tax_id"`
+	Token       *string            `form:"card"`
+	Type        *string            `form:"-"` // Doesn't seem to be used anywhere
 }
 
 // AppendTo implements some custom behavior around a recipient's bank account.
@@ -31,8 +31,8 @@ type RecipientParams struct {
 // behavior for the time being.
 func (p *RecipientParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.BankAccount != nil {
-		if len(p.BankAccount.Token) > 0 {
-			body.Add("bank_account", p.BankAccount.Token)
+		if p.BankAccount.Token != nil {
+			body.Add("bank_account", StringValue(p.BankAccount.Token))
 		} else {
 			form.AppendToPrefixed(body, p.BankAccount, append(keyParts, "bank_account"))
 		}
@@ -43,7 +43,7 @@ func (p *RecipientParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#list_recipients.
 type RecipientListParams struct {
 	ListParams `form:"*"`
-	Verified   bool `form:"verified"`
+	Verified   *bool `form:"verified"`
 }
 
 // Recipient is the resource representing a Stripe recipient.

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -108,8 +108,8 @@ func (c Client) List(params *stripe.RecipientListParams) *Iter {
 		list := &stripe.RecipientList{}
 		err := c.B.Call("GET", "/recipients", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/recipient/client_test.go
+++ b/recipient/client_test.go
@@ -31,7 +31,7 @@ func TestRecipientList(t *testing.T) {
 
 func TestRecipientUpdate(t *testing.T) {
 	recipient, err := Update("rp_123", &stripe.RecipientParams{
-		Name: "Updated Name",
+		Name: stripe.String("Updated Name"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, recipient)

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -25,7 +25,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{Bank: &BankAccountParams{Token: "ba_123"}}
+		params := &RecipientParams{BankAccount: &BankAccountParams{Token: "ba_123"}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -33,7 +33,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{Bank: &BankAccountParams{Account: "123"}}
+		params := &RecipientParams{BankAccount: &BankAccountParams{AccountNumber: "123"}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRecipientParams_AppendTo(t *testing.T) {
 	{
-		params := &RecipientParams{Token: "card_123"}
+		params := &RecipientParams{Token: String("card_123")}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -17,7 +17,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{Card: &CardParams{Name: "A Card"}}
+		params := &RecipientParams{Card: &CardParams{Name: String("A Card")}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -25,7 +25,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{BankAccount: &BankAccountParams{Token: "ba_123"}}
+		params := &RecipientParams{BankAccount: &BankAccountParams{Token: String("ba_123")}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -33,7 +33,7 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &RecipientParams{BankAccount: &BankAccountParams{AccountNumber: "123"}}
+		params := &RecipientParams{BankAccount: &BankAccountParams{AccountNumber: String("123")}}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/recipienttransfer.go
+++ b/recipienttransfer.go
@@ -57,30 +57,30 @@ type RecipientTransferDestination struct {
 // RecipientTransfer is the resource representing a Stripe recipient_transfer.
 // For more details see https://stripe.com/docs/api#recipient_transfers.
 type RecipientTransfer struct {
-	Amount             int64                        `json:"amount"`
-	AmountReversed     int64                        `json:"amount_reversed"`
-	BalanceTransaction *Transaction                 `json:"balance_transaction"`
-	Bank               *BankAccount                 `json:"bank_account"`
-	Card               *Card                        `json:"card"`
-	Created            int64                        `json:"created"`
-	Currency           Currency                     `json:"currency"`
-	Date               int64                        `json:"date"`
-	Desc               string                       `json:"description"`
-	Dest               RecipientTransferDestination `json:"destination"`
-	FailCode           RecipientTransferFailCode    `json:"failure_code"`
-	FailMsg            string                       `json:"failure_message"`
-	ID                 string                       `json:"id"`
-	Live               bool                         `json:"livemode"`
-	Meta               map[string]string            `json:"metadata"`
-	Method             RecipientTransferMethodType  `json:"method"`
-	Recipient          *Recipient                   `json:"recipient"`
-	Reversals          *ReversalList                `json:"reversals"`
-	Reversed           bool                         `json:"reversed"`
-	SourceTx           *TransactionSource           `json:"source_transaction"`
-	SourceType         RecipientTransferSourceType  `json:"source_type"`
-	Statement          string                       `json:"statement_descriptor"`
-	Status             RecipientTransferStatus      `json:"status"`
-	Type               RecipientTransferType        `json:"type"`
+	Amount              int64                        `json:"amount"`
+	AmountReversed      int64                        `json:"amount_reversed"`
+	BalanceTransaction  *BalanceTransaction          `json:"balance_transaction"`
+	BankAccount         *BankAccount                 `json:"bank_account"`
+	Card                *Card                        `json:"card"`
+	Created             int64                        `json:"created"`
+	Currency            Currency                     `json:"currency"`
+	Date                int64                        `json:"date"`
+	Description         string                       `json:"description"`
+	Destination         RecipientTransferDestination `json:"destination"`
+	FailureCode         RecipientTransferFailCode    `json:"failure_code"`
+	FailureMessage      string                       `json:"failure_message"`
+	ID                  string                       `json:"id"`
+	Livemode            bool                         `json:"livemode"`
+	Metadata            map[string]string            `json:"metadata"`
+	Method              RecipientTransferMethodType  `json:"method"`
+	Recipient           *Recipient                   `json:"recipient"`
+	Reversals           *ReversalList                `json:"reversals"`
+	Reversed            bool                         `json:"reversed"`
+	SourceTransaction   *BalanceTransactionSource    `json:"source_transaction"`
+	SourceType          RecipientTransferSourceType  `json:"source_type"`
+	StatementDescriptor string                       `json:"statement_descriptor"`
+	Status              RecipientTransferStatus      `json:"status"`
+	Type                RecipientTransferType        `json:"type"`
 }
 
 // UnmarshalJSON handles deserialization of a RecipientTransfer.

--- a/refund.go
+++ b/refund.go
@@ -14,12 +14,12 @@ type RefundStatus string
 // RefundParams is the set of parameters that can be used when refunding a charge.
 // For more details see https://stripe.com/docs/api#refund.
 type RefundParams struct {
-	Params   `form:"*"`
-	Amount   uint64       `form:"amount"`
-	Charge   string       `form:"charge"`
-	Fee      bool         `form:"refund_application_fee"`
-	Reason   RefundReason `form:"reason"`
-	Transfer bool         `form:"reverse_transfer"`
+	Params               `form:"*"`
+	Amount               uint64       `form:"amount"`
+	Charge               string       `form:"charge"`
+	Reason               RefundReason `form:"reason"`
+	RefundApplicationFee bool         `form:"refund_application_fee"`
+	ReverseTransfer      bool         `form:"reverse_transfer"`
 }
 
 // RefundListParams is the set of parameters that can be used when listing refunds.
@@ -31,22 +31,22 @@ type RefundListParams struct {
 // Refund is the resource representing a Stripe refund.
 // For more details see https://stripe.com/docs/api#refunds.
 type Refund struct {
-	Amount        uint64            `json:"amount"`
-	Charge        *Charge           `json:"charge"`
-	Created       int64             `json:"created"`
-	Currency      Currency          `json:"currency"`
-	ID            string            `json:"id"`
-	Meta          map[string]string `json:"metadata"`
-	Reason        RefundReason      `json:"reason"`
-	ReceiptNumber string            `json:"receipt_number"`
-	Status        RefundStatus      `json:"status"`
-	Tx            *Transaction      `json:"balance_transaction"`
+	Amount             uint64              `json:"amount"`
+	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
+	Charge             *Charge             `json:"charge"`
+	Created            int64               `json:"created"`
+	Currency           Currency            `json:"currency"`
+	ID                 string              `json:"id"`
+	Metadata           map[string]string   `json:"metadata"`
+	Reason             RefundReason        `json:"reason"`
+	ReceiptNumber      string              `json:"receipt_number"`
+	Status             RefundStatus        `json:"status"`
 }
 
 // RefundList is a list object for refunds.
 type RefundList struct {
 	ListMeta
-	Values []*Refund `json:"data"`
+	Data []*Refund `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Refund.

--- a/refund.go
+++ b/refund.go
@@ -15,11 +15,11 @@ type RefundStatus string
 // For more details see https://stripe.com/docs/api#refund.
 type RefundParams struct {
 	Params               `form:"*"`
-	Amount               uint64       `form:"amount"`
-	Charge               string       `form:"charge"`
-	Reason               RefundReason `form:"reason"`
-	RefundApplicationFee bool         `form:"refund_application_fee"`
-	ReverseTransfer      bool         `form:"reverse_transfer"`
+	Amount               *uint64 `form:"amount"`
+	Charge               *string `form:"charge"`
+	Reason               *string `form:"reason"`
+	RefundApplicationFee *bool   `form:"refund_application_fee"`
+	ReverseTransfer      *bool   `form:"reverse_transfer"`
 }
 
 // RefundListParams is the set of parameters that can be used when listing refunds.

--- a/refund.go
+++ b/refund.go
@@ -15,7 +15,7 @@ type RefundStatus string
 // For more details see https://stripe.com/docs/api#refund.
 type RefundParams struct {
 	Params               `form:"*"`
-	Amount               *uint64 `form:"amount"`
+	Amount               *int64  `form:"amount"`
 	Charge               *string `form:"charge"`
 	Reason               *string `form:"reason"`
 	RefundApplicationFee *bool   `form:"refund_application_fee"`
@@ -31,7 +31,7 @@ type RefundListParams struct {
 // Refund is the resource representing a Stripe refund.
 // For more details see https://stripe.com/docs/api#refunds.
 type Refund struct {
-	Amount             uint64              `json:"amount"`
+	Amount             int64               `json:"amount"`
 	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
 	Charge             *Charge             `json:"charge"`
 	Created            int64               `json:"created"`

--- a/refund/client.go
+++ b/refund/client.go
@@ -91,8 +91,8 @@ func (c Client) List(params *stripe.RefundListParams) *Iter {
 		list := &stripe.RefundList{}
 		err := c.B.Call("GET", "/refunds", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -34,7 +34,7 @@ func TestRefundNew(t *testing.T) {
 func TestRefundUpdate(t *testing.T) {
 	refund, err := Update("gold", &stripe.RefundParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -25,7 +25,8 @@ func TestRefundList(t *testing.T) {
 
 func TestRefundNew(t *testing.T) {
 	refund, err := New(&stripe.RefundParams{
-		Charge: "ch_123",
+		Charge: stripe.String("ch_123"),
+		Reason: stripe.String(string(RefundDuplicate)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)

--- a/refund_test.go
+++ b/refund_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestRefundUnmarshal(t *testing.T) {
 	refundData := map[string]interface{}{
-		"id":     "re_1234",
-		"object": "refund",
-		"charge": "ch_1234",
+		"id":     String("re_1234"),
+		"object": String("refund"),
+		"charge": String("ch_1234"),
 	}
 
 	bytes, err := json.Marshal(&refundData)

--- a/reversal.go
+++ b/reversal.go
@@ -5,15 +5,15 @@ import "encoding/json"
 // ReversalParams is the set of parameters that can be used when reversing a transfer.
 type ReversalParams struct {
 	Params               `form:"*"`
-	Amount               uint64 `form:"amount"`
-	RefundApplicationFee bool   `form:"refund_application_fee"`
-	Transfer             string `form:"-"` // Included in URL
+	Amount               *uint64 `form:"amount"`
+	RefundApplicationFee *bool   `form:"refund_application_fee"`
+	Transfer             *string `form:"-"` // Included in URL
 }
 
 // ReversalListParams is the set of parameters that can be used when listing reversals.
 type ReversalListParams struct {
 	ListParams `form:"*"`
-	Transfer   string `form:"-"` // Included in URL
+	Transfer   *string `form:"-"` // Included in URL
 }
 
 // Reversal represents a transfer reversal.

--- a/reversal.go
+++ b/reversal.go
@@ -4,10 +4,10 @@ import "encoding/json"
 
 // ReversalParams is the set of parameters that can be used when reversing a transfer.
 type ReversalParams struct {
-	Params   `form:"*"`
-	Transfer string `form:"-"` // Included in URL
-	Amount   uint64 `form:"amount"`
-	Fee      bool   `form:"refund_application_fee"`
+	Params               `form:"*"`
+	Amount               uint64 `form:"amount"`
+	RefundApplicationFee bool   `form:"refund_application_fee"`
+	Transfer             string `form:"-"` // Included in URL
 }
 
 // ReversalListParams is the set of parameters that can be used when listing reversals.
@@ -18,19 +18,19 @@ type ReversalListParams struct {
 
 // Reversal represents a transfer reversal.
 type Reversal struct {
-	Amount   uint64            `json:"amount"`
-	Created  int64             `json:"created"`
-	Currency Currency          `json:"currency"`
-	ID       string            `json:"id"`
-	Meta     map[string]string `json:"metadata"`
-	Transfer string            `json:"transfer"`
-	Tx       *Transaction      `json:"balance_transaction"`
+	Amount             uint64              `json:"amount"`
+	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
+	Created            int64               `json:"created"`
+	Currency           Currency            `json:"currency"`
+	ID                 string              `json:"id"`
+	Metadata           map[string]string   `json:"metadata"`
+	Transfer           string              `json:"transfer"`
 }
 
 // ReversalList is a list of object for reversals.
 type ReversalList struct {
 	ListMeta
-	Values []*Reversal `json:"data"`
+	Data []*Reversal `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Reversal.

--- a/reversal.go
+++ b/reversal.go
@@ -5,7 +5,7 @@ import "encoding/json"
 // ReversalParams is the set of parameters that can be used when reversing a transfer.
 type ReversalParams struct {
 	Params               `form:"*"`
-	Amount               *uint64 `form:"amount"`
+	Amount               *int64  `form:"amount"`
 	RefundApplicationFee *bool   `form:"refund_application_fee"`
 	Transfer             *string `form:"-"` // Included in URL
 }
@@ -18,7 +18,7 @@ type ReversalListParams struct {
 
 // Reversal represents a transfer reversal.
 type Reversal struct {
-	Amount             uint64              `json:"amount"`
+	Amount             int64               `json:"amount"`
 	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
 	Created            int64               `json:"created"`
 	Currency           Currency            `json:"currency"`

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -78,8 +78,8 @@ func (c Client) List(params *stripe.ReversalListParams) *Iter {
 		list := &stripe.ReversalList{}
 		err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals", params.Transfer), c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/reversal/client_test.go
+++ b/reversal/client_test.go
@@ -39,7 +39,7 @@ func TestReversalNew(t *testing.T) {
 func TestReversalUpdate(t *testing.T) {
 	reversal, err := Update("trr_123", &stripe.ReversalParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/reversal/client_test.go
+++ b/reversal/client_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestReversalGet(t *testing.T) {
 	reversal, err := Get("trr_123", &stripe.ReversalParams{
-		Transfer: "tr_123",
+		Transfer: stripe.String("tr_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, reversal)
@@ -18,7 +18,7 @@ func TestReversalGet(t *testing.T) {
 
 func TestReversalList(t *testing.T) {
 	i := List(&stripe.ReversalListParams{
-		Transfer: "tr_123",
+		Transfer: stripe.String("tr_123"),
 	})
 
 	// Verify that we can get at least one reversal
@@ -29,8 +29,8 @@ func TestReversalList(t *testing.T) {
 
 func TestReversalNew(t *testing.T) {
 	reversal, err := New(&stripe.ReversalParams{
-		Amount:   123,
-		Transfer: "tr_123",
+		Amount:   stripe.UInt64(123),
+		Transfer: stripe.String("tr_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, reversal)
@@ -43,7 +43,7 @@ func TestReversalUpdate(t *testing.T) {
 				"foo": "bar",
 			},
 		},
-		Transfer: "tr_123",
+		Transfer: stripe.String("tr_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, reversal)

--- a/reversal/client_test.go
+++ b/reversal/client_test.go
@@ -29,7 +29,7 @@ func TestReversalList(t *testing.T) {
 
 func TestReversalNew(t *testing.T) {
 	reversal, err := New(&stripe.ReversalParams{
-		Amount:   stripe.UInt64(123),
+		Amount:   stripe.Int64(123),
 		Transfer: stripe.String("tr_123"),
 	})
 	assert.Nil(t, err)

--- a/review.go
+++ b/review.go
@@ -17,12 +17,12 @@ const (
 )
 
 type Review struct {
-	Charge  *Charge    `json:"charge"`
-	Created int64      `json:"created"`
-	ID      string     `json:"id"`
-	Live    bool       `json:"livemode"`
-	Open    bool       `json:"open"`
-	Reason  ReasonType `json:"reason"`
+	Charge   *Charge    `json:"charge"`
+	Created  int64      `json:"created"`
+	ID       string     `json:"id"`
+	Livemode bool       `json:"livemode"`
+	Open     bool       `json:"open"`
+	Reason   ReasonType `json:"reason"`
 }
 
 func (r *Review) UnmarshalJSON(data []byte) error {

--- a/sku.go
+++ b/sku.go
@@ -5,9 +5,9 @@ import "encoding/json"
 type SKUParams struct {
 	Params            `form:"*"`
 	Active            *bool              `form:"active"`
-	Attrs             map[string]string  `form:"attributes"`
+	Attributes        map[string]string  `form:"attributes"`
 	Currency          string             `form:"currency"`
-	Desc              string             `form:"description"`
+	Description       string             `form:"description"`
 	ID                string             `form:"id"`
 	Image             string             `form:"image"`
 	Inventory         Inventory          `form:"inventory"`
@@ -24,15 +24,15 @@ type Inventory struct {
 
 type SKU struct {
 	Active            bool               `json:"active"`
-	Attrs             map[string]string  `json:"attributes"`
+	Attributes        map[string]string  `json:"attributes"`
 	Created           int64              `json:"created"`
 	Currency          string             `json:"currency"`
-	Desc              string             `json:"description"`
+	Description       string             `json:"description"`
 	ID                string             `json:"id"`
 	Image             string             `json:"image"`
 	Inventory         Inventory          `json:"inventory"`
-	Live              bool               `json:"livemode"`
-	Meta              map[string]string  `json:"metadata"`
+	Livemode          bool               `json:"livemode"`
+	Metadata          map[string]string  `json:"metadata"`
 	PackageDimensions *PackageDimensions `json:"package_dimensions"`
 	Price             int64              `json:"price"`
 	Product           Product            `json:"product"`
@@ -41,7 +41,7 @@ type SKU struct {
 
 type SKUList struct {
 	ListMeta
-	Values []*SKU `json:"data"`
+	Data []*SKU `json:"data"`
 }
 
 type SKUListParams struct {

--- a/sku.go
+++ b/sku.go
@@ -2,31 +2,37 @@ package stripe
 
 import "encoding/json"
 
+type InventoryParams struct {
+	Quantity *int64  `form:"quantity"`
+	Type     *string `form:"type"`
+	Value    *string `form:"value"`
+}
+
 type SKUParams struct {
 	Params            `form:"*"`
-	Active            *bool              `form:"active"`
-	Attributes        map[string]string  `form:"attributes"`
-	Currency          string             `form:"currency"`
-	Description       string             `form:"description"`
-	ID                string             `form:"id"`
-	Image             string             `form:"image"`
-	Inventory         Inventory          `form:"inventory"`
-	PackageDimensions *PackageDimensions `form:"package_dimensions"`
-	Price             int64              `form:"price"`
-	Product           string             `form:"product"`
+	Active            *bool                    `form:"active"`
+	Attributes        map[string]string        `form:"attributes"`
+	Currency          *string                  `form:"currency"`
+	Description       *string                  `form:"description"`
+	ID                *string                  `form:"id"`
+	Image             *string                  `form:"image"`
+	Inventory         *InventoryParams         `form:"inventory"`
+	PackageDimensions *PackageDimensionsParams `form:"package_dimensions"`
+	Price             *int64                   `form:"price"`
+	Product           *string                  `form:"product"`
 }
 
 type Inventory struct {
-	Quantity int64  `json:"quantity" form:"quantity"`
-	Type     string `json:"type" form:"type"`
-	Value    string `json:"value" form:"value"`
+	Quantity int64  `json:"quantity"`
+	Type     string `json:"type"`
+	Value    string `json:"value"`
 }
 
 type SKU struct {
 	Active            bool               `json:"active"`
 	Attributes        map[string]string  `json:"attributes"`
 	Created           int64              `json:"created"`
-	Currency          string             `json:"currency"`
+	Currency          Currency           `json:"currency"`
 	Description       string             `json:"description"`
 	ID                string             `json:"id"`
 	Image             string             `json:"image"`
@@ -50,7 +56,7 @@ type SKUListParams struct {
 	Attributes map[string]string `form:"attributes"`
 	IDs        []string          `form:"ids"`
 	InStock    *bool             `form:"in_stock"`
-	Product    string            `form:"product"`
+	Product    *string           `form:"product"`
 }
 
 func (s *SKU) UnmarshalJSON(data []byte) error {

--- a/sku/client.go
+++ b/sku/client.go
@@ -103,8 +103,8 @@ func (c Client) List(params *stripe.SKUListParams) *Iter {
 		list := &stripe.SKUList{}
 		err := c.B.Call("GET", "/skus", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/sku/client_test.go
+++ b/sku/client_test.go
@@ -32,13 +32,13 @@ func TestSKUList(t *testing.T) {
 func TestSKUNew(t *testing.T) {
 	active := true
 	sku, err := New(&stripe.SKUParams{
-		Active:    &active,
-		Attrs:     map[string]string{"attr1": "val1", "attr2": "val2"},
-		Price:     499,
-		Currency:  "usd",
-		Inventory: stripe.Inventory{Type: "bucket", Value: "limited"},
-		Product:   "prod_123",
-		Image:     "http://example.com/foo.png",
+		Active:     &active,
+		Attributes: map[string]string{"attr1": "val1", "attr2": "val2"},
+		Price:      499,
+		Currency:   "usd",
+		Inventory:  stripe.Inventory{Type: "bucket", Value: "limited"},
+		Product:    "prod_123",
+		Image:      "http://example.com/foo.png",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sku)

--- a/sku/client_test.go
+++ b/sku/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -30,15 +31,17 @@ func TestSKUList(t *testing.T) {
 }
 
 func TestSKUNew(t *testing.T) {
-	active := true
 	sku, err := New(&stripe.SKUParams{
-		Active:     &active,
+		Active:     stripe.Bool(true),
 		Attributes: map[string]string{"attr1": "val1", "attr2": "val2"},
-		Price:      499,
-		Currency:   "usd",
-		Inventory:  stripe.Inventory{Type: "bucket", Value: "limited"},
-		Product:    "prod_123",
-		Image:      "http://example.com/foo.png",
+		Price:      stripe.Int64(499),
+		Currency:   stripe.String(string(currency.USD)),
+		Inventory: &stripe.InventoryParams{
+			Type:  stripe.String("bucket"),
+			Value: stripe.String("limited"),
+		},
+		Product: stripe.String("prod_123"),
+		Image:   stripe.String("http://example.com/foo.png"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sku)
@@ -46,7 +49,10 @@ func TestSKUNew(t *testing.T) {
 
 func TestSKUUpdate(t *testing.T) {
 	sku, err := Update("sku_123", &stripe.SKUParams{
-		Inventory: stripe.Inventory{Type: "bucket", Value: "in_stock"},
+		Inventory: &stripe.InventoryParams{
+			Type:  stripe.String("bucket"),
+			Value: stripe.String("in_stock"),
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, sku)

--- a/source.go
+++ b/source.go
@@ -211,9 +211,9 @@ type Source struct {
 	Currency            Currency              `json:"currency"`
 	Flow                SourceFlow            `json:"flow"`
 	ID                  string                `json:"id"`
-	Live                bool                  `json:"livemode"`
+	Livemode            bool                  `json:"livemode"`
 	Mandate             SourceMandate         `json:"mandate"`
-	Meta                map[string]string     `json:"metadata"`
+	Metadata            map[string]string     `json:"metadata"`
 	Owner               SourceOwner           `json:"owner"`
 	Receiver            *ReceiverFlow         `json:"receiver,omitempty"`
 	Redirect            *RedirectFlow         `json:"redirect,omitempty"`

--- a/source.go
+++ b/source.go
@@ -77,7 +77,7 @@ type RedirectParams struct {
 
 type SourceObjectParams struct {
 	Params              `form:"*"`
-	Amount              *uint64            `form:"amount"`
+	Amount              *int64             `form:"amount"`
 	Currency            *string            `form:"currency"`
 	Customer            *string            `form:"customer"`
 	Flow                *string            `form:"flow"`
@@ -185,7 +185,7 @@ const (
 
 // CodeVerificationFlow informs of the state of a verification authentication flow.
 type CodeVerificationFlow struct {
-	AttemptsRemaining uint64                     `json:"attempts_remaining"`
+	AttemptsRemaining int64                      `json:"attempts_remaining"`
 	Status            CodeVerificationFlowStatus `json:"status"`
 }
 

--- a/source.go
+++ b/source.go
@@ -66,36 +66,36 @@ const (
 
 type SourceOwnerParams struct {
 	Address *AddressParams `form:"address"`
-	Email   string         `form:"email"`
-	Name    string         `form:"name"`
-	Phone   string         `form:"phone"`
+	Email   *string        `form:"email"`
+	Name    *string        `form:"name"`
+	Phone   *string        `form:"phone"`
 }
 
 type RedirectParams struct {
-	ReturnURL string `form:"return_url"`
+	ReturnURL *string `form:"return_url"`
 }
 
 type SourceObjectParams struct {
 	Params              `form:"*"`
-	Amount              uint64             `form:"amount"`
-	Currency            Currency           `form:"currency"`
-	Customer            string             `form:"customer"`
-	Flow                SourceFlow         `form:"flow"`
-	OriginalSource      string             `form:"original_source"`
+	Amount              *uint64            `form:"amount"`
+	Currency            *string            `form:"currency"`
+	Customer            *string            `form:"customer"`
+	Flow                *string            `form:"flow"`
+	OriginalSource      *string            `form:"original_source"`
 	Owner               *SourceOwnerParams `form:"owner"`
 	Redirect            *RedirectParams    `form:"redirect"`
-	StatementDescriptor string             `form:"statement_descriptor"`
-	Token               string             `form:"token"`
-	Type                string             `form:"type"`
+	StatementDescriptor *string            `form:"statement_descriptor"`
+	Token               *string            `form:"token"`
+	Type                *string            `form:"type"`
 	TypeData            map[string]string  `form:"-"`
-	Usage               SourceUsage        `form:"usage"`
+	Usage               *string            `form:"usage"`
 }
 
 // SourceObjectDetachParams is the set of parameters that can be used when detaching
 // a source from a customer.
 type SourceObjectDetachParams struct {
 	Params   `form:"*"`
-	Customer string `form:"-"`
+	Customer *string `form:"-"`
 }
 
 type SourceOwner struct {
@@ -227,12 +227,12 @@ type Source struct {
 // AppendTo implements custom encoding logic for SourceObjectParams so that the special
 // "TypeData" value for is sent as the correct parameter based on the Source type
 func (p *SourceObjectParams) AppendTo(body *form.Values, keyParts []string) {
-	if len(p.TypeData) > 0 && len(p.Type) == 0 {
+	if len(p.TypeData) > 0 && p.Type == nil {
 		panic("You can not fill TypeData if you don't explicitly set Type")
 	}
 
 	for k, vs := range p.TypeData {
-		body.Add(form.FormatKey(append(keyParts, p.Type, k)), vs)
+		body.Add(form.FormatKey(append(keyParts, StringValue(p.Type), k)), vs)
 	}
 }
 

--- a/source/client.go
+++ b/source/client.go
@@ -105,7 +105,7 @@ func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*str
 	source := &stripe.Source{}
 	var err error
 
-	if len(params.Customer) > 0 {
+	if params.Customer != nil {
 		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", params.Customer, id), c.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source detach params: Customer needs to be set")

--- a/source/client_test.go
+++ b/source/client_test.go
@@ -17,11 +17,12 @@ func TestSourceGet(t *testing.T) {
 
 func TestSourceNew(t *testing.T) {
 	source, err := New(&stripe.SourceObjectParams{
-		Type:     "bitcoin",
-		Amount:   1000,
-		Currency: currency.USD,
+		Type:     stripe.String("bitcoin"),
+		Amount:   stripe.UInt64(1000),
+		Currency: stripe.String(string(currency.USD)),
+		Flow:     stripe.String(string(stripe.FlowReceiver)),
 		Owner: &stripe.SourceOwnerParams{
-			Email: "jenny.rosen@example.com",
+			Email: stripe.String("jenny.rosen@example.com"),
 		},
 	})
 	assert.Nil(t, err)
@@ -31,7 +32,7 @@ func TestSourceNew(t *testing.T) {
 func TestSourceUpdate(t *testing.T) {
 	source, err := Update("src_123", &stripe.SourceObjectParams{
 		Owner: &stripe.SourceOwnerParams{
-			Email: "jenny.rosen@example.com",
+			Email: stripe.String("jenny.rosen@example.com"),
 		},
 	})
 	assert.Nil(t, err)
@@ -40,7 +41,7 @@ func TestSourceUpdate(t *testing.T) {
 
 func TestSourceDetach(t *testing.T) {
 	source, err := Detach("src_123", &stripe.SourceObjectDetachParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, source)
@@ -48,10 +49,10 @@ func TestSourceDetach(t *testing.T) {
 
 func TestSourceSharing(t *testing.T) {
 	params := &stripe.SourceObjectParams{
-		Type:           "card",
-		Customer:       "cus_123",
-		OriginalSource: "src_123",
-		Usage:          stripe.UsageReusable,
+		Type:           stripe.String("card"),
+		Customer:       stripe.String("cus_123"),
+		OriginalSource: stripe.String("src_123"),
+		Usage:          stripe.String(string(stripe.UsageReusable)),
 	}
 	params.SetStripeAccount("acct_123")
 	source, err := New(params)

--- a/source/client_test.go
+++ b/source/client_test.go
@@ -18,7 +18,7 @@ func TestSourceGet(t *testing.T) {
 func TestSourceNew(t *testing.T) {
 	source, err := New(&stripe.SourceObjectParams{
 		Type:     stripe.String("bitcoin"),
-		Amount:   stripe.UInt64(1000),
+		Amount:   stripe.Int64(1000),
 		Currency: stripe.String(string(currency.USD)),
 		Flow:     stripe.String(string(stripe.FlowReceiver)),
 		Owner: &stripe.SourceOwnerParams{

--- a/source_test.go
+++ b/source_test.go
@@ -12,7 +12,7 @@ func TestSourceObjectParams_AppendTo(t *testing.T) {
 	// encoding
 	{
 		params := &SourceObjectParams{
-			Type: "source_type",
+			Type: String("source_type"),
 			TypeData: map[string]string{
 				"foo": "bar",
 			},

--- a/sourcetransaction.go
+++ b/sourcetransaction.go
@@ -5,7 +5,7 @@ import "encoding/json"
 // SourceTransactionListParams is the set of parameters that can be used when listing SourceTransactions.
 type SourceTransactionListParams struct {
 	ListParams `form:"*"`
-	Source     string `form:"-"` // Sent in with the URL
+	Source     *string `form:"-"` // Sent in with the URL
 }
 
 // SourceTransactionList is a list object for SourceTransactions.

--- a/sourcetransaction.go
+++ b/sourcetransaction.go
@@ -11,7 +11,7 @@ type SourceTransactionListParams struct {
 // SourceTransactionList is a list object for SourceTransactions.
 type SourceTransactionList struct {
 	ListMeta
-	Values []*SourceTransaction `json:"data"`
+	Data []*SourceTransaction `json:"data"`
 }
 
 // SourceTransaction is the resource representing a Stripe source transaction.

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -34,7 +34,7 @@ func (c Client) List(params *stripe.SourceTransactionListParams) *Iter {
 		list := &stripe.SourceTransactionList{}
 		var err error
 
-		if params != nil && len(params.Source) > 0 {
+		if params != nil && params.Source != nil {
 			err = c.B.Call("GET", fmt.Sprintf("/sources/%v/source_transactions", params.Source), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid source transaction params: Source needs to be set")

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -40,8 +40,8 @@ func (c Client) List(params *stripe.SourceTransactionListParams) *Iter {
 			err = errors.New("Invalid source transaction params: Source needs to be set")
 		}
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/sourcetransaction/client_test.go
+++ b/sourcetransaction/client_test.go
@@ -13,7 +13,7 @@ func TestSourceTransactionList(t *testing.T) {
 	t.Skip("not yet supported by stripe-mock")
 
 	i := List(&stripe.SourceTransactionListParams{
-		Source: "src_123",
+		Source: stripe.String("src_123"),
 	})
 
 	// Verify that we can get at least one transaction

--- a/stripe.go
+++ b/stripe.go
@@ -285,11 +285,6 @@ func (s *BackendConfiguration) NewRequest(method, path, key, contentType string,
 			req.Header.Add("Idempotency-Key", idempotency)
 		}
 
-		// Support the value of the old Account field for now.
-		if account := strings.TrimSpace(params.Account); account != "" {
-			req.Header.Add("Stripe-Account", account)
-		}
-
 		// But prefer StripeAccount.
 		if stripeAccount := strings.TrimSpace(params.StripeAccount); stripeAccount != "" {
 			req.Header.Add("Stripe-Account", stripeAccount)

--- a/stripe.go
+++ b/stripe.go
@@ -480,3 +480,115 @@ func initUserAgent() {
 	}
 	encodedStripeUserAgent = string(marshaled)
 }
+
+// Bool returns a pointer to the bool value passed in.
+func Bool(v bool) *bool {
+	return &v
+}
+
+// BoolValue returns the value of the bool pointer passed in or
+// false if the pointer is nil.
+func BoolValue(v *bool) bool {
+	if v != nil {
+		return *v
+	}
+	return false
+}
+
+// String returns a pointer to the string value passed in.
+func String(v string) *string {
+	return &v
+}
+
+// StringValue returns the value of the string pointer passed in or
+// "" if the pointer is nil.
+func StringValue(v *string) string {
+	if v != nil {
+		return *v
+	}
+	return ""
+}
+
+// Int returns a pointer to the int value passed in.
+func Int(v int) *int {
+	return &v
+}
+
+// IntValue returns the value of the int pointer passed in or
+// 0 if the pointer is nil.
+func IntValue(v *int) int {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// UInt returns a pointer to the uint value passed in.
+func UInt(v uint) *uint {
+	return &v
+}
+
+// UIntValue returns the value of the uint pointer passed in or
+// 0 if the pointer is nil.
+func UIntValue(v *uint) uint {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int64 returns a pointer to the int64 value passed in.
+func Int64(v int64) *int64 {
+	return &v
+}
+
+// Int64Value returns the value of the int64 pointer passed in or
+// 0 if the pointer is nil.
+func Int64Value(v *int64) int64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// UInt64 returns a pointer to the uint64 value passed in.
+func UInt64(v uint64) *uint64 {
+	return &v
+}
+
+// UInt64Value returns the value of the uint64 pointer passed in or
+// 0 if the pointer is nil.
+func UInt64Value(v *uint64) uint64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Float32 returns a pointer to the float32 value passed in.
+func Float32(v float32) *float32 {
+	return &v
+}
+
+// Float32Value returns the value of the float32 pointer passed in or
+// 0 if the pointer is nil.
+func Float32Value(v *float32) float32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Float64 returns a pointer to the float64 value passed in.
+func Float64(v float64) *float64 {
+	return &v
+}
+
+// Float64Value returns the value of the float64 pointer passed in or
+// 0 if the pointer is nil.
+func Float64Value(v *float64) float64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}

--- a/stripe.go
+++ b/stripe.go
@@ -509,34 +509,6 @@ func StringValue(v *string) string {
 	return ""
 }
 
-// Int returns a pointer to the int value passed in.
-func Int(v int) *int {
-	return &v
-}
-
-// IntValue returns the value of the int pointer passed in or
-// 0 if the pointer is nil.
-func IntValue(v *int) int {
-	if v != nil {
-		return *v
-	}
-	return 0
-}
-
-// UInt returns a pointer to the uint value passed in.
-func UInt(v uint) *uint {
-	return &v
-}
-
-// UIntValue returns the value of the uint pointer passed in or
-// 0 if the pointer is nil.
-func UIntValue(v *uint) uint {
-	if v != nil {
-		return *v
-	}
-	return 0
-}
-
 // Int64 returns a pointer to the int64 value passed in.
 func Int64(v int64) *int64 {
 	return &v
@@ -545,34 +517,6 @@ func Int64(v int64) *int64 {
 // Int64Value returns the value of the int64 pointer passed in or
 // 0 if the pointer is nil.
 func Int64Value(v *int64) int64 {
-	if v != nil {
-		return *v
-	}
-	return 0
-}
-
-// UInt64 returns a pointer to the uint64 value passed in.
-func UInt64(v uint64) *uint64 {
-	return &v
-}
-
-// UInt64Value returns the value of the uint64 pointer passed in or
-// 0 if the pointer is nil.
-func UInt64Value(v *uint64) uint64 {
-	if v != nil {
-		return *v
-	}
-	return 0
-}
-
-// Float32 returns a pointer to the float32 value passed in.
-func Float32(v float32) *float32 {
-	return &v
-}
-
-// Float32Value returns the value of the float32 pointer passed in or
-// 0 if the pointer is nil.
-func Float32Value(v *float32) float32 {
 	if v != nil {
 		return *v
 	}

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -105,15 +105,6 @@ func TestStripeAccount(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, TestMerchantID, req.Header.Get("Stripe-Account"))
-
-	// Also test the deprecated Account field for now as well. This should be
-	// identical to the exercise above.
-	p = &stripe.Params{Account: TestMerchantID}
-
-	req, err = c.NewRequest("", "", "", "", nil, p)
-	assert.NoError(t, err)
-
-	assert.Equal(t, TestMerchantID, req.Header.Get("Stripe-Account"))
 }
 
 func TestUserAgent(t *testing.T) {
@@ -219,7 +210,7 @@ func TestResponseToError(t *testing.T) {
 	// An error that contains expected fields which we're going to serialize to
 	// JSON and inject into our conversion function.
 	expectedErr := &stripe.Error{
-		Code:  stripe.Missing,
+		Code:  stripe.ErrorCodeMissing,
 		Msg:   "That card was declined",
 		Param: "expiry_date",
 		Type:  stripe.ErrorTypeCard,

--- a/sub.go
+++ b/sub.go
@@ -19,45 +19,45 @@ type SubscriptionBilling string
 type SubscriptionParams struct {
 	Params                      `form:"*"`
 	ApplicationFeePercent       *float64                   `form:"application_fee_percent"`
-	Billing                     SubscriptionBilling        `form:"billing"`
-	BillingCycleAnchor          int64                      `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow       bool                       `form:"-"` // See custom AppendTo
-	BillingCycleAnchorUnchanged bool                       `form:"-"` // See custom AppendTo
+	Billing                     *string                    `form:"billing"`
+	BillingCycleAnchor          *int64                     `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       *bool                      `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged *bool                      `form:"-"` // See custom AppendTo
 	Card                        *CardParams                `form:"card"`
 	Coupon                      *string                    `form:"coupon"`
-	Customer                    string                     `form:"customer"`
-	DaysUntilDue                uint64                     `form:"days_until_due"`
+	Customer                    *string                    `form:"customer"`
+	DaysUntilDue                *uint64                    `form:"days_until_due"`
 	Items                       []*SubscriptionItemsParams `form:"items,indexed"`
-	OnBehalfOf                  string                     `form:"on_behalf_of"`
-	Plan                        string                     `form:"plan"`
+	OnBehalfOf                  *string                    `form:"on_behalf_of"`
+	Plan                        *string                    `form:"plan"`
 	Prorate                     *bool                      `form:"prorate"`
-	ProrationDate               int64                      `form:"proration_date"`
+	ProrationDate               *int64                     `form:"proration_date"`
 	Quantity                    *uint64                    `form:"quantity"`
-	Source                      string                     `form:"source"`
+	Source                      *string                    `form:"source"`
 	TaxPercent                  *float64                   `form:"tax_percent"`
-	TrialEnd                    int64                      `form:"trial_end"`
-	TrialEndNow                 bool                       `form:"-"` // See custom AppendTo
-	TrialFromPlan               bool                       `form:"trial_from_plan"`
-	TrialPeriodDays             int64                      `form:"trial_period_days"`
+	TrialEnd                    *int64                     `form:"trial_end"`
+	TrialEndNow                 *bool                      `form:"-"` // See custom AppendTo
+	TrialFromPlan               *bool                      `form:"trial_from_plan"`
+	TrialPeriodDays             *int64                     `form:"trial_period_days"`
 
 	// Used for Cancel
 
-	AtPeriodEnd bool `form:"at_period_end"`
+	AtPeriodEnd *bool `form:"at_period_end"`
 }
 
 // AppendTo implements custom encoding logic for SubscriptionParams so that the special
 // "now" value for billing_cycle_anchor and trial_end can be implemented
 // (they're otherwise timestamps rather than strings).
 func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
-	if p.BillingCycleAnchorNow {
+	if p.BillingCycleAnchorNow != nil {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "now")
 	}
 
-	if p.BillingCycleAnchorUnchanged {
+	if p.BillingCycleAnchorUnchanged != nil {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "unchanged")
 	}
 
-	if p.TrialEndNow {
+	if p.TrialEndNow != nil {
 		body.Add(form.FormatKey(append(keyParts, "trial_end")), "now")
 	}
 }

--- a/sub.go
+++ b/sub.go
@@ -6,53 +6,53 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
-// SubStatus is the list of allowed values for the subscription's status.
+// SubscriptionStatus is the list of allowed values for the subscription's status.
 // Allowed values are "trialing", "active", "past_due", "canceled", "unpaid", "all".
-type SubStatus string
+type SubscriptionStatus string
 
-// SubBilling is the type of billing method for this subscription's invoices.
+// SubscriptionBilling is the type of billing method for this subscription's invoices.
 // Currently supported values are "send_invoice" and "charge_automatically".
-type SubBilling string
+type SubscriptionBilling string
 
-// SubParams is the set of parameters that can be used when creating or updating a subscription.
+// SubscriptionParams is the set of parameters that can be used when creating or updating a subscription.
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
-type SubParams struct {
+type SubscriptionParams struct {
 	Params                      `form:"*"`
-	Billing                     SubBilling        `form:"billing"`
-	BillingCycleAnchor          int64             `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow       bool              `form:"-"` // See custom AppendTo
-	BillingCycleAnchorUnchanged bool              `form:"-"` // See custom AppendTo
-	Card                        *CardParams       `form:"card"`
-	Coupon                      string            `form:"coupon"`
-	CouponEmpty                 bool              `form:"coupon,empty"`
-	Customer                    string            `form:"customer"`
-	DaysUntilDue                uint64            `form:"days_until_due"`
-	FeePercent                  float64           `form:"application_fee_percent"`
-	FeePercentZero              bool              `form:"application_fee_percent,zero"`
-	Items                       []*SubItemsParams `form:"items,indexed"`
-	NoProrate                   bool              `form:"prorate,invert"`
-	OnBehalfOf                  string            `form:"on_behalf_of"`
-	Plan                        string            `form:"plan"`
-	ProrationDate               int64             `form:"proration_date"`
-	Quantity                    uint64            `form:"quantity"`
-	QuantityZero                bool              `form:"quantity,zero"`
-	TaxPercent                  float64           `form:"tax_percent"`
-	TaxPercentZero              bool              `form:"tax_percent,zero"`
-	Token                       string            `form:"card"`
-	TrialEnd                    int64             `form:"trial_end"`
-	TrialEndNow                 bool              `form:"-"` // See custom AppendTo
-	TrialFromPlan               bool              `form:"trial_from_plan"`
-	TrialPeriod                 int64             `form:"trial_period_days"`
+	ApplicationFeePercent       float64                    `form:"application_fee_percent"`
+	ApplicationFeePercentZero   bool                       `form:"application_fee_percent,zero"`
+	Billing                     SubscriptionBilling        `form:"billing"`
+	BillingCycleAnchor          int64                      `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       bool                       `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged bool                       `form:"-"` // See custom AppendTo
+	Card                        *CardParams                `form:"card"`
+	Coupon                      string                     `form:"coupon"`
+	CouponEmpty                 bool                       `form:"coupon,empty"`
+	Customer                    string                     `form:"customer"`
+	DaysUntilDue                uint64                     `form:"days_until_due"`
+	Items                       []*SubscriptionItemsParams `form:"items,indexed"`
+	NoProrate                   bool                       `form:"prorate,invert"`
+	OnBehalfOf                  string                     `form:"on_behalf_of"`
+	Plan                        string                     `form:"plan"`
+	ProrationDate               int64                      `form:"proration_date"`
+	Quantity                    uint64                     `form:"quantity"`
+	QuantityZero                bool                       `form:"quantity,zero"`
+	Source                      string                     `form:"source"`
+	TaxPercent                  float64                    `form:"tax_percent"`
+	TaxPercentZero              bool                       `form:"tax_percent,zero"`
+	TrialEnd                    int64                      `form:"trial_end"`
+	TrialEndNow                 bool                       `form:"-"` // See custom AppendTo
+	TrialFromPlan               bool                       `form:"trial_from_plan"`
+	TrialPeriodDays             int64                      `form:"trial_period_days"`
 
 	// Used for Cancel
 
-	EndCancel bool `form:"at_period_end"`
+	AtPeriodEnd bool `form:"at_period_end"`
 }
 
-// AppendTo implements custom encoding logic for SubParams so that the special
+// AppendTo implements custom encoding logic for SubscriptionParams so that the special
 // "now" value for billing_cycle_anchor and trial_end can be implemented
 // (they're otherwise timestamps rather than strings).
-func (p *SubParams) AppendTo(body *form.Values, keyParts []string) {
+func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.BillingCycleAnchorNow {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "now")
 	}
@@ -66,9 +66,9 @@ func (p *SubParams) AppendTo(body *form.Values, keyParts []string) {
 	}
 }
 
-// SubItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription
+// SubscriptionItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
-type SubItemsParams struct {
+type SubscriptionItemsParams struct {
 	Params       `form:"*"`
 	ClearUsage   bool   `form:"clear_usage"`
 	Deleted      bool   `form:"deleted"`
@@ -78,60 +78,60 @@ type SubItemsParams struct {
 	QuantityZero bool   `form:"quantity,zero"`
 }
 
-// SubListParams is the set of parameters that can be used when listing active subscriptions.
+// SubscriptionListParams is the set of parameters that can be used when listing active subscriptions.
 // For more details see https://stripe.com/docs/api#list_subscriptions.
-type SubListParams struct {
+type SubscriptionListParams struct {
 	ListParams   `form:"*"`
-	Billing      SubBilling        `form:"billing"`
-	Created      int64             `form:"created"`
-	CreatedRange *RangeQueryParams `form:"created"`
-	Customer     string            `form:"customer"`
-	Plan         string            `form:"plan"`
-	Status       SubStatus         `form:"status"`
+	Billing      SubscriptionBilling `form:"billing"`
+	Created      int64               `form:"created"`
+	CreatedRange *RangeQueryParams   `form:"created"`
+	Customer     string              `form:"customer"`
+	Plan         string              `form:"plan"`
+	Status       SubscriptionStatus  `form:"status"`
 }
 
-// Sub is the resource representing a Stripe subscription.
+// Subscription is the resource representing a Stripe subscription.
 // For more details see https://stripe.com/docs/api#subscriptions.
-type Sub struct {
-	Billing            SubBilling        `json:"billing"`
-	BillingCycleAnchor int64             `json:"billing_cycle_anchor"`
-	Canceled           int64             `json:"canceled_at"`
-	Created            int64             `json:"created"`
-	Customer           *Customer         `json:"customer"`
-	DaysUntilDue       uint64            `json:"days_until_due"`
-	Discount           *Discount         `json:"discount"`
-	EndCancel          bool              `json:"cancel_at_period_end"`
-	Ended              int64             `json:"ended_at"`
-	FeePercent         float64           `json:"application_fee_percent"`
-	ID                 string            `json:"id"`
-	Items              *SubItemList      `json:"items"`
-	Meta               map[string]string `json:"metadata"`
-	PeriodEnd          int64             `json:"current_period_end"`
-	PeriodStart        int64             `json:"current_period_start"`
-	Plan               *Plan             `json:"plan"`
-	Quantity           uint64            `json:"quantity"`
-	Start              int64             `json:"start"`
-	Status             SubStatus         `json:"status"`
-	TaxPercent         float64           `json:"tax_percent"`
-	TrialEnd           int64             `json:"trial_end"`
-	TrialStart         int64             `json:"trial_start"`
+type Subscription struct {
+	ApplicationFeePercent float64               `json:"application_fee_percent"`
+	Billing               SubscriptionBilling   `json:"billing"`
+	BillingCycleAnchor    int64                 `json:"billing_cycle_anchor"`
+	CanceledAt            int64                 `json:"canceled_at"`
+	Created               int64                 `json:"created"`
+	CurrentPeriodEnd      int64                 `json:"current_period_end"`
+	CurrentPeriodStart    int64                 `json:"current_period_start"`
+	Customer              *Customer             `json:"customer"`
+	DaysUntilDue          uint64                `json:"days_until_due"`
+	Discount              *Discount             `json:"discount"`
+	CancelAtPeriodEnd     bool                  `json:"cancel_at_period_end"`
+	EndedAt               int64                 `json:"ended_at"`
+	ID                    string                `json:"id"`
+	Items                 *SubscriptionItemList `json:"items"`
+	Metadata              map[string]string     `json:"metadata"`
+	Plan                  *Plan                 `json:"plan"`
+	Quantity              uint64                `json:"quantity"`
+	Start                 int64                 `json:"start"`
+	Status                SubscriptionStatus    `json:"status"`
+	TaxPercent            float64               `json:"tax_percent"`
+	TrialEnd              int64                 `json:"trial_end"`
+	TrialStart            int64                 `json:"trial_start"`
 }
 
-// SubList is a list object for subscriptions.
-type SubList struct {
+// SubscriptionList is a list object for subscriptions.
+type SubscriptionList struct {
 	ListMeta
-	Values []*Sub `json:"data"`
+	Data []*Subscription `json:"data"`
 }
 
-// UnmarshalJSON handles deserialization of a Sub.
+// UnmarshalJSON handles deserialization of a Subscription.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (s *Sub) UnmarshalJSON(data []byte) error {
-	type sub Sub
+func (s *Subscription) UnmarshalJSON(data []byte) error {
+	type sub Subscription
 	var ss sub
 	err := json.Unmarshal(data, &ss)
 	if err == nil {
-		*s = Sub(ss)
+		*s = Subscription(ss)
 	} else {
 		// the id is surrounded by "\" characters, so strip them
 		s.ID = string(data[1 : len(data)-1])

--- a/sub.go
+++ b/sub.go
@@ -26,13 +26,13 @@ type SubscriptionParams struct {
 	Card                        *CardParams                `form:"card"`
 	Coupon                      *string                    `form:"coupon"`
 	Customer                    *string                    `form:"customer"`
-	DaysUntilDue                *uint64                    `form:"days_until_due"`
+	DaysUntilDue                *int64                     `form:"days_until_due"`
 	Items                       []*SubscriptionItemsParams `form:"items,indexed"`
 	OnBehalfOf                  *string                    `form:"on_behalf_of"`
 	Plan                        *string                    `form:"plan"`
 	Prorate                     *bool                      `form:"prorate"`
 	ProrationDate               *int64                     `form:"proration_date"`
-	Quantity                    *uint64                    `form:"quantity"`
+	Quantity                    *int64                     `form:"quantity"`
 	Source                      *string                    `form:"source"`
 	TaxPercent                  *float64                   `form:"tax_percent"`
 	TrialEnd                    *int64                     `form:"trial_end"`
@@ -66,11 +66,11 @@ func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubscriptionItemsParams struct {
 	Params     `form:"*"`
-	ClearUsage bool    `form:"clear_usage"`
-	Deleted    bool    `form:"deleted"`
-	ID         string  `form:"id"`
-	Plan       string  `form:"plan"`
-	Quantity   *uint64 `form:"quantity"`
+	ClearUsage bool   `form:"clear_usage"`
+	Deleted    bool   `form:"deleted"`
+	ID         string `form:"id"`
+	Plan       string `form:"plan"`
+	Quantity   *int64 `form:"quantity"`
 }
 
 // SubscriptionListParams is the set of parameters that can be used when listing active subscriptions.
@@ -96,7 +96,7 @@ type Subscription struct {
 	CurrentPeriodEnd      int64                 `json:"current_period_end"`
 	CurrentPeriodStart    int64                 `json:"current_period_start"`
 	Customer              *Customer             `json:"customer"`
-	DaysUntilDue          uint64                `json:"days_until_due"`
+	DaysUntilDue          int64                 `json:"days_until_due"`
 	Discount              *Discount             `json:"discount"`
 	CancelAtPeriodEnd     bool                  `json:"cancel_at_period_end"`
 	EndedAt               int64                 `json:"ended_at"`
@@ -104,7 +104,7 @@ type Subscription struct {
 	Items                 *SubscriptionItemList `json:"items"`
 	Metadata              map[string]string     `json:"metadata"`
 	Plan                  *Plan                 `json:"plan"`
-	Quantity              uint64                `json:"quantity"`
+	Quantity              int64                 `json:"quantity"`
 	Start                 int64                 `json:"start"`
 	Status                SubscriptionStatus    `json:"status"`
 	TaxPercent            float64               `json:"tax_percent"`

--- a/sub.go
+++ b/sub.go
@@ -18,27 +18,23 @@ type SubscriptionBilling string
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubscriptionParams struct {
 	Params                      `form:"*"`
-	ApplicationFeePercent       float64                    `form:"application_fee_percent"`
-	ApplicationFeePercentZero   bool                       `form:"application_fee_percent,zero"`
+	ApplicationFeePercent       *float64                   `form:"application_fee_percent"`
 	Billing                     SubscriptionBilling        `form:"billing"`
 	BillingCycleAnchor          int64                      `form:"billing_cycle_anchor"`
 	BillingCycleAnchorNow       bool                       `form:"-"` // See custom AppendTo
 	BillingCycleAnchorUnchanged bool                       `form:"-"` // See custom AppendTo
 	Card                        *CardParams                `form:"card"`
-	Coupon                      string                     `form:"coupon"`
-	CouponEmpty                 bool                       `form:"coupon,empty"`
+	Coupon                      *string                    `form:"coupon"`
 	Customer                    string                     `form:"customer"`
 	DaysUntilDue                uint64                     `form:"days_until_due"`
 	Items                       []*SubscriptionItemsParams `form:"items,indexed"`
-	NoProrate                   bool                       `form:"prorate,invert"`
 	OnBehalfOf                  string                     `form:"on_behalf_of"`
 	Plan                        string                     `form:"plan"`
+	Prorate                     *bool                      `form:"prorate"`
 	ProrationDate               int64                      `form:"proration_date"`
-	Quantity                    uint64                     `form:"quantity"`
-	QuantityZero                bool                       `form:"quantity,zero"`
+	Quantity                    *uint64                    `form:"quantity"`
 	Source                      string                     `form:"source"`
-	TaxPercent                  float64                    `form:"tax_percent"`
-	TaxPercentZero              bool                       `form:"tax_percent,zero"`
+	TaxPercent                  *float64                   `form:"tax_percent"`
 	TrialEnd                    int64                      `form:"trial_end"`
 	TrialEndNow                 bool                       `form:"-"` // See custom AppendTo
 	TrialFromPlan               bool                       `form:"trial_from_plan"`
@@ -69,13 +65,12 @@ func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
 // SubscriptionItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubscriptionItemsParams struct {
-	Params       `form:"*"`
-	ClearUsage   bool   `form:"clear_usage"`
-	Deleted      bool   `form:"deleted"`
-	ID           string `form:"id"`
-	Plan         string `form:"plan"`
-	Quantity     uint64 `form:"quantity"`
-	QuantityZero bool   `form:"quantity,zero"`
+	Params     `form:"*"`
+	ClearUsage bool    `form:"clear_usage"`
+	Deleted    bool    `form:"deleted"`
+	ID         string  `form:"id"`
+	Plan       string  `form:"plan"`
+	Quantity   *uint64 `form:"quantity"`
 }
 
 // SubscriptionListParams is the set of parameters that can be used when listing active subscriptions.

--- a/sub.go
+++ b/sub.go
@@ -66,11 +66,11 @@ func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubscriptionItemsParams struct {
 	Params     `form:"*"`
-	ClearUsage bool   `form:"clear_usage"`
-	Deleted    bool   `form:"deleted"`
-	ID         string `form:"id"`
-	Plan       string `form:"plan"`
-	Quantity   *int64 `form:"quantity"`
+	ClearUsage *bool   `form:"clear_usage"`
+	Deleted    *bool   `form:"deleted"`
+	ID         *string `form:"id"`
+	Plan       *string `form:"plan"`
+	Quantity   *int64  `form:"quantity"`
 }
 
 // SubscriptionListParams is the set of parameters that can be used when listing active subscriptions.

--- a/sub/client.go
+++ b/sub/client.go
@@ -9,12 +9,12 @@ import (
 )
 
 const (
-	Trialing stripe.SubStatus = "trialing"
-	Active   stripe.SubStatus = "active"
-	PastDue  stripe.SubStatus = "past_due"
-	Canceled stripe.SubStatus = "canceled"
-	Unpaid   stripe.SubStatus = "unpaid"
-	All      stripe.SubStatus = "all"
+	Trialing stripe.SubscriptionStatus = "trialing"
+	Active   stripe.SubscriptionStatus = "active"
+	PastDue  stripe.SubscriptionStatus = "past_due"
+	Canceled stripe.SubscriptionStatus = "canceled"
+	Unpaid   stripe.SubscriptionStatus = "unpaid"
+	All      stripe.SubscriptionStatus = "all"
 )
 
 // Client is used to invoke /subscriptions APIs.
@@ -25,11 +25,11 @@ type Client struct {
 
 // New POSTS a new subscription for a customer.
 // For more details see https://stripe.com/docs/api#create_subscription.
-func New(params *stripe.SubParams) (*stripe.Sub, error) {
+func New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().New(params)
 }
 
-func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
+func (c Client) New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -39,7 +39,7 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 		form.AppendTo(body, params)
 	}
 
-	sub := &stripe.Sub{}
+	sub := &stripe.Subscription{}
 	err := c.B.Call("POST", "/subscriptions", c.Key, body, commonParams, sub)
 
 	return sub, err
@@ -47,11 +47,11 @@ func (c Client) New(params *stripe.SubParams) (*stripe.Sub, error) {
 
 // Get returns the details of a subscription.
 // For more details see https://stripe.com/docs/api#retrieve_subscription.
-func Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -61,7 +61,7 @@ func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 		commonParams = &params.Params
 	}
 
-	sub := &stripe.Sub{}
+	sub := &stripe.Subscription{}
 	err := c.B.Call("GET", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
 
 	return sub, err
@@ -69,11 +69,11 @@ func (c Client) Get(id string, params *stripe.SubParams) (*stripe.Sub, error) {
 
 // Update updates a subscription's properties.
 // For more details see https://stripe.com/docs/api#update_subscription.
-func Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().Update(id, params)
 }
 
-func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -83,7 +83,7 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 		form.AppendTo(body, params)
 	}
 
-	sub := &stripe.Sub{}
+	sub := &stripe.Subscription{}
 	err := c.B.Call("POST", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
 
 	return sub, err
@@ -91,11 +91,11 @@ func (c Client) Update(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 // Cancel removes a subscription.
 // For more details see https://stripe.com/docs/api#cancel_subscription.
-func Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func Cancel(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().Cancel(id, params)
 }
 
-func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error) {
+func (c Client) Cancel(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -105,7 +105,7 @@ func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error)
 		form.AppendTo(body, params)
 	}
 
-	sub := &stripe.Sub{}
+	sub := &stripe.Subscription{}
 	err := c.B.Call("DELETE", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
 
 	return sub, err
@@ -113,11 +113,11 @@ func (c Client) Cancel(id string, params *stripe.SubParams) (*stripe.Sub, error)
 
 // List returns a list of subscriptions.
 // For more details see https://stripe.com/docs/api#list_subscriptions.
-func List(params *stripe.SubListParams) *Iter {
+func List(params *stripe.SubscriptionListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SubListParams) *Iter {
+func (c Client) List(params *stripe.SubscriptionListParams) *Iter {
 	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -130,11 +130,11 @@ func (c Client) List(params *stripe.SubListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.SubList{}
+		list := &stripe.SubscriptionList{}
 		err := c.B.Call("GET", "/subscriptions", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -149,10 +149,10 @@ type Iter struct {
 	*stripe.Iter
 }
 
-// Sub returns the most recent Sub
+// Subscription returns the most recent Subscription
 // visited by a call to Next.
-func (i *Iter) Sub() *stripe.Sub {
-	return i.Current().(*stripe.Sub)
+func (i *Iter) Subscription() *stripe.Subscription {
+	return i.Current().(*stripe.Subscription)
 }
 
 func getC() Client {

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -32,14 +32,14 @@ func TestSubscriptionList(t *testing.T) {
 
 func TestSubscriptionNew(t *testing.T) {
 	subscription, err := New(&stripe.SubscriptionParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 		Items: []*stripe.SubscriptionItemsParams{
 			{Plan: "plan_123", Quantity: stripe.UInt64(10)},
 		},
 		TaxPercent:         stripe.Float64(20.0),
-		BillingCycleAnchor: time.Now().AddDate(0, 0, 12).Unix(),
-		Billing:            "send_invoice",
-		DaysUntilDue:       30,
+		BillingCycleAnchor: stripe.Int64(time.Now().AddDate(0, 0, 12).Unix()),
+		Billing:            stripe.String("send_invoice"),
+		DaysUntilDue:       stripe.UInt64(30),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
@@ -47,7 +47,7 @@ func TestSubscriptionNew(t *testing.T) {
 
 func TestSubscriptionNew_WithItems(t *testing.T) {
 	subscription, err := New(&stripe.SubscriptionParams{
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 		Items: []*stripe.SubscriptionItemsParams{
 			{
 				Plan:     "gold",

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -34,9 +34,9 @@ func TestSubscriptionNew(t *testing.T) {
 	subscription, err := New(&stripe.SubscriptionParams{
 		Customer: "cus_123",
 		Items: []*stripe.SubscriptionItemsParams{
-			{Plan: "plan_123", Quantity: 10},
+			{Plan: "plan_123", Quantity: stripe.UInt64(10)},
 		},
-		TaxPercent:         20.0,
+		TaxPercent:         stripe.Float64(20.0),
 		BillingCycleAnchor: time.Now().AddDate(0, 0, 12).Unix(),
 		Billing:            "send_invoice",
 		DaysUntilDue:       30,
@@ -50,8 +50,8 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 		Customer: "cus_123",
 		Items: []*stripe.SubscriptionItemsParams{
 			{
-				Plan:         "gold",
-				QuantityZero: true,
+				Plan:     "gold",
+				Quantity: stripe.UInt64(0),
 			},
 		},
 	})
@@ -61,8 +61,9 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 
 func TestSubscriptionUpdate(t *testing.T) {
 	subscription, err := Update("sub_123", &stripe.SubscriptionParams{
-		NoProrate:      true,
-		TaxPercentZero: true,
+		Prorate:    stripe.Bool(true),
+		Quantity:   stripe.UInt64(0),
+		TaxPercent: stripe.Float64(0),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -9,31 +9,31 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestSubCancel(t *testing.T) {
+func TestSubscriptionCancel(t *testing.T) {
 	subscription, err := Cancel("sub_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
 }
 
-func TestSubGet(t *testing.T) {
+func TestSubscriptionGet(t *testing.T) {
 	subscription, err := Get("sub_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
 }
 
-func TestSubList(t *testing.T) {
-	i := List(&stripe.SubListParams{})
+func TestSubscriptionList(t *testing.T) {
+	i := List(&stripe.SubscriptionListParams{})
 
 	// Verify that we can get at least one subscription
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.Sub())
+	assert.NotNil(t, i.Subscription())
 }
 
-func TestSubNew(t *testing.T) {
-	subscription, err := New(&stripe.SubParams{
+func TestSubscriptionNew(t *testing.T) {
+	subscription, err := New(&stripe.SubscriptionParams{
 		Customer: "cus_123",
-		Items: []*stripe.SubItemsParams{
+		Items: []*stripe.SubscriptionItemsParams{
 			{Plan: "plan_123", Quantity: 10},
 		},
 		TaxPercent:         20.0,
@@ -45,10 +45,10 @@ func TestSubNew(t *testing.T) {
 	assert.NotNil(t, subscription)
 }
 
-func TestSubNew_WithItems(t *testing.T) {
-	subscription, err := New(&stripe.SubParams{
+func TestSubscriptionNew_WithItems(t *testing.T) {
+	subscription, err := New(&stripe.SubscriptionParams{
 		Customer: "cus_123",
-		Items: []*stripe.SubItemsParams{
+		Items: []*stripe.SubscriptionItemsParams{
 			{
 				Plan:         "gold",
 				QuantityZero: true,
@@ -59,8 +59,8 @@ func TestSubNew_WithItems(t *testing.T) {
 	assert.NotNil(t, subscription)
 }
 
-func TestSubUpdate(t *testing.T) {
-	subscription, err := Update("sub_123", &stripe.SubParams{
+func TestSubscriptionUpdate(t *testing.T) {
+	subscription, err := Update("sub_123", &stripe.SubscriptionParams{
 		NoProrate:      true,
 		TaxPercentZero: true,
 	})

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -50,7 +50,7 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 		Customer: stripe.String("cus_123"),
 		Items: []*stripe.SubscriptionItemsParams{
 			{
-				Plan:     "gold",
+				Plan:     stripe.String("gold"),
 				Quantity: stripe.Int64(0),
 			},
 		},

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -34,7 +34,7 @@ func TestSubscriptionNew(t *testing.T) {
 	subscription, err := New(&stripe.SubscriptionParams{
 		Customer: stripe.String("cus_123"),
 		Items: []*stripe.SubscriptionItemsParams{
-			{Plan: "plan_123", Quantity: stripe.Int64(10)},
+			{Plan: stripe.String("plan_123"), Quantity: stripe.Int64(10)},
 		},
 		TaxPercent:         stripe.Float64(20.0),
 		BillingCycleAnchor: stripe.Int64(time.Now().AddDate(0, 0, 12).Unix()),

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -34,12 +34,12 @@ func TestSubscriptionNew(t *testing.T) {
 	subscription, err := New(&stripe.SubscriptionParams{
 		Customer: stripe.String("cus_123"),
 		Items: []*stripe.SubscriptionItemsParams{
-			{Plan: "plan_123", Quantity: stripe.UInt64(10)},
+			{Plan: "plan_123", Quantity: stripe.Int64(10)},
 		},
 		TaxPercent:         stripe.Float64(20.0),
 		BillingCycleAnchor: stripe.Int64(time.Now().AddDate(0, 0, 12).Unix()),
 		Billing:            stripe.String("send_invoice"),
-		DaysUntilDue:       stripe.UInt64(30),
+		DaysUntilDue:       stripe.Int64(30),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
@@ -51,7 +51,7 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 		Items: []*stripe.SubscriptionItemsParams{
 			{
 				Plan:     "gold",
-				Quantity: stripe.UInt64(0),
+				Quantity: stripe.Int64(0),
 			},
 		},
 	})
@@ -62,7 +62,7 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 func TestSubscriptionUpdate(t *testing.T) {
 	subscription, err := Update("sub_123", &stripe.SubscriptionParams{
 		Prorate:    stripe.Bool(true),
-		Quantity:   stripe.UInt64(0),
+		Quantity:   stripe.Int64(0),
 		TaxPercent: stripe.Float64(0),
 	})
 	assert.Nil(t, err)

--- a/sub_test.go
+++ b/sub_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSubscriptionParams_AppendTo(t *testing.T) {
 	{
-		params := &SubscriptionParams{BillingCycleAnchorNow: true}
+		params := &SubscriptionParams{BillingCycleAnchorNow: Bool(true)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -17,7 +17,7 @@ func TestSubscriptionParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SubscriptionParams{BillingCycleAnchorUnchanged: true}
+		params := &SubscriptionParams{BillingCycleAnchorUnchanged: Bool(true)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -25,7 +25,7 @@ func TestSubscriptionParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SubscriptionParams{TrialEndNow: true}
+		params := &SubscriptionParams{TrialEndNow: Bool(true)}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/sub_test.go
+++ b/sub_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
-func TestSubParams_AppendTo(t *testing.T) {
+func TestSubscriptionParams_AppendTo(t *testing.T) {
 	{
-		params := &SubParams{BillingCycleAnchorNow: true}
+		params := &SubscriptionParams{BillingCycleAnchorNow: true}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -17,7 +17,7 @@ func TestSubParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SubParams{BillingCycleAnchorUnchanged: true}
+		params := &SubscriptionParams{BillingCycleAnchorUnchanged: true}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
@@ -25,7 +25,7 @@ func TestSubParams_AppendTo(t *testing.T) {
 	}
 
 	{
-		params := &SubParams{TrialEndNow: true}
+		params := &SubscriptionParams{TrialEndNow: true}
 		body := &form.Values{}
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)

--- a/subitem.go
+++ b/subitem.go
@@ -4,13 +4,12 @@ package stripe
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
 type SubscriptionItemParams struct {
 	Params        `form:"*"`
-	ID            string `form:"-"` // Handled in URL
-	NoProrate     bool   `form:"prorate,invert"`
-	Plan          string `form:"plan"`
-	ProrationDate int64  `form:"proration_date"`
-	Quantity      uint64 `form:"quantity"`
-	QuantityZero  bool   `form:"quantity,zero"`
-	Subscription  string `form:"subscription"`
+	ID            string  `form:"-"` // Handled in URL
+	Plan          string  `form:"plan"`
+	Prorate       *bool   `form:"prorate"`
+	ProrationDate int64   `form:"proration_date"`
+	Quantity      *uint64 `form:"quantity"`
+	Subscription  string  `form:"subscription"`
 }
 
 // SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.

--- a/subitem.go
+++ b/subitem.go
@@ -1,8 +1,8 @@
 package stripe
 
-// SubItemParams is the set of parameters that can be used when creating or updating a subscription item.
+// SubscriptionItemParams is the set of parameters that can be used when creating or updating a subscription item.
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
-type SubItemParams struct {
+type SubscriptionItemParams struct {
 	Params        `form:"*"`
 	ID            string `form:"-"` // Handled in URL
 	NoProrate     bool   `form:"prorate,invert"`
@@ -10,29 +10,29 @@ type SubItemParams struct {
 	ProrationDate int64  `form:"proration_date"`
 	Quantity      uint64 `form:"quantity"`
 	QuantityZero  bool   `form:"quantity,zero"`
-	Sub           string `form:"subscription"`
+	Subscription  string `form:"subscription"`
 }
 
-// SubItemListParams is the set of parameters that can be used when listing invoice items.
+// SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
-type SubItemListParams struct {
-	ListParams `form:"*"`
-	Sub        string `form:"subscription"`
+type SubscriptionItemListParams struct {
+	ListParams   `form:"*"`
+	Subscription string `form:"subscription"`
 }
 
-// SubItem is the resource representing a Stripe subscription item.
+// SubscriptionItem is the resource representing a Stripe subscription item.
 // For more details see https://stripe.com/docs/api#subscription_items.
-type SubItem struct {
+type SubscriptionItem struct {
 	Created  int64             `json:"created"`
 	Deleted  bool              `json:"deleted"`
 	ID       string            `json:"id"`
-	Meta     map[string]string `json:"metadata"`
+	Metadata map[string]string `json:"metadata"`
 	Plan     *Plan             `json:"plan"`
 	Quantity uint64            `json:"quantity"`
 }
 
-// SubItemList is a list of invoice items as retrieved from a list endpoint.
-type SubItemList struct {
+// SubscriptionItemList is a list of invoice items as retrieved from a list endpoint.
+type SubscriptionItemList struct {
 	ListMeta
-	Values []*SubItem `json:"data"`
+	Data []*SubscriptionItem `json:"data"`
 }

--- a/subitem.go
+++ b/subitem.go
@@ -4,19 +4,19 @@ package stripe
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
 type SubscriptionItemParams struct {
 	Params        `form:"*"`
-	ID            string  `form:"-"` // Handled in URL
-	Plan          string  `form:"plan"`
+	ID            *string `form:"-"` // Handled in URL
+	Plan          *string `form:"plan"`
 	Prorate       *bool   `form:"prorate"`
-	ProrationDate int64   `form:"proration_date"`
+	ProrationDate *int64  `form:"proration_date"`
 	Quantity      *uint64 `form:"quantity"`
-	Subscription  string  `form:"subscription"`
+	Subscription  *string `form:"subscription"`
 }
 
 // SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
 type SubscriptionItemListParams struct {
 	ListParams   `form:"*"`
-	Subscription string `form:"subscription"`
+	Subscription *string `form:"subscription"`
 }
 
 // SubscriptionItem is the resource representing a Stripe subscription item.

--- a/subitem.go
+++ b/subitem.go
@@ -8,7 +8,7 @@ type SubscriptionItemParams struct {
 	Plan          *string `form:"plan"`
 	Prorate       *bool   `form:"prorate"`
 	ProrationDate *int64  `form:"proration_date"`
-	Quantity      *uint64 `form:"quantity"`
+	Quantity      *int64  `form:"quantity"`
 	Subscription  *string `form:"subscription"`
 }
 
@@ -27,7 +27,7 @@ type SubscriptionItem struct {
 	ID       string            `json:"id"`
 	Metadata map[string]string `json:"metadata"`
 	Plan     *Plan             `json:"plan"`
-	Quantity uint64            `json:"quantity"`
+	Quantity int64             `json:"quantity"`
 }
 
 // SubscriptionItemList is a list of invoice items as retrieved from a list endpoint.

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -1,4 +1,4 @@
-// Package sub provides the /subscriptions APIs
+// Package subitem provides the /subscription_items APIs
 package subitem
 
 import (
@@ -16,11 +16,11 @@ type Client struct {
 
 // New POSTS a new subscription for a customer.
 // For more details see https://stripe.com/docs/api#create_subscription_item.
-func New(params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().New(params)
 }
 
-func (c Client) New(params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func (c Client) New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 	token := c.Key
@@ -31,18 +31,18 @@ func (c Client) New(params *stripe.SubItemParams) (*stripe.SubItem, error) {
 		form.AppendTo(body, params)
 	}
 
-	item := &stripe.SubItem{}
+	item := &stripe.SubscriptionItem{}
 	err := c.B.Call("POST", "/subscription_items", token, body, commonParams, item)
 	return item, err
 }
 
 // Get returns the details of a subscription.
 // For more details see https://stripe.com/docs/api#retrieve_subscription.
-func Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -52,7 +52,7 @@ func (c Client) Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 		form.AppendTo(body, params)
 	}
 
-	item := &stripe.SubItem{}
+	item := &stripe.SubscriptionItem{}
 	err := c.B.Call("GET", fmt.Sprintf("/subscription_items/%v", id), c.Key, body, commonParams, item)
 
 	return item, err
@@ -60,11 +60,11 @@ func (c Client) Get(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 
 // Update updates a subscription's properties.
 // For more details see https://stripe.com/docs/api#update_subscription.
-func Update(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Update(id, params)
 }
 
-func (c Client) Update(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 	token := c.Key
@@ -75,7 +75,7 @@ func (c Client) Update(id string, params *stripe.SubItemParams) (*stripe.SubItem
 		form.AppendTo(body, params)
 	}
 
-	subi := &stripe.SubItem{}
+	subi := &stripe.SubscriptionItem{}
 	err := c.B.Call("POST", fmt.Sprintf("/subscription_items/%v", id), token, body, commonParams, subi)
 
 	return subi, err
@@ -83,11 +83,11 @@ func (c Client) Update(id string, params *stripe.SubItemParams) (*stripe.SubItem
 
 // Del removes a subscription item.
 // For more details see https://stripe.com/docs/api#cancel_subscription.
-func Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Del(id, params)
 }
 
-func (c Client) Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, error) {
+func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	var body *form.Values
 	var commonParams *stripe.Params
 
@@ -97,7 +97,7 @@ func (c Client) Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 		commonParams = &params.Params
 	}
 
-	item := &stripe.SubItem{}
+	item := &stripe.SubscriptionItem{}
 	err := c.B.Call("DELETE", fmt.Sprintf("/subscription_items/%v", id), c.Key, body, commonParams, item)
 
 	return item, err
@@ -105,11 +105,11 @@ func (c Client) Del(id string, params *stripe.SubItemParams) (*stripe.SubItem, e
 
 // List returns a list of subscription items.
 // For more details see https://stripe.com/docs/api#list_subscription_items.
-func List(params *stripe.SubItemListParams) *Iter {
+func List(params *stripe.SubscriptionItemListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SubItemListParams) *Iter {
+func (c Client) List(params *stripe.SubscriptionItemListParams) *Iter {
 	var body *form.Values
 	var lp *stripe.ListParams
 	var p *stripe.Params
@@ -122,11 +122,11 @@ func (c Client) List(params *stripe.SubItemListParams) *Iter {
 	}
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.SubItemList{}
+		list := &stripe.SubscriptionItemList{}
 		err := c.B.Call("GET", "/subscription_items", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 
@@ -134,17 +134,17 @@ func (c Client) List(params *stripe.SubItemListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Subs.
+// Iter is an iterator for lists of Subscriptions.
 // The embedded Iter carries methods with it;
 // see its documentation for details.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Sub returns the most recent Sub
+// SubscriptionItem returns the most recent SubscriptionItem
 // visited by a call to Next.
-func (i *Iter) SubItem() *stripe.SubItem {
-	return i.Current().(*stripe.SubItem)
+func (i *Iter) SubscriptionItem() *stripe.SubscriptionItem {
+	return i.Current().(*stripe.SubscriptionItem)
 }
 
 func getC() Client {

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -31,7 +31,7 @@ func TestSubscriptionItemList(t *testing.T) {
 
 func TestSubscriptionItemNew(t *testing.T) {
 	item, err := New(&stripe.SubscriptionItemParams{
-		Quantity:     99,
+		Quantity:     stripe.UInt64(99),
 		Plan:         "plan_123",
 		Subscription: "sub_123",
 	})
@@ -41,7 +41,7 @@ func TestSubscriptionItemNew(t *testing.T) {
 
 func TestSubscriptionItemUpdate(t *testing.T) {
 	item, err := Update("si_123", &stripe.SubscriptionItemParams{
-		Quantity: 10,
+		Quantity: stripe.UInt64(10),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -32,8 +32,8 @@ func TestSubscriptionItemList(t *testing.T) {
 func TestSubscriptionItemNew(t *testing.T) {
 	item, err := New(&stripe.SubscriptionItemParams{
 		Quantity:     stripe.UInt64(99),
-		Plan:         "plan_123",
-		Subscription: "sub_123",
+		Plan:         stripe.String("plan_123"),
+		Subscription: stripe.String("sub_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -8,39 +8,39 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestSubItemDel(t *testing.T) {
+func TestSubscriptionItemDel(t *testing.T) {
 	item, err := Del("si_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, item)
 }
 
-func TestSubItemGet(t *testing.T) {
+func TestSubscriptionItemGet(t *testing.T) {
 	item, err := Get("si_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, item)
 }
 
-func TestSubItemList(t *testing.T) {
-	i := List(&stripe.SubItemListParams{})
+func TestSubscriptionItemList(t *testing.T) {
+	i := List(&stripe.SubscriptionItemListParams{})
 
 	// Verify that we can get at least one item
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.SubItem())
+	assert.NotNil(t, i.SubscriptionItem())
 }
 
-func TestSubItemNew(t *testing.T) {
-	item, err := New(&stripe.SubItemParams{
-		Quantity: 99,
-		Plan:     "plan_123",
-		Sub:      "sub_123",
+func TestSubscriptionItemNew(t *testing.T) {
+	item, err := New(&stripe.SubscriptionItemParams{
+		Quantity:     99,
+		Plan:         "plan_123",
+		Subscription: "sub_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)
 }
 
-func TestSubItemUpdate(t *testing.T) {
-	item, err := Update("si_123", &stripe.SubItemParams{
+func TestSubscriptionItemUpdate(t *testing.T) {
+	item, err := Update("si_123", &stripe.SubscriptionItemParams{
 		Quantity: 10,
 	})
 	assert.Nil(t, err)

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -31,7 +31,7 @@ func TestSubscriptionItemList(t *testing.T) {
 
 func TestSubscriptionItemNew(t *testing.T) {
 	item, err := New(&stripe.SubscriptionItemParams{
-		Quantity:     stripe.UInt64(99),
+		Quantity:     stripe.Int64(99),
 		Plan:         stripe.String("plan_123"),
 		Subscription: stripe.String("sub_123"),
 	})
@@ -41,7 +41,7 @@ func TestSubscriptionItemNew(t *testing.T) {
 
 func TestSubscriptionItemUpdate(t *testing.T) {
 	item, err := Update("si_123", &stripe.SubscriptionItemParams{
-		Quantity: stripe.UInt64(10),
+		Quantity: stripe.Int64(10),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, item)

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -22,7 +22,7 @@ type ThreeDSecure struct {
 	Created       int64              `json:"created"`
 	Currency      Currency           `json:"currency"`
 	ID            string             `json:"id"`
-	Live          bool               `json:"livemode"`
+	Livemode      bool               `json:"livemode"`
 	RedirectURL   string             `json:"redirect_url"`
 	Status        ThreeDSecureStatus `json:"status"`
 	Supported     string             `json:"supported"`

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -6,11 +6,11 @@ type ThreeDSecureStatus string
 // For more details see https://stripe.com/docs/api#create_three_d_secure.
 type ThreeDSecureParams struct {
 	Params    `form:"*"`
-	Amount    uint64   `form:"amount"`
-	Card      string   `form:"card"`
-	Currency  Currency `form:"currency"`
-	Customer  string   `form:"customer"`
-	ReturnURL string   `form:"return_url"`
+	Amount    *uint64 `form:"amount"`
+	Card      *string `form:"card"`
+	Currency  *string `form:"currency"`
+	Customer  *string `form:"customer"`
+	ReturnURL *string `form:"return_url"`
 }
 
 // ThreeDSecure is the resource representing a Stripe 3DS object

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -6,7 +6,7 @@ type ThreeDSecureStatus string
 // For more details see https://stripe.com/docs/api#create_three_d_secure.
 type ThreeDSecureParams struct {
 	Params    `form:"*"`
-	Amount    *uint64 `form:"amount"`
+	Amount    *int64  `form:"amount"`
 	Card      *string `form:"card"`
 	Currency  *string `form:"currency"`
 	Customer  *string `form:"customer"`
@@ -16,7 +16,7 @@ type ThreeDSecureParams struct {
 // ThreeDSecure is the resource representing a Stripe 3DS object
 // For more details see https://stripe.com/docs/api#three_d_secure.
 type ThreeDSecure struct {
-	Amount        uint64             `json:"amount"`
+	Amount        int64              `json:"amount"`
 	Authenticated bool               `json:"authenticated"`
 	Card          *Card              `json:"card"`
 	Created       int64              `json:"created"`

--- a/threedsecure/client_test.go
+++ b/threedsecure/client_test.go
@@ -17,7 +17,7 @@ func TestThreeDSecureGet(t *testing.T) {
 
 func TestThreeDSecureNew(t *testing.T) {
 	threeDSecure, err := New(&stripe.ThreeDSecureParams{
-		Amount:    stripe.UInt64(1000),
+		Amount:    stripe.Int64(1000),
 		Currency:  stripe.String(string(currency.USD)),
 		Customer:  stripe.String("cus_123"),
 		Card:      stripe.String("card_123"),

--- a/threedsecure/client_test.go
+++ b/threedsecure/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -16,11 +17,11 @@ func TestThreeDSecureGet(t *testing.T) {
 
 func TestThreeDSecureNew(t *testing.T) {
 	threeDSecure, err := New(&stripe.ThreeDSecureParams{
-		Amount:    1000,
-		Currency:  "usd",
-		Customer:  "cus_123",
-		Card:      "card_123",
-		ReturnURL: "https://test.com",
+		Amount:    stripe.UInt64(1000),
+		Currency:  stripe.String(string(currency.USD)),
+		Customer:  stripe.String("cus_123"),
+		Card:      stripe.String("card_123"),
+		ReturnURL: stripe.String("https://test.com"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, threeDSecure)

--- a/token.go
+++ b/token.go
@@ -7,10 +7,10 @@ type TokenType string
 // TokenParams is the set of parameters that can be used when creating a token.
 // For more details see https://stripe.com/docs/api#create_card_token and https://stripe.com/docs/api#create_bank_account_token.
 type TokenParams struct {
-	Params   `form:"*"`
-	Bank     *BankAccountParams `form:"bank_account"`
-	Card     *CardParams        `form:"card"`
-	Customer string             `form:"customer"`
+	Params      `form:"*"`
+	BankAccount *BankAccountParams `form:"bank_account"`
+	Card        *CardParams        `form:"card"`
+	Customer    string             `form:"customer"`
 
 	// Email is an undocumented parameter used by Stripe Checkout
 	// It may be removed from the API without notice.
@@ -22,19 +22,19 @@ type TokenParams struct {
 // Token is the resource representing a Stripe token.
 // For more details see https://stripe.com/docs/api#tokens.
 type Token struct {
-	Bank     *BankAccount `json:"bank_account"`
-	Card     *Card        `json:"card"`
-	ClientIP string       `json:"client_ip"`
-	Created  int64        `json:"created"`
+	BankAccount *BankAccount `json:"bank_account"`
+	Card        *Card        `json:"card"`
+	ClientIP    string       `json:"client_ip"`
+	Created     int64        `json:"created"`
 
 	// Email is an undocumented field but included for all tokens created
 	// with Stripe Checkout.
 	Email string `json:"email"`
 
-	ID   string    `json:"id"`
-	Live bool      `json:"livemode"`
-	Type TokenType `json:"type"`
-	Used bool      `json:"used"`
+	ID       string    `json:"id"`
+	Livemode bool      `json:"livemode"`
+	Type     TokenType `json:"type"`
+	Used     bool      `json:"used"`
 }
 
 // PIIParams are parameters for personal identifiable information (PII).

--- a/token.go
+++ b/token.go
@@ -10,11 +10,11 @@ type TokenParams struct {
 	Params      `form:"*"`
 	BankAccount *BankAccountParams `form:"bank_account"`
 	Card        *CardParams        `form:"card"`
-	Customer    string             `form:"customer"`
+	Customer    *string            `form:"customer"`
 
 	// Email is an undocumented parameter used by Stripe Checkout
 	// It may be removed from the API without notice.
-	Email string `form:"email"`
+	Email *string `form:"email"`
 
 	PII *PIIParams `form:"pii"`
 }
@@ -40,5 +40,5 @@ type Token struct {
 // PIIParams are parameters for personal identifiable information (PII).
 type PIIParams struct {
 	Params           `form:"*"`
-	PersonalIDNumber string `form:"personal_id_number"`
+	PersonalIDNumber *string `form:"personal_id_number"`
 }

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -16,10 +16,10 @@ func TestTokenGet(t *testing.T) {
 
 func TestTokenNew_WithBankAccount(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
-		Bank: &stripe.BankAccountParams{
-			Country: "US",
-			Routing: "110000000",
-			Account: "000123456789",
+		BankAccount: &stripe.BankAccountParams{
+			Country:       "US",
+			RoutingNumber: "110000000",
+			AccountNumber: "000123456789",
 		},
 	})
 	assert.Nil(t, err)
@@ -29,9 +29,9 @@ func TestTokenNew_WithBankAccount(t *testing.T) {
 func TestTokenNew_WithCard(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
 		Card: &stripe.CardParams{
-			Number: "4242424242424242", // raw PAN as we're testing token creation
-			Month:  "10",
-			Year:   "20",
+			Number:   "4242424242424242", // raw PAN as we're testing token creation
+			ExpMonth: "10",
+			ExpYear:  "20",
 		},
 	})
 	assert.Nil(t, err)
@@ -63,7 +63,7 @@ func TestTokenNew_SharedCustomerCard(t *testing.T) {
 
 func TestTokenNew_SharedCustomerBankAccount(t *testing.T) {
 	params := &stripe.TokenParams{
-		Bank: &stripe.BankAccountParams{
+		BankAccount: &stripe.BankAccountParams{
 			ID: "ba_123",
 		},
 		Customer: "cus_123",

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -17,9 +17,9 @@ func TestTokenGet(t *testing.T) {
 func TestTokenNew_WithBankAccount(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
 		BankAccount: &stripe.BankAccountParams{
-			Country:       "US",
-			RoutingNumber: "110000000",
-			AccountNumber: "000123456789",
+			Country:       stripe.String("US"),
+			RoutingNumber: stripe.String("110000000"),
+			AccountNumber: stripe.String("000123456789"),
 		},
 	})
 	assert.Nil(t, err)
@@ -29,9 +29,9 @@ func TestTokenNew_WithBankAccount(t *testing.T) {
 func TestTokenNew_WithCard(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
 		Card: &stripe.CardParams{
-			Number:   "4242424242424242", // raw PAN as we're testing token creation
-			ExpMonth: "10",
-			ExpYear:  "20",
+			Number:   stripe.String("4242424242424242"), // raw PAN as we're testing token creation
+			ExpMonth: stripe.String("10"),
+			ExpYear:  stripe.String("20"),
 		},
 	})
 	assert.Nil(t, err)
@@ -41,7 +41,7 @@ func TestTokenNew_WithCard(t *testing.T) {
 func TestTokenNew_WithPII(t *testing.T) {
 	token, err := New(&stripe.TokenParams{
 		PII: &stripe.PIIParams{
-			PersonalIDNumber: "000000000",
+			PersonalIDNumber: stripe.String("000000000"),
 		},
 	})
 	assert.Nil(t, err)
@@ -53,7 +53,7 @@ func TestTokenNew_SharedCustomerCard(t *testing.T) {
 		Card: &stripe.CardParams{
 			ID: "card_123",
 		},
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	}
 	params.SetStripeAccount("acct_123")
 	token, err := New(params)
@@ -64,9 +64,9 @@ func TestTokenNew_SharedCustomerCard(t *testing.T) {
 func TestTokenNew_SharedCustomerBankAccount(t *testing.T) {
 	params := &stripe.TokenParams{
 		BankAccount: &stripe.BankAccountParams{
-			ID: "ba_123",
+			ID: stripe.String("ba_123"),
 		},
-		Customer: "cus_123",
+		Customer: stripe.String("cus_123"),
 	}
 	params.SetStripeAccount("acct_123")
 	token, err := New(params)

--- a/topup.go
+++ b/topup.go
@@ -4,11 +4,11 @@ package stripe
 // For more details see https://stripe.com/docs/api#create_topup and https://stripe.com/docs/api#update_topup.
 type TopupParams struct {
 	Params              `form:"*"`
-	Amount              uint64        `form:"amount"`
-	Currency            Currency      `form:"currency"`
-	Description         string        `form:"description"`
+	Amount              *uint64       `form:"amount"`
+	Currency            *string       `form:"currency"`
+	Description         *string       `form:"description"`
 	Source              *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	StatementDescriptor string        `form:"statement_descriptor"`
+	StatementDescriptor *string       `form:"statement_descriptor"`
 }
 
 // SetSource adds valid sources to a TopupParams object,
@@ -23,7 +23,7 @@ func (p *TopupParams) SetSource(sp interface{}) error {
 // For more details see https://stripe.com/docs/api#list_topups.
 type TopupListParams struct {
 	ListParams   `form:"*"`
-	Created      int64             `form:"created"`
+	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 

--- a/topup.go
+++ b/topup.go
@@ -3,12 +3,12 @@ package stripe
 // TopupParams is the set of parameters that can be used when creating or updating a top-up.
 // For more details see https://stripe.com/docs/api#create_topup and https://stripe.com/docs/api#update_topup.
 type TopupParams struct {
-	Params    `form:"*"`
-	Amount    uint64        `form:"amount"`
-	Currency  Currency      `form:"currency"`
-	Desc      string        `form:"description"`
-	Source    *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	Statement string        `form:"statement_descriptor"`
+	Params              `form:"*"`
+	Amount              uint64        `form:"amount"`
+	Currency            Currency      `form:"currency"`
+	Description         string        `form:"description"`
+	Source              *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	StatementDescriptor string        `form:"statement_descriptor"`
 }
 
 // SetSource adds valid sources to a TopupParams object,
@@ -36,18 +36,18 @@ type TopupList struct {
 // Topup is the resource representing a Stripe top-up.
 // For more details see https://stripe.com/docs/api#topups.
 type Topup struct {
-	Amount                   uint64         `json:"amount"`
-	ArrivalDate              int64          `json:"arrival_date"`
-	Created                  int64          `json:"created"`
-	Currency                 Currency       `json:"currency"`
-	Desc                     string         `json:"description"`
-	ExpectedAvailabilityDate int64          `json:"expected_availability_date"`
-	FailCode                 string         `json:"failure_code"`
-	FailMsg                  string         `json:"failure_message"`
-	ID                       string         `json:"id"`
-	Live                     bool           `json:"livemode"`
-	Source                   *PaymentSource `json:"source"`
-	Statement                string         `json:"statement_descriptor"`
-	Status                   string         `json:"status"`
-	Tx                       *Transaction   `json:"balance_transaction"`
+	Amount                   uint64              `json:"amount"`
+	ArrivalDate              int64               `json:"arrival_date"`
+	BalanceTransaction       *BalanceTransaction `json:"balance_transaction"`
+	Created                  int64               `json:"created"`
+	Currency                 Currency            `json:"currency"`
+	Description              string              `json:"description"`
+	ExpectedAvailabilityDate int64               `json:"expected_availability_date"`
+	FailureCode              string              `json:"failure_code"`
+	FailureMessage           string              `json:"failure_message"`
+	ID                       string              `json:"id"`
+	Livemode                 bool                `json:"livemode"`
+	Source                   *PaymentSource      `json:"source"`
+	StatementDescriptor      string              `json:"statement_descriptor"`
+	Status                   string              `json:"status"`
 }

--- a/topup.go
+++ b/topup.go
@@ -4,7 +4,7 @@ package stripe
 // For more details see https://stripe.com/docs/api#create_topup and https://stripe.com/docs/api#update_topup.
 type TopupParams struct {
 	Params              `form:"*"`
-	Amount              *uint64       `form:"amount"`
+	Amount              *int64        `form:"amount"`
 	Currency            *string       `form:"currency"`
 	Description         *string       `form:"description"`
 	Source              *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
@@ -36,7 +36,7 @@ type TopupList struct {
 // Topup is the resource representing a Stripe top-up.
 // For more details see https://stripe.com/docs/api#topups.
 type Topup struct {
-	Amount                   uint64              `json:"amount"`
+	Amount                   int64               `json:"amount"`
 	ArrivalDate              int64               `json:"arrival_date"`
 	BalanceTransaction       *BalanceTransaction `json:"balance_transaction"`
 	Created                  int64               `json:"created"`

--- a/topup.go
+++ b/topup.go
@@ -30,7 +30,7 @@ type TopupListParams struct {
 // TopupList is a list of top-ups as retrieved from a list endpoint.
 type TopupList struct {
 	ListMeta
-	Values []*Topup `json:"data"`
+	Data []*Topup `json:"data"`
 }
 
 // Topup is the resource representing a Stripe top-up.

--- a/topup/client.go
+++ b/topup/client.go
@@ -93,8 +93,8 @@ func (c Client) List(params *stripe.TopupListParams) *Iter {
 		list := &stripe.TopupList{}
 		err := c.B.Call("GET", "/topups", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/topup/client_test.go
+++ b/topup/client_test.go
@@ -17,7 +17,7 @@ func TestTopupGet(t *testing.T) {
 
 func TestTopupNew(t *testing.T) {
 	topup, err := New(&stripe.TopupParams{
-		Amount:              stripe.UInt64(123),
+		Amount:              stripe.Int64(123),
 		Currency:            stripe.String(string(currency.USD)),
 		Source:              &stripe.SourceParams{Token: stripe.String("src_123")},
 		Description:         stripe.String("creating a topup"),
@@ -29,7 +29,7 @@ func TestTopupNew(t *testing.T) {
 
 func TestTopupNew_WithSetSource(t *testing.T) {
 	params := stripe.TopupParams{
-		Amount:              stripe.UInt64(123),
+		Amount:              stripe.Int64(123),
 		Currency:            stripe.String("usd"),
 		Description:         stripe.String("creating a topup"),
 		StatementDescriptor: stripe.String("topup"),

--- a/topup/client_test.go
+++ b/topup/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -16,11 +17,11 @@ func TestTopupGet(t *testing.T) {
 
 func TestTopupNew(t *testing.T) {
 	topup, err := New(&stripe.TopupParams{
-		Amount:              123,
-		Currency:            "usd",
-		Source:              &stripe.SourceParams{Token: "src_123"},
-		Description:         "creating a topup",
-		StatementDescriptor: "topup",
+		Amount:              stripe.UInt64(123),
+		Currency:            stripe.String(string(currency.USD)),
+		Source:              &stripe.SourceParams{Token: stripe.String("src_123")},
+		Description:         stripe.String("creating a topup"),
+		StatementDescriptor: stripe.String("topup"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, topup)
@@ -28,10 +29,10 @@ func TestTopupNew(t *testing.T) {
 
 func TestTopupNew_WithSetSource(t *testing.T) {
 	params := stripe.TopupParams{
-		Amount:              123,
-		Currency:            "usd",
-		Description:         "creating a topup",
-		StatementDescriptor: "topup",
+		Amount:              stripe.UInt64(123),
+		Currency:            stripe.String("usd"),
+		Description:         stripe.String("creating a topup"),
+		StatementDescriptor: stripe.String("topup"),
 	}
 	params.SetSource("src_123")
 

--- a/topup/client_test.go
+++ b/topup/client_test.go
@@ -16,11 +16,11 @@ func TestTopupGet(t *testing.T) {
 
 func TestTopupNew(t *testing.T) {
 	topup, err := New(&stripe.TopupParams{
-		Amount:    123,
-		Currency:  "usd",
-		Source:    &stripe.SourceParams{Token: "src_123"},
-		Desc:      "creating a topup",
-		Statement: "topup",
+		Amount:              123,
+		Currency:            "usd",
+		Source:              &stripe.SourceParams{Token: "src_123"},
+		Description:         "creating a topup",
+		StatementDescriptor: "topup",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, topup)
@@ -28,10 +28,10 @@ func TestTopupNew(t *testing.T) {
 
 func TestTopupNew_WithSetSource(t *testing.T) {
 	params := stripe.TopupParams{
-		Amount:    123,
-		Currency:  "usd",
-		Desc:      "creating a topup",
-		Statement: "topup",
+		Amount:              123,
+		Currency:            "usd",
+		Description:         "creating a topup",
+		StatementDescriptor: "topup",
 	}
 	params.SetSource("src_123")
 
@@ -42,7 +42,7 @@ func TestTopupNew_WithSetSource(t *testing.T) {
 
 func TestTopupUpdate(t *testing.T) {
 	params := &stripe.TopupParams{}
-	params.AddMeta("key", "value")
+	params.AddMetadata("key", "value")
 	topup, err := Update("tu_123", params)
 	assert.Nil(t, err)
 	assert.NotNil(t, topup)

--- a/transfer.go
+++ b/transfer.go
@@ -17,13 +17,13 @@ type TransferDestination struct {
 // TransferParams is the set of parameters that can be used when creating or updating a transfer.
 // For more details see https://stripe.com/docs/api#create_transfer and https://stripe.com/docs/api#update_transfer.
 type TransferParams struct {
-	Params        `form:"*"`
-	Amount        int64              `form:"amount"`
-	Currency      Currency           `form:"currency"`
-	Dest          string             `form:"destination"`
-	SourceTx      string             `form:"source_transaction"`
-	SourceType    TransferSourceType `form:"source_type"`
-	TransferGroup string             `form:"transfer_group"`
+	Params            `form:"*"`
+	Amount            int64              `form:"amount"`
+	Currency          Currency           `form:"currency"`
+	Destination       string             `form:"destination"`
+	SourceTransaction string             `form:"source_transaction"`
+	SourceType        TransferSourceType `form:"source_type"`
+	TransferGroup     string             `form:"transfer_group"`
 }
 
 // TransferListParams is the set of parameters that can be used when listing transfers.
@@ -32,35 +32,33 @@ type TransferListParams struct {
 	ListParams    `form:"*"`
 	Created       int64             `form:"created"`
 	CreatedRange  *RangeQueryParams `form:"created"`
-	Currency      Currency          `form:"currency"`
-	Dest          string            `form:"destination"`
+	Destination   string            `form:"destination"`
 	TransferGroup string            `form:"transfer_group"`
 }
 
 // Transfer is the resource representing a Stripe transfer.
 // For more details see https://stripe.com/docs/api#transfers.
 type Transfer struct {
-	Amount         int64               `json:"amount"`
-	AmountReversed int64               `json:"amount_reversed"`
-	Created        int64               `json:"created"`
-	Currency       Currency            `json:"currency"`
-	Dest           TransferDestination `json:"destination"`
-	DestPayment    *Charge             `json:"destination_payment"`
-	ID             string              `json:"id"`
-	Live           bool                `json:"livemode"`
-	Meta           map[string]string   `json:"metadata"`
-	Reversals      *ReversalList       `json:"reversals"`
-	Reversed       bool                `json:"reversed"`
-	SourceTx       *TransactionSource  `json:"source_transaction"`
-	Statement      string              `json:"statement_descriptor"`
-	TransferGroup  string              `json:"transfer_group"`
-	Tx             *Transaction        `json:"balance_transaction"`
+	Amount             int64                     `json:"amount"`
+	AmountReversed     int64                     `json:"amount_reversed"`
+	BalanceTransaction *BalanceTransaction       `json:"balance_transaction"`
+	Created            int64                     `json:"created"`
+	Currency           Currency                  `json:"currency"`
+	Destination        TransferDestination       `json:"destination"`
+	DestinationPayment *Charge                   `json:"destination_payment"`
+	ID                 string                    `json:"id"`
+	Livemode           bool                      `json:"livemode"`
+	Metadata           map[string]string         `json:"metadata"`
+	Reversals          *ReversalList             `json:"reversals"`
+	Reversed           bool                      `json:"reversed"`
+	SourceTransaction  *BalanceTransactionSource `json:"source_transaction"`
+	TransferGroup      string                    `json:"transfer_group"`
 }
 
 // TransferList is a list of transfers as retrieved from a list endpoint.
 type TransferList struct {
 	ListMeta
-	Values []*Transfer `json:"data"`
+	Data []*Transfer `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Transfer.

--- a/transfer.go
+++ b/transfer.go
@@ -18,22 +18,22 @@ type TransferDestination struct {
 // For more details see https://stripe.com/docs/api#create_transfer and https://stripe.com/docs/api#update_transfer.
 type TransferParams struct {
 	Params            `form:"*"`
-	Amount            int64              `form:"amount"`
-	Currency          Currency           `form:"currency"`
-	Destination       string             `form:"destination"`
-	SourceTransaction string             `form:"source_transaction"`
-	SourceType        TransferSourceType `form:"source_type"`
-	TransferGroup     string             `form:"transfer_group"`
+	Amount            *int64  `form:"amount"`
+	Currency          *string `form:"currency"`
+	Destination       *string `form:"destination"`
+	SourceTransaction *string `form:"source_transaction"`
+	SourceType        *string `form:"source_type"`
+	TransferGroup     *string `form:"transfer_group"`
 }
 
 // TransferListParams is the set of parameters that can be used when listing transfers.
 // For more details see https://stripe.com/docs/api#list_transfers.
 type TransferListParams struct {
 	ListParams    `form:"*"`
-	Created       int64             `form:"created"`
+	Created       *int64            `form:"created"`
 	CreatedRange  *RangeQueryParams `form:"created"`
-	Destination   string            `form:"destination"`
-	TransferGroup string            `form:"transfer_group"`
+	Destination   *string           `form:"destination"`
+	TransferGroup *string           `form:"transfer_group"`
 }
 
 // Transfer is the resource representing a Stripe transfer.

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -103,8 +103,8 @@ func (c Client) List(params *stripe.TransferListParams) *Iter {
 		list := &stripe.TransferList{}
 		err := c.B.Call("GET", "/transfers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
 			ret[i] = v
 		}
 

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -25,10 +25,10 @@ func TestTransferList(t *testing.T) {
 
 func TestTransferNew(t *testing.T) {
 	transfer, err := New(&stripe.TransferParams{
-		Amount:   123,
-		Currency: "usd",
-		Dest:     "acct_123",
-		SourceTx: "ch_123",
+		Amount:            123,
+		Currency:          "usd",
+		Destination:       "acct_123",
+		SourceTransaction: "ch_123",
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, transfer)
@@ -37,7 +37,7 @@ func TestTransferNew(t *testing.T) {
 func TestTransferUpdate(t *testing.T) {
 	transfer, err := Update("tr_123", &stripe.TransferParams{
 		Params: stripe.Params{
-			Meta: map[string]string{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/currency"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -25,10 +26,11 @@ func TestTransferList(t *testing.T) {
 
 func TestTransferNew(t *testing.T) {
 	transfer, err := New(&stripe.TransferParams{
-		Amount:            123,
-		Currency:          "usd",
-		Destination:       "acct_123",
-		SourceTransaction: "ch_123",
+		Amount:            stripe.Int64(123),
+		Currency:          stripe.String(string(currency.USD)),
+		Destination:       stripe.String("acct_123"),
+		SourceTransaction: stripe.String("ch_123"),
+		SourceType:        stripe.String(string(SourceCard)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, transfer)

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -30,24 +30,24 @@ func TestTransferUnmarshal(t *testing.T) {
 		t.Errorf("Problem deserializing transfer, got ID %v", transfer.ID)
 	}
 
-	source_tx := transfer.SourceTx
-	if source_tx == nil {
-		t.Errorf("Problem deserializing transfer, didn't get a SourceTx")
+	source_transaction := transfer.SourceTransaction
+	if source_transaction == nil {
+		t.Errorf("Problem deserializing transfer, didn't get a SourceTransaction")
 	}
 
-	if source_tx.ID != "ch_1234" {
+	if source_transaction.ID != "ch_1234" {
 		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for ID")
 	}
 
-	if source_tx.Type != TransactionSourceCharge {
+	if source_transaction.Type != BalanceTransactionSourceTypeCharge {
 		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for Type")
 	}
 
-	if source_tx.Charge == nil {
+	if source_transaction.Charge == nil {
 		t.Errorf("Problem deserializing transfer.source_transaction, didn't get a Charge")
 	}
 
-	if source_tx.Charge.ID != "ch_1234" {
+	if source_transaction.Charge.ID != "ch_1234" {
 		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for Charge.ID")
 	}
 }

--- a/usage_record.go
+++ b/usage_record.go
@@ -16,9 +16,9 @@ const (
 type UsageRecord struct {
 	ID               string `json:"id"`
 	Live             bool   `json:"livemode"`
-	Quantity         uint64 `json:"quantity"`
+	Quantity         int64  `json:"quantity"`
 	SubscriptionItem string `json:"subscription_item"`
-	Timestamp        uint64 `json:"timestamp"`
+	Timestamp        int64  `json:"timestamp"`
 }
 
 // UsageRecordParams create a usage record for a specified subscription item
@@ -26,7 +26,7 @@ type UsageRecord struct {
 type UsageRecordParams struct {
 	Params           `form:"*"`
 	Action           *string `form:"action"`
-	Quantity         *uint64 `form:"quantity"`
+	Quantity         *int64  `form:"quantity"`
 	SubscriptionItem *string `form:"-"` // passed in the URL
-	Timestamp        *uint64 `form:"timestamp"`
+	Timestamp        *int64  `form:"timestamp"`
 }

--- a/usage_record.go
+++ b/usage_record.go
@@ -25,9 +25,8 @@ type UsageRecord struct {
 // and date, and fills it with a quantity.
 type UsageRecordParams struct {
 	Params           `form:"*"`
-	Action           string `form:"action"`
-	Quantity         uint64 `form:"quantity"`
-	QuantityZero     bool   `form:"quantity,zero"`
-	SubscriptionItem string `form:"-"` // passed in the URL
-	Timestamp        uint64 `form:"timestamp"`
+	Action           *string `form:"action"`
+	Quantity         *uint64 `form:"quantity"`
+	SubscriptionItem *string `form:"-"` // passed in the URL
+	Timestamp        *uint64 `form:"timestamp"`
 }

--- a/usage_record_test.go
+++ b/usage_record_test.go
@@ -14,10 +14,10 @@ func TestUsageRecordParams_AppendTo(t *testing.T) {
 		params *UsageRecordParams
 		want   interface{}
 	}{
-		{"action", &UsageRecordParams{Action: "increment"}, "increment"},
-		{"quantity", &UsageRecordParams{Quantity: 2000}, strconv.FormatUint(2000, 10)},
-		{"quantity", &UsageRecordParams{QuantityZero: true}, strconv.FormatUint(0, 10)},
-		{"timestamp", &UsageRecordParams{Timestamp: 123123123}, strconv.FormatUint(123123123, 10)},
+		{"action", &UsageRecordParams{Action: String("increment")}, "increment"},
+		{"quantity", &UsageRecordParams{Quantity: UInt64(2000)}, strconv.FormatUint(2000, 10)},
+		{"quantity", &UsageRecordParams{Quantity: UInt64(0)}, strconv.FormatUint(0, 10)},
+		{"timestamp", &UsageRecordParams{Timestamp: UInt64(123123123)}, strconv.FormatUint(123123123, 10)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {

--- a/usage_record_test.go
+++ b/usage_record_test.go
@@ -15,9 +15,9 @@ func TestUsageRecordParams_AppendTo(t *testing.T) {
 		want   interface{}
 	}{
 		{"action", &UsageRecordParams{Action: String("increment")}, "increment"},
-		{"quantity", &UsageRecordParams{Quantity: UInt64(2000)}, strconv.FormatUint(2000, 10)},
-		{"quantity", &UsageRecordParams{Quantity: UInt64(0)}, strconv.FormatUint(0, 10)},
-		{"timestamp", &UsageRecordParams{Timestamp: UInt64(123123123)}, strconv.FormatUint(123123123, 10)},
+		{"quantity", &UsageRecordParams{Quantity: Int64(2000)}, strconv.FormatUint(2000, 10)},
+		{"quantity", &UsageRecordParams{Quantity: Int64(0)}, strconv.FormatUint(0, 10)},
+		{"timestamp", &UsageRecordParams{Timestamp: Int64(123123123)}, strconv.FormatUint(123123123, 10)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {

--- a/usagerecord/client.go
+++ b/usagerecord/client.go
@@ -26,7 +26,7 @@ func (c Client) New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, erro
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	url := fmt.Sprintf("/subscription_items/%s/usage_records", url.QueryEscape(params.SubscriptionItem))
+	url := fmt.Sprintf("/subscription_items/%s/usage_records", url.QueryEscape(stripe.StringValue(params.SubscriptionItem)))
 	record := &stripe.UsageRecord{}
 	err := c.B.Call("POST", url, c.Key, body, &params.Params, record)
 

--- a/usagerecord/client_test.go
+++ b/usagerecord/client_test.go
@@ -12,10 +12,10 @@ import (
 func TestUsageRecordNew(t *testing.T) {
 	now := uint64(time.Now().Unix())
 	usageRecord, err := New(&stripe.UsageRecordParams{
-		Quantity:         123,
-		Timestamp:        now,
-		Action:           stripe.UsageRecordParamsActionIncrement,
-		SubscriptionItem: "si_123",
+		Quantity:         stripe.UInt64(123),
+		Timestamp:        stripe.UInt64(now),
+		Action:           stripe.String(stripe.UsageRecordParamsActionIncrement),
+		SubscriptionItem: stripe.String("si_123"),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, usageRecord)

--- a/usagerecord/client_test.go
+++ b/usagerecord/client_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestUsageRecordNew(t *testing.T) {
-	now := uint64(time.Now().Unix())
+	now := int64(time.Now().Unix())
 	usageRecord, err := New(&stripe.UsageRecordParams{
-		Quantity:         stripe.UInt64(123),
-		Timestamp:        stripe.UInt64(now),
+		Quantity:         stripe.Int64(123),
+		Timestamp:        stripe.Int64(now),
 		Action:           stripe.String(stripe.UsageRecordParamsActionIncrement),
 		SubscriptionItem: stripe.String("si_123"),
 	})


### PR DESCRIPTION
Yet another attempt to make sure the way to use constants is the right direction.