### PR TITLE
Add `go.mod` for aspiring vgo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ changelog](CHANGELOG) and [API changelog][api-changelog].
 go get github.com/stripe/stripe-go
 ```
 
+Then import the package from your Go code:
+
+``` go
+import "github.com/stripe/stripe-go"
+```
+
+### vgo
+
+If using [vgo], don't `go get` it manually, but do use an `import` statement
+that includes the latest major version:
+
+``` go
+import "github.com/stripe/stripe-go/v30"
+```
+
 ## Documentation
 
 For a comprehensive list of examples, check out the [API
@@ -313,6 +328,7 @@ pull request][pulls].
 [package-management]: https://code.google.com/p/go-wiki/wiki/PackageManagementTools
 [pulls]: https://github.com/stripe/stripe-go/pulls
 [stripe]: https://stripe.com
+[vgo]: https://github.com/golang/vgo
 
 <!--
 # vim: set tw=79:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module "github.com/stripe/stripe-go/v30"


### PR DESCRIPTION
Adds a `go.mod` file to the project for aspiring vgo support. As
described in #559, without such a file, vgo will default to the lowest
released major version available, which in our case is `v1.0.3`. The vgo
proposal seems to have been officially accepted, so having support for
it early is a bit of a nicety that we can offer.

The one caveat of this addition is that while vgo users should import
stripe-go like this:

    import (
        "github.com/stripe/stripe-go/v30"
    )

We can't actually recommend this `import` style anywhere in our core
documentation yet (although it's okay to put it in the `README.md` in a
vgo-specific section). This is because the `v30` suffix at the end of
the path isn't a real physical path, but rather just a symbolic one that
vgo knows how to parse and resolve as a tag. Trying to use this import
convention with `go get` will fail.

The good news is that this problem has been acknowledged by the core
team, and there will eventually be a pre-vgo `go get` that understands
how to do basic tag resolution [1]. At some point in the future after
this has become widely available, we can probably switch over to
recommending a single install invocation for vgo and pre-vgo users.

I'll update our release scripts to correctly write new major versions to 
these files as appropriate.

Fixes #559.

[1] https://go-review.googlesource.com/c/go/+/109340

r? @remi-stripe Want to take a shot at this one?