### PR TITLE
doc(webhook): cleanup example

### DIFF
--- a/webhook/client_handler_test.go
+++ b/webhook/client_handler_test.go
@@ -27,7 +27,6 @@ func Example() {
 			return
 		}
 
-		defer req.Body.Close()
 		fmt.Fprintf(w, "Received signed event: %v", event)
 	})
 	log.Fatal(http.ListenAndServe(":8080", nil))


### PR DESCRIPTION
There is no need in closing request body.

From https://golang.org/pkg/net/http/#Request:
// The Server will close the request body. The ServeHTTP
// Handler does not need to.