### PR TITLE
Support stripe.DisputeParams for Close dispute API

### DIFF
--- a/dispute/client.go
+++ b/dispute/client.go
@@ -123,13 +123,22 @@ func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute
 
 // Close dismisses a dispute in the customer's favor.
 // For more details see https://stripe.com/docs/api#close_dispute.
-func Close(id string) (*stripe.Dispute, error) {
-	return getC().Close(id)
+func Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
+	return getC().Close(id, params)
 }
 
-func (c Client) Close(id string) (*stripe.Dispute, error) {
+func (c Client) Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
+	var body *form.Values
+	var commonParams *stripe.Params
+
+	if params != nil {
+		commonParams = &params.Params
+		body = &form.Values{}
+		form.AppendTo(body, params)
+	}
+
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", fmt.Sprintf("/disputes/%v/close", id), c.Key, nil, nil, dispute)
+	err := c.B.Call("POST", fmt.Sprintf("/disputes/%v/close", id), c.Key, body, commonParams, dispute)
 
 	return dispute, err
 }

--- a/dispute/client_test.go
+++ b/dispute/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDisputeClose(t *testing.T) {
-	dispute, err := Close("dp_123")
+	dispute, err := Close("dp_123", &stripe.DisputeParams{})
 	assert.Nil(t, err)
 	assert.NotNil(t, dispute)
 }


### PR DESCRIPTION
We should accept and pass forward stripe.DisputeParams that will include `StripeAccount` as for any other calls for Connected Accounts
Right now `Close` dispute doesn't work for Connected accounts

```
{
    "error": {
        "code": "resource_missing",
        "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
        "message": "No such dispute: dp_***",
        "param": "dispute",
        "type": "invalid_request_error"
    }
}
```

Works fine if i am doing manual call with one more header field `Stripe-Account`