### PR TITLE
Add `FormatURLPath` helper to allow safer URL path building

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -61,7 +61,7 @@ func (c Client) GetByID(id string, params *stripe.AccountParams) (*stripe.Accoun
 	}
 
 	account := &stripe.Account{}
-	err := c.B.Call("GET", "/accounts/"+id, c.Key, body, commonParams, account)
+	err := c.B.Call("GET", stripe.FormatURLPath("/accounts/%s", id), c.Key, body, commonParams, account)
 
 	return account, err
 }
@@ -82,7 +82,7 @@ func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account
 	}
 
 	acct := &stripe.Account{}
-	err := c.B.Call("POST", "/accounts/"+id, c.Key, body, commonParams, acct)
+	err := c.B.Call("POST", stripe.FormatURLPath("/accounts/%s", id), c.Key, body, commonParams, acct)
 
 	return acct, err
 }
@@ -103,7 +103,7 @@ func (c Client) Del(id string, params *stripe.AccountParams) (*stripe.Account, e
 	}
 
 	acct := &stripe.Account{}
-	err := c.B.Call("DELETE", "/accounts/"+id, c.Key, body, commonParams, acct)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/accounts/%s", id), c.Key, body, commonParams, acct)
 
 	return acct, err
 }
@@ -119,7 +119,7 @@ func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.A
 		body.Add("reason", stripe.StringValue(params.Reason))
 	}
 	acct := &stripe.Account{}
-	err := c.B.Call("POST", "/accounts/"+id+"/reject", c.Key, body, nil, acct)
+	err := c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/reject", id), c.Key, body, nil, acct)
 
 	return acct, err
 }

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -42,7 +42,7 @@ func (c Client) Get(id string, params *stripe.ApplePayDomainParams) (*stripe.App
 	}
 
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("GET", "/apple_pay/domains/"+id, c.Key, body, commonParams, domain)
+	err := c.B.Call("GET", stripe.FormatURLPath("/apple_pay/domains/%s", id), c.Key, body, commonParams, domain)
 
 	return domain, err
 }
@@ -63,7 +63,7 @@ func (c Client) Del(id string, params *stripe.ApplePayDomainParams) (*stripe.App
 	}
 
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("DELETE", "/apple_pay/domains/"+id, c.Key, body, commonParams, domain)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/apple_pay/domains/%s", id), c.Key, body, commonParams, domain)
 
 	return domain, err
 }

--- a/balance/client.go
+++ b/balance/client.go
@@ -51,7 +51,7 @@ func (c Client) GetBalanceTransaction(id string, params *stripe.BalanceTransacti
 	}
 
 	balance := &stripe.BalanceTransaction{}
-	err := c.B.Call("GET", "/balance/history/"+id, c.Key, body, commonParams, balance)
+	err := c.B.Call("GET", stripe.FormatURLPath("/balance/history/%s", id), c.Key, body, commonParams, balance)
 
 	return balance, err
 }

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -3,7 +3,6 @@ package bankaccount
 
 import (
 	"errors"
-	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -31,9 +30,9 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 	ba := &stripe.BankAccount{}
 	var err error
 	if params.Customer != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, ba)
+		err = c.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, ba)
 	} else {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, ba)
+		err = c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/external_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, ba)
 	}
 
 	return ba, err
@@ -58,9 +57,9 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	var err error
 
 	if params != nil && params.Customer != nil {
-		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+		err = c.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
 	} else if params != nil && params.Account != nil {
-		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
+		err = c.B.Call("GET", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -87,9 +86,9 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 	var err error
 
 	if params.Customer != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+		err = c.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
 	} else if params.Account != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
+		err = c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -116,9 +115,9 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	var err error
 
 	if params.Customer != nil {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
+		err = c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, ba)
 	} else if params.Account != nil {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
+		err = c.B.Call("DELETE", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, commonParams, ba)
 	} else {
 		err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
@@ -145,9 +144,9 @@ func (c Client) List(params *stripe.BankAccountListParams) *Iter {
 		var err error
 
 		if params.Customer != nil {
-			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/sources?object=bank_account", stripe.StringValue(params.Customer)), c.Key, b, p, list)
+			err = c.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources?object=bank_account", stripe.StringValue(params.Customer)), c.Key, b, p, list)
 		} else if params.Account != nil {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts?object=bank_account", stripe.StringValue(params.Account)), c.Key, b, p, list)
+			err = c.B.Call("GET", stripe.FormatURLPath("/accounts/%s/external_accounts?object=bank_account", stripe.StringValue(params.Account)), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid bank account params: either Customer or Account need to be set")
 		}

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -5,8 +5,6 @@
 package bitcoinreceiver
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -47,7 +45,7 @@ func (c Client) Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.Bi
 	}
 
 	bitcoinReceiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call("GET", "/bitcoin/receivers/"+id, c.Key, nil, commonParams, bitcoinReceiver)
+	err := c.B.Call("GET", stripe.FormatURLPath("/bitcoin/receivers/%s", id), c.Key, nil, commonParams, bitcoinReceiver)
 
 	return bitcoinReceiver, err
 }
@@ -63,7 +61,7 @@ func (c Client) Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*
 	form.AppendTo(body, params)
 
 	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call("POST", fmt.Sprintf("/bitcoin/receivers/%v", id), c.Key, body, &params.Params, receiver)
+	err := c.B.Call("POST", stripe.FormatURLPath("/bitcoin/receivers/%s", id), c.Key, body, &params.Params, receiver)
 
 	return receiver, err
 }

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -2,8 +2,6 @@
 package bitcointransaction
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -34,7 +32,7 @@ func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinTransactionList{}
-		err := c.B.Call("GET", fmt.Sprintf("/bitcoin/receivers/%v/transactions", stripe.StringValue(params.Receiver)), c.Key, b, p, list)
+		err := c.B.Call("GET", stripe.FormatURLPath("/bitcoin/receivers/%s/transactions", stripe.StringValue(params.Receiver)), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/card/client.go
+++ b/card/client.go
@@ -3,7 +3,6 @@ package card
 
 import (
 	"errors"
-	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -37,11 +36,11 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	var err error
 
 	if params.Account != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, card)
+		err = c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/external_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, card)
 	} else if params.Customer != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, card)
+		err = c.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, card)
 	} else if params.Recipient != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards", stripe.StringValue(params.Recipient)), c.Key, body, &params.Params, card)
+		err = c.B.Call("POST", stripe.FormatURLPath("/recipients/%s/cards", stripe.StringValue(params.Recipient)), c.Key, body, &params.Params, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -73,11 +72,11 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	var err error
 
 	if params.Account != nil {
-		err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
+		err = c.B.Call("GET", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
 	} else if params.Customer != nil {
-		err = c.B.Call("GET", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
+		err = c.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
 	} else if params.Recipient != nil {
-		err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
+		err = c.B.Call("GET", stripe.FormatURLPath("/recipients/%s/cards/%s", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -103,11 +102,11 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 	var err error
 
 	if params.Account != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, &params.Params, card)
+		err = c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, &params.Params, card)
 	} else if params.Customer != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), c.Key, body, &params.Params, card)
+		err = c.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, &params.Params, card)
 	} else if params.Recipient != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, &params.Params, card)
+		err = c.B.Call("POST", stripe.FormatURLPath("/recipients/%s/cards/%s", stripe.StringValue(params.Recipient), id), c.Key, body, &params.Params, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -137,11 +136,11 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	var err error
 
 	if params.Account != nil {
-		err = c.B.Call("DELETE", fmt.Sprintf("/accounts/%v/external_accounts/%v", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
+		err = c.B.Call("DELETE", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
 	} else if params.Customer != nil {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
+		err = c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
 	} else if params.Recipient != nil {
-		err = c.B.Call("DELETE", fmt.Sprintf("/recipients/%v/cards/%v", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
+		err = c.B.Call("DELETE", stripe.FormatURLPath("/recipients/%s/cards/%s", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
 	} else {
 		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
@@ -175,11 +174,11 @@ func (c Client) List(params *stripe.CardListParams) *Iter {
 		}
 
 		if params.Account != nil {
-			err = c.B.Call("GET", fmt.Sprintf("/accounts/%v/external_accounts?object=card", stripe.StringValue(params.Account)), c.Key, b, p, list)
+			err = c.B.Call("GET", stripe.FormatURLPath("/accounts/%s/external_accounts?object=card", stripe.StringValue(params.Account)), c.Key, b, p, list)
 		} else if params.Customer != nil {
-			err = c.B.Call("GET", fmt.Sprintf("/customers/%v/sources?object=card", stripe.StringValue(params.Customer)), c.Key, b, p, list)
+			err = c.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources?object=card", stripe.StringValue(params.Customer)), c.Key, b, p, list)
 		} else if params.Recipient != nil {
-			err = c.B.Call("GET", fmt.Sprintf("/recipients/%v/cards", stripe.StringValue(params.Recipient)), c.Key, b, p, list)
+			err = c.B.Call("GET", stripe.FormatURLPath("/recipients/%s/cards", stripe.StringValue(params.Recipient)), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid card params: either account, customer or recipient need to be set")
 		}

--- a/charge/client.go
+++ b/charge/client.go
@@ -2,8 +2,6 @@
 package charge
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -47,7 +45,7 @@ func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, err
 	}
 
 	charge := &stripe.Charge{}
-	err := c.B.Call("GET", "/charges/"+id, c.Key, body, commonParams, charge)
+	err := c.B.Call("GET", stripe.FormatURLPath("/charges/%s", id), c.Key, body, commonParams, charge)
 
 	return charge, err
 }
@@ -69,7 +67,7 @@ func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, 
 	}
 
 	charge := &stripe.Charge{}
-	err := c.B.Call("POST", "/charges/"+id, c.Key, body, commonParams, charge)
+	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s", id), c.Key, body, commonParams, charge)
 
 	return charge, err
 }
@@ -92,7 +90,7 @@ func (c Client) Capture(id string, params *stripe.CaptureParams) (*stripe.Charge
 
 	charge := &stripe.Charge{}
 
-	err := c.B.Call("POST", fmt.Sprintf("/charges/%v/capture", id), c.Key, body, commonParams, charge)
+	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s/capture", id), c.Key, body, commonParams, charge)
 
 	return charge, err
 }
@@ -177,7 +175,7 @@ func (c Client) UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.
 	}
 
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", fmt.Sprintf("/charges/%v/dispute", id), c.Key, body, commonParams, dispute)
+	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s/dispute", id), c.Key, body, commonParams, dispute)
 
 	return dispute, err
 }
@@ -190,7 +188,7 @@ func CloseDispute(id string) (*stripe.Dispute, error) {
 
 func (c Client) CloseDispute(id string) (*stripe.Dispute, error) {
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", fmt.Sprintf("/charges/%v/dispute/close", id), c.Key, nil, nil, dispute)
+	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s/dispute/close", id), c.Key, nil, nil, dispute)
 
 	return dispute, err
 }

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -20,7 +20,7 @@ func Get(country string) (*stripe.CountrySpec, error) {
 
 func (c Client) Get(country string) (*stripe.CountrySpec, error) {
 	countrySpec := &stripe.CountrySpec{}
-	err := c.B.Call("GET", "/country_specs/"+country, c.Key, nil, nil, countrySpec)
+	err := c.B.Call("GET", stripe.FormatURLPath("/country_specs/%s", country), c.Key, nil, nil, countrySpec)
 
 	return countrySpec, err
 }

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -2,8 +2,6 @@
 package coupon
 
 import (
-	"net/url"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -48,7 +46,7 @@ func (c Client) Get(id string, params *stripe.CouponParams) (*stripe.Coupon, err
 
 	coupon := &stripe.Coupon{}
 
-	err := c.B.Call("GET", "/coupons/"+url.QueryEscape(id), c.Key, body, commonParams, coupon)
+	err := c.B.Call("GET", stripe.FormatURLPath("/coupons/%s", id), c.Key, body, commonParams, coupon)
 
 	return coupon, err
 }
@@ -64,7 +62,7 @@ func (c Client) Update(id string, params *stripe.CouponParams) (*stripe.Coupon, 
 	form.AppendTo(body, params)
 
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("POST", "/coupons/"+url.QueryEscape(id), c.Key, body, &params.Params, coupon)
+	err := c.B.Call("POST", stripe.FormatURLPath("/coupons/%s", id), c.Key, body, &params.Params, coupon)
 
 	return coupon, err
 }
@@ -86,7 +84,7 @@ func (c Client) Del(id string, params *stripe.CouponParams) (*stripe.Coupon, err
 	}
 
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("DELETE", "/coupons/"+url.QueryEscape(id), c.Key, body, commonParams, coupon)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/coupons/%s", id), c.Key, body, commonParams, coupon)
 
 	return coupon, err
 }

--- a/customer/client.go
+++ b/customer/client.go
@@ -51,7 +51,7 @@ func (c Client) Get(id string, params *stripe.CustomerParams) (*stripe.Customer,
 	}
 
 	cust := &stripe.Customer{}
-	err := c.B.Call("GET", "/customers/"+id, c.Key, body, commonParams, cust)
+	err := c.B.Call("GET", stripe.FormatURLPath("/customers/%s", id), c.Key, body, commonParams, cust)
 
 	return cust, err
 }
@@ -73,7 +73,7 @@ func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Custom
 	}
 
 	cust := &stripe.Customer{}
-	err := c.B.Call("POST", "/customers/"+id, c.Key, body, commonParams, cust)
+	err := c.B.Call("POST", stripe.FormatURLPath("/customers/%s", id), c.Key, body, commonParams, cust)
 
 	return cust, err
 }
@@ -95,7 +95,7 @@ func (c Client) Del(id string, params *stripe.CustomerParams) (*stripe.Customer,
 	}
 
 	cust := &stripe.Customer{}
-	err := c.B.Call("DELETE", "/customers/"+id, c.Key, body, commonParams, cust)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s", id), c.Key, body, commonParams, cust)
 
 	return cust, err
 }

--- a/discount/client.go
+++ b/discount/client.go
@@ -2,8 +2,6 @@
 package discount
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -31,7 +29,7 @@ func (c Client) Del(customerID string, params *stripe.DiscountParams) (*stripe.D
 	}
 
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", fmt.Sprintf("/customers/%v/discount", customerID), c.Key, body, commonParams, discount)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/discount", customerID), c.Key, body, commonParams, discount)
 
 	return discount, err
 }
@@ -53,7 +51,7 @@ func (c Client) DelSub(subscriptionID string, params *stripe.DiscountParams) (*s
 	}
 
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", fmt.Sprintf("/subscriptions/%v/discount", subscriptionID), c.Key, body, commonParams, discount)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/subscriptions/%s/discount", subscriptionID), c.Key, body, commonParams, discount)
 
 	return discount, err
 }

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -1,8 +1,6 @@
 package dispute
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -30,7 +28,7 @@ func (c Client) Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, e
 	}
 
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("GET", "/disputes/"+id, c.Key, body, commonParams, dispute)
+	err := c.B.Call("GET", stripe.FormatURLPath("/disputes/%s", id), c.Key, body, commonParams, dispute)
 
 	return dispute, err
 }
@@ -96,7 +94,7 @@ func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute
 	}
 
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", fmt.Sprintf("/disputes/%v", id), c.Key, body, commonParams, dispute)
+	err := c.B.Call("POST", stripe.FormatURLPath("/disputes/%s", id), c.Key, body, commonParams, dispute)
 
 	return dispute, err
 }
@@ -118,7 +116,7 @@ func (c Client) Close(id string, params *stripe.DisputeParams) (*stripe.Dispute,
 	}
 
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", fmt.Sprintf("/disputes/%v/close", id), c.Key, body, commonParams, dispute)
+	err := c.B.Call("POST", stripe.FormatURLPath("/disputes/%s/close", id), c.Key, body, commonParams, dispute)
 
 	return dispute, err
 }

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -61,7 +61,7 @@ func (c Client) Del(id string, params *stripe.EphemeralKeyParams) (*stripe.Ephem
 	}
 
 	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call("DELETE", "/ephemeral_keys/"+id, c.Key, body, commonParams, ephemeralKey)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/ephemeral_keys/%s", id), c.Key, body, commonParams, ephemeralKey)
 
 	return ephemeralKey, err
 }

--- a/event/client.go
+++ b/event/client.go
@@ -20,7 +20,7 @@ func Get(id string, params *stripe.Params) (*stripe.Event, error) {
 
 func (c Client) Get(id string, params *stripe.Params) (*stripe.Event, error) {
 	event := &stripe.Event{}
-	err := c.B.Call("GET", "/events/"+id, c.Key, nil, params, event)
+	err := c.B.Call("GET", stripe.FormatURLPath("/events/%s", id), c.Key, nil, params, event)
 	return event, err
 }
 

--- a/exchangerate/client.go
+++ b/exchangerate/client.go
@@ -19,7 +19,7 @@ func Get(currency string) (*stripe.ExchangeRate, error) {
 
 func (c Client) Get(currency string) (*stripe.ExchangeRate, error) {
 	exchangeRate := &stripe.ExchangeRate{}
-	err := c.B.Call("GET", "/exchange_rates/"+currency, c.Key, nil, nil, exchangeRate)
+	err := c.B.Call("GET", stripe.FormatURLPath("/exchange_rates/%s", currency), c.Key, nil, nil, exchangeRate)
 
 	return exchangeRate, err
 }

--- a/fee/client.go
+++ b/fee/client.go
@@ -2,8 +2,6 @@
 package fee
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -31,7 +29,7 @@ func (c Client) Get(id string, params *stripe.ApplicationFeeParams) (*stripe.App
 	}
 
 	fee := &stripe.ApplicationFee{}
-	err := c.B.Call("GET", fmt.Sprintf("application_fees/%v", id), c.Key, body, commonParams, fee)
+	err := c.B.Call("GET", stripe.FormatURLPath("/application_fees/%s", id), c.Key, body, commonParams, fee)
 
 	return fee, err
 }

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -32,7 +32,7 @@ func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	form.AppendTo(body, params)
 
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("application_fees/%v/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", stripe.FormatURLPath("application_fees/%s/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -55,7 +55,7 @@ func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefun
 	form.AppendTo(body, params)
 
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds/%v", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
+	err := c.B.Call("GET", stripe.FormatURLPath("/application_fees/%s/refunds/%s", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -78,7 +78,7 @@ func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRe
 	form.AppendTo(body, params)
 
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", fmt.Sprintf("/application_fees/%v/refunds/%v", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", stripe.FormatURLPath("/application_fees/%s/refunds/%s", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }
@@ -100,7 +100,7 @@ func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeRefundList{}
-		err := c.B.Call("GET", fmt.Sprintf("/application_fees/%v/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, b, p, list)
+		err := c.B.Call("GET", stripe.FormatURLPath("/application_fees/%s/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -56,7 +56,7 @@ func (c Client) Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpl
 	}
 
 	upload := &stripe.FileUpload{}
-	err := c.B.Call("GET", "/files/"+id, c.Key, body, commonParams, upload)
+	err := c.B.Call("GET", stripe.FormatURLPath("/files/%s", id), c.Key, body, commonParams, upload)
 
 	return upload, err
 }

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -2,8 +2,6 @@
 package invoice
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -47,7 +45,7 @@ func (c Client) Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, e
 	}
 
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("GET", "/invoices/"+id, c.Key, body, commonParams, invoice)
+	err := c.B.Call("GET", stripe.FormatURLPath("/invoices/%s", id), c.Key, body, commonParams, invoice)
 
 	return invoice, err
 }
@@ -69,7 +67,7 @@ func (c Client) Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice
 	}
 
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("POST", fmt.Sprintf("/invoices/%v/pay", id), c.Key, body, commonParams, invoice)
+	err := c.B.Call("POST", stripe.FormatURLPath("/invoices/%s/pay", id), c.Key, body, commonParams, invoice)
 
 	return invoice, err
 }
@@ -91,7 +89,7 @@ func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice
 	}
 
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("POST", "/invoices/"+id, c.Key, body, commonParams, invoice)
+	err := c.B.Call("POST", stripe.FormatURLPath("/invoices/%s", id), c.Key, body, commonParams, invoice)
 
 	return invoice, err
 }
@@ -157,7 +155,7 @@ func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 
 	return &LineIter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceLineList{}
-		err := c.B.Call("GET", fmt.Sprintf("/invoices/%v/lines", stripe.StringValue(params.ID)), c.Key, b, p, list)
+		err := c.B.Call("GET", stripe.FormatURLPath("/invoices/%s/lines", stripe.StringValue(params.ID)), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -45,7 +45,7 @@ func (c Client) Get(id string, params *stripe.InvoiceItemParams) (*stripe.Invoic
 	}
 
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call("GET", "/invoiceitems/"+id, c.Key, body, commonParams, invoiceItem)
+	err := c.B.Call("GET", stripe.FormatURLPath("/invoiceitems/%s", id), c.Key, body, commonParams, invoiceItem)
 
 	return invoiceItem, err
 }
@@ -67,7 +67,7 @@ func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.Inv
 	}
 
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call("POST", "/invoiceitems/"+id, c.Key, body, commonParams, invoiceItem)
+	err := c.B.Call("POST", stripe.FormatURLPath("/invoiceitems/%s", id), c.Key, body, commonParams, invoiceItem)
 
 	return invoiceItem, err
 }
@@ -89,7 +89,7 @@ func (c Client) Del(id string, params *stripe.InvoiceItemParams) (*stripe.Invoic
 	}
 
 	ii := &stripe.InvoiceItem{}
-	err := c.B.Call("DELETE", "/invoiceitems/"+id, c.Key, body, commonParams, ii)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/invoiceitems/%s", id), c.Key, body, commonParams, ii)
 
 	return ii, err
 }

--- a/issuerfraudrecord/client.go
+++ b/issuerfraudrecord/client.go
@@ -21,7 +21,7 @@ func Get(id string) (*stripe.IssuerFraudRecord, error) {
 // For more details see https://stripe.com/docs/api#retrieve_issuer_fraud_record.
 func (c Client) Get(id string) (*stripe.IssuerFraudRecord, error) {
 	ifr := &stripe.IssuerFraudRecord{}
-	err := c.B.Call("GET", "/issuer_fraud_records/"+id, c.Key, nil, nil, ifr)
+	err := c.B.Call("GET", stripe.FormatURLPath("/issuer_fraud_records/%s", id), c.Key, nil, nil, ifr)
 	return ifr, err
 }
 

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -3,7 +3,6 @@ package loginlink
 
 import (
 	"errors"
-	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -28,7 +27,7 @@ func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 	var err error
 
 	if params.Account != nil {
-		err = c.B.Call("POST", fmt.Sprintf("/accounts/%v/login_links", stripe.StringValue(params.Account)), c.Key, body, nil, loginLink)
+		err = c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/login_links", stripe.StringValue(params.Account)), c.Key, body, nil, loginLink)
 	} else {
 		err = errors.New("Invalid login link params: Account must be set")
 	}

--- a/order/client.go
+++ b/order/client.go
@@ -2,7 +2,6 @@ package order
 
 import (
 	"errors"
-	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -57,7 +56,7 @@ func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Ord
 	}
 
 	o := &stripe.Order{}
-	err := c.B.Call("POST", "/orders/"+id, c.Key, body, commonParams, o)
+	err := c.B.Call("POST", stripe.FormatURLPath("/orders/%s", id), c.Key, body, commonParams, o)
 
 	return o, err
 }
@@ -86,7 +85,7 @@ func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, er
 	}
 
 	o := &stripe.Order{}
-	err := c.B.Call("POST", "/orders/"+id+"/pay", c.Key, body, commonParams, o)
+	err := c.B.Call("POST", stripe.FormatURLPath("/orders/%s/pay", id), c.Key, body, commonParams, o)
 
 	return o, err
 }
@@ -108,7 +107,7 @@ func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error
 	}
 
 	order := &stripe.Order{}
-	err := c.B.Call("GET", "/orders/"+id, c.Key, body, commonParams, order)
+	err := c.B.Call("GET", stripe.FormatURLPath("/orders/%s", id), c.Key, body, commonParams, order)
 	return order, err
 }
 
@@ -175,7 +174,7 @@ func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.Ord
 	}
 
 	ret := &stripe.OrderReturn{}
-	err := c.B.Call("POST", fmt.Sprintf("/orders/%s/returns", id), c.Key, body, commonParams, ret)
+	err := c.B.Call("POST", stripe.FormatURLPath("/orders/%s/returns", id), c.Key, body, commonParams, ret)
 
 	return ret, err
 }

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -3,7 +3,6 @@ package paymentsource
 
 import (
 	"errors"
-	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -29,7 +28,7 @@ func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 	var err error
 
 	if params.Customer != nil {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), s.Key, body, &params.Params, source)
+		err = s.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer)), s.Key, body, &params.Params, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -57,7 +56,7 @@ func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 	var err error
 
 	if params.Customer != nil {
-		err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
+		err = s.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -79,7 +78,7 @@ func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.
 	var err error
 
 	if params.Customer != nil {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
+		err = s.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -107,7 +106,7 @@ func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 	var err error
 
 	if params.Customer != nil {
-		err = s.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
+		err = s.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source params: customer needs to be set")
 	}
@@ -132,7 +131,7 @@ func (s Client) List(params *stripe.SourceListParams) *Iter {
 		var err error
 
 		if params.Customer != nil {
-			err = s.B.Call("GET", fmt.Sprintf("/customers/%v/sources", stripe.StringValue(params.Customer)), s.Key, b, p, list)
+			err = s.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer)), s.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid source params: customer needs to be set")
 		}
@@ -160,9 +159,9 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 	var err error
 
 	if params.Customer != nil {
-		err = s.B.Call("POST", fmt.Sprintf("/customers/%v/sources/%v/verify", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
+		err = s.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources/%s/verify", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
 	} else if len(params.Values) > 0 {
-		err = s.B.Call("POST", fmt.Sprintf("/sources/%v/verify", id), s.Key, body, &params.Params, source)
+		err = s.B.Call("POST", stripe.FormatURLPath("/sources/%s/verify", id), s.Key, body, &params.Params, source)
 	} else {
 		err = errors.New("Only customer bank accounts or sources can be verified in this manner.")
 	}

--- a/payout/client.go
+++ b/payout/client.go
@@ -2,8 +2,6 @@
 package payout
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -47,7 +45,7 @@ func (c Client) Get(id string, params *stripe.PayoutParams) (*stripe.Payout, err
 	}
 
 	payout := &stripe.Payout{}
-	err := c.B.Call("GET", "/payouts/"+id, c.Key, body, commonParams, payout)
+	err := c.B.Call("GET", stripe.FormatURLPath("/payouts/%s", id), c.Key, body, commonParams, payout)
 
 	return payout, err
 }
@@ -69,7 +67,7 @@ func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, 
 	}
 
 	payout := &stripe.Payout{}
-	err := c.B.Call("POST", "/payouts/"+id, c.Key, body, commonParams, payout)
+	err := c.B.Call("POST", stripe.FormatURLPath("/payouts/%s", id), c.Key, body, commonParams, payout)
 
 	return payout, err
 }
@@ -91,7 +89,7 @@ func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, 
 	}
 
 	payout := &stripe.Payout{}
-	err := c.B.Call("POST", fmt.Sprintf("/payouts/%v/cancel", id), c.Key, body, commonParams, payout)
+	err := c.B.Call("POST", stripe.FormatURLPath("/payouts/%s/cancel", id), c.Key, body, commonParams, payout)
 
 	return payout, err
 }

--- a/plan/client.go
+++ b/plan/client.go
@@ -2,9 +2,6 @@
 package plan
 
 import (
-	"fmt"
-	"net/url"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -48,7 +45,7 @@ func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) 
 	}
 
 	plan := &stripe.Plan{}
-	err := c.B.Call("GET", "/plans/"+url.QueryEscape(id), c.Key, body, commonParams, plan)
+	err := c.B.Call("GET", stripe.FormatURLPath("/plans/%s", id), c.Key, body, commonParams, plan)
 
 	return plan, err
 }
@@ -70,7 +67,7 @@ func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, erro
 	}
 
 	plan := &stripe.Plan{}
-	err := c.B.Call("POST", "/plans/"+url.QueryEscape(id), c.Key, body, commonParams, plan)
+	err := c.B.Call("POST", stripe.FormatURLPath("/plans/%s", id), c.Key, body, commonParams, plan)
 
 	return plan, err
 }
@@ -92,8 +89,7 @@ func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) 
 	}
 
 	plan := &stripe.Plan{}
-	qid := url.QueryEscape(id) //Added query escape per commit 9821176
-	err := c.B.Call("DELETE", fmt.Sprintf("/plans/%v", qid), c.Key, body, commonParams, plan)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/plans/%s", id), c.Key, body, commonParams, plan)
 	return plan, err
 }
 

--- a/product/client.go
+++ b/product/client.go
@@ -54,7 +54,7 @@ func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product
 	}
 
 	p := &stripe.Product{}
-	err := c.B.Call("POST", "/products/"+id, c.Key, body, commonParams, p)
+	err := c.B.Call("POST", stripe.FormatURLPath("/products/%s", id), c.Key, body, commonParams, p)
 
 	return p, err
 }
@@ -76,7 +76,7 @@ func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, e
 	}
 
 	p := &stripe.Product{}
-	err := c.B.Call("GET", "/products/"+id, c.Key, body, commonParams, p)
+	err := c.B.Call("GET", stripe.FormatURLPath("/products/%s", id), c.Key, body, commonParams, p)
 
 	return p, err
 }
@@ -144,7 +144,7 @@ func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, e
 	}
 
 	p := &stripe.Product{}
-	err := c.B.Call("DELETE", "/products/"+id, c.Key, body, commonParams, p)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/products/%s", id), c.Key, body, commonParams, p)
 
 	return p, err
 }

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -32,7 +32,7 @@ func (c Client) Get(id string, params *stripe.RecipientParams) (*stripe.Recipien
 	}
 
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("GET", "/recipients/"+id, c.Key, body, commonParams, recipient)
+	err := c.B.Call("GET", stripe.FormatURLPath("/recipients/%s", id), c.Key, body, commonParams, recipient)
 
 	return recipient, err
 }
@@ -54,7 +54,7 @@ func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recip
 	}
 
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("POST", "/recipients/"+id, c.Key, body, commonParams, recipient)
+	err := c.B.Call("POST", stripe.FormatURLPath("/recipients/%s", id), c.Key, body, commonParams, recipient)
 
 	return recipient, err
 }
@@ -76,7 +76,7 @@ func (c Client) Del(id string, params *stripe.RecipientParams) (*stripe.Recipien
 	}
 
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("DELETE", "/recipients/"+id, c.Key, body, commonParams, recipient)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/recipients/%s", id), c.Key, body, commonParams, recipient)
 
 	return recipient, err
 }

--- a/refund/client.go
+++ b/refund/client.go
@@ -45,7 +45,7 @@ func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, err
 	}
 
 	refund := &stripe.Refund{}
-	err := c.B.Call("GET", "/refunds/"+id, c.Key, body, commonParams, refund)
+	err := c.B.Call("GET", stripe.FormatURLPath("/refunds/%s", id), c.Key, body, commonParams, refund)
 
 	return refund, err
 }
@@ -61,7 +61,7 @@ func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, 
 	form.AppendTo(body, params)
 
 	refund := &stripe.Refund{}
-	err := c.B.Call("POST", "/refunds/"+id, c.Key, body, &params.Params, refund)
+	err := c.B.Call("POST", stripe.FormatURLPath("/refunds/%s", id), c.Key, body, &params.Params, refund)
 
 	return refund, err
 }

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -24,7 +24,7 @@ func (c Client) New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	form.AppendTo(body, params)
 
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("POST", fmt.Sprintf("/transfers/%v/reversals", stripe.StringValue(params.Transfer)), c.Key, body, &params.Params, reversal)
+	err := c.B.Call("POST", stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(params.Transfer)), c.Key, body, &params.Params, reversal)
 
 	return reversal, err
 }
@@ -43,7 +43,7 @@ func (c Client) Get(id string, params *stripe.ReversalParams) (*stripe.Reversal,
 	form.AppendTo(body, params)
 
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals/%v", stripe.StringValue(params.Transfer), id), c.Key, body, &params.Params, reversal)
+	err := c.B.Call("GET", stripe.FormatURLPath("/transfers/%s/reversals/%s", stripe.StringValue(params.Transfer), id), c.Key, body, &params.Params, reversal)
 
 	return reversal, err
 }
@@ -58,7 +58,7 @@ func (c Client) Update(id string, params *stripe.ReversalParams) (*stripe.Revers
 	form.AppendTo(body, params)
 
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("POST", fmt.Sprintf("/transfers/%v/reversals/%v", stripe.StringValue(params.Transfer), id), c.Key, body, &params.Params, reversal)
+	err := c.B.Call("POST", stripe.FormatURLPath("/transfers/%s/reversals/%s", stripe.StringValue(params.Transfer), id), c.Key, body, &params.Params, reversal)
 
 	return reversal, err
 }
@@ -76,7 +76,7 @@ func (c Client) List(params *stripe.ReversalListParams) *Iter {
 
 	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ReversalList{}
-		err := c.B.Call("GET", fmt.Sprintf("/transfers/%v/reversals", stripe.StringValue(params.Transfer)), c.Key, b, p, list)
+		err := c.B.Call("GET", stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(params.Transfer)), c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/sku/client.go
+++ b/sku/client.go
@@ -54,7 +54,7 @@ func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error)
 	}
 
 	s := &stripe.SKU{}
-	err := c.B.Call("POST", "/skus/"+id, c.Key, body, commonParams, s)
+	err := c.B.Call("POST", stripe.FormatURLPath("/skus/%s", id), c.Key, body, commonParams, s)
 
 	return s, err
 }
@@ -76,7 +76,7 @@ func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	}
 
 	s := &stripe.SKU{}
-	err := c.B.Call("GET", "/skus/"+id, c.Key, body, commonParams, s)
+	err := c.B.Call("GET", stripe.FormatURLPath("/skus/%s", id), c.Key, body, commonParams, s)
 
 	return s, err
 }
@@ -144,7 +144,7 @@ func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	}
 
 	s := &stripe.SKU{}
-	err := c.B.Call("DELETE", "/skus/"+id, c.Key, body, commonParams, s)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/skus/%s", id), c.Key, body, commonParams, s)
 
 	return s, err
 }

--- a/source/client.go
+++ b/source/client.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"errors"
-	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -57,7 +56,7 @@ func (c Client) Get(id string, params *stripe.SourceObjectParams) (*stripe.Sourc
 	}
 
 	source := &stripe.Source{}
-	err := c.B.Call("GET", "/sources/"+id, c.Key, body, commonParams, source)
+	err := c.B.Call("GET", stripe.FormatURLPath("/sources/%s", id), c.Key, body, commonParams, source)
 	return source, err
 }
 
@@ -78,7 +77,7 @@ func (c Client) Update(id string, params *stripe.SourceObjectParams) (*stripe.So
 	}
 
 	source := &stripe.Source{}
-	err := c.B.Call("POST", "/sources/"+id, c.Key, body, commonParams, source)
+	err := c.B.Call("POST", stripe.FormatURLPath("/sources/%s", id), c.Key, body, commonParams, source)
 
 	return source, err
 }
@@ -106,7 +105,7 @@ func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*str
 	var err error
 
 	if params.Customer != nil {
-		err = c.B.Call("DELETE", fmt.Sprintf("/customers/%v/sources/%v", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, source)
+		err = c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, source)
 	} else {
 		err = errors.New("Invalid source detach params: Customer needs to be set")
 	}

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -3,7 +3,6 @@ package sourcetransaction
 
 import (
 	"errors"
-	"fmt"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -35,7 +34,7 @@ func (c Client) List(params *stripe.SourceTransactionListParams) *Iter {
 		var err error
 
 		if params != nil && params.Source != nil {
-			err = c.B.Call("GET", fmt.Sprintf("/sources/%v/source_transactions", stripe.StringValue(params.Source)), c.Key, b, p, list)
+			err = c.B.Call("GET", stripe.FormatURLPath("/sources/%s/source_transactions", stripe.StringValue(params.Source)), c.Key, b, p, list)
 		} else {
 			err = errors.New("Invalid source transaction params: Source needs to be set")
 		}

--- a/stripe.go
+++ b/stripe.go
@@ -445,23 +445,7 @@ func FormatURLPath(format string, params ...string) string {
 		untypedParams[i] = interface{}(url.QueryEscape(param))
 	}
 
-	path := fmt.Sprintf(format, untypedParams...)
-
-	// Protect against not enough parameters.
-	//
-	// We panic here because this is a misuse that should only be noticed while
-	// making changes to the library -- it won't happen accidentally later at
-	// runtime.
-	if strings.Index(path, "(MISSING)") != -1 {
-		panic(fmt.Sprintf("Missing URL path parameter: %s", path))
-	}
-
-	// Protect against too many parameters.
-	if strings.Index(path, "%!(EXTRA ") != -1 {
-		panic(fmt.Sprintf("Extra URL path parameter: %s", path))
-	}
-
-	return path
+	return fmt.Sprintf(format, untypedParams...)
 }
 
 // SetAppInfo sets app information. See AppInfo.

--- a/stripe.go
+++ b/stripe.go
@@ -445,7 +445,23 @@ func FormatURLPath(format string, params ...string) string {
 		untypedParams[i] = interface{}(url.QueryEscape(param))
 	}
 
-	return fmt.Sprintf(format, untypedParams...)
+	path := fmt.Sprintf(format, untypedParams...)
+
+	// Protect against not enough parameters.
+	//
+	// We panic here because this is a misuse that should only be noticed while
+	// making changes to the library -- it won't happen accidentally later at
+	// runtime.
+	if strings.Index(path, "(MISSING)") != -1 {
+		panic(fmt.Sprintf("Missing URL path parameter: %s", path))
+	}
+
+	// Protect against too many parameters.
+	if strings.Index(path, "%!(EXTRA ") != -1 {
+		panic(fmt.Sprintf("Extra URL path parameter: %s", path))
+	}
+
+	return path
 }
 
 // SetAppInfo sets app information. See AppInfo.

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -68,6 +68,15 @@ func TestContext_Cancel(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`(request canceled|context canceled\z)`), err.Error())
 }
 
+func TestFormatURLPath(t *testing.T) {
+	assert.Equal(t, "/resources/1/subresources/2",
+		stripe.FormatURLPath("/resources/%s/subresources/%s", "1", "2"))
+
+	// Tests that each parameter is escaped for use in URLs
+	assert.Equal(t, "/resources/%25",
+		stripe.FormatURLPath("/resources/%s", "%"))
+}
+
 // TestMultipleAPICalls will fail the test run if a race condition is thrown while running multiple NewRequest calls.
 func TestMultipleAPICalls(t *testing.T) {
 	wg := &sync.WaitGroup{}

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -75,6 +75,14 @@ func TestFormatURLPath(t *testing.T) {
 	// Tests that each parameter is escaped for use in URLs
 	assert.Equal(t, "/resources/%25",
 		stripe.FormatURLPath("/resources/%s", "%"))
+
+	assert.PanicsWithValue(t, "Missing URL path parameter: /resources/1/subresources/%!s(MISSING)", func() {
+		stripe.FormatURLPath("/resources/%s/subresources/%s", "1")
+	})
+
+	assert.PanicsWithValue(t, "Extra URL path parameter: /resources/1/subresources/2%!(EXTRA string=3)", func() {
+		stripe.FormatURLPath("/resources/%s/subresources/%s", "1", "2", "3")
+	})
 }
 
 // TestMultipleAPICalls will fail the test run if a race condition is thrown while running multiple NewRequest calls.

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -75,14 +75,6 @@ func TestFormatURLPath(t *testing.T) {
 	// Tests that each parameter is escaped for use in URLs
 	assert.Equal(t, "/resources/%25",
 		stripe.FormatURLPath("/resources/%s", "%"))
-
-	assert.PanicsWithValue(t, "Missing URL path parameter: /resources/1/subresources/%!s(MISSING)", func() {
-		stripe.FormatURLPath("/resources/%s/subresources/%s", "1")
-	})
-
-	assert.PanicsWithValue(t, "Extra URL path parameter: /resources/1/subresources/2%!(EXTRA string=3)", func() {
-		stripe.FormatURLPath("/resources/%s/subresources/%s", "1", "2", "3")
-	})
 }
 
 // TestMultipleAPICalls will fail the test run if a race condition is thrown while running multiple NewRequest calls.

--- a/sub/client.go
+++ b/sub/client.go
@@ -2,8 +2,6 @@
 package sub
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -53,7 +51,7 @@ func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subsc
 	}
 
 	sub := &stripe.Subscription{}
-	err := c.B.Call("GET", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
+	err := c.B.Call("GET", stripe.FormatURLPath("/subscriptions/%s", id), c.Key, body, commonParams, sub)
 
 	return sub, err
 }
@@ -75,7 +73,7 @@ func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Su
 	}
 
 	sub := &stripe.Subscription{}
-	err := c.B.Call("POST", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
+	err := c.B.Call("POST", stripe.FormatURLPath("/subscriptions/%s", id), c.Key, body, commonParams, sub)
 
 	return sub, err
 }
@@ -97,7 +95,7 @@ func (c Client) Cancel(id string, params *stripe.SubscriptionCancelParams) (*str
 	}
 
 	sub := &stripe.Subscription{}
-	err := c.B.Call("DELETE", fmt.Sprintf("/subscriptions/%v", id), c.Key, body, commonParams, sub)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/subscriptions/%s", id), c.Key, body, commonParams, sub)
 
 	return sub, err
 }

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -2,8 +2,6 @@
 package subitem
 
 import (
-	"fmt"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -53,7 +51,7 @@ func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.S
 	}
 
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call("GET", fmt.Sprintf("/subscription_items/%v", id), c.Key, body, commonParams, item)
+	err := c.B.Call("GET", stripe.FormatURLPath("/subscription_items/%s", id), c.Key, body, commonParams, item)
 
 	return item, err
 }
@@ -76,7 +74,7 @@ func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*strip
 	}
 
 	subi := &stripe.SubscriptionItem{}
-	err := c.B.Call("POST", fmt.Sprintf("/subscription_items/%v", id), token, body, commonParams, subi)
+	err := c.B.Call("POST", stripe.FormatURLPath("/subscription_items/%s", id), token, body, commonParams, subi)
 
 	return subi, err
 }
@@ -98,7 +96,7 @@ func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.S
 	}
 
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call("DELETE", fmt.Sprintf("/subscription_items/%v", id), c.Key, body, commonParams, item)
+	err := c.B.Call("DELETE", stripe.FormatURLPath("/subscription_items/%s", id), c.Key, body, commonParams, item)
 
 	return item, err
 }

--- a/threedsecure/client.go
+++ b/threedsecure/client.go
@@ -44,7 +44,7 @@ func (c Client) Get(id string, params *stripe.ThreeDSecureParams) (*stripe.Three
 	}
 
 	tds := &stripe.ThreeDSecure{}
-	err := c.B.Call("GET", "/3d_secure/"+id, c.Key, body, commonParams, tds)
+	err := c.B.Call("GET", stripe.FormatURLPath("/3d_secure/%s", id), c.Key, body, commonParams, tds)
 
 	return tds, err
 }

--- a/token/client.go
+++ b/token/client.go
@@ -45,7 +45,7 @@ func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error
 	}
 
 	token := &stripe.Token{}
-	err := c.B.Call("GET", "/tokens/"+id, c.Key, body, commonParams, token)
+	err := c.B.Call("GET", stripe.FormatURLPath("/tokens/%s", id), c.Key, body, commonParams, token)
 
 	return token, err
 }

--- a/topup/client.go
+++ b/topup/client.go
@@ -44,7 +44,7 @@ func (c Client) Get(id string, params *stripe.TopupParams) (*stripe.Topup, error
 	}
 
 	topup := &stripe.Topup{}
-	err := c.B.Call("GET", "/topups/"+id, c.Key, body, commonParams, topup)
+	err := c.B.Call("GET", stripe.FormatURLPath("/topups/%s", id), c.Key, body, commonParams, topup)
 
 	return topup, err
 }
@@ -66,7 +66,7 @@ func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, er
 	}
 
 	topup := &stripe.Topup{}
-	err := c.B.Call("POST", "/topups/"+id, c.Key, body, commonParams, topup)
+	err := c.B.Call("POST", stripe.FormatURLPath("/topups/%s", id), c.Key, body, commonParams, topup)
 
 	return topup, err
 }

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -45,7 +45,7 @@ func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer,
 	}
 
 	transfer := &stripe.Transfer{}
-	err := c.B.Call("GET", "/transfers/"+id, c.Key, body, commonParams, transfer)
+	err := c.B.Call("GET", stripe.FormatURLPath("/transfers/%s", id), c.Key, body, commonParams, transfer)
 
 	return transfer, err
 }
@@ -69,7 +69,7 @@ func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transf
 	}
 
 	transfer := &stripe.Transfer{}
-	err := c.B.Call("POST", "/transfers/"+id, c.Key, body, commonParams, transfer)
+	err := c.B.Call("POST", stripe.FormatURLPath("/transfers/%s", id), c.Key, body, commonParams, transfer)
 
 	return transfer, err
 }

--- a/usagerecord/client.go
+++ b/usagerecord/client.go
@@ -2,7 +2,6 @@
 package usagerecord
 
 import (
-	"fmt"
 	"net/url"
 
 	stripe "github.com/stripe/stripe-go"
@@ -26,7 +25,7 @@ func (c Client) New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, erro
 	body := &form.Values{}
 	form.AppendTo(body, params)
 
-	url := fmt.Sprintf("/subscription_items/%s/usage_records", url.QueryEscape(stripe.StringValue(params.SubscriptionItem)))
+	url := stripe.FormatURLPath("/subscription_items/%s/usage_records", url.QueryEscape(stripe.StringValue(params.SubscriptionItem)))
 	record := &stripe.UsageRecord{}
 	err := c.B.Call("POST", url, c.Key, body, &params.Params, record)
 


### PR DESCRIPTION
Adds a helper to the top-level package called `FormatURLPath`. It's
basically a pass-through to `Sprintf`, except that it only takes string
parameters. This is designed to make invocations slightly more safe —
we've had a little trouble in the past where a string pointer was
accidentally passed instead of a string, and because `Sprintf` doesn't
automatically dereference or anything, the result is an invalid URL.

It also gives us the opportunity to call `url.QueryEscape` on every
parameter for a little additional safety. Previously, this was being
invoked manually only in certain packages like `plan`.

I changed all uses of `%v` in invocations to `%s` for consistency and
because we won't need any types beyond strings. In the same spirit, I
also changed all the places that we were concatenating strings (like
`"/skus/"+id`) to invoke `FormatURLPath`.

This patch is fairly noisy, but you can mostly just examine the added
function in `stripe.go` and test in `stripe_test.go`:

``` go
func FormatURLPath(format string, params ...string) string {
    untypedParams := make([]interface{}, len(params))
    for i, param := range params {
	    untypedParams[i] = interface{}(url.QueryEscape(param))
    }

    return fmt.Sprintf(format, untypedParams...)
}
```

r? @remi-stripe If you wouldn't mind.
cc @stripe/api-libraries 