### PR TITLE
Improve expansion parsing by not discarding unmarshal errors

### DIFF
--- a/account_test.go
+++ b/account_test.go
@@ -30,7 +30,7 @@ func TestAccountExternalAccountParams_AppendTo(t *testing.T) {
 	}
 }
 
-func TestAccountUnmarshal(t *testing.T) {
+func TestAccount_Unmarshal(t *testing.T) {
 	accountData := map[string]interface{}{
 		"id": "acct_123",
 		"external_accounts": map[string]interface{}{
@@ -245,6 +245,46 @@ func TestAccountUnmarshal(t *testing.T) {
 	assert.Equal(t, "file_345", account.LegalEntity.Verification.Document.ID)
 	assert.Equal(t, "file_456", account.LegalEntity.Verification.DocumentBack.ID)
 	assert.Equal(t, IdentityVerificationStatusUnverified, account.LegalEntity.Verification.Status)
+}
+
+func TestAccount_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Account
+		err := json.Unmarshal([]byte(`"acct_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "acct_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := Account{ID: "acct_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "acct_123", v.ID)
+	}
+}
+
+func TestExternalAccount_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON object
+	{
+		// We build the JSON object manually here because it's key that the
+		// `object` field is included so that the source knows what type to
+		// decode
+		data := []byte(`{"id":"ba_123", "object":"bank_account"}`)
+
+		var v ExternalAccount
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, ExternalAccountTypeBankAccount, v.Type)
+
+		// The external account has a field for each possible type, so the
+		// bank account is located one level down
+		assert.Equal(t, "ba_123", v.BankAccount.ID)
+	}
 }
 
 func TestPayoutScheduleParams_AppendTo(t *testing.T) {

--- a/application.go
+++ b/application.go
@@ -11,15 +11,17 @@ type Application struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (a *Application) UnmarshalJSON(data []byte) error {
-	type application Application
-	var aa application
-	err := json.Unmarshal(data, &aa)
-	if err == nil {
-		*a = Application(aa)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		a.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		a.ID = id
+		return nil
 	}
 
+	type application Application
+	var v application
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*a = Application(v)
 	return nil
 }

--- a/balance.go
+++ b/balance.go
@@ -140,16 +140,18 @@ type BalanceTransactionFee struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (t *BalanceTransaction) UnmarshalJSON(data []byte) error {
-	type bt BalanceTransaction
-	var tt bt
-	err := json.Unmarshal(data, &tt)
-	if err == nil {
-		*t = BalanceTransaction(tt)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		t.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		t.ID = id
+		return nil
 	}
 
+	type balanceTransaction BalanceTransaction
+	var v balanceTransaction
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*t = BalanceTransaction(v)
 	return nil
 }
 

--- a/balance.go
+++ b/balance.go
@@ -157,40 +157,40 @@ func (t *BalanceTransaction) UnmarshalJSON(data []byte) error {
 // This custom unmarshaling is needed because the specific
 // type of transaction source it refers to is specified in the JSON
 func (s *BalanceTransactionSource) UnmarshalJSON(data []byte) error {
-	type source BalanceTransactionSource
-	var ss source
-	err := json.Unmarshal(data, &ss)
-	if err == nil {
-		*s = BalanceTransactionSource(ss)
-
-		switch s.Type {
-		case BalanceTransactionSourceTypeApplicationFee:
-			err = json.Unmarshal(data, &s.ApplicationFee)
-		case BalanceTransactionSourceTypeCharge:
-			err = json.Unmarshal(data, &s.Charge)
-		case BalanceTransactionSourceTypeDispute:
-			err = json.Unmarshal(data, &s.Dispute)
-		case BalanceTransactionSourceTypePayout:
-			err = json.Unmarshal(data, &s.Payout)
-		case BalanceTransactionSourceTypeRecipientTransfer:
-			err = json.Unmarshal(data, &s.RecipientTransfer)
-		case BalanceTransactionSourceTypeRefund:
-			err = json.Unmarshal(data, &s.Refund)
-		case BalanceTransactionSourceTypeReversal:
-			err = json.Unmarshal(data, &s.Reversal)
-		case BalanceTransactionSourceTypeTransfer:
-			err = json.Unmarshal(data, &s.Transfer)
-		}
-
-		if err != nil {
-			return err
-		}
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		s.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		s.ID = id
+		return nil
 	}
 
-	return nil
+	type balanceTransactionSource BalanceTransactionSource
+	var v balanceTransactionSource
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	var err error
+	*s = BalanceTransactionSource(v)
+
+	switch s.Type {
+	case BalanceTransactionSourceTypeApplicationFee:
+		err = json.Unmarshal(data, &s.ApplicationFee)
+	case BalanceTransactionSourceTypeCharge:
+		err = json.Unmarshal(data, &s.Charge)
+	case BalanceTransactionSourceTypeDispute:
+		err = json.Unmarshal(data, &s.Dispute)
+	case BalanceTransactionSourceTypePayout:
+		err = json.Unmarshal(data, &s.Payout)
+	case BalanceTransactionSourceTypeRecipientTransfer:
+		err = json.Unmarshal(data, &s.RecipientTransfer)
+	case BalanceTransactionSourceTypeRefund:
+		err = json.Unmarshal(data, &s.Refund)
+	case BalanceTransactionSourceTypeReversal:
+		err = json.Unmarshal(data, &s.Reversal)
+	case BalanceTransactionSourceTypeTransfer:
+		err = json.Unmarshal(data, &s.Transfer)
+	}
+
+	return err
 }
 
 // MarshalJSON handles serialization of a BalanceTransactionSource.

--- a/balance_test.go
+++ b/balance_test.go
@@ -7,6 +7,27 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
+func TestBalanceTransaction_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v BalanceTransaction
+		err := json.Unmarshal([]byte(`"bt_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "bt_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := BalanceTransaction{ID: "bt_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "bt_123", v.ID)
+	}
+}
+
 func TestBalanceTransactionSource_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{

--- a/balance_test.go
+++ b/balance_test.go
@@ -1,0 +1,35 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestBalanceTransactionSource_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v BalanceTransactionSource
+		err := json.Unmarshal([]byte(`"ch_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ch_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		// We build the JSON object manually here because it's key that the
+		// `object` field is included so that the source knows what type to
+		// decode
+		data := []byte(`{"id":"ch_123", "object":"charge"}`)
+
+		var v BalanceTransactionSource
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, BalanceTransactionSourceTypeCharge, v.Type)
+
+		// The source has a field for each possible type, so the charge is
+		// located one level down
+		assert.Equal(t, "ch_123", v.Charge.ID)
+	}
+}

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -153,15 +153,17 @@ type BankAccountList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (b *BankAccount) UnmarshalJSON(data []byte) error {
-	type bankAccount BankAccount
-	var bb bankAccount
-	err := json.Unmarshal(data, &bb)
-	if err == nil {
-		*b = BankAccount(bb)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		b.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		b.ID = id
+		return nil
 	}
 
+	type bankAccount BankAccount
+	var v bankAccount
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*b = BankAccount(v)
 	return nil
 }

--- a/bankaccount_test.go
+++ b/bankaccount_test.go
@@ -1,11 +1,33 @@
 package stripe
 
 import (
+	"encoding/json"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 	"github.com/stripe/stripe-go/form"
 )
+
+func TestBankAccount_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v BankAccount
+		err := json.Unmarshal([]byte(`"ba_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ba_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := BankAccount{ID: "ba_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ba_123", v.ID)
+	}
+}
 
 func TestBankAccountParams_AppendToAsSourceOrExternalAccount(t *testing.T) {
 	// We should add more tests for all the various corner cases here ...

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -66,16 +66,18 @@ type BitcoinReceiverList struct {
 // UnmarshalJSON handles deserialization of a BitcoinReceiver.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (br *BitcoinReceiver) UnmarshalJSON(data []byte) error {
-	type bitcoinReceiver BitcoinReceiver
-	var r bitcoinReceiver
-	err := json.Unmarshal(data, &r)
-	if err == nil {
-		*br = BitcoinReceiver(r)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		br.ID = string(data[1 : len(data)-1])
+func (r *BitcoinReceiver) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		r.ID = id
+		return nil
 	}
 
+	type bitcoinReceiver BitcoinReceiver
+	var v bitcoinReceiver
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*r = BitcoinReceiver(v)
 	return nil
 }

--- a/bitcoinreceiver_test.go
+++ b/bitcoinreceiver_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestBitcoinReceiver_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v BitcoinReceiver
+		err := json.Unmarshal([]byte(`"btcrcv_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "btcrcv_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := BitcoinReceiver{ID: "btcrcv_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "btcrcv_123", v.ID)
 	}
 }

--- a/bitcointransaction.go
+++ b/bitcointransaction.go
@@ -33,15 +33,17 @@ type BitcoinTransaction struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (bt *BitcoinTransaction) UnmarshalJSON(data []byte) error {
-	type bitcoinTransaction BitcoinTransaction
-	var t bitcoinTransaction
-	err := json.Unmarshal(data, &t)
-	if err == nil {
-		*bt = BitcoinTransaction(t)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		bt.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		bt.ID = id
+		return nil
 	}
 
+	type bitcoinTransaction BitcoinTransaction
+	var v bitcoinTransaction
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*bt = BitcoinTransaction(v)
 	return nil
 }

--- a/bitcointransaction_test.go
+++ b/bitcointransaction_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestBitcoinTransaction_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v BitcoinTransaction
+		err := json.Unmarshal([]byte(`"btctxn_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "btctxn_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := BitcoinTransaction{ID: "btctxn_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "btctxn_123", v.ID)
 	}
 }

--- a/card.go
+++ b/card.go
@@ -230,15 +230,17 @@ type CardList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (c *Card) UnmarshalJSON(data []byte) error {
-	type card Card
-	var cc card
-	err := json.Unmarshal(data, &cc)
-	if err == nil {
-		*c = Card(cc)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		c.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		c.ID = id
+		return nil
 	}
 
+	type card Card
+	var v card
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*c = Card(v)
 	return nil
 }

--- a/card_test.go
+++ b/card_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestCard_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v Card
+		err := json.Unmarshal([]byte(`"card_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "card_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := Card{ID: "card_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "card_123", v.ID)
 	}
 }

--- a/charge.go
+++ b/charge.go
@@ -187,15 +187,17 @@ var depth int = -1
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (c *ChargeOutcomeRule) UnmarshalJSON(data []byte) error {
-	type chargeOutcomeRule ChargeOutcomeRule
-	var cc chargeOutcomeRule
-	err := json.Unmarshal(data, &cc)
-	if err == nil {
-		*c = ChargeOutcomeRule(cc)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		c.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		c.ID = id
+		return nil
 	}
 
+	type chargeOutcomeRule ChargeOutcomeRule
+	var v chargeOutcomeRule
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*c = ChargeOutcomeRule(v)
 	return nil
 }

--- a/charge.go
+++ b/charge.go
@@ -130,15 +130,18 @@ type Charge struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an ID or the full struct if it was expanded.
 func (c *Charge) UnmarshalJSON(data []byte) error {
-	type charge Charge
-	var cc charge
-	err := json.Unmarshal(data, &cc)
-	if err == nil {
-		*c = Charge(cc)
-	} else {
-		// the ID is surrounded by "\" characters, so strip them
-		c.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		c.ID = id
+		return nil
 	}
+
+	type charge Charge
+	var v charge
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*c = Charge(v)
 	return nil
 }
 

--- a/charge_test.go
+++ b/charge_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
+func TestCharge_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Charge
+		err := json.Unmarshal([]byte(`"ch_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ch_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := Charge{ID: "ch_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ch_123", v.ID)
+	}
+}
+
 func TestChargeOutcomeRule_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{

--- a/charge_test.go
+++ b/charge_test.go
@@ -1,11 +1,33 @@
 package stripe
 
 import (
+	"encoding/json"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 	"github.com/stripe/stripe-go/form"
 )
+
+func TestChargeOutcomeRule_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v ChargeOutcomeRule
+		err := json.Unmarshal([]byte(`"ssr_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ssr_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := ChargeOutcomeRule{ID: "ssr_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ssr_123", v.ID)
+	}
+}
 
 func TestChargeParams_AppendTo(t *testing.T) {
 	{

--- a/coupon.go
+++ b/coupon.go
@@ -62,15 +62,17 @@ type CouponList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (c *Coupon) UnmarshalJSON(data []byte) error {
-	type coupon Coupon
-	var cc coupon
-	err := json.Unmarshal(data, &cc)
-	if err == nil {
-		*c = Coupon(cc)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		c.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		c.ID = id
+		return nil
 	}
 
+	type coupon Coupon
+	var v coupon
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*c = Coupon(v)
 	return nil
 }

--- a/coupon_test.go
+++ b/coupon_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestCoupon_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v Coupon
+		err := json.Unmarshal([]byte(`"25OFF"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "25OFF", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := Coupon{ID: "25OFF"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "25OFF", v.ID)
 	}
 }

--- a/customer.go
+++ b/customer.go
@@ -84,15 +84,17 @@ type CustomerShippingDetails struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (c *Customer) UnmarshalJSON(data []byte) error {
-	type customer Customer
-	var cc customer
-	err := json.Unmarshal(data, &cc)
-	if err == nil {
-		*c = Customer(cc)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		c.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		c.ID = id
+		return nil
 	}
 
+	type customer Customer
+	var v customer
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*c = Customer(v)
 	return nil
 }

--- a/customer_test.go
+++ b/customer_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestCustomer_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v Customer
+		err := json.Unmarshal([]byte(`"cus_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "cus_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := Customer{ID: "cus_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "cus_123", v.ID)
 	}
 }

--- a/dispute.go
+++ b/dispute.go
@@ -160,17 +160,19 @@ type File struct {
 // UnmarshalJSON handles deserialization of a Dispute.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (t *Dispute) UnmarshalJSON(data []byte) error {
-	type dispute Dispute
-	var dd dispute
-	err := json.Unmarshal(data, &dd)
-	if err == nil {
-		*t = Dispute(dd)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		t.ID = string(data[1 : len(data)-1])
+func (d *Dispute) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		d.ID = id
+		return nil
 	}
 
+	type dispute Dispute
+	var v dispute
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*d = Dispute(v)
 	return nil
 }
 
@@ -178,15 +180,17 @@ func (t *Dispute) UnmarshalJSON(data []byte) error {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (f *File) UnmarshalJSON(data []byte) error {
-	type file File
-	var ff file
-	err := json.Unmarshal(data, &ff)
-	if err == nil {
-		*f = File(ff)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		f.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		f.ID = id
+		return nil
 	}
 
+	type file File
+	var v file
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*f = File(v)
 	return nil
 }

--- a/dispute.go
+++ b/dispute.go
@@ -147,16 +147,6 @@ type DisputeEvidence struct {
 	UncategorizedText            string `json:"uncategorized_text"`
 }
 
-// File represents a link to downloadable content.
-type File struct {
-	Created  int64  `json:"created"`
-	ID       string `json:"id"`
-	MIMEType string `json:"mime_type"`
-	Purpose  string `json:"purpose"`
-	Size     int64  `json:"size"`
-	URL      string `json:"url"`
-}
-
 // UnmarshalJSON handles deserialization of a Dispute.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
@@ -173,24 +163,5 @@ func (d *Dispute) UnmarshalJSON(data []byte) error {
 	}
 
 	*d = Dispute(v)
-	return nil
-}
-
-// UnmarshalJSON handles deserialization of a File.
-// This custom unmarshaling is needed because the resulting
-// property may be an id or the full struct if it was expanded.
-func (f *File) UnmarshalJSON(data []byte) error {
-	if id, ok := ParseID(data); ok {
-		f.ID = id
-		return nil
-	}
-
-	type file File
-	var v file
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-
-	*f = File(v)
 	return nil
 }

--- a/dispute_test.go
+++ b/dispute_test.go
@@ -27,24 +27,3 @@ func TestDispute_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, "dp_123", v.ID)
 	}
 }
-
-func TestFile_UnmarshalJSON(t *testing.T) {
-	// Unmarshals from a JSON string
-	{
-		var v File
-		err := json.Unmarshal([]byte(`"file_123"`), &v)
-		assert.NoError(t, err)
-		assert.Equal(t, "file_123", v.ID)
-	}
-
-	// Unmarshals from a JSON object
-	{
-		v := File{ID: "file_123"}
-		data, err := json.Marshal(&v)
-		assert.NoError(t, err)
-
-		err = json.Unmarshal(data, &v)
-		assert.NoError(t, err)
-		assert.Equal(t, "file_123", v.ID)
-	}
-}

--- a/dispute_test.go
+++ b/dispute_test.go
@@ -1,0 +1,50 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestDispute_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Dispute
+		err := json.Unmarshal([]byte(`"dp_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "dp_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := Dispute{ID: "dp_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "dp_123", v.ID)
+	}
+}
+
+func TestFile_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v File
+		err := json.Unmarshal([]byte(`"file_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "file_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := File{ID: "file_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "file_123", v.ID)
+	}
+}

--- a/fee.go
+++ b/fee.go
@@ -45,15 +45,17 @@ type ApplicationFeeList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (f *ApplicationFee) UnmarshalJSON(data []byte) error {
-	type appfee ApplicationFee
-	var ff appfee
-	err := json.Unmarshal(data, &ff)
-	if err == nil {
-		*f = ApplicationFee(ff)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		f.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		f.ID = id
+		return nil
 	}
 
+	type applicationFee ApplicationFee
+	var v applicationFee
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*f = ApplicationFee(v)
 	return nil
 }

--- a/fee_test.go
+++ b/fee_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestApplicationFee_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v ApplicationFee
+		err := json.Unmarshal([]byte(`"fee_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "fee_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := ApplicationFee{ID: "fee_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "fee_123", v.ID)
 	}
 }

--- a/feerefund.go
+++ b/feerefund.go
@@ -40,16 +40,18 @@ type FeeRefundList struct {
 // UnmarshalJSON handles deserialization of a FeeRefund.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (f *FeeRefund) UnmarshalJSON(data []byte) error {
-	type feerefund FeeRefund
-	var ff feerefund
-	err := json.Unmarshal(data, &ff)
-	if err == nil {
-		*f = FeeRefund(ff)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		f.ID = string(data[1 : len(data)-1])
+func (r *FeeRefund) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		r.ID = id
+		return nil
 	}
 
+	type feeRefund FeeRefund
+	var v feeRefund
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*r = FeeRefund(v)
 	return nil
 }

--- a/feerefund_test.go
+++ b/feerefund_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestFeeRefund_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v FeeRefund
+		err := json.Unmarshal([]byte(`"fr_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "fr_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := FeeRefund{ID: "fr_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "fr_123", v.ID)
 	}
 }

--- a/fileupload.go
+++ b/fileupload.go
@@ -15,6 +15,38 @@ const (
 	FileUploadPurposeIdentityDocument FileUploadPurpose = "identity_document"
 )
 
+// File represents a link to downloadable content.
+//
+// This is an earlier incarnation of FileUpload, and they'll eventually be
+// merged into the same struct.
+type File struct {
+	Created  int64  `json:"created"`
+	ID       string `json:"id"`
+	MIMEType string `json:"mime_type"`
+	Purpose  string `json:"purpose"`
+	Size     int64  `json:"size"`
+	URL      string `json:"url"`
+}
+
+// UnmarshalJSON handles deserialization of a File.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (f *File) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		f.ID = id
+		return nil
+	}
+
+	type file File
+	var v file
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*f = File(v)
+	return nil
+}
+
 // FileUploadParams is the set of parameters that can be used when creating a
 // file upload.
 // For more details see https://stripe.com/docs/api#create_file_upload.

--- a/fileupload.go
+++ b/fileupload.go
@@ -96,15 +96,17 @@ func (f *FileUploadParams) AppendDetails(body io.ReadWriter) (string, error) {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (f *FileUpload) UnmarshalJSON(data []byte) error {
-	type file FileUpload
-	var ff file
-	err := json.Unmarshal(data, &ff)
-	if err == nil {
-		*f = FileUpload(ff)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		f.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		f.ID = id
+		return nil
 	}
 
+	type fileUpload FileUpload
+	var v fileUpload
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*f = FileUpload(v)
 	return nil
 }

--- a/fileupload_test.go
+++ b/fileupload_test.go
@@ -7,6 +7,27 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
+func TestFile_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v File
+		err := json.Unmarshal([]byte(`"file_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "file_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := File{ID: "file_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "file_123", v.ID)
+	}
+}
+
 func TestFileUpload_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{

--- a/fileupload_test.go
+++ b/fileupload_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestFileUpload_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v FileUpload
+		err := json.Unmarshal([]byte(`"file_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "file_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := FileUpload{ID: "file_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "file_123", v.ID)
 	}
 }

--- a/invoice.go
+++ b/invoice.go
@@ -161,15 +161,17 @@ type InvoicePayParams struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (i *Invoice) UnmarshalJSON(data []byte) error {
-	type invoice Invoice
-	var ii invoice
-	err := json.Unmarshal(data, &ii)
-	if err == nil {
-		*i = Invoice(ii)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		i.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		i.ID = id
+		return nil
 	}
 
+	type invoice Invoice
+	var v invoice
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*i = Invoice(v)
 	return nil
 }

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestInvoice_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v Invoice
+		err := json.Unmarshal([]byte(`"in_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "in_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := Invoice{ID: "in_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "in_123", v.ID)
 	}
 }

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -55,15 +55,17 @@ type InvoiceItemList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (i *InvoiceItem) UnmarshalJSON(data []byte) error {
-	type invoiceitem InvoiceItem
-	var ii invoiceitem
-	err := json.Unmarshal(data, &ii)
-	if err == nil {
-		*i = InvoiceItem(ii)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		i.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		i.ID = id
+		return nil
 	}
 
+	type invoiceItem InvoiceItem
+	var v invoiceItem
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*i = InvoiceItem(v)
 	return nil
 }

--- a/invoiceitem_test.go
+++ b/invoiceitem_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestInvoiceItem_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v InvoiceItem
+		err := json.Unmarshal([]byte(`"ii_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "ii_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := InvoiceItem{ID: "ii_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "ii_123", v.ID)
 	}
 }

--- a/order.go
+++ b/order.go
@@ -185,17 +185,17 @@ func (op *OrderPayParams) SetSource(sp interface{}) error {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (o *Order) UnmarshalJSON(data []byte) error {
-	type order Order
-	var oo order
-	err := json.Unmarshal(data, &oo)
-	if err == nil {
-		*o = Order(oo)
-		{
-		}
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		o.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		o.ID = id
+		return nil
 	}
 
+	type order Order
+	var v order
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*o = Order(v)
 	return nil
 }

--- a/order_test.go
+++ b/order_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
+func TestOrder_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Order
+		err := json.Unmarshal([]byte(`"or_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "or_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := Order{ID: "or_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "or_123", v.ID)
+	}
+}
+
 func TestOrderUpdateParams_AppendTo(t *testing.T) {
 	{
 		params := &OrderUpdateParams{

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -31,16 +31,18 @@ type OrderReturnListParams struct {
 // UnmarshalJSON handles deserialization of an OrderReturn.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (ret *OrderReturn) UnmarshalJSON(data []byte) error {
-	type orderReturn OrderReturn
-	var rr orderReturn
-	err := json.Unmarshal(data, &rr)
-	if err == nil {
-		*ret = OrderReturn(rr)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		ret.ID = string(data[1 : len(data)-1])
+func (r *OrderReturn) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		r.ID = id
+		return nil
 	}
 
+	type orderReturn OrderReturn
+	var v orderReturn
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*r = OrderReturn(v)
 	return nil
 }

--- a/orderreturn_test.go
+++ b/orderreturn_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestOrderReturn_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v OrderReturn
+		err := json.Unmarshal([]byte(`"orret_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "orret_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := OrderReturn{ID: "orret_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "orret_123", v.ID)
 	}
 }

--- a/paymentsource_test.go
+++ b/paymentsource_test.go
@@ -80,3 +80,30 @@ func TestPaymentSource_MarshalJSON(t *testing.T) {
 		assert.Equal(t, unmarshalled.BankAccount.AccountHolderName, name)
 	}
 }
+
+func TestPaymentSource_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v PaymentSource
+		err := json.Unmarshal([]byte(`"ba_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ba_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		// We build the JSON object manually here because it's key that the
+		// `object` field is included so that the source knows what type to
+		// decode
+		data := []byte(`{"id":"ba_123", "object":"bank_account"}`)
+
+		var v PaymentSource
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, PaymentSourceTypeBankAccount, v.Type)
+
+		// The payment source has a field for each possible type, so the bank
+		// account is located one level down
+		assert.Equal(t, "ba_123", v.BankAccount.ID)
+	}
+}

--- a/payout_test.go
+++ b/payout_test.go
@@ -1,0 +1,56 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestPayout_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Payout
+		err := json.Unmarshal([]byte(`"po_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "po_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := Payout{ID: "po_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "po_123", v.ID)
+	}
+}
+
+func TestPayoutDestination_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v PayoutDestination
+		err := json.Unmarshal([]byte(`"ba_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ba_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		// We build the JSON object manually here because it's key that the
+		// `object` field is included so that the source knows what type to
+		// decode
+		data := []byte(`{"id":"ba_123", "object":"bank_account"}`)
+
+		var v PayoutDestination
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, PayoutDestinationTypeBankAccount, v.Type)
+
+		// The destination has a field for each possible type, so the bank
+		// account is located one level down
+		assert.Equal(t, "ba_123", v.BankAccount.ID)
+	}
+}

--- a/product.go
+++ b/product.go
@@ -95,14 +95,17 @@ type ProductListParams struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (p *Product) UnmarshalJSON(data []byte) error {
-	type product Product
-	var pr product
-	err := json.Unmarshal(data, &pr)
-	if err == nil {
-		*p = Product(pr)
-	} else {
-		p.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		p.ID = id
+		return nil
 	}
 
+	type product Product
+	var v product
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*p = Product(v)
 	return nil
 }

--- a/product_test.go
+++ b/product_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestProduct_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v Product
+		err := json.Unmarshal([]byte(`"prod_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "prod_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := Product{ID: "prod_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "prod_123", v.ID)
 	}
 }

--- a/recipient.go
+++ b/recipient.go
@@ -78,15 +78,17 @@ type RecipientList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (r *Recipient) UnmarshalJSON(data []byte) error {
-	type recipient Recipient
-	var rr recipient
-	err := json.Unmarshal(data, &rr)
-	if err == nil {
-		*r = Recipient(rr)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		r.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		r.ID = id
+		return nil
 	}
 
+	type recipient Recipient
+	var v recipient
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*r = Recipient(v)
 	return nil
 }

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"encoding/json"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -38,5 +39,26 @@ func TestRecipientParams_AppendTo(t *testing.T) {
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
 		assert.Equal(t, []string{"123"}, body.Get("bank_account[account_number]"))
+	}
+}
+
+func TestRecipient_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Recipient
+		err := json.Unmarshal([]byte(`"rp_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "rp_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := Recipient{ID: "rp_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "rp_123", v.ID)
 	}
 }

--- a/refund.go
+++ b/refund.go
@@ -63,15 +63,17 @@ type RefundList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (r *Refund) UnmarshalJSON(data []byte) error {
-	type refund Refund
-	var rr refund
-	err := json.Unmarshal(data, &rr)
-	if err == nil {
-		*r = Refund(rr)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		r.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		r.ID = id
+		return nil
 	}
 
+	type refund Refund
+	var v refund
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*r = Refund(v)
 	return nil
 }

--- a/refund_test.go
+++ b/refund_test.go
@@ -3,69 +3,27 @@ package stripe
 import (
 	"encoding/json"
 	"testing"
+
+	assert "github.com/stretchr/testify/require"
 )
 
-func TestRefundUnmarshal(t *testing.T) {
-	refundData := map[string]interface{}{
-		"id":     String("re_1234"),
-		"object": String("refund"),
-		"charge": String("ch_1234"),
+func TestRefund_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Refund
+		err := json.Unmarshal([]byte(`"re_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "re_123", v.ID)
 	}
 
-	bytes, err := json.Marshal(&refundData)
-	if err != nil {
-		t.Error(err)
-	}
+	// Unmarshals from a JSON object
+	{
+		v := Refund{ID: "re_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
 
-	var refund Refund
-	err = json.Unmarshal(bytes, &refund)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if refund.ID != "re_1234" {
-		t.Errorf("Problem deserializing refund, got ID %v", refund.ID)
-	}
-
-	if refund.Charge == nil {
-		t.Errorf("Problem deserializing refund, didn't get a Charge")
-	}
-
-	if refund.Charge.ID != "ch_1234" {
-		t.Errorf("Problem deserializing refund.charge, wrong value for ID")
-	}
-}
-
-func TestRefundUnmarshalExpandedCharge(t *testing.T) {
-	refundData := map[string]interface{}{
-		"id":     "re_1234",
-		"object": "refund",
-		"charge": map[string]interface{}{
-			"id":     "ch_1234",
-			"object": "charge",
-		},
-	}
-
-	bytes, err := json.Marshal(&refundData)
-	if err != nil {
-		t.Error(err)
-	}
-
-	var refund Refund
-	err = json.Unmarshal(bytes, &refund)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if refund.ID != "re_1234" {
-		t.Errorf("Problem deserializing refund, got ID %v", refund.ID)
-	}
-
-	if refund.Charge == nil {
-		t.Errorf("Problem deserializing refund, didn't get a Charge")
-	}
-
-	if refund.Charge.ID != "ch_1234" {
-		t.Errorf("Problem deserializing refund.charge, wrong value for ID")
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "re_123", v.ID)
 	}
 }

--- a/reversal.go
+++ b/reversal.go
@@ -37,15 +37,17 @@ type ReversalList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (r *Reversal) UnmarshalJSON(data []byte) error {
-	type reversal Reversal
-	var rr reversal
-	err := json.Unmarshal(data, &rr)
-	if err == nil {
-		*r = Reversal(rr)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		r.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		r.ID = id
+		return nil
 	}
 
+	type reversal Reversal
+	var v reversal
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*r = Reversal(v)
 	return nil
 }

--- a/reversal_test.go
+++ b/reversal_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestReversal_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v Reversal
+		err := json.Unmarshal([]byte(`"trr_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "trr_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := Reversal{ID: "trr_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "trr_123", v.ID)
 	}
 }

--- a/review.go
+++ b/review.go
@@ -24,16 +24,17 @@ type Review struct {
 }
 
 func (r *Review) UnmarshalJSON(data []byte) error {
-	type review Review
-	var rr review
-
-	err := json.Unmarshal(data, &rr)
-	if err == nil {
-		*r = Review(rr)
-	} else {
-		// Otherwise...we have to strip the escaping
-		r.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		r.ID = id
+		return nil
 	}
 
+	type review Review
+	var v review
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*r = Review(v)
 	return nil
 }

--- a/review_test.go
+++ b/review_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestReview_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v Review
+		err := json.Unmarshal([]byte(`"prv_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "prv_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := Review{ID: "prv_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "prv_123", v.ID)
 	}
 }

--- a/sku.go
+++ b/sku.go
@@ -78,14 +78,17 @@ type SKUListParams struct {
 }
 
 func (s *SKU) UnmarshalJSON(data []byte) error {
-	type sku SKU
-	var sk sku
-	err := json.Unmarshal(data, &sk)
-	if err == nil {
-		*s = SKU(sk)
-	} else {
-		s.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		s.ID = id
+		return nil
 	}
 
+	type sku SKU
+	var v sku
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*s = SKU(v)
 	return nil
 }

--- a/sku_test.go
+++ b/sku_test.go
@@ -7,23 +7,23 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestApplication_UnmarshalJSON(t *testing.T) {
+func TestSKU_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{
-		var v Application
-		err := json.Unmarshal([]byte(`"ca_123"`), &v)
+		var v SKU
+		err := json.Unmarshal([]byte(`"sku_123"`), &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "sku_123", v.ID)
 	}
 
 	// Unmarshals from a JSON object
 	{
-		v := Application{ID: "ca_123"}
+		v := SKU{ID: "sku_123"}
 		data, err := json.Marshal(&v)
 		assert.NoError(t, err)
 
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "ca_123", v.ID)
+		assert.Equal(t, "sku_123", v.ID)
 	}
 }

--- a/source.go
+++ b/source.go
@@ -209,18 +209,17 @@ func (p *SourceObjectParams) AppendTo(body *form.Values, keyParts []string) {
 // but stored in JSON under a hash named after the `type` of the source.
 func (s *Source) UnmarshalJSON(data []byte) error {
 	type source Source
-	var ss source
-	err := json.Unmarshal(data, &ss)
-	if err != nil {
+	var v source
+	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
-	*s = Source(ss)
+	*s = Source(v)
 
 	var raw map[string]interface{}
-	err = json.Unmarshal(data, &raw)
-	if err != nil {
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
+
 	if d, ok := raw[s.Type]; ok {
 		if m, ok := d.(map[string]interface{}); ok {
 			s.TypeData = m

--- a/source_test.go
+++ b/source_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"encoding/json"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -21,5 +22,35 @@ func TestSourceObjectParams_AppendTo(t *testing.T) {
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
 		assert.Equal(t, []string{"bar"}, body.Get("source_type[foo]"))
+	}
+}
+
+func TestSource_UnmarshalJSON(t *testing.T) {
+	{
+		// We build the JSON object manually here because it's key that the
+		// `object` field is included so that the source knows what type to
+		// decode
+		data := []byte(`{"id":"src_123", "type":"ach", "ach":{"foo":"bar"}}`)
+
+		var v Source
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "src_123", v.ID)
+		assert.Equal(t, "ach", v.Type)
+
+		// The source data is extracted to the special TypeData field
+		assert.Equal(t, "bar", v.TypeData["foo"])
+	}
+
+	// Test a degenerate case without a type key (this shouldn't happen, but
+	// also shouldn't crash)
+	{
+		data := []byte(`{"id":"src_123", "type":"ach"}`)
+
+		var v Source
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "src_123", v.ID)
+		assert.Equal(t, "ach", v.Type)
 	}
 }

--- a/sourcetransaction.go
+++ b/sourcetransaction.go
@@ -33,12 +33,12 @@ type SourceTransaction struct {
 // source transaction.
 func (t *SourceTransaction) UnmarshalJSON(data []byte) error {
 	type sourceTransaction SourceTransaction
-	var st sourceTransaction
-	err := json.Unmarshal(data, &st)
+	var v sourceTransaction
+	err := json.Unmarshal(data, &v)
 	if err != nil {
 		return err
 	}
-	*t = SourceTransaction(st)
+	*t = SourceTransaction(v)
 
 	var raw map[string]interface{}
 	err = json.Unmarshal(data, &raw)

--- a/sourcetransaction_test.go
+++ b/sourcetransaction_test.go
@@ -1,0 +1,36 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestSourceTransaction_UnmarshalJSON(t *testing.T) {
+	{
+		// We build the JSON object manually here because it's key that the
+		// `object` field is included so that the source knows what type to
+		// decode
+		data := []byte(`{"type":"ach", "ach":{"foo":"bar"}}`)
+
+		var v SourceTransaction
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ach", v.Type)
+
+		// The source data is extracted to the special TypeData field
+		assert.Equal(t, "bar", v.TypeData["foo"])
+	}
+
+	// Test a degenerate case without a type key (this shouldn't happen, but
+	// also shouldn't crash)
+	{
+		data := []byte(`{"type":"ach"}`)
+
+		var v SourceTransaction
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "ach", v.Type)
+	}
+}

--- a/stripe.go
+++ b/stripe.go
@@ -448,6 +448,27 @@ func FormatURLPath(format string, params ...string) string {
 	return fmt.Sprintf(format, untypedParams...)
 }
 
+// ParseID attempts to parse a string scalar from a given JSON value which is
+// still encoded as []byte. If the value was a string, it returns the string
+// along with true as the second return value. If not, false is returned as the
+// second return value.
+//
+// The purpose of this function is to detect whether a given value in a
+// response from the Stripe API is a string ID or an expanded object.
+func ParseID(data []byte) (string, bool) {
+	s := string(data)
+
+	if !strings.HasPrefix(s, "\"") {
+		return "", false
+	}
+
+	if !strings.HasSuffix(s, "\"") {
+		return "", false
+	}
+
+	return s[1 : len(s)-1], true
+}
+
 // SetAppInfo sets app information. See AppInfo.
 func SetAppInfo(info *AppInfo) {
 	if info != nil && info.Name == "" {

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -77,6 +77,29 @@ func TestFormatURLPath(t *testing.T) {
 		stripe.FormatURLPath("/resources/%s", "%"))
 }
 
+func TestParseID(t *testing.T) {
+	// JSON string
+	{
+		id, ok := stripe.ParseID([]byte(`"ch_123"`))
+		assert.Equal(t, "ch_123", id)
+		assert.True(t, ok)
+	}
+
+	// JSON object
+	{
+		id, ok := stripe.ParseID([]byte(`{"id":"ch_123"}`))
+		assert.Equal(t, "", id)
+		assert.False(t, ok)
+	}
+
+	// Other JSON scalar (this should never be used, but check the results anyway)
+	{
+		id, ok := stripe.ParseID([]byte(`123`))
+		assert.Equal(t, "", id)
+		assert.False(t, ok)
+	}
+}
+
 // TestMultipleAPICalls will fail the test run if a race condition is thrown while running multiple NewRequest calls.
 func TestMultipleAPICalls(t *testing.T) {
 	wg := &sync.WaitGroup{}

--- a/sub.go
+++ b/sub.go
@@ -138,15 +138,17 @@ type SubscriptionList struct {
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
 func (s *Subscription) UnmarshalJSON(data []byte) error {
-	type sub Subscription
-	var ss sub
-	err := json.Unmarshal(data, &ss)
-	if err == nil {
-		*s = Subscription(ss)
-	} else {
-		// the id is surrounded by "\" characters, so strip them
-		s.ID = string(data[1 : len(data)-1])
+	if id, ok := ParseID(data); ok {
+		s.ID = id
+		return nil
 	}
 
+	type subscription Subscription
+	var v subscription
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*s = Subscription(v)
 	return nil
 }

--- a/sub_test.go
+++ b/sub_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"encoding/json"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -30,5 +31,26 @@ func TestSubscriptionParams_AppendTo(t *testing.T) {
 		form.AppendTo(body, params)
 		t.Logf("body = %+v", body)
 		assert.Equal(t, []string{"now"}, body.Get("trial_end"))
+	}
+}
+
+func TestSubscription_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Subscription
+		err := json.Unmarshal([]byte(`"sub_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "sub_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := Subscription{ID: "sub_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "sub_123", v.ID)
 	}
 }

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -3,51 +3,55 @@ package stripe
 import (
 	"encoding/json"
 	"testing"
+
+	assert "github.com/stretchr/testify/require"
 )
 
-func TestTransferUnmarshal(t *testing.T) {
-	transferData := map[string]interface{}{
-		"id":     "tr_1234",
-		"object": "transfer",
-		"source_transaction": map[string]interface{}{
-			"id":     "ch_1234",
-			"object": "charge",
-		},
+func TestTransfer_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v Transfer
+		err := json.Unmarshal([]byte(`"tr_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "tr_123", v.ID)
 	}
 
-	bytes, err := json.Marshal(&transferData)
-	if err != nil {
-		t.Error(err)
+	// Unmarshals from a JSON object
+	{
+		v := Transfer{ID: "tr_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "tr_123", v.ID)
+	}
+}
+
+func TestTransferDestination_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v TransferDestination
+		err := json.Unmarshal([]byte(`"acct_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "acct_123", v.ID)
 	}
 
-	var transfer Transfer
-	err = json.Unmarshal(bytes, &transfer)
-	if err != nil {
-		t.Error(err)
-	}
+	// Unmarshals from a JSON object
+	{
+		// We build the JSON object manually here because TransferDestination
+		// has a custom MarshalJSON implementation as well, and it'll turn into
+		// a string if we marshaled a struct instance. This ensures that we're
+		// working with a JSON objects.
+		data := []byte(`{"id":"acct_123"}`)
 
-	if transfer.ID != "tr_1234" {
-		t.Errorf("Problem deserializing transfer, got ID %v", transfer.ID)
-	}
+		var v TransferDestination
+		err := json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "acct_123", v.ID)
 
-	source_transaction := transfer.SourceTransaction
-	if source_transaction == nil {
-		t.Errorf("Problem deserializing transfer, didn't get a SourceTransaction")
-	}
-
-	if source_transaction.ID != "ch_1234" {
-		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for ID")
-	}
-
-	if source_transaction.Type != BalanceTransactionSourceTypeCharge {
-		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for Type")
-	}
-
-	if source_transaction.Charge == nil {
-		t.Errorf("Problem deserializing transfer.source_transaction, didn't get a Charge")
-	}
-
-	if source_transaction.Charge.ID != "ch_1234" {
-		t.Errorf("Problem deserializing transfer.source_transaction, wrong value for Charge.ID")
+		// The child Account field should also be expanded. For legacy reasons
+		// it's a different object.
+		assert.Equal(t, "acct_123", v.Account.ID)
 	}
 }


### PR DESCRIPTION
As described in #570, the current pattern in custom `UnmarshalJSON`
implementations used to perform object expansion is quite poor because
it assumes that *any* unmarshal error on an object indicates that the
object was actually a string. This is not true, and these custom
functions can have the effect of hiding actual problems and making
debugging difficult (see #569).

Here I introduce a new pattern for custom `UnmarshalJSON`
implementations. Instead of trying for an object right away, it tries to
detect whether the value is a string, and if it is, sets that as the
object's ID. If it isn't, it then performs unmarshaling on the full
object. If that errors, we return the error.

This also has the benefit of making unmarshaling on values that are
strings faster -- we return almost immediately instead of allocating an
object, trying to decode it, failing, and falling back.

I was hoping to be able to cut down the length of the implementation by
quite a bit, and although it is shortened some, it's not too different.
I'll also try to use this opportunity to standardize on conventions
(name values `v`) and add some tests.

For now, I just redid two implementations to demonstrate the pattern. One easy
one in the form of "charge outcome rule", and one harder one in the form of
"balance transaction source". If this looks good, we can redo them all.

Fixes #570.

r? @remi-stripe Mind taking a look?
cc @stripe/api-libraries