### PR TITLE
Push parameter encoding into `BackendConfiguration.Call`

### DIFF
--- a/account.go
+++ b/account.go
@@ -444,5 +444,6 @@ type PayoutSchedule struct {
 
 // AccountRejectParams is the structure for the Reject function.
 type AccountRejectParams struct {
+	Params `form:"*"`
 	Reason *string `form:"reason"`
 }

--- a/account/client.go
+++ b/account/client.go
@@ -17,19 +17,8 @@ func New(params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
-	body := &form.Values{}
-
-	// Type is now required on creation and not allowed on update
-	// It can't be passed if you pass `from_recipient` though
-	if params.FromRecipient != nil {
-		body.Add("type", stripe.StringValue(params.Type))
-	}
-
-	form.AppendTo(body, params)
-
 	acct := &stripe.Account{}
-	err := c.B.Call("POST", "/accounts", c.Key, body, &params.Params, acct)
-
+	err := c.B.Call2("POST", "/accounts", c.Key, params, acct)
 	return acct, err
 }
 
@@ -40,8 +29,7 @@ func Get() (*stripe.Account, error) {
 
 func (c Client) Get() (*stripe.Account, error) {
 	account := &stripe.Account{}
-	err := c.B.Call("GET", "/account", c.Key, nil, nil, account)
-
+	err := c.B.Call2("GET", "/account", c.Key, nil, account)
 	return account, err
 }
 
@@ -51,18 +39,9 @@ func GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func (c Client) GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/accounts/%s", id)
 	account := &stripe.Account{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/accounts/%s", id), c.Key, body, commonParams, account)
-
+	err := c.B.Call2("GET", path, c.Key, params, account)
 	return account, err
 }
 
@@ -72,18 +51,9 @@ func Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/accounts/%s", id)
 	acct := &stripe.Account{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/accounts/%s", id), c.Key, body, commonParams, acct)
-
+	err := c.B.Call2("POST", path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -93,18 +63,9 @@ func Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 }
 
 func (c Client) Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/accounts/%s", id)
 	acct := &stripe.Account{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/accounts/%s", id), c.Key, body, commonParams, acct)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -114,13 +75,9 @@ func Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, err
 }
 
 func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, error) {
-	body := &form.Values{}
-	if params.Reason != nil {
-		body.Add("reason", stripe.StringValue(params.Reason))
-	}
+	path := stripe.FormatURLPath("/accounts/%s/reject", id)
 	acct := &stripe.Account{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/reject", id), c.Key, body, nil, acct)
-
+	err := c.B.Call2("POST", path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -129,22 +86,10 @@ func List(params *stripe.AccountListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.AccountListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.AccountListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.AccountList{}
-		err := c.B.Call("GET", "/accounts", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/accounts", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/account/client.go
+++ b/account/client.go
@@ -18,7 +18,7 @@ func New(params *stripe.AccountParams) (*stripe.Account, error) {
 
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 	acct := &stripe.Account{}
-	err := c.B.Call2("POST", "/accounts", c.Key, params, acct)
+	err := c.B.Call("POST", "/accounts", c.Key, params, acct)
 	return acct, err
 }
 
@@ -29,7 +29,7 @@ func Get() (*stripe.Account, error) {
 
 func (c Client) Get() (*stripe.Account, error) {
 	account := &stripe.Account{}
-	err := c.B.Call2("GET", "/account", c.Key, nil, account)
+	err := c.B.Call("GET", "/account", c.Key, nil, account)
 	return account, err
 }
 
@@ -41,7 +41,7 @@ func GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/accounts/%s", id)
 	account := &stripe.Account{}
-	err := c.B.Call2("GET", path, c.Key, params, account)
+	err := c.B.Call("GET", path, c.Key, params, account)
 	return account, err
 }
 
@@ -53,7 +53,7 @@ func Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/accounts/%s", id)
 	acct := &stripe.Account{}
-	err := c.B.Call2("POST", path, c.Key, params, acct)
+	err := c.B.Call("POST", path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -65,7 +65,7 @@ func Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/accounts/%s", id)
 	acct := &stripe.Account{}
-	err := c.B.Call2("DELETE", path, c.Key, params, acct)
+	err := c.B.Call("DELETE", path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -77,7 +77,7 @@ func Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, err
 func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/accounts/%s/reject", id)
 	acct := &stripe.Account{}
-	err := c.B.Call2("POST", path, c.Key, params, acct)
+	err := c.B.Call("POST", path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -87,7 +87,7 @@ func List(params *stripe.AccountListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.AccountListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.AccountList{}
 		err := c.B.CallRaw("GET", "/accounts", c.Key, b, p, list)
 

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -18,11 +18,8 @@ func New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 }
 
 func (c Client) New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("POST", "/apple_pay/domains", c.Key, body, &params.Params, domain)
+	err := c.B.Call2("POST", "/apple_pay/domains", c.Key, params, domain)
 	return domain, err
 }
 
@@ -32,18 +29,9 @@ func Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 }
 
 func (c Client) Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/apple_pay/domains/%s", id)
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/apple_pay/domains/%s", id), c.Key, body, commonParams, domain)
-
+	err := c.B.Call2("GET", path, c.Key, params, domain)
 	return domain, err
 }
 
@@ -53,18 +41,9 @@ func Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 }
 
 func (c Client) Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/apple_pay/domains/%s", id)
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/apple_pay/domains/%s", id), c.Key, body, commonParams, domain)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, domain)
 	return domain, err
 }
 
@@ -73,21 +52,10 @@ func List(params *stripe.ApplePayDomainListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.ApplePayDomainListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplePayDomainList{}
-		err := c.B.Call("GET", "/apple_pay/domains", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/apple_pay/domains", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -19,7 +19,7 @@ func New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 
 func (c Client) New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call2("POST", "/apple_pay/domains", c.Key, params, domain)
+	err := c.B.Call("POST", "/apple_pay/domains", c.Key, params, domain)
 	return domain, err
 }
 
@@ -31,7 +31,7 @@ func Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 func (c Client) Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	path := stripe.FormatURLPath("/apple_pay/domains/%s", id)
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call2("GET", path, c.Key, params, domain)
+	err := c.B.Call("GET", path, c.Key, params, domain)
 	return domain, err
 }
 
@@ -43,7 +43,7 @@ func Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 func (c Client) Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	path := stripe.FormatURLPath("/apple_pay/domains/%s", id)
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call2("DELETE", path, c.Key, params, domain)
+	err := c.B.Call("DELETE", path, c.Key, params, domain)
 	return domain, err
 }
 
@@ -53,7 +53,7 @@ func List(params *stripe.ApplePayDomainListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplePayDomainList{}
 		err := c.B.CallRaw("GET", "/apple_pay/domains", c.Key, b, p, list)
 

--- a/balance/client.go
+++ b/balance/client.go
@@ -20,7 +20,7 @@ func Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 
 func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 	balance := &stripe.Balance{}
-	err := c.B.Call2("GET", "/balance", c.Key, params, balance)
+	err := c.B.Call("GET", "/balance", c.Key, params, balance)
 	return balance, err
 }
 
@@ -33,7 +33,7 @@ func GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (
 func (c Client) GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
 	path := stripe.FormatURLPath("/balance/history/%s", id)
 	balance := &stripe.BalanceTransaction{}
-	err := c.B.Call2("GET", path, c.Key, params, balance)
+	err := c.B.Call("GET", path, c.Key, params, balance)
 	return balance, err
 }
 
@@ -44,7 +44,7 @@ func List(params *stripe.BalanceTransactionListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.BalanceTransactionListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BalanceTransactionList{}
 		err := c.B.CallRaw("GET", "/balance/history", c.Key, b, p, list)
 

--- a/balance/client.go
+++ b/balance/client.go
@@ -19,18 +19,8 @@ func Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 }
 
 func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
 	balance := &stripe.Balance{}
-	err := c.B.Call("GET", "/balance", c.Key, body, commonParams, balance)
-
+	err := c.B.Call2("GET", "/balance", c.Key, params, balance)
 	return balance, err
 }
 
@@ -41,18 +31,9 @@ func GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (
 }
 
 func (c Client) GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/balance/history/%s", id)
 	balance := &stripe.BalanceTransaction{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/balance/history/%s", id), c.Key, body, commonParams, balance)
-
+	err := c.B.Call2("GET", path, c.Key, params, balance)
 	return balance, err
 }
 
@@ -62,21 +43,10 @@ func List(params *stripe.BalanceTransactionListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.BalanceTransactionListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.BalanceTransactionListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BalanceTransactionList{}
-		err := c.B.Call("GET", "/balance/history", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/balance/history", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -55,7 +55,7 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	}
 
 	ba := &stripe.BankAccount{}
-	err := c.B.Call2("GET", path, c.Key, params, ba)
+	err := c.B.Call("GET", path, c.Key, params, ba)
 	return ba, err
 }
 
@@ -75,7 +75,7 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 	}
 
 	ba := &stripe.BankAccount{}
-	err := c.B.Call2("POST", path, c.Key, params, ba)
+	err := c.B.Call("POST", path, c.Key, params, ba)
 	return ba, err
 }
 
@@ -95,7 +95,7 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	}
 
 	ba := &stripe.BankAccount{}
-	err := c.B.Call2("DELETE", path, c.Key, params, ba)
+	err := c.B.Call("DELETE", path, c.Key, params, ba)
 	return ba, err
 }
 
@@ -118,7 +118,7 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 		outerErr = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
 
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BankAccountList{}
 
 		if outerErr != nil {

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -22,12 +22,8 @@ func New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) 
 }
 
 func (c Client) New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call("POST", "/bitcoin/receivers", c.Key, body, &params.Params, receiver)
-
+	err := c.B.Call2("POST", "/bitcoin/receivers", c.Key, params, receiver)
 	return receiver, err
 }
 
@@ -38,15 +34,9 @@ func Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiv
 }
 
 func (c Client) Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/bitcoin/receivers/%s", id)
 	bitcoinReceiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/bitcoin/receivers/%s", id), c.Key, nil, commonParams, bitcoinReceiver)
-
+	err := c.B.Call2("GET", path, c.Key, params, bitcoinReceiver)
 	return bitcoinReceiver, err
 }
 
@@ -57,12 +47,9 @@ func Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.Bitc
 }
 
 func (c Client) Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.BitcoinReceiver, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/bitcoin/receivers/%s", id)
 	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/bitcoin/receivers/%s", id), c.Key, body, &params.Params, receiver)
-
+	err := c.B.Call2("POST", path, c.Key, params, receiver)
 	return receiver, err
 }
 
@@ -72,21 +59,10 @@ func List(params *stripe.BitcoinReceiverListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.BitcoinReceiverListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.BitcoinReceiverListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinReceiverList{}
-		err := c.B.Call("GET", "/bitcoin/receivers", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/bitcoin/receivers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -23,7 +23,7 @@ func New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) 
 
 func (c Client) New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
 	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call2("POST", "/bitcoin/receivers", c.Key, params, receiver)
+	err := c.B.Call("POST", "/bitcoin/receivers", c.Key, params, receiver)
 	return receiver, err
 }
 
@@ -36,7 +36,7 @@ func Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiv
 func (c Client) Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
 	path := stripe.FormatURLPath("/bitcoin/receivers/%s", id)
 	bitcoinReceiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call2("GET", path, c.Key, params, bitcoinReceiver)
+	err := c.B.Call("GET", path, c.Key, params, bitcoinReceiver)
 	return bitcoinReceiver, err
 }
 
@@ -49,7 +49,7 @@ func Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.Bitc
 func (c Client) Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.BitcoinReceiver, error) {
 	path := stripe.FormatURLPath("/bitcoin/receivers/%s", id)
 	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call2("POST", path, c.Key, params, receiver)
+	err := c.B.Call("POST", path, c.Key, params, receiver)
 	return receiver, err
 }
 
@@ -60,7 +60,7 @@ func List(params *stripe.BitcoinReceiverListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.BitcoinReceiverListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinReceiverList{}
 		err := c.B.CallRaw("GET", "/bitcoin/receivers", c.Key, b, p, list)
 

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -19,7 +19,7 @@ func List(params *stripe.BitcoinTransactionListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.BitcoinTransactionListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		path := stripe.FormatURLPath("/bitcoin/receivers/%s/transactions",
 			stripe.StringValue(listParams.Receiver))
 		list := &stripe.BitcoinTransactionList{}

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -18,21 +18,12 @@ func List(params *stripe.BitcoinTransactionListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.BitcoinTransactionListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.BitcoinTransactionListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+		path := stripe.FormatURLPath("/bitcoin/receivers/%s/transactions",
+			stripe.StringValue(listParams.Receiver))
 		list := &stripe.BitcoinTransactionList{}
-		err := c.B.Call("GET", stripe.FormatURLPath("/bitcoin/receivers/%s/transactions", stripe.StringValue(params.Receiver)), c.Key, b, p, list)
+		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/card/client.go
+++ b/card/client.go
@@ -46,6 +46,9 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	// include some parameters that are undesirable here.
 	params.AppendToAsCardSourceOrExternalAccount(body, nil)
 
+	// Because card creation uses the custom append above, we have to make an
+	// explicit call using a form and CallRaw instead of the standard Call
+	// (which takes a set of parameters).
 	card := &stripe.Card{}
 	err := c.B.CallRaw("POST", path, c.Key, body, &params.Params, card)
 	return card, err

--- a/card/client.go
+++ b/card/client.go
@@ -25,6 +25,20 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 		return nil, errors.New("params should not be nil")
 	}
 
+	var path string
+	if params.Account != nil {
+		path = stripe.FormatURLPath("/accounts/%s/external_accounts",
+			stripe.StringValue(params.Account))
+	} else if params.Customer != nil {
+		path = stripe.FormatURLPath("/customers/%s/sources",
+			stripe.StringValue(params.Customer))
+	} else if params.Recipient != nil {
+		path = stripe.FormatURLPath("/recipients/%s/cards",
+			stripe.StringValue(params.Recipient))
+	} else {
+		return nil, errors.New("Invalid card params: either account, customer or recipient need to be set")
+	}
+
 	body := &form.Values{}
 
 	// Note that we call this special append method instead of the standard one
@@ -33,18 +47,7 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	params.AppendToAsCardSourceOrExternalAccount(body, nil)
 
 	card := &stripe.Card{}
-	var err error
-
-	if params.Account != nil {
-		err = c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/external_accounts", stripe.StringValue(params.Account)), c.Key, body, &params.Params, card)
-	} else if params.Customer != nil {
-		err = c.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer)), c.Key, body, &params.Params, card)
-	} else if params.Recipient != nil {
-		err = c.B.Call("POST", stripe.FormatURLPath("/recipients/%s/cards", stripe.StringValue(params.Recipient)), c.Key, body, &params.Params, card)
-	} else {
-		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
-	}
-
+	err := c.B.CallRaw("POST", path, c.Key, body, &params.Params, card)
 	return card, err
 }
 
@@ -59,28 +62,22 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 		return nil, errors.New("params should not be nil")
 	}
 
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
+	var path string
+	if params.Account != nil {
+		path = stripe.FormatURLPath("/accounts/%s/external_accounts/%s",
+			stripe.StringValue(params.Account), id)
+	} else if params.Customer != nil {
+		path = stripe.FormatURLPath("/customers/%s/sources/%s",
+			stripe.StringValue(params.Customer), id)
+	} else if params.Recipient != nil {
+		path = stripe.FormatURLPath("/recipients/%s/cards/%s",
+			stripe.StringValue(params.Recipient), id)
+	} else {
+		return nil, errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
 
 	card := &stripe.Card{}
-	var err error
-
-	if params.Account != nil {
-		err = c.B.Call("GET", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
-	} else if params.Customer != nil {
-		err = c.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
-	} else if params.Recipient != nil {
-		err = c.B.Call("GET", stripe.FormatURLPath("/recipients/%s/cards/%s", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
-	} else {
-		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
-	}
-
+	err := c.B.Call2("GET", path, c.Key, params, card)
 	return card, err
 }
 
@@ -95,22 +92,22 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 		return nil, errors.New("params should not be nil")
 	}
 
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
-	card := &stripe.Card{}
-	var err error
-
+	var path string
 	if params.Account != nil {
-		err = c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, &params.Params, card)
+		path = stripe.FormatURLPath("/accounts/%s/external_accounts/%s",
+			stripe.StringValue(params.Account), id)
 	} else if params.Customer != nil {
-		err = c.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, &params.Params, card)
+		path = stripe.FormatURLPath("/customers/%s/sources/%s",
+			stripe.StringValue(params.Customer), id)
 	} else if params.Recipient != nil {
-		err = c.B.Call("POST", stripe.FormatURLPath("/recipients/%s/cards/%s", stripe.StringValue(params.Recipient), id), c.Key, body, &params.Params, card)
+		path = stripe.FormatURLPath("/recipients/%s/cards/%s",
+			stripe.StringValue(params.Recipient), id)
 	} else {
-		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
+		return nil, errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
 
+	card := &stripe.Card{}
+	err := c.B.Call2("POST", path, c.Key, params, card)
 	return card, err
 }
 
@@ -125,26 +122,19 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 		return nil, errors.New("params should not be nil")
 	}
 
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	body = &form.Values{}
-	form.AppendTo(body, params)
-	commonParams = &params.Params
-
-	card := &stripe.Card{}
-	var err error
-
+	var path string
 	if params.Account != nil {
-		err = c.B.Call("DELETE", stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id), c.Key, body, commonParams, card)
+		path = stripe.FormatURLPath("/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else if params.Customer != nil {
-		err = c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, card)
+		path = stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	} else if params.Recipient != nil {
-		err = c.B.Call("DELETE", stripe.FormatURLPath("/recipients/%s/cards/%s", stripe.StringValue(params.Recipient), id), c.Key, body, commonParams, card)
+		path = stripe.FormatURLPath("/recipients/%s/cards/%s", stripe.StringValue(params.Recipient), id)
 	} else {
-		err = errors.New("Invalid card params: either account, customer or recipient need to be set")
+		return nil, errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
 
+	card := &stripe.Card{}
+	err := c.B.Call2("DELETE", path, c.Key, params, card)
 	return card, err
 }
 
@@ -154,34 +144,32 @@ func List(params *stripe.CardListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.CardListParams) *Iter {
-	body := &form.Values{}
-	var lp *stripe.ListParams
-	var p *stripe.Params
+func (c Client) List(listParams *stripe.CardListParams) *Iter {
+	var path string
+	var outerErr error
 
-	if params != nil {
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
+	if listParams == nil {
+		outerErr = errors.New("params should not be nil")
+	} else if listParams.Account != nil {
+		path = stripe.FormatURLPath("/accounts/%s/external_accounts?object=card",
+			stripe.StringValue(listParams.Account))
+	} else if listParams.Customer != nil {
+		path = stripe.FormatURLPath("/customers/%s/sources?object=card",
+			stripe.StringValue(listParams.Customer))
+	} else if listParams.Recipient != nil {
+		path = stripe.FormatURLPath("/recipients/%s/cards", stripe.StringValue(listParams.Recipient))
+	} else {
+		outerErr = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CardList{}
-		var err error
 
-		if params == nil {
-			return nil, list.ListMeta, errors.New("params should not be nil")
+		if outerErr != nil {
+			return nil, list.ListMeta, outerErr
 		}
 
-		if params.Account != nil {
-			err = c.B.Call("GET", stripe.FormatURLPath("/accounts/%s/external_accounts?object=card", stripe.StringValue(params.Account)), c.Key, b, p, list)
-		} else if params.Customer != nil {
-			err = c.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources?object=card", stripe.StringValue(params.Customer)), c.Key, b, p, list)
-		} else if params.Recipient != nil {
-			err = c.B.Call("GET", stripe.FormatURLPath("/recipients/%s/cards", stripe.StringValue(params.Recipient)), c.Key, b, p, list)
-		} else {
-			err = errors.New("Invalid card params: either account, customer or recipient need to be set")
-		}
+		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/card/client.go
+++ b/card/client.go
@@ -77,7 +77,7 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call2("GET", path, c.Key, params, card)
+	err := c.B.Call("GET", path, c.Key, params, card)
 	return card, err
 }
 
@@ -107,7 +107,7 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call2("POST", path, c.Key, params, card)
+	err := c.B.Call("POST", path, c.Key, params, card)
 	return card, err
 }
 
@@ -134,7 +134,7 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call2("DELETE", path, c.Key, params, card)
+	err := c.B.Call("DELETE", path, c.Key, params, card)
 	return card, err
 }
 
@@ -162,7 +162,7 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 		outerErr = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
 
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CardList{}
 
 		if outerErr != nil {

--- a/charge/client.go
+++ b/charge/client.go
@@ -122,17 +122,9 @@ func UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, er
 }
 
 func (c Client) UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/charges/%s/dispute", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s/dispute", id), c.Key, body, commonParams, dispute)
+	err := c.B.Call2("POST", path, c.Key, params, dispute)
 
 	return dispute, err
 }

--- a/charge/client.go
+++ b/charge/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 
 func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 	charge := &stripe.Charge{}
-	err := c.B.Call2("POST", "/charges", c.Key, params, charge)
+	err := c.B.Call("POST", "/charges", c.Key, params, charge)
 	return charge, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/charges/%s", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call2("GET", path, c.Key, params, charge)
+	err := c.B.Call("GET", path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/charges/%s", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call2("POST", path, c.Key, params, charge)
+	err := c.B.Call("POST", path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -59,7 +59,7 @@ func Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 func (c Client) Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/charges/%s/capture", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call2("POST", path, c.Key, params, charge)
+	err := c.B.Call("POST", path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -70,7 +70,7 @@ func List(params *stripe.ChargeListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ChargeList{}
 		err := c.B.CallRaw("GET", "/charges", c.Key, b, p, list)
 
@@ -124,7 +124,7 @@ func UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, er
 func (c Client) UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/charges/%s/dispute", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call2("POST", path, c.Key, params, dispute)
+	err := c.B.Call("POST", path, c.Key, params, dispute)
 
 	return dispute, err
 }
@@ -137,7 +137,7 @@ func CloseDispute(id string) (*stripe.Dispute, error) {
 
 func (c Client) CloseDispute(id string) (*stripe.Dispute, error) {
 	dispute := &stripe.Dispute{}
-	err := c.B.Call2("POST", stripe.FormatURLPath("/charges/%s/dispute/close", id), c.Key, nil, dispute)
+	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s/dispute/close", id), c.Key, nil, dispute)
 	return dispute, err
 }
 

--- a/charge/client.go
+++ b/charge/client.go
@@ -19,12 +19,8 @@ func New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	charge := &stripe.Charge{}
-	err := c.B.Call("POST", "/charges", c.Key, body, &params.Params, charge)
-
+	err := c.B.Call2("POST", "/charges", c.Key, params, charge)
 	return charge, err
 }
 
@@ -35,18 +31,9 @@ func Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/charges/%s", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/charges/%s", id), c.Key, body, commonParams, charge)
-
+	err := c.B.Call2("GET", path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -57,18 +44,9 @@ func Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/charges/%s", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s", id), c.Key, body, commonParams, charge)
-
+	err := c.B.Call2("POST", path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -79,19 +57,9 @@ func Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 }
 
 func (c Client) Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/charges/%s/capture", id)
 	charge := &stripe.Charge{}
-
-	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s/capture", id), c.Key, body, commonParams, charge)
-
+	err := c.B.Call2("POST", path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -101,21 +69,10 @@ func List(params *stripe.ChargeListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.ChargeListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ChargeList{}
-		err := c.B.Call("GET", "/charges", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/charges", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -188,8 +145,7 @@ func CloseDispute(id string) (*stripe.Dispute, error) {
 
 func (c Client) CloseDispute(id string) (*stripe.Dispute, error) {
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s/dispute/close", id), c.Key, nil, nil, dispute)
-
+	err := c.B.Call2("POST", stripe.FormatURLPath("/charges/%s/dispute/close", id), c.Key, nil, dispute)
 	return dispute, err
 }
 

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -19,9 +19,9 @@ func Get(country string) (*stripe.CountrySpec, error) {
 }
 
 func (c Client) Get(country string) (*stripe.CountrySpec, error) {
+	path := stripe.FormatURLPath("/country_specs/%s", country)
 	countrySpec := &stripe.CountrySpec{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/country_specs/%s", country), c.Key, nil, nil, countrySpec)
-
+	err := c.B.Call2("GET", path, c.Key, nil, countrySpec)
 	return countrySpec, err
 }
 
@@ -30,21 +30,10 @@ func List(params *stripe.CountrySpecListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.CountrySpecListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CountrySpecList{}
-		err := c.B.Call("GET", "/country_specs", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/country_specs", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -21,7 +21,7 @@ func Get(country string) (*stripe.CountrySpec, error) {
 func (c Client) Get(country string) (*stripe.CountrySpec, error) {
 	path := stripe.FormatURLPath("/country_specs/%s", country)
 	countrySpec := &stripe.CountrySpec{}
-	err := c.B.Call2("GET", path, c.Key, nil, countrySpec)
+	err := c.B.Call("GET", path, c.Key, nil, countrySpec)
 	return countrySpec, err
 }
 
@@ -31,7 +31,7 @@ func List(params *stripe.CountrySpecListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CountrySpecList{}
 		err := c.B.CallRaw("GET", "/country_specs", c.Key, b, p, list)
 

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -19,12 +19,8 @@ func New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 }
 
 func (c Client) New(params *stripe.CouponParams) (*stripe.Coupon, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("POST", "/coupons", c.Key, body, &params.Params, coupon)
-
+	err := c.B.Call2("POST", "/coupons", c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -35,19 +31,9 @@ func Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-
-	err := c.B.Call("GET", stripe.FormatURLPath("/coupons/%s", id), c.Key, body, commonParams, coupon)
-
+	err := c.B.Call2("GET", path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -58,12 +44,9 @@ func Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 }
 
 func (c Client) Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/coupons/%s", id), c.Key, body, &params.Params, coupon)
-
+	err := c.B.Call2("POST", path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -74,18 +57,9 @@ func Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 }
 
 func (c Client) Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/coupons/%s", id), c.Key, body, commonParams, coupon)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -95,21 +69,10 @@ func List(params *stripe.CouponListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.CouponListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.CouponListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CouponList{}
-		err := c.B.Call("GET", "/coupons", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/coupons", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 
 func (c Client) New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 	coupon := &stripe.Coupon{}
-	err := c.B.Call2("POST", "/coupons", c.Key, params, coupon)
+	err := c.B.Call("POST", "/coupons", c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call2("GET", path, c.Key, params, coupon)
+	err := c.B.Call("GET", path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call2("POST", path, c.Key, params, coupon)
+	err := c.B.Call("POST", path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -59,7 +59,7 @@ func Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call2("DELETE", path, c.Key, params, coupon)
+	err := c.B.Call("DELETE", path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -70,7 +70,7 @@ func List(params *stripe.CouponListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.CouponListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CouponList{}
 		err := c.B.CallRaw("GET", "/coupons", c.Key, b, p, list)
 

--- a/customer/client.go
+++ b/customer/client.go
@@ -19,18 +19,8 @@ func New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 }
 
 func (c Client) New(params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
 	cust := &stripe.Customer{}
-	err := c.B.Call("POST", "/customers", c.Key, body, commonParams, cust)
-
+	err := c.B.Call2("POST", "/customers", c.Key, params, cust)
 	return cust, err
 }
 
@@ -41,18 +31,9 @@ func Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 }
 
 func (c Client) Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/customers/%s", id), c.Key, body, commonParams, cust)
-
+	err := c.B.Call2("GET", path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -63,18 +44,9 @@ func Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) 
 }
 
 func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/customers/%s", id), c.Key, body, commonParams, cust)
-
+	err := c.B.Call2("POST", path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -85,18 +57,9 @@ func Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 }
 
 func (c Client) Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s", id), c.Key, body, commonParams, cust)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -106,21 +69,10 @@ func List(params *stripe.CustomerListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.CustomerListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.CustomerListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CustomerList{}
-		err := c.B.Call("GET", "/customers", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/customers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/customer/client.go
+++ b/customer/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 
 func (c Client) New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 	cust := &stripe.Customer{}
-	err := c.B.Call2("POST", "/customers", c.Key, params, cust)
+	err := c.B.Call("POST", "/customers", c.Key, params, cust)
 	return cust, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 func (c Client) Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call2("GET", path, c.Key, params, cust)
+	err := c.B.Call("GET", path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) 
 func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call2("POST", path, c.Key, params, cust)
+	err := c.B.Call("POST", path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -59,7 +59,7 @@ func Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 func (c Client) Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call2("DELETE", path, c.Key, params, cust)
+	err := c.B.Call("DELETE", path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -70,7 +70,7 @@ func List(params *stripe.CustomerListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.CustomerListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CustomerList{}
 		err := c.B.CallRaw("GET", "/customers", c.Key, b, p, list)
 

--- a/discount/client.go
+++ b/discount/client.go
@@ -3,7 +3,6 @@ package discount
 
 import (
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke discount-related APIs.
@@ -19,18 +18,9 @@ func Del(customerID string, params *stripe.DiscountParams) (*stripe.Discount, er
 }
 
 func (c Client) Del(customerID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/customers/%s/discount", customerID)
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/discount", customerID), c.Key, body, commonParams, discount)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, discount)
 	return discount, err
 }
 
@@ -41,17 +31,9 @@ func DelSubscription(subscriptionID string, params *stripe.DiscountParams) (*str
 }
 
 func (c Client) DelSub(subscriptionID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/subscriptions/%s/discount", subscriptionID)
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/subscriptions/%s/discount", subscriptionID), c.Key, body, commonParams, discount)
+	err := c.B.Call2("DELETE", path, c.Key, params, discount)
 
 	return discount, err
 }

--- a/discount/client.go
+++ b/discount/client.go
@@ -20,7 +20,7 @@ func Del(customerID string, params *stripe.DiscountParams) (*stripe.Discount, er
 func (c Client) Del(customerID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
 	path := stripe.FormatURLPath("/customers/%s/discount", customerID)
 	discount := &stripe.Discount{}
-	err := c.B.Call2("DELETE", path, c.Key, params, discount)
+	err := c.B.Call("DELETE", path, c.Key, params, discount)
 	return discount, err
 }
 
@@ -33,7 +33,7 @@ func DelSubscription(subscriptionID string, params *stripe.DiscountParams) (*str
 func (c Client) DelSub(subscriptionID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s/discount", subscriptionID)
 	discount := &stripe.Discount{}
-	err := c.B.Call2("DELETE", path, c.Key, params, discount)
+	err := c.B.Call("DELETE", path, c.Key, params, discount)
 
 	return discount, err
 }

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -18,18 +18,9 @@ func Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 }
 
 func (c Client) Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/disputes/%s", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/disputes/%s", id), c.Key, body, commonParams, dispute)
-
+	err := c.B.Call2("GET", path, c.Key, params, dispute)
 	return dispute, err
 }
 
@@ -39,21 +30,10 @@ func List(params *stripe.DisputeListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.DisputeListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.DisputeListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.DisputeList{}
-		err := c.B.Call("GET", "/disputes", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/disputes", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -84,18 +64,9 @@ func Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 }
 
 func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/disputes/%s", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/disputes/%s", id), c.Key, body, commonParams, dispute)
-
+	err := c.B.Call2("POST", path, c.Key, params, dispute)
 	return dispute, err
 }
 
@@ -106,18 +77,9 @@ func Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 }
 
 func (c Client) Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/disputes/%s/close", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/disputes/%s/close", id), c.Key, body, commonParams, dispute)
-
+	err := c.B.Call2("POST", path, c.Key, params, dispute)
 	return dispute, err
 }
 

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -20,7 +20,7 @@ func Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/disputes/%s", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call2("GET", path, c.Key, params, dispute)
+	err := c.B.Call("GET", path, c.Key, params, dispute)
 	return dispute, err
 }
 
@@ -31,7 +31,7 @@ func List(params *stripe.DisputeListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.DisputeListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.DisputeList{}
 		err := c.B.CallRaw("GET", "/disputes", c.Key, b, p, list)
 
@@ -66,7 +66,7 @@ func Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/disputes/%s", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call2("POST", path, c.Key, params, dispute)
+	err := c.B.Call("POST", path, c.Key, params, dispute)
 	return dispute, err
 }
 
@@ -79,7 +79,7 @@ func Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/disputes/%s/close", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call2("POST", path, c.Key, params, dispute)
+	err := c.B.Call("POST", path, c.Key, params, dispute)
 	return dispute, err
 }
 

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /ephemeral_keys APIs.
@@ -28,17 +27,13 @@ func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 		return nil, fmt.Errorf("params.StripeVersion must be specified")
 	}
 
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	if params.Headers == nil {
 		params.Headers = make(http.Header)
 	}
 	params.Headers.Add("Stripe-Version", stripe.StringValue(params.StripeVersion))
 
 	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call("POST", "ephemeral_keys", c.Key, body, &params.Params, ephemeralKey)
-
+	err := c.B.Call2("POST", "/ephemeral_keys", c.Key, params, ephemeralKey)
 	return ephemeralKey, err
 }
 
@@ -51,18 +46,9 @@ func Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 // Del removes an ephemeral key.
 // For more details see https://stripe.com/docs/api#delete_ephemeral_key.
 func (c Client) Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/ephemeral_keys/%s", id)
 	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/ephemeral_keys/%s", id), c.Key, body, commonParams, ephemeralKey)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, ephemeralKey)
 	return ephemeralKey, err
 }
 

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -33,7 +33,7 @@ func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 	params.Headers.Add("Stripe-Version", stripe.StringValue(params.StripeVersion))
 
 	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call2("POST", "/ephemeral_keys", c.Key, params, ephemeralKey)
+	err := c.B.Call("POST", "/ephemeral_keys", c.Key, params, ephemeralKey)
 	return ephemeralKey, err
 }
 
@@ -48,7 +48,7 @@ func Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 func (c Client) Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
 	path := stripe.FormatURLPath("/ephemeral_keys/%s", id)
 	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call2("DELETE", path, c.Key, params, ephemeralKey)
+	err := c.B.Call("DELETE", path, c.Key, params, ephemeralKey)
 	return ephemeralKey, err
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -28,7 +28,7 @@ func TestErrorResponse(t *testing.T) {
 		&http.Client{},
 	})
 
-	err := GetBackend(APIBackend).Call("GET", "/v1/account", "sk_test_badKey", nil, nil, nil)
+	err := GetBackend(APIBackend).Call2("GET", "/v1/account", "sk_test_badKey", nil, nil)
 	assert.Error(t, err)
 
 	stripeErr := err.(*Error)

--- a/error_test.go
+++ b/error_test.go
@@ -28,7 +28,7 @@ func TestErrorResponse(t *testing.T) {
 		&http.Client{},
 	})
 
-	err := GetBackend(APIBackend).Call2("GET", "/v1/account", "sk_test_badKey", nil, nil)
+	err := GetBackend(APIBackend).Call("GET", "/v1/account", "sk_test_badKey", nil, nil)
 	assert.Error(t, err)
 
 	stripeErr := err.(*Error)

--- a/event/client.go
+++ b/event/client.go
@@ -19,8 +19,9 @@ func Get(id string, params *stripe.Params) (*stripe.Event, error) {
 }
 
 func (c Client) Get(id string, params *stripe.Params) (*stripe.Event, error) {
+	path := stripe.FormatURLPath("/events/%s", id)
 	event := &stripe.Event{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/events/%s", id), c.Key, nil, params, event)
+	err := c.B.Call2("GET", path, c.Key, params, event)
 	return event, err
 }
 
@@ -30,21 +31,10 @@ func List(params *stripe.EventListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.EventListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.EventListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.EventList{}
-		err := c.B.Call("GET", "/events", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/events", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/event/client.go
+++ b/event/client.go
@@ -21,7 +21,7 @@ func Get(id string, params *stripe.Params) (*stripe.Event, error) {
 func (c Client) Get(id string, params *stripe.Params) (*stripe.Event, error) {
 	path := stripe.FormatURLPath("/events/%s", id)
 	event := &stripe.Event{}
-	err := c.B.Call2("GET", path, c.Key, params, event)
+	err := c.B.Call("GET", path, c.Key, params, event)
 	return event, err
 }
 
@@ -32,7 +32,7 @@ func List(params *stripe.EventListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.EventListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.EventList{}
 		err := c.B.CallRaw("GET", "/events", c.Key, b, p, list)
 

--- a/exchangerate/client.go
+++ b/exchangerate/client.go
@@ -20,7 +20,7 @@ func Get(currency string) (*stripe.ExchangeRate, error) {
 func (c Client) Get(currency string) (*stripe.ExchangeRate, error) {
 	path := stripe.FormatURLPath("/exchange_rates/%s", currency)
 	exchangeRate := &stripe.ExchangeRate{}
-	err := c.B.Call2("GET", path, c.Key, nil, exchangeRate)
+	err := c.B.Call("GET", path, c.Key, nil, exchangeRate)
 
 	return exchangeRate, err
 }
@@ -31,7 +31,7 @@ func List(params *stripe.ExchangeRateListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.ExchangeRateListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ExchangeRateList{}
 		err := c.B.CallRaw("GET", "/exchange_rates", c.Key, b, p, list)
 

--- a/exchangerate/client.go
+++ b/exchangerate/client.go
@@ -18,8 +18,9 @@ func Get(currency string) (*stripe.ExchangeRate, error) {
 }
 
 func (c Client) Get(currency string) (*stripe.ExchangeRate, error) {
+	path := stripe.FormatURLPath("/exchange_rates/%s", currency)
 	exchangeRate := &stripe.ExchangeRate{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/exchange_rates/%s", currency), c.Key, nil, nil, exchangeRate)
+	err := c.B.Call2("GET", path, c.Key, nil, exchangeRate)
 
 	return exchangeRate, err
 }
@@ -29,21 +30,10 @@ func List(params *stripe.ExchangeRateListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.ExchangeRateListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.ExchangeRateListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ExchangeRateList{}
-		err := c.B.Call("GET", "/exchange_rates", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/exchange_rates", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/fee/client.go
+++ b/fee/client.go
@@ -21,7 +21,7 @@ func Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee
 func (c Client) Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
 	path := stripe.FormatURLPath("/application_fees/%s", id)
 	fee := &stripe.ApplicationFee{}
-	err := c.B.Call2("GET", path, c.Key, params, fee)
+	err := c.B.Call("GET", path, c.Key, params, fee)
 	return fee, err
 }
 
@@ -32,7 +32,7 @@ func List(params *stripe.ApplicationFeeListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.ApplicationFeeListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplicationFeeList{}
 		err := c.B.CallRaw("GET", "/application_fees", c.Key, b, p, list)
 

--- a/fee/client.go
+++ b/fee/client.go
@@ -19,18 +19,9 @@ func Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee
 }
 
 func (c Client) Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/application_fees/%s", id)
 	fee := &stripe.ApplicationFee{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/application_fees/%s", id), c.Key, body, commonParams, fee)
-
+	err := c.B.Call2("GET", path, c.Key, params, fee)
 	return fee, err
 }
 
@@ -40,21 +31,10 @@ func List(params *stripe.ApplicationFeeListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.ApplicationFeeListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.ApplicationFeeListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplicationFeeList{}
-		err := c.B.Call("GET", "/application_fees", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/application_fees", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -28,12 +28,10 @@ func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/application_fees/%s/refunds",
+		stripe.StringValue(params.ApplicationFee))
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", stripe.FormatURLPath("application_fees/%s/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, body, &params.Params, refund)
-
+	err := c.B.Call2("POST", path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -51,12 +49,10 @@ func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefun
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/application_fees/%s/refunds/%s",
+		stripe.StringValue(params.ApplicationFee), id)
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/application_fees/%s/refunds/%s", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
-
+	err := c.B.Call2("GET", path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -74,11 +70,10 @@ func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRe
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
 
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/application_fees/%s/refunds/%s",
+		stripe.StringValue(params.ApplicationFee), id)
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/application_fees/%s/refunds/%s", stripe.StringValue(params.ApplicationFee), id), c.Key, body, &params.Params, refund)
+	err := c.B.Call2("POST", path, c.Key, params, refund)
 
 	return refund, err
 }
@@ -89,18 +84,13 @@ func List(params *stripe.FeeRefundListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.FeeRefundListParams) *Iter {
-	body := &form.Values{}
-	var lp *stripe.ListParams
-	var p *stripe.Params
+func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
+	path := stripe.FormatURLPath("/application_fees/%s/refunds",
+		stripe.StringValue(listParams.ApplicationFee))
 
-	form.AppendTo(body, params)
-	lp = &params.ListParams
-	p = params.ToParams()
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeRefundList{}
-		err := c.B.Call("GET", stripe.FormatURLPath("/application_fees/%s/refunds", stripe.StringValue(params.ApplicationFee)), c.Key, b, p, list)
+		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -31,7 +31,7 @@ func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	path := stripe.FormatURLPath("/application_fees/%s/refunds",
 		stripe.StringValue(params.ApplicationFee))
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call2("POST", path, c.Key, params, refund)
+	err := c.B.Call("POST", path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -52,7 +52,7 @@ func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefun
 	path := stripe.FormatURLPath("/application_fees/%s/refunds/%s",
 		stripe.StringValue(params.ApplicationFee), id)
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call2("GET", path, c.Key, params, refund)
+	err := c.B.Call("GET", path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -73,7 +73,7 @@ func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRe
 	path := stripe.FormatURLPath("/application_fees/%s/refunds/%s",
 		stripe.StringValue(params.ApplicationFee), id)
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call2("POST", path, c.Key, params, refund)
+	err := c.B.Call("POST", path, c.Key, params, refund)
 
 	return refund, err
 }
@@ -88,7 +88,7 @@ func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
 	path := stripe.FormatURLPath("/application_fees/%s/refunds",
 		stripe.StringValue(listParams.ApplicationFee))
 
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeRefundList{}
 		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -46,18 +46,9 @@ func Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error)
 }
 
 func (c Client) Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/files/%s", id)
 	upload := &stripe.FileUpload{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/files/%s", id), c.Key, body, commonParams, upload)
-
+	err := c.B.Call2("GET", path, c.Key, params, upload)
 	return upload, err
 }
 
@@ -67,21 +58,10 @@ func List(params *stripe.FileUploadListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.FileUploadListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.FileUploadListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FileUploadList{}
-		err := c.B.Call("GET", "/files", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/files", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -48,7 +48,7 @@ func Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error)
 func (c Client) Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error) {
 	path := stripe.FormatURLPath("/files/%s", id)
 	upload := &stripe.FileUpload{}
-	err := c.B.Call2("GET", path, c.Key, params, upload)
+	err := c.B.Call("GET", path, c.Key, params, upload)
 	return upload, err
 }
 
@@ -59,7 +59,7 @@ func List(params *stripe.FileUploadListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.FileUploadListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FileUploadList{}
 		err := c.B.CallRaw("GET", "/files", c.Key, b, p, list)
 

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 
 func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	invoice := &stripe.Invoice{}
-	err := c.B.Call2("POST", "/invoices", c.Key, params, invoice)
+	err := c.B.Call("POST", "/invoices", c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 func (c Client) Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call2("GET", path, c.Key, params, invoice)
+	err := c.B.Call("GET", path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -46,7 +46,7 @@ func Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 func (c Client) Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/invoices/%s/pay", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call2("POST", path, c.Key, params, invoice)
+	err := c.B.Call("POST", path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -59,7 +59,7 @@ func Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call2("POST", path, c.Key, params, invoice)
+	err := c.B.Call("POST", path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -71,7 +71,7 @@ func GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 
 func (c Client) GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	invoice := &stripe.Invoice{}
-	err := c.B.Call2("GET", "/invoices/upcoming", c.Key, params, invoice)
+	err := c.B.Call("GET", "/invoices/upcoming", c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -82,7 +82,7 @@ func List(params *stripe.InvoiceListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.InvoiceListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceList{}
 		err := c.B.CallRaw("GET", "/invoices", c.Key, b, p, list)
 
@@ -103,7 +103,7 @@ func ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 
 func (c Client) ListLines(listParams *stripe.InvoiceLineListParams) *LineIter {
 	path := stripe.FormatURLPath("/invoices/%s/lines", stripe.StringValue(listParams.ID))
-	return &LineIter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &LineIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceLineList{}
 		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -19,12 +19,8 @@ func New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("POST", "/invoices", c.Key, body, &params.Params, invoice)
-
+	err := c.B.Call2("POST", "/invoices", c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -35,18 +31,9 @@ func Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/invoices/%s", id), c.Key, body, commonParams, invoice)
-
+	err := c.B.Call2("GET", path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -57,18 +44,9 @@ func Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/invoices/%s/pay", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/invoices/%s/pay", id), c.Key, body, commonParams, invoice)
-
+	err := c.B.Call2("POST", path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -79,18 +57,9 @@ func Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/invoices/%s", id), c.Key, body, commonParams, invoice)
-
+	err := c.B.Call2("POST", path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -101,12 +70,8 @@ func GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 }
 
 func (c Client) GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("GET", "/invoices/upcoming", c.Key, body, &params.Params, invoice)
-
+	err := c.B.Call2("GET", "/invoices/upcoming", c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -116,21 +81,10 @@ func List(params *stripe.InvoiceListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.InvoiceListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.InvoiceListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceList{}
-		err := c.B.Call("GET", "/invoices", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/invoices", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -147,15 +101,11 @@ func ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 	return getC().ListLines(params)
 }
 
-func (c Client) ListLines(params *stripe.InvoiceLineListParams) *LineIter {
-	body := &form.Values{}
-	var lp *stripe.ListParams = &params.ListParams
-	var p *stripe.Params = params.ToParams()
-	form.AppendTo(body, params)
-
-	return &LineIter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) ListLines(listParams *stripe.InvoiceLineListParams) *LineIter {
+	path := stripe.FormatURLPath("/invoices/%s/lines", stripe.StringValue(listParams.ID))
+	return &LineIter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceLineList{}
-		err := c.B.Call("GET", stripe.FormatURLPath("/invoices/%s/lines", stripe.StringValue(params.ID)), c.Key, b, p, list)
+		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 
 func (c Client) New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call2("POST", "/invoiceitems", c.Key, params, invoiceItem)
+	err := c.B.Call("POST", "/invoiceitems", c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 func (c Client) Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call2("GET", path, c.Key, params, invoiceItem)
+	err := c.B.Call("GET", path, c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, e
 func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call2("POST", path, c.Key, params, invoiceItem)
+	err := c.B.Call("POST", path, c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -59,7 +59,7 @@ func Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 func (c Client) Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	ii := &stripe.InvoiceItem{}
-	err := c.B.Call2("DELETE", path, c.Key, params, ii)
+	err := c.B.Call("DELETE", path, c.Key, params, ii)
 	return ii, err
 }
 
@@ -70,7 +70,7 @@ func List(params *stripe.InvoiceItemListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.InvoiceItemListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceItemList{}
 		err := c.B.CallRaw("GET", "/invoiceitems", c.Key, b, p, list)
 

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -19,12 +19,8 @@ func New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 }
 
 func (c Client) New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call("POST", "/invoiceitems", c.Key, body, &params.Params, invoiceItem)
-
+	err := c.B.Call2("POST", "/invoiceitems", c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -35,18 +31,9 @@ func Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 }
 
 func (c Client) Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/invoiceitems/%s", id), c.Key, body, commonParams, invoiceItem)
-
+	err := c.B.Call2("GET", path, c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -57,18 +44,9 @@ func Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, e
 }
 
 func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/invoiceitems/%s", id), c.Key, body, commonParams, invoiceItem)
-
+	err := c.B.Call2("POST", path, c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -79,18 +57,9 @@ func Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 }
 
 func (c Client) Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	ii := &stripe.InvoiceItem{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/invoiceitems/%s", id), c.Key, body, commonParams, ii)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, ii)
 	return ii, err
 }
 
@@ -100,21 +69,10 @@ func List(params *stripe.InvoiceItemListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.InvoiceItemListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.InvoiceItemListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceItemList{}
-		err := c.B.Call("GET", "/invoiceitems", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/invoiceitems", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/issuerfraudrecord/client.go
+++ b/issuerfraudrecord/client.go
@@ -22,7 +22,7 @@ func Get(id string) (*stripe.IssuerFraudRecord, error) {
 func (c Client) Get(id string) (*stripe.IssuerFraudRecord, error) {
 	path := stripe.FormatURLPath("/issuer_fraud_records/%s", id)
 	ifr := &stripe.IssuerFraudRecord{}
-	err := c.B.Call2("GET", path, c.Key, nil, ifr)
+	err := c.B.Call("GET", path, c.Key, nil, ifr)
 	return ifr, err
 }
 
@@ -35,7 +35,7 @@ func List(params *stripe.IssuerFraudRecordListParams) *Iter {
 // List returns a list of issuer fraud records on a client.
 // For more details see https://stripe.com/docs/api#list_issuer_fraud_records.
 func (c Client) List(listParams *stripe.IssuerFraudRecordListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.IssuerFraudRecordList{}
 		err := c.B.CallRaw("GET", "/issuer_fraud_records", c.Key, b, p, list)
 

--- a/issuerfraudrecord/client.go
+++ b/issuerfraudrecord/client.go
@@ -20,8 +20,9 @@ func Get(id string) (*stripe.IssuerFraudRecord, error) {
 // Get returns the details of an issuer fraud record on a client.
 // For more details see https://stripe.com/docs/api#retrieve_issuer_fraud_record.
 func (c Client) Get(id string) (*stripe.IssuerFraudRecord, error) {
+	path := stripe.FormatURLPath("/issuer_fraud_records/%s", id)
 	ifr := &stripe.IssuerFraudRecord{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/issuer_fraud_records/%s", id), c.Key, nil, nil, ifr)
+	err := c.B.Call2("GET", path, c.Key, nil, ifr)
 	return ifr, err
 }
 
@@ -33,21 +34,10 @@ func List(params *stripe.IssuerFraudRecordListParams) *Iter {
 
 // List returns a list of issuer fraud records on a client.
 // For more details see https://stripe.com/docs/api#list_issuer_fraud_records.
-func (c Client) List(params *stripe.IssuerFraudRecordListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.IssuerFraudRecordListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.IssuerFraudRecordList{}
-		err := c.B.Call("GET", "/issuer_fraud_records", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/issuer_fraud_records", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/iter.go
+++ b/iter.go
@@ -7,10 +7,7 @@ import (
 )
 
 // Query is the function used to get a page listing.
-type Query func(*form.Values) ([]interface{}, ListMeta, error)
-
-// Query2 is the function used to get a page listing.
-type Query2 func(*Params, *form.Values) ([]interface{}, ListMeta, error)
+type Query func(*Params, *form.Values) ([]interface{}, ListMeta, error)
 
 // Iter provides a convenient interface
 // for iterating over the elements
@@ -27,35 +24,11 @@ type Iter struct {
 	listParams ListParams
 	meta       ListMeta
 	query      Query
-	query2     Query2
 	values     []interface{}
 }
 
 // GetIter returns a new Iter for a given query and its options.
-func GetIter(listParams *ListParams, formValues *form.Values, query Query) *Iter {
-	iter := &Iter{}
-	iter.query = query
-
-	p := listParams
-	if p == nil {
-		p = &ListParams{}
-	}
-	iter.listParams = *p
-
-	q := formValues
-	if q == nil {
-		q = &form.Values{}
-	}
-	iter.formValues = q
-
-	iter.getPage()
-	return iter
-}
-
-// TODO: After every list API call uses GetIter2, remove GetIter, then rename
-// all instances of GetIter2 to GetIter. This only exists as a separate method
-// to keep the build/tests working while we refactor.
-func GetIter2(container ListParamsContainer, query Query2) *Iter {
+func GetIter(container ListParamsContainer, query Query) *Iter {
 	var listParams *ListParams
 	formValues := &form.Values{}
 
@@ -75,7 +48,7 @@ func GetIter2(container ListParamsContainer, query Query2) *Iter {
 	iter := &Iter{
 		formValues: formValues,
 		listParams: *listParams,
-		query2:     query,
+		query:      query,
 	}
 
 	iter.getPage()
@@ -84,11 +57,7 @@ func GetIter2(container ListParamsContainer, query Query2) *Iter {
 }
 
 func (it *Iter) getPage() {
-	if it.query != nil {
-		it.values, it.meta, it.err = it.query(it.formValues)
-	} else {
-		it.values, it.meta, it.err = it.query2(it.listParams.GetParams(), it.formValues)
-	}
+	it.values, it.meta, it.err = it.query(it.listParams.GetParams(), it.formValues)
 
 	if it.listParams.EndingBefore != nil {
 		// We are moving backward,

--- a/iter_test.go
+++ b/iter_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestIterEmpty(t *testing.T) {
 	tq := testQuery{{nil, ListMeta{}, nil}}
-	g, gerr := collect(GetIter(nil, nil, tq.query))
+	g, gerr := collect(GetIter(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, 0, len(g))
 	assert.NoError(t, gerr)
@@ -18,7 +18,7 @@ func TestIterEmpty(t *testing.T) {
 
 func TestIterEmptyErr(t *testing.T) {
 	tq := testQuery{{nil, ListMeta{}, errTest}}
-	g, gerr := collect(GetIter(nil, nil, tq.query))
+	g, gerr := collect(GetIter(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, 0, len(g))
 	assert.Equal(t, errTest, gerr)
@@ -27,7 +27,7 @@ func TestIterEmptyErr(t *testing.T) {
 func TestIterOne(t *testing.T) {
 	tq := testQuery{{[]interface{}{1}, ListMeta{}, nil}}
 	want := []interface{}{1}
-	g, gerr := collect(GetIter(nil, nil, tq.query))
+	g, gerr := collect(GetIter(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -36,7 +36,7 @@ func TestIterOne(t *testing.T) {
 func TestIterOneErr(t *testing.T) {
 	tq := testQuery{{[]interface{}{1}, ListMeta{}, errTest}}
 	want := []interface{}{1}
-	g, gerr := collect(GetIter(nil, nil, tq.query))
+	g, gerr := collect(GetIter(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.Equal(t, errTest, gerr)
@@ -48,7 +48,7 @@ func TestIterPage2Empty(t *testing.T) {
 		{nil, ListMeta{}, nil},
 	}
 	want := []interface{}{&item{"x"}}
-	g, gerr := collect(GetIter(nil, nil, tq.query))
+	g, gerr := collect(GetIter(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -60,7 +60,7 @@ func TestIterPage2EmptyErr(t *testing.T) {
 		{nil, ListMeta{}, errTest},
 	}
 	want := []interface{}{&item{"x"}}
-	g, gerr := collect(GetIter(nil, nil, tq.query))
+	g, gerr := collect(GetIter(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.Equal(t, errTest, gerr)
@@ -72,7 +72,7 @@ func TestIterTwoPages(t *testing.T) {
 		{[]interface{}{2}, ListMeta{HasMore: false, TotalCount: 0, URL: ""}, nil},
 	}
 	want := []interface{}{&item{"x"}, 2}
-	g, gerr := collect(GetIter(nil, nil, tq.query))
+	g, gerr := collect(GetIter(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -84,7 +84,7 @@ func TestIterTwoPagesErr(t *testing.T) {
 		{[]interface{}{2}, ListMeta{HasMore: false, TotalCount: 0, URL: ""}, errTest},
 	}
 	want := []interface{}{&item{"x"}, 2}
-	g, gerr := collect(GetIter(nil, nil, tq.query))
+	g, gerr := collect(GetIter(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.Equal(t, errTest, gerr)
@@ -93,7 +93,7 @@ func TestIterTwoPagesErr(t *testing.T) {
 func TestIterReversed(t *testing.T) {
 	tq := testQuery{{[]interface{}{1, 2}, ListMeta{}, nil}}
 	want := []interface{}{2, 1}
-	g, gerr := collect(GetIter(&ListParams{EndingBefore: String("x")}, nil, tq.query))
+	g, gerr := collect(GetIter(&ListParams{EndingBefore: String("x")}, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -105,7 +105,7 @@ func TestIterReversedTwoPages(t *testing.T) {
 		{[]interface{}{1, 2}, ListMeta{}, nil},
 	}
 	want := []interface{}{4, &item{"3"}, 2, 1}
-	g, gerr := collect(GetIter(&ListParams{EndingBefore: String("x")}, nil, tq.query))
+	g, gerr := collect(GetIter(&ListParams{EndingBefore: String("x")}, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -146,7 +146,7 @@ type testQuery []struct {
 	e error
 }
 
-func (tq *testQuery) query(*form.Values) ([]interface{}, ListMeta, error) {
+func (tq *testQuery) query(*Params, *form.Values) ([]interface{}, ListMeta, error) {
 	x := (*tq)[0]
 	*tq = (*tq)[1:]
 	return x.v, x.m, x.e

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -26,7 +26,7 @@ func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 
 	path := stripe.FormatURLPath("/accounts/%s/login_links", stripe.StringValue(params.Account))
 	loginLink := &stripe.LoginLink{}
-	err := c.B.Call2("POST", path, c.Key, nil, loginLink)
+	err := c.B.Call("POST", path, c.Key, nil, loginLink)
 	return loginLink, err
 }
 

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /login_links APIs.
@@ -21,17 +20,13 @@ func New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 }
 
 func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
-	body := &form.Values{}
-
-	loginLink := &stripe.LoginLink{}
-	var err error
-
-	if params.Account != nil {
-		err = c.B.Call("POST", stripe.FormatURLPath("/accounts/%s/login_links", stripe.StringValue(params.Account)), c.Key, body, nil, loginLink)
-	} else {
-		err = errors.New("Invalid login link params: Account must be set")
+	if params.Account == nil {
+		return nil, errors.New("Invalid login link params: Account must be set")
 	}
 
+	path := stripe.FormatURLPath("/accounts/%s/login_links", stripe.StringValue(params.Account))
+	loginLink := &stripe.LoginLink{}
+	err := c.B.Call2("POST", path, c.Key, nil, loginLink)
 	return loginLink, err
 }
 

--- a/order/client.go
+++ b/order/client.go
@@ -23,7 +23,7 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 // For more details see https://stripe.com/docs/api#create_order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
 	p := &stripe.Order{}
-	err := c.B.Call2("POST", "/orders", c.Key, params, p)
+	err := c.B.Call("POST", "/orders", c.Key, params, p)
 	return p, err
 }
 
@@ -38,7 +38,7 @@ func Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) 
 func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/orders/%s", id)
 	o := &stripe.Order{}
-	err := c.B.Call2("POST", path, c.Key, params, o)
+	err := c.B.Call("POST", path, c.Key, params, o)
 	return o, err
 }
 
@@ -57,7 +57,7 @@ func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, er
 
 	path := stripe.FormatURLPath("/orders/%s/pay", id)
 	o := &stripe.Order{}
-	err := c.B.Call2("POST", path, c.Key, params, o)
+	err := c.B.Call("POST", path, c.Key, params, o)
 	return o, err
 }
 
@@ -70,7 +70,7 @@ func Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/orders/%s", id)
 	order := &stripe.Order{}
-	err := c.B.Call2("GET", path, c.Key, params, order)
+	err := c.B.Call("GET", path, c.Key, params, order)
 	return order, err
 }
 
@@ -81,7 +81,7 @@ func List(params *stripe.OrderListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.OrderListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderList{}
 		err := c.B.CallRaw("GET", "/orders", c.Key, b, p, list)
 
@@ -118,7 +118,7 @@ func Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, e
 func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
 	path := stripe.FormatURLPath("/orders/%s/returns", id)
 	ret := &stripe.OrderReturn{}
-	err := c.B.Call2("POST", path, c.Key, params, ret)
+	err := c.B.Call("POST", path, c.Key, params, ret)
 	return ret, err
 }
 

--- a/order/client.go
+++ b/order/client.go
@@ -1,8 +1,6 @@
 package order
 
 import (
-	"errors"
-
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -51,10 +49,6 @@ func Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 // Pay pays an order
 // For more details see https://stripe.com/docs/api#pay_order.
 func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
-	if params != nil && params.Source == nil && params.Customer == nil {
-		return nil, errors.New("Invalid order pay params: either customer or a source must be set")
-	}
-
 	path := stripe.FormatURLPath("/orders/%s/pay", id)
 	o := &stripe.Order{}
 	err := c.B.Call("POST", path, c.Key, params, o)

--- a/order/client.go
+++ b/order/client.go
@@ -22,18 +22,8 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 // New POSTs a new order.
 // For more details see https://stripe.com/docs/api#create_order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
 	p := &stripe.Order{}
-	err := c.B.Call("POST", "/orders", c.Key, body, commonParams, p)
-
+	err := c.B.Call2("POST", "/orders", c.Key, params, p)
 	return p, err
 }
 
@@ -46,18 +36,9 @@ func Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) 
 // Update updates an order's properties.
 // For more details see https://stripe.com/docs/api#update_order.
 func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/orders/%s", id)
 	o := &stripe.Order{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/orders/%s", id), c.Key, body, commonParams, o)
-
+	err := c.B.Call2("POST", path, c.Key, params, o)
 	return o, err
 }
 
@@ -70,23 +51,13 @@ func Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 // Pay pays an order
 // For more details see https://stripe.com/docs/api#pay_order.
 func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		if params.Source == nil && params.Customer == nil {
-			err := errors.New("Invalid order pay params: either customer or a source must be set")
-			return nil, err
-		}
-
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
+	if params != nil && params.Source == nil && params.Customer == nil {
+		return nil, errors.New("Invalid order pay params: either customer or a source must be set")
 	}
 
+	path := stripe.FormatURLPath("/orders/%s/pay", id)
 	o := &stripe.Order{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/orders/%s/pay", id), c.Key, body, commonParams, o)
-
+	err := c.B.Call2("POST", path, c.Key, params, o)
 	return o, err
 }
 
@@ -97,17 +68,9 @@ func Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 }
 
 func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/orders/%s", id)
 	order := &stripe.Order{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/orders/%s", id), c.Key, body, commonParams, order)
+	err := c.B.Call2("GET", path, c.Key, params, order)
 	return order, err
 }
 
@@ -117,21 +80,10 @@ func List(params *stripe.OrderListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.OrderListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.OrderListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderList{}
-		err := c.B.Call("GET", "/orders", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/orders", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -164,18 +116,9 @@ func Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, e
 // Return returns all or part of an order.
 // For more details see https://stripe.com/docs/api#return_order.
 func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/orders/%s/returns", id)
 	ret := &stripe.OrderReturn{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/orders/%s/returns", id), c.Key, body, commonParams, ret)
-
+	err := c.B.Call2("POST", path, c.Key, params, ret)
 	return ret, err
 }
 

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -17,7 +17,7 @@ func List(params *stripe.OrderReturnListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.OrderReturnListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderReturnList{}
 		err := c.B.CallRaw("GET", "/order_returns", c.Key, b, p, list)
 

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -16,21 +16,10 @@ func List(params *stripe.OrderReturnListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.OrderReturnListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.OrderReturnListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderReturnList{}
-		err := c.B.Call("GET", "/order_returns", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/order_returns", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/params.go
+++ b/params.go
@@ -17,10 +17,16 @@ const (
 	StartingAfter = "starting_after"
 )
 
+// ParamsContainer is a general interface for which all parameter structs
+// should comply. They achieve this by embedding a Params struct and inheriting
+// its implementation of this interface.
 type ParamsContainer interface {
 	GetParams() *Params
 }
 
+// ListParamsContainer is a general interface for which all list parameter
+// structs should comply. They achieve this by embedding a ListParams struct
+// and inheriting its implementation of this interface.
 type ListParamsContainer interface {
 	GetListParams() *ListParams
 }

--- a/params.go
+++ b/params.go
@@ -17,6 +17,14 @@ const (
 	StartingAfter = "starting_after"
 )
 
+type ParamsContainer interface {
+	GetParams() *Params
+}
+
+type ListParamsContainer interface {
+	GetListParams() *ListParams
+}
+
 // Params is the structure that contains the common properties
 // of any *Params structure.
 type Params struct {
@@ -44,6 +52,13 @@ type Params struct {
 	// account instead of under the account of the owner of the configured
 	// Stripe key.
 	StripeAccount *string `form:"-"` // Passed as header
+}
+
+// GetParams returns a Params struct (itself). It exists because any structs
+// that embed Params will inherit it, and thus implement the ParamsContainer
+// interface.
+func (p *Params) GetParams() *Params {
+	return p
 }
 
 // ExtraValues are extra parameters that are attached to an API request.
@@ -198,6 +213,20 @@ func (p *Params) AddExtra(key, value string) {
 // AddExpand appends a new field to expand.
 func (p *ListParams) AddExpand(f string) {
 	p.Expand = append(p.Expand, &f)
+}
+
+// GetListParams returns a ListParams struct (itself). It exists because any
+// structs that embed ListParams will inherit it, and thus implement the
+// ListParamsContainer interface.
+func (p *ListParams) GetListParams() *ListParams {
+	return p
+}
+
+// GetParams returns ListParams as a Params struct. It exists because any
+// structs that embed Params will inherit it, and thus implement the
+// ParamsContainer interface.
+func (p *ListParams) GetParams() *Params {
+	return p.ToParams()
 }
 
 // SetStripeAccount sets a value for the Stripe-Account header.

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -27,7 +27,7 @@ func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 
 	path := stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer))
 	source := &stripe.PaymentSource{}
-	err := s.B.Call2("POST", path, s.Key, params, source)
+	err := s.B.Call("POST", path, s.Key, params, source)
 	return source, err
 }
 
@@ -44,7 +44,7 @@ func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 
 	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	source := &stripe.PaymentSource{}
-	err := s.B.Call2("GET", path, s.Key, params, source)
+	err := s.B.Call("GET", path, s.Key, params, source)
 	return source, err
 }
 
@@ -61,7 +61,7 @@ func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.
 
 	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	source := &stripe.PaymentSource{}
-	err := s.B.Call2("POST", path, s.Key, params, source)
+	err := s.B.Call("POST", path, s.Key, params, source)
 	return source, err
 }
 
@@ -78,7 +78,7 @@ func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 
 	source := &stripe.PaymentSource{}
 	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
-	err := s.B.Call2("DELETE", path, s.Key, params, source)
+	err := s.B.Call("DELETE", path, s.Key, params, source)
 	return source, err
 }
 
@@ -99,7 +99,7 @@ func (s Client) List(listParams *stripe.SourceListParams) *Iter {
 			stripe.StringValue(listParams.Customer))
 	}
 
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SourceList{}
 
 		if outerErr != nil {
@@ -135,7 +135,7 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 	}
 
 	source := &stripe.PaymentSource{}
-	err := s.B.Call2("POST", path, s.Key, params, source)
+	err := s.B.Call("POST", path, s.Key, params, source)
 	return source, err
 }
 

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -21,6 +21,10 @@ func New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 }
 
 func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	if params.Customer == nil {
 		return nil, errors.New("Invalid source params: customer needs to be set")
 	}
@@ -38,6 +42,10 @@ func Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 }
 
 func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	if params.Customer == nil {
 		return nil, errors.New("Invalid source params: customer needs to be set")
 	}
@@ -55,6 +63,10 @@ func Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSour
 }
 
 func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	if params.Customer == nil {
 		return nil, errors.New("Invalid source params: customer needs to be set")
 	}
@@ -72,6 +84,10 @@ func Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 }
 
 func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	if params.Customer == nil {
 		return nil, errors.New("Invalid source params: customer needs to be set")
 	}
@@ -92,7 +108,9 @@ func (s Client) List(listParams *stripe.SourceListParams) *Iter {
 	var outerErr error
 	var path string
 
-	if listParams.Customer == nil {
+	if listParams == nil {
+		outerErr = errors.New("params should not be nil")
+	} else if listParams.Customer == nil {
 		outerErr = errors.New("Invalid source params: customer needs to be set")
 	} else {
 		path = stripe.FormatURLPath("/customers/%s/sources",
@@ -124,6 +142,10 @@ func Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource
 }
 
 func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
 	var path string
 	if params.Customer != nil {
 		path = stripe.FormatURLPath("/customers/%s/sources/%s/verify",

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -21,18 +21,13 @@ func New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 }
 
 func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
-	source := &stripe.PaymentSource{}
-	var err error
-
-	if params.Customer != nil {
-		err = s.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer)), s.Key, body, &params.Params, source)
-	} else {
-		err = errors.New("Invalid source params: customer needs to be set")
+	if params.Customer == nil {
+		return nil, errors.New("Invalid source params: customer needs to be set")
 	}
 
+	path := stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer))
+	source := &stripe.PaymentSource{}
+	err := s.B.Call2("POST", path, s.Key, params, source)
 	return source, err
 }
 
@@ -43,24 +38,13 @@ func Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 }
 
 func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
+	if params.Customer == nil {
+		return nil, errors.New("Invalid source params: customer needs to be set")
 	}
 
+	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	source := &stripe.PaymentSource{}
-	var err error
-
-	if params.Customer != nil {
-		err = s.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
-	} else {
-		err = errors.New("Invalid source params: customer needs to be set")
-	}
-
+	err := s.B.Call2("GET", path, s.Key, params, source)
 	return source, err
 }
 
@@ -71,18 +55,13 @@ func Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSour
 }
 
 func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
-	source := &stripe.PaymentSource{}
-	var err error
-
-	if params.Customer != nil {
-		err = s.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
-	} else {
-		err = errors.New("Invalid source params: customer needs to be set")
+	if params.Customer == nil {
+		return nil, errors.New("Invalid source params: customer needs to be set")
 	}
 
+	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
+	source := &stripe.PaymentSource{}
+	err := s.B.Call2("POST", path, s.Key, params, source)
 	return source, err
 }
 
@@ -93,24 +72,13 @@ func Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 }
 
 func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
+	if params.Customer == nil {
+		return nil, errors.New("Invalid source params: customer needs to be set")
 	}
 
 	source := &stripe.PaymentSource{}
-	var err error
-
-	if params.Customer != nil {
-		err = s.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), s.Key, body, commonParams, source)
-	} else {
-		err = errors.New("Invalid source params: customer needs to be set")
-	}
-
+	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
+	err := s.B.Call2("DELETE", path, s.Key, params, source)
 	return source, err
 }
 
@@ -120,21 +88,25 @@ func List(params *stripe.SourceListParams) *Iter {
 	return getC().List(params)
 }
 
-func (s Client) List(params *stripe.SourceListParams) *Iter {
-	body := &form.Values{}
-	var lp *stripe.ListParams = &params.ListParams
-	var p *stripe.Params = params.ToParams()
-	form.AppendTo(body, params)
+func (s Client) List(listParams *stripe.SourceListParams) *Iter {
+	var outerErr error
+	var path string
 
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	if listParams.Customer == nil {
+		outerErr = errors.New("Invalid source params: customer needs to be set")
+	} else {
+		path = stripe.FormatURLPath("/customers/%s/sources",
+			stripe.StringValue(listParams.Customer))
+	}
+
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SourceList{}
-		var err error
 
-		if params.Customer != nil {
-			err = s.B.Call("GET", stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer)), s.Key, b, p, list)
-		} else {
-			err = errors.New("Invalid source params: customer needs to be set")
+		if outerErr != nil {
+			return nil, list.ListMeta, outerErr
 		}
+
+		err := s.B.CallRaw("GET", path, s.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -152,20 +124,18 @@ func Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource
 }
 
 func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
-	source := &stripe.PaymentSource{}
-	var err error
-
+	var path string
 	if params.Customer != nil {
-		err = s.B.Call("POST", stripe.FormatURLPath("/customers/%s/sources/%s/verify", stripe.StringValue(params.Customer), id), s.Key, body, &params.Params, source)
+		path = stripe.FormatURLPath("/customers/%s/sources/%s/verify",
+			stripe.StringValue(params.Customer), id)
 	} else if len(params.Values) > 0 {
-		err = s.B.Call("POST", stripe.FormatURLPath("/sources/%s/verify", id), s.Key, body, &params.Params, source)
+		path = stripe.FormatURLPath("/sources/%s/verify", id)
 	} else {
-		err = errors.New("Only customer bank accounts or sources can be verified in this manner.")
+		return nil, errors.New("Only customer bank accounts or sources can be verified in this manner.")
 	}
 
+	source := &stripe.PaymentSource{}
+	err := s.B.Call2("POST", path, s.Key, params, source)
 	return source, err
 }
 

--- a/payout/client.go
+++ b/payout/client.go
@@ -19,12 +19,8 @@ func New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 func (c Client) New(params *stripe.PayoutParams) (*stripe.Payout, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	payout := &stripe.Payout{}
-	err := c.B.Call("POST", "/payouts", c.Key, body, &params.Params, payout)
-
+	err := c.B.Call2("POST", "/payouts", c.Key, params, payout)
 	return payout, err
 }
 
@@ -35,18 +31,9 @@ func Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 func (c Client) Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/payouts/%s", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/payouts/%s", id), c.Key, body, commonParams, payout)
-
+	err := c.B.Call2("GET", path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -57,18 +44,9 @@ func Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/payouts/%s", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/payouts/%s", id), c.Key, body, commonParams, payout)
-
+	err := c.B.Call2("POST", path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -79,18 +57,9 @@ func Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/payouts/%s/cancel", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/payouts/%s/cancel", id), c.Key, body, commonParams, payout)
-
+	err := c.B.Call2("POST", path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -100,21 +69,10 @@ func List(params *stripe.PayoutListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.PayoutListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PayoutList{}
-		err := c.B.Call("GET", "/payouts", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/payouts", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/payout/client.go
+++ b/payout/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 
 func (c Client) New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 	payout := &stripe.Payout{}
-	err := c.B.Call2("POST", "/payouts", c.Key, params, payout)
+	err := c.B.Call("POST", "/payouts", c.Key, params, payout)
 	return payout, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call2("GET", path, c.Key, params, payout)
+	err := c.B.Call("GET", path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call2("POST", path, c.Key, params, payout)
+	err := c.B.Call("POST", path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -59,7 +59,7 @@ func Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s/cancel", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call2("POST", path, c.Key, params, payout)
+	err := c.B.Call("POST", path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -70,7 +70,7 @@ func List(params *stripe.PayoutListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PayoutList{}
 		err := c.B.CallRaw("GET", "/payouts", c.Key, b, p, list)
 

--- a/plan/client.go
+++ b/plan/client.go
@@ -19,12 +19,8 @@ func New(params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	plan := &stripe.Plan{}
-	err := c.B.Call("POST", "/plans", c.Key, body, &params.Params, plan)
-
+	err := c.B.Call2("POST", "/plans", c.Key, params, plan)
 	return plan, err
 }
 
@@ -35,18 +31,9 @@ func Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/plans/%s", id), c.Key, body, commonParams, plan)
-
+	err := c.B.Call2("GET", path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -57,18 +44,9 @@ func Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/plans/%s", id), c.Key, body, commonParams, plan)
-
+	err := c.B.Call2("POST", path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -79,17 +57,9 @@ func Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/plans/%s", id), c.Key, body, commonParams, plan)
+	err := c.B.Call2("DELETE", path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -99,21 +69,10 @@ func List(params *stripe.PlanListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.PlanListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.PlanListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PlanList{}
-		err := c.B.Call("GET", "/plans", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/plans", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/plan/client.go
+++ b/plan/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.PlanParams) (*stripe.Plan, error) {
 
 func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
 	plan := &stripe.Plan{}
-	err := c.B.Call2("POST", "/plans", c.Key, params, plan)
+	err := c.B.Call("POST", "/plans", c.Key, params, plan)
 	return plan, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call2("GET", path, c.Key, params, plan)
+	err := c.B.Call("GET", path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call2("POST", path, c.Key, params, plan)
+	err := c.B.Call("POST", path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -59,7 +59,7 @@ func Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call2("DELETE", path, c.Key, params, plan)
+	err := c.B.Call("DELETE", path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -70,7 +70,7 @@ func List(params *stripe.PlanListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.PlanListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PlanList{}
 		err := c.B.CallRaw("GET", "/plans", c.Key, b, p, list)
 

--- a/product/client.go
+++ b/product/client.go
@@ -20,18 +20,8 @@ func New(params *stripe.ProductParams) (*stripe.Product, error) {
 // New POSTs a new product.
 // For more details see https://stripe.com/docs/api#create_product.
 func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
 	p := &stripe.Product{}
-	err := c.B.Call("POST", "/products", c.Key, body, commonParams, p)
-
+	err := c.B.Call2("POST", "/products", c.Key, params, p)
 	return p, err
 }
 
@@ -44,18 +34,9 @@ func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 // Update updates a product's properties.
 // For more details see https://stripe.com/docs/api#update_product.
 func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/products/%s", id), c.Key, body, commonParams, p)
-
+	err := c.B.Call2("POST", path, c.Key, params, p)
 	return p, err
 }
 
@@ -66,18 +47,9 @@ func Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 }
 
 func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/products/%s", id), c.Key, body, commonParams, p)
-
+	err := c.B.Call2("GET", path, c.Key, params, p)
 	return p, err
 }
 
@@ -87,21 +59,10 @@ func List(params *stripe.ProductListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.ProductListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.ProductListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ProductList{}
-		err := c.B.Call("GET", "/products", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/products", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -134,17 +95,9 @@ func Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 // Delete deletes a product.
 // For more details see https://stripe.com/docs/api#delete_product.
 func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/products/%s", id), c.Key, body, commonParams, p)
+	err := c.B.Call2("DELETE", path, c.Key, params, p)
 
 	return p, err
 }

--- a/product/client.go
+++ b/product/client.go
@@ -21,7 +21,7 @@ func New(params *stripe.ProductParams) (*stripe.Product, error) {
 // For more details see https://stripe.com/docs/api#create_product.
 func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
 	p := &stripe.Product{}
-	err := c.B.Call2("POST", "/products", c.Key, params, p)
+	err := c.B.Call("POST", "/products", c.Key, params, p)
 	return p, err
 }
 
@@ -36,7 +36,7 @@ func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call2("POST", path, c.Key, params, p)
+	err := c.B.Call("POST", path, c.Key, params, p)
 	return p, err
 }
 
@@ -49,7 +49,7 @@ func Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call2("GET", path, c.Key, params, p)
+	err := c.B.Call("GET", path, c.Key, params, p)
 	return p, err
 }
 
@@ -60,7 +60,7 @@ func List(params *stripe.ProductListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.ProductListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ProductList{}
 		err := c.B.CallRaw("GET", "/products", c.Key, b, p, list)
 
@@ -97,7 +97,7 @@ func Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call2("DELETE", path, c.Key, params, p)
+	err := c.B.Call("DELETE", path, c.Key, params, p)
 
 	return p, err
 }

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -24,7 +24,7 @@ func Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 func (c Client) Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call2("GET", path, c.Key, params, recipient)
+	err := c.B.Call("GET", path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -37,7 +37,7 @@ func Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error
 func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call2("POST", path, c.Key, params, recipient)
+	err := c.B.Call("POST", path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -50,7 +50,7 @@ func Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 func (c Client) Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call2("DELETE", path, c.Key, params, recipient)
+	err := c.B.Call("DELETE", path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -61,7 +61,7 @@ func List(params *stripe.RecipientListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.RecipientListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RecipientList{}
 		err := c.B.CallRaw("GET", "/recipients", c.Key, b, p, list)
 

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -22,18 +22,9 @@ func Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 }
 
 func (c Client) Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/recipients/%s", id), c.Key, body, commonParams, recipient)
-
+	err := c.B.Call2("GET", path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -44,18 +35,9 @@ func Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error
 }
 
 func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/recipients/%s", id), c.Key, body, commonParams, recipient)
-
+	err := c.B.Call2("POST", path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -66,18 +48,9 @@ func Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 }
 
 func (c Client) Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/recipients/%s", id), c.Key, body, commonParams, recipient)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -87,21 +60,10 @@ func List(params *stripe.RecipientListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.RecipientListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.RecipientListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RecipientList{}
-		err := c.B.Call("GET", "/recipients", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/recipients", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/refund/client.go
+++ b/refund/client.go
@@ -19,12 +19,8 @@ func New(params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	refund := &stripe.Refund{}
-	err := c.B.Call("POST", "/refunds", c.Key, body, &params.Params, refund)
-
+	err := c.B.Call2("POST", "/refunds", c.Key, params, refund)
 	return refund, err
 }
 
@@ -35,18 +31,9 @@ func Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/refunds/%s", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/refunds/%s", id), c.Key, body, commonParams, refund)
-
+	err := c.B.Call2("GET", path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -57,12 +44,9 @@ func Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/refunds/%s", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/refunds/%s", id), c.Key, body, &params.Params, refund)
-
+	err := c.B.Call2("POST", path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -72,18 +56,10 @@ func List(params *stripe.RefundListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.RefundListParams) *Iter {
-	body := &form.Values{}
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	form.AppendTo(body, params)
-	lp = &params.ListParams
-	p = params.ToParams()
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.RefundListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RefundList{}
-		err := c.B.Call("GET", "/refunds", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/refunds", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/refund/client.go
+++ b/refund/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.RefundParams) (*stripe.Refund, error) {
 
 func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	refund := &stripe.Refund{}
-	err := c.B.Call2("POST", "/refunds", c.Key, params, refund)
+	err := c.B.Call("POST", "/refunds", c.Key, params, refund)
 	return refund, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/refunds/%s", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call2("GET", path, c.Key, params, refund)
+	err := c.B.Call("GET", path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/refunds/%s", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call2("POST", path, c.Key, params, refund)
+	err := c.B.Call("POST", path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -57,7 +57,7 @@ func List(params *stripe.RefundListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.RefundListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RefundList{}
 		err := c.B.CallRaw("GET", "/refunds", c.Key, b, p, list)
 

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -20,12 +20,9 @@ func New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 }
 
 func (c Client) New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(params.Transfer))
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(params.Transfer)), c.Key, body, &params.Params, reversal)
-
+	err := c.B.Call2("POST", path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -39,12 +36,10 @@ func (c Client) Get(id string, params *stripe.ReversalParams) (*stripe.Reversal,
 		return nil, fmt.Errorf("params cannot be nil, and params.Transfer must be set")
 	}
 
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/transfers/%s/reversals/%s",
+		stripe.StringValue(params.Transfer), id)
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/transfers/%s/reversals/%s", stripe.StringValue(params.Transfer), id), c.Key, body, &params.Params, reversal)
-
+	err := c.B.Call2("GET", path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -54,12 +49,10 @@ func Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) 
 }
 
 func (c Client) Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
+	path := stripe.FormatURLPath("/transfers/%s/reversals/%s",
+		stripe.StringValue(params.Transfer), id)
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/transfers/%s/reversals/%s", stripe.StringValue(params.Transfer), id), c.Key, body, &params.Params, reversal)
-
+	err := c.B.Call2("POST", path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -68,15 +61,12 @@ func List(params *stripe.ReversalListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.ReversalListParams) *Iter {
-	body := &form.Values{}
-	var lp *stripe.ListParams = &params.ListParams
-	var p *stripe.Params = params.ToParams()
-	form.AppendTo(body, params)
+func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
+	path := stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(listParams.Transfer))
 
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ReversalList{}
-		err := c.B.Call("GET", stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(params.Transfer)), c.Key, b, p, list)
+		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -22,7 +22,7 @@ func New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 func (c Client) New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	path := stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(params.Transfer))
 	reversal := &stripe.Reversal{}
-	err := c.B.Call2("POST", path, c.Key, params, reversal)
+	err := c.B.Call("POST", path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -39,7 +39,7 @@ func (c Client) Get(id string, params *stripe.ReversalParams) (*stripe.Reversal,
 	path := stripe.FormatURLPath("/transfers/%s/reversals/%s",
 		stripe.StringValue(params.Transfer), id)
 	reversal := &stripe.Reversal{}
-	err := c.B.Call2("GET", path, c.Key, params, reversal)
+	err := c.B.Call("GET", path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -52,7 +52,7 @@ func (c Client) Update(id string, params *stripe.ReversalParams) (*stripe.Revers
 	path := stripe.FormatURLPath("/transfers/%s/reversals/%s",
 		stripe.StringValue(params.Transfer), id)
 	reversal := &stripe.Reversal{}
-	err := c.B.Call2("POST", path, c.Key, params, reversal)
+	err := c.B.Call("POST", path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -64,7 +64,7 @@ func List(params *stripe.ReversalListParams) *Iter {
 func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
 	path := stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(listParams.Transfer))
 
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ReversalList{}
 		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 

--- a/sku/client.go
+++ b/sku/client.go
@@ -20,18 +20,8 @@ func New(params *stripe.SKUParams) (*stripe.SKU, error) {
 // New POSTs a new SKU.
 // For more details see https://stripe.com/docs/api#create_sku.
 func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
 	s := &stripe.SKU{}
-	err := c.B.Call("POST", "/skus", c.Key, body, commonParams, s)
-
+	err := c.B.Call2("POST", "/skus", c.Key, params, s)
 	return s, err
 }
 
@@ -44,18 +34,9 @@ func Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 // Update updates a SKU's properties.
 // For more details see https://stripe.com/docs/api#update_sku.
 func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/skus/%s", id), c.Key, body, commonParams, s)
-
+	err := c.B.Call2("POST", path, c.Key, params, s)
 	return s, err
 }
 
@@ -66,18 +47,9 @@ func Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 }
 
 func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/skus/%s", id), c.Key, body, commonParams, s)
-
+	err := c.B.Call2("GET", path, c.Key, params, s)
 	return s, err
 }
 
@@ -87,21 +59,10 @@ func List(params *stripe.SKUListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SKUListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.SKUListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SKUList{}
-		err := c.B.Call("GET", "/skus", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/skus", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -134,17 +95,9 @@ func Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 // Delete destroys a SKU.
 // For more details see https://stripe.com/docs/api#delete_sku.
 func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/skus/%s", id), c.Key, body, commonParams, s)
+	err := c.B.Call2("DELETE", path, c.Key, params, s)
 
 	return s, err
 }

--- a/sku/client.go
+++ b/sku/client.go
@@ -21,7 +21,7 @@ func New(params *stripe.SKUParams) (*stripe.SKU, error) {
 // For more details see https://stripe.com/docs/api#create_sku.
 func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
 	s := &stripe.SKU{}
-	err := c.B.Call2("POST", "/skus", c.Key, params, s)
+	err := c.B.Call("POST", "/skus", c.Key, params, s)
 	return s, err
 }
 
@@ -36,7 +36,7 @@ func Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call2("POST", path, c.Key, params, s)
+	err := c.B.Call("POST", path, c.Key, params, s)
 	return s, err
 }
 
@@ -49,7 +49,7 @@ func Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call2("GET", path, c.Key, params, s)
+	err := c.B.Call("GET", path, c.Key, params, s)
 	return s, err
 }
 
@@ -60,7 +60,7 @@ func List(params *stripe.SKUListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.SKUListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SKUList{}
 		err := c.B.CallRaw("GET", "/skus", c.Key, b, p, list)
 
@@ -97,7 +97,7 @@ func Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call2("DELETE", path, c.Key, params, s)
+	err := c.B.Call("DELETE", path, c.Key, params, s)
 
 	return s, err
 }

--- a/source/client.go
+++ b/source/client.go
@@ -22,7 +22,7 @@ func New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 // For more details see https://stripe.com/docs/api#create_source.
 func (c Client) New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	p := &stripe.Source{}
-	err := c.B.Call2("POST", "/sources", c.Key, params, p)
+	err := c.B.Call("POST", "/sources", c.Key, params, p)
 	return p, err
 }
 
@@ -37,7 +37,7 @@ func Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 func (c Client) Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	path := stripe.FormatURLPath("/sources/%s", id)
 	source := &stripe.Source{}
-	err := c.B.Call2("GET", path, c.Key, params, source)
+	err := c.B.Call("GET", path, c.Key, params, source)
 	return source, err
 }
 
@@ -50,7 +50,7 @@ func Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error
 func (c Client) Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	path := stripe.FormatURLPath("/sources/%s", id)
 	source := &stripe.Source{}
-	err := c.B.Call2("POST", path, c.Key, params, source)
+	err := c.B.Call("POST", path, c.Key, params, source)
 	return source, err
 }
 
@@ -71,6 +71,6 @@ func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*str
 	path := stripe.FormatURLPath("/customers/%s/sources/%s",
 		stripe.StringValue(params.Customer), id)
 	source := &stripe.Source{}
-	err := c.B.Call2("DELETE", path, c.Key, params, source)
+	err := c.B.Call("DELETE", path, c.Key, params, source)
 	return source, err
 }

--- a/source/client.go
+++ b/source/client.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /sources APIs.
@@ -22,18 +21,8 @@ func New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 // New POSTs a new source.
 // For more details see https://stripe.com/docs/api#create_source.
 func (c Client) New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
 	p := &stripe.Source{}
-	err := c.B.Call("POST", "/sources", c.Key, body, commonParams, p)
-
+	err := c.B.Call2("POST", "/sources", c.Key, params, p)
 	return p, err
 }
 
@@ -46,17 +35,9 @@ func Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 // Get returns the details of a source
 // For more details see https://stripe.com/docs/api#retrieve_source.
 func (c Client) Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/sources/%s", id)
 	source := &stripe.Source{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/sources/%s", id), c.Key, body, commonParams, source)
+	err := c.B.Call2("GET", path, c.Key, params, source)
 	return source, err
 }
 
@@ -67,18 +48,9 @@ func Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error
 }
 
 func (c Client) Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		commonParams = &params.Params
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/sources/%s", id)
 	source := &stripe.Source{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/sources/%s", id), c.Key, body, commonParams, source)
-
+	err := c.B.Call2("POST", path, c.Key, params, source)
 	return source, err
 }
 
@@ -92,23 +64,13 @@ func Detach(id string, params *stripe.SourceObjectDetachParams) (*stripe.Source,
 }
 
 func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*stripe.Source, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
+	if params.Customer == nil {
+		return nil, errors.New("Invalid source detach params: Customer needs to be set")
 	}
 
+	path := stripe.FormatURLPath("/customers/%s/sources/%s",
+		stripe.StringValue(params.Customer), id)
 	source := &stripe.Source{}
-	var err error
-
-	if params.Customer != nil {
-		err = c.B.Call("DELETE", stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id), c.Key, body, commonParams, source)
-	} else {
-		err = errors.New("Invalid source detach params: Customer needs to be set")
-	}
-
+	err := c.B.Call2("DELETE", path, c.Key, params, source)
 	return source, err
 }

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -20,24 +20,25 @@ func List(params *stripe.SourceTransactionListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SourceTransactionListParams) *Iter {
-	body := &form.Values{}
-	var lp *stripe.ListParams
-	var p *stripe.Params
+func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
+	var outerErr error
+	var path string
 
-	form.AppendTo(body, params)
-	lp = &params.ListParams
-	p = params.ToParams()
+	if listParams == nil || listParams.Source == nil {
+		outerErr = errors.New("Invalid source transaction params: Source needs to be set")
+	} else {
+		path = stripe.FormatURLPath("/sources/%s/source_transactions",
+			stripe.StringValue(listParams.Source))
+	}
 
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SourceTransactionList{}
-		var err error
 
-		if params != nil && params.Source != nil {
-			err = c.B.Call("GET", stripe.FormatURLPath("/sources/%s/source_transactions", stripe.StringValue(params.Source)), c.Key, b, p, list)
-		} else {
-			err = errors.New("Invalid source transaction params: Source needs to be set")
+		if outerErr != nil {
+			return nil, list.ListMeta, outerErr
 		}
+
+		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -31,7 +31,7 @@ func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 			stripe.StringValue(listParams.Source))
 	}
 
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SourceTransactionList{}
 
 		if outerErr != nil {

--- a/stripe.go
+++ b/stripe.go
@@ -72,8 +72,7 @@ func (a *AppInfo) formatUserAgent() string {
 // Backend is an interface for making calls against a Stripe service.
 // This interface exists to enable mocking for during testing if needed.
 type Backend interface {
-	Call(method, path, key string, body *form.Values, params *Params, v interface{}) error
-	Call2(method, path, key string, params ParamsContainer, v interface{}) error
+	Call(method, path, key string, params ParamsContainer, v interface{}) error
 	CallRaw(method, path, key string, body *form.Values, params *Params, v interface{}) error
 	CallMultipart(method, path, key, boundary string, body io.Reader, params *Params, v interface{}) error
 }
@@ -212,14 +211,7 @@ func SetBackend(backend SupportedBackend, b Backend) {
 }
 
 // Call is the Backend.Call implementation for invoking Stripe APIs.
-func (s *BackendConfiguration) Call(method, path, key string, form *form.Values, params *Params, v interface{}) error {
-	return s.CallRaw(method, path, key, form, params, v)
-}
-
-// TODO: After every API call uses Call2, remove Call, then rename all
-// instances of Call2 to Call. This only exists as a separate method to keep
-// the build/tests working while we refactor.
-func (s *BackendConfiguration) Call2(method, path, key string, params ParamsContainer, v interface{}) error {
+func (s *BackendConfiguration) Call(method, path, key string, params ParamsContainer, v interface{}) error {
 	var body *form.Values
 	var commonParams *Params
 
@@ -241,7 +233,7 @@ func (s *BackendConfiguration) Call2(method, path, key string, params ParamsCont
 		}
 	}
 
-	return s.Call(method, path, key, body, commonParams, v)
+	return s.CallRaw(method, path, key, body, commonParams, v)
 }
 
 func (s *BackendConfiguration) CallRaw(method, path, key string, form *form.Values, params *Params, v interface{}) error {

--- a/stripe.go
+++ b/stripe.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -72,6 +73,8 @@ func (a *AppInfo) formatUserAgent() string {
 // This interface exists to enable mocking for during testing if needed.
 type Backend interface {
 	Call(method, path, key string, body *form.Values, params *Params, v interface{}) error
+	Call2(method, path, key string, params ParamsContainer, v interface{}) error
+	CallRaw(method, path, key string, body *form.Values, params *Params, v interface{}) error
 	CallMultipart(method, path, key, boundary string, body io.Reader, params *Params, v interface{}) error
 }
 
@@ -210,6 +213,38 @@ func SetBackend(backend SupportedBackend, b Backend) {
 
 // Call is the Backend.Call implementation for invoking Stripe APIs.
 func (s *BackendConfiguration) Call(method, path, key string, form *form.Values, params *Params, v interface{}) error {
+	return s.CallRaw(method, path, key, form, params, v)
+}
+
+// TODO: After every API call uses Call2, remove Call, then rename all
+// instances of Call2 to Call. This only exists as a separate method to keep
+// the build/tests working while we refactor.
+func (s *BackendConfiguration) Call2(method, path, key string, params ParamsContainer, v interface{}) error {
+	var body *form.Values
+	var commonParams *Params
+
+	if params != nil {
+		// This is a little unfortunate, but Go makes it impossible to compare
+		// an interface value to nil without the use of the reflect package and
+		// its true disciples insist that this is a feature and not a bug.
+		//
+		// Here we do invoke reflect because (1) we have to reflect anyway to
+		// use encode with the form package, and (2) the corresponding removal
+		// of boilerplate that this enables makes the small performance penalty
+		// worth it.
+		reflectValue := reflect.ValueOf(params)
+
+		if reflectValue.Kind() == reflect.Ptr && !reflectValue.IsNil() {
+			commonParams = params.GetParams()
+			body = &form.Values{}
+			form.AppendTo(body, params)
+		}
+	}
+
+	return s.Call(method, path, key, body, commonParams, v)
+}
+
+func (s *BackendConfiguration) CallRaw(method, path, key string, form *form.Values, params *Params, v interface{}) error {
 	var body io.Reader
 	if form != nil && !form.Empty() {
 		data := form.Encode()

--- a/sub/client.go
+++ b/sub/client.go
@@ -19,18 +19,8 @@ func New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 }
 
 func (c Client) New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
 	sub := &stripe.Subscription{}
-	err := c.B.Call("POST", "/subscriptions", c.Key, body, commonParams, sub)
-
+	err := c.B.Call2("POST", "/subscriptions", c.Key, params, sub)
 	return sub, err
 }
 
@@ -41,18 +31,9 @@ func Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, er
 }
 
 func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/subscriptions/%s", id), c.Key, body, commonParams, sub)
-
+	err := c.B.Call2("GET", path, c.Key, params, sub)
 	return sub, err
 }
 
@@ -63,17 +44,9 @@ func Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription,
 }
 
 func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/subscriptions/%s", id), c.Key, body, commonParams, sub)
+	err := c.B.Call2("POST", path, c.Key, params, sub)
 
 	return sub, err
 }
@@ -85,18 +58,9 @@ func Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscri
 }
 
 func (c Client) Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/subscriptions/%s", id), c.Key, body, commonParams, sub)
-
+	err := c.B.Call2("DELETE", path, c.Key, params, sub)
 	return sub, err
 }
 
@@ -106,21 +70,10 @@ func List(params *stripe.SubscriptionListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SubscriptionListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubscriptionList{}
-		err := c.B.Call("GET", "/subscriptions", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/subscriptions", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/sub/client.go
+++ b/sub/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 
 func (c Client) New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	sub := &stripe.Subscription{}
-	err := c.B.Call2("POST", "/subscriptions", c.Key, params, sub)
+	err := c.B.Call("POST", "/subscriptions", c.Key, params, sub)
 	return sub, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, er
 func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call2("GET", path, c.Key, params, sub)
+	err := c.B.Call("GET", path, c.Key, params, sub)
 	return sub, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription,
 func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call2("POST", path, c.Key, params, sub)
+	err := c.B.Call("POST", path, c.Key, params, sub)
 
 	return sub, err
 }
@@ -60,7 +60,7 @@ func Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscri
 func (c Client) Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call2("DELETE", path, c.Key, params, sub)
+	err := c.B.Call("DELETE", path, c.Key, params, sub)
 	return sub, err
 }
 
@@ -71,7 +71,7 @@ func List(params *stripe.SubscriptionListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubscriptionList{}
 		err := c.B.CallRaw("GET", "/subscriptions", c.Key, b, p, list)
 

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error
 
 func (c Client) New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call2("POST", "/subscription_items", c.Key, params, item)
+	err := c.B.Call("POST", "/subscription_items", c.Key, params, item)
 	return item, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call2("GET", path, c.Key, params, item)
+	err := c.B.Call("GET", path, c.Key, params, item)
 	return item, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscript
 func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	subi := &stripe.SubscriptionItem{}
-	err := c.B.Call2("POST", path, c.Key, params, subi)
+	err := c.B.Call("POST", path, c.Key, params, subi)
 	return subi, err
 }
 
@@ -59,7 +59,7 @@ func Del(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call2("DELETE", path, c.Key, params, item)
+	err := c.B.Call("DELETE", path, c.Key, params, item)
 
 	return item, err
 }
@@ -71,7 +71,7 @@ func List(params *stripe.SubscriptionItemListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubscriptionItemList{}
 		err := c.B.CallRaw("GET", "/subscription_items", c.Key, b, p, list)
 

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -19,18 +19,8 @@ func New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error
 }
 
 func (c Client) New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-	token := c.Key
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call("POST", "/subscription_items", token, body, commonParams, item)
+	err := c.B.Call2("POST", "/subscription_items", c.Key, params, item)
 	return item, err
 }
 
@@ -41,18 +31,9 @@ func Get(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 }
 
 func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/subscription_items/%s", id), c.Key, body, commonParams, item)
-
+	err := c.B.Call2("GET", path, c.Key, params, item)
 	return item, err
 }
 
@@ -63,19 +44,9 @@ func Update(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscript
 }
 
 func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-	token := c.Key
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	subi := &stripe.SubscriptionItem{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/subscription_items/%s", id), token, body, commonParams, subi)
-
+	err := c.B.Call2("POST", path, c.Key, params, subi)
 	return subi, err
 }
 
@@ -86,17 +57,9 @@ func Del(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 }
 
 func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		commonParams = &params.Params
-	}
-
+	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call("DELETE", stripe.FormatURLPath("/subscription_items/%s", id), c.Key, body, commonParams, item)
+	err := c.B.Call2("DELETE", path, c.Key, params, item)
 
 	return item, err
 }
@@ -107,21 +70,10 @@ func List(params *stripe.SubscriptionItemListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.SubscriptionItemListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubscriptionItemList{}
-		err := c.B.Call("GET", "/subscription_items", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/subscription_items", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/threedsecure/client.go
+++ b/threedsecure/client.go
@@ -3,7 +3,6 @@ package threedsecure
 
 import (
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /3d_secure APIs.
@@ -19,11 +18,8 @@ func New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 }
 
 func (c Client) New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	tds := &stripe.ThreeDSecure{}
-	err := c.B.Call("POST", "/3d_secure", c.Key, body, &params.Params, tds)
+	err := c.B.Call2("POST", "/3d_secure", c.Key, params, tds)
 	return tds, err
 }
 
@@ -34,17 +30,9 @@ func Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, er
 }
 
 func (c Client) Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/3d_secure/%s", id)
 	tds := &stripe.ThreeDSecure{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/3d_secure/%s", id), c.Key, body, commonParams, tds)
+	err := c.B.Call2("GET", path, c.Key, params, tds)
 
 	return tds, err
 }

--- a/threedsecure/client.go
+++ b/threedsecure/client.go
@@ -19,7 +19,7 @@ func New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 
 func (c Client) New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 	tds := &stripe.ThreeDSecure{}
-	err := c.B.Call2("POST", "/3d_secure", c.Key, params, tds)
+	err := c.B.Call("POST", "/3d_secure", c.Key, params, tds)
 	return tds, err
 }
 
@@ -32,7 +32,7 @@ func Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, er
 func (c Client) Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 	path := stripe.FormatURLPath("/3d_secure/%s", id)
 	tds := &stripe.ThreeDSecure{}
-	err := c.B.Call2("GET", path, c.Key, params, tds)
+	err := c.B.Call("GET", path, c.Key, params, tds)
 
 	return tds, err
 }

--- a/token/client.go
+++ b/token/client.go
@@ -3,7 +3,6 @@ package token
 
 import (
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /tokens APIs.
@@ -19,12 +18,8 @@ func New(params *stripe.TokenParams) (*stripe.Token, error) {
 }
 
 func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	tok := &stripe.Token{}
-	err := c.B.Call("POST", "/tokens", c.Key, body, &params.Params, tok)
-
+	err := c.B.Call2("POST", "/tokens", c.Key, params, tok)
 	return tok, err
 }
 
@@ -35,17 +30,9 @@ func Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 }
 
 func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/tokens/%s", id)
 	token := &stripe.Token{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/tokens/%s", id), c.Key, body, commonParams, token)
+	err := c.B.Call2("GET", path, c.Key, params, token)
 
 	return token, err
 }

--- a/token/client.go
+++ b/token/client.go
@@ -19,7 +19,7 @@ func New(params *stripe.TokenParams) (*stripe.Token, error) {
 
 func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
 	tok := &stripe.Token{}
-	err := c.B.Call2("POST", "/tokens", c.Key, params, tok)
+	err := c.B.Call("POST", "/tokens", c.Key, params, tok)
 	return tok, err
 }
 
@@ -32,7 +32,7 @@ func Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 	path := stripe.FormatURLPath("/tokens/%s", id)
 	token := &stripe.Token{}
-	err := c.B.Call2("GET", path, c.Key, params, token)
+	err := c.B.Call("GET", path, c.Key, params, token)
 
 	return token, err
 }

--- a/topup/client.go
+++ b/topup/client.go
@@ -19,7 +19,7 @@ func New(params *stripe.TopupParams) (*stripe.Topup, error) {
 
 func (c Client) New(params *stripe.TopupParams) (*stripe.Topup, error) {
 	topup := &stripe.Topup{}
-	err := c.B.Call2("POST", "/topups", c.Key, params, topup)
+	err := c.B.Call("POST", "/topups", c.Key, params, topup)
 	return topup, err
 }
 
@@ -32,7 +32,7 @@ func Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 func (c Client) Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/topups/%s", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call2("GET", path, c.Key, params, topup)
+	err := c.B.Call("GET", path, c.Key, params, topup)
 	return topup, err
 }
 
@@ -45,7 +45,7 @@ func Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/topups/%s", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call2("POST", path, c.Key, params, topup)
+	err := c.B.Call("POST", path, c.Key, params, topup)
 	return topup, err
 }
 
@@ -56,7 +56,7 @@ func List(params *stripe.TopupListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.TopupListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TopupList{}
 		err := c.B.CallRaw("GET", "/topups", c.Key, b, p, list)
 

--- a/topup/client.go
+++ b/topup/client.go
@@ -18,12 +18,8 @@ func New(params *stripe.TopupParams) (*stripe.Topup, error) {
 }
 
 func (c Client) New(params *stripe.TopupParams) (*stripe.Topup, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	topup := &stripe.Topup{}
-	err := c.B.Call("POST", "/topups", c.Key, body, &params.Params, topup)
-
+	err := c.B.Call2("POST", "/topups", c.Key, params, topup)
 	return topup, err
 }
 
@@ -34,18 +30,9 @@ func Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 }
 
 func (c Client) Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/topups/%s", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/topups/%s", id), c.Key, body, commonParams, topup)
-
+	err := c.B.Call2("GET", path, c.Key, params, topup)
 	return topup, err
 }
 
@@ -56,18 +43,9 @@ func Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 }
 
 func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/topups/%s", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/topups/%s", id), c.Key, body, commonParams, topup)
-
+	err := c.B.Call2("POST", path, c.Key, params, topup)
 	return topup, err
 }
 
@@ -77,21 +55,10 @@ func List(params *stripe.TopupListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.TopupListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.TopupListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TopupList{}
-		err := c.B.Call("GET", "/topups", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/topups", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -19,12 +19,8 @@ func New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 }
 
 func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
 	transfer := &stripe.Transfer{}
-	err := c.B.Call("POST", "/transfers", c.Key, body, &params.Params, transfer)
-
+	err := c.B.Call2("POST", "/transfers", c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -35,18 +31,9 @@ func Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 }
 
 func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-		body = &form.Values{}
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/transfers/%s", id)
 	transfer := &stripe.Transfer{}
-	err := c.B.Call("GET", stripe.FormatURLPath("/transfers/%s", id), c.Key, body, commonParams, transfer)
-
+	err := c.B.Call2("GET", path, c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -57,20 +44,9 @@ func Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) 
 }
 
 func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
-	var body *form.Values
-	var commonParams *stripe.Params
-
-	if params != nil {
-		commonParams = &params.Params
-
-		body = &form.Values{}
-
-		form.AppendTo(body, params)
-	}
-
+	path := stripe.FormatURLPath("/transfers/%s", id)
 	transfer := &stripe.Transfer{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/transfers/%s", id), c.Key, body, commonParams, transfer)
-
+	err := c.B.Call2("POST", path, c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -80,21 +56,10 @@ func List(params *stripe.TransferListParams) *Iter {
 	return getC().List(params)
 }
 
-func (c Client) List(params *stripe.TransferListParams) *Iter {
-	var body *form.Values
-	var lp *stripe.ListParams
-	var p *stripe.Params
-
-	if params != nil {
-		body = &form.Values{}
-		form.AppendTo(body, params)
-		lp = &params.ListParams
-		p = params.ToParams()
-	}
-
-	return &Iter{stripe.GetIter(lp, body, func(b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+func (c Client) List(listParams *stripe.TransferListParams) *Iter {
+	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TransferList{}
-		err := c.B.Call("GET", "/transfers", c.Key, b, p, list)
+		err := c.B.CallRaw("GET", "/transfers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -20,7 +20,7 @@ func New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 
 func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 	transfer := &stripe.Transfer{}
-	err := c.B.Call2("POST", "/transfers", c.Key, params, transfer)
+	err := c.B.Call("POST", "/transfers", c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -33,7 +33,7 @@ func Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	path := stripe.FormatURLPath("/transfers/%s", id)
 	transfer := &stripe.Transfer{}
-	err := c.B.Call2("GET", path, c.Key, params, transfer)
+	err := c.B.Call("GET", path, c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -46,7 +46,7 @@ func Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) 
 func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	path := stripe.FormatURLPath("/transfers/%s", id)
 	transfer := &stripe.Transfer{}
-	err := c.B.Call2("POST", path, c.Key, params, transfer)
+	err := c.B.Call("POST", path, c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -57,7 +57,7 @@ func List(params *stripe.TransferListParams) *Iter {
 }
 
 func (c Client) List(listParams *stripe.TransferListParams) *Iter {
-	return &Iter{stripe.GetIter2(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TransferList{}
 		err := c.B.CallRaw("GET", "/transfers", c.Key, b, p, list)
 

--- a/usagerecord/client.go
+++ b/usagerecord/client.go
@@ -2,10 +2,7 @@
 package usagerecord
 
 import (
-	"net/url"
-
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /plans APIs.
@@ -22,13 +19,9 @@ func New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
 
 // New internal implementation to create a new usage record.
 func (c Client) New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
-	body := &form.Values{}
-	form.AppendTo(body, params)
-
-	url := stripe.FormatURLPath("/subscription_items/%s/usage_records", url.QueryEscape(stripe.StringValue(params.SubscriptionItem)))
+	path := stripe.FormatURLPath("/subscription_items/%s/usage_records", stripe.StringValue(params.SubscriptionItem))
 	record := &stripe.UsageRecord{}
-	err := c.B.Call("POST", url, c.Key, body, &params.Params, record)
-
+	err := c.B.Call2("POST", path, c.Key, params, record)
 	return record, err
 }
 

--- a/usagerecord/client.go
+++ b/usagerecord/client.go
@@ -21,7 +21,7 @@ func New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
 func (c Client) New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s/usage_records", stripe.StringValue(params.SubscriptionItem))
 	record := &stripe.UsageRecord{}
-	err := c.B.Call2("POST", path, c.Key, params, record)
+	err := c.B.Call("POST", path, c.Key, params, record)
 	return record, err
 }
 


### PR DESCRIPTION
Now that we have a little more consistency throughout the library, here
we modify `BackendConfiguration.Call` (temporarily renamed to `Call2`
while we refactor) so that it can take parameter structs directly, then
encode them. This allows us to remove this common boilerplate from every
API call throughout the entire library:

``` go
if params != nil {
    commonParams = &params.Params
    body = &form.Values{}
    form.AppendTo(body, params)
}
```

Temporarily though, only the `charge/` package has been converted over
to show what it looks like before we convert everything.

There is a little bit of type trickiness that allows this to happen, and
which requires a somewhat advanced understanding of some Go language
semantics. We define a `ParamsContainer` interface as this:

``` go
type ParamsContainer interface {
    GetParams() *Params
}
```

Then on the `Params` struct itself, we define an implementation:

``` go
func (p *Params) GetParams() *Params {
    return p
}
```

In Go, whenever a struct is embedded in another struct, the host
inherits the function implementations of the struct which was embedded.
Because every parameter struct in the library embeds `Params`, they all
get a `GetParams` implementation and thus implement `ParamsContainer`
automatically:

``` go
type ChargeParams struct {
    Params `form:"*"`
    ...
}
```

This allows us to take a `ParamsContainer` from `Call`.

Most of this applies similarly for `ListParams`, and similarly `iter.go`
also gets a `Query2` and `GetIter2` to keep everything compiling while
we refactor everything. I did a little more refactoring in `iter.go` as
well just because there was quite a few very bad names in there. If this
patch lands, I'll probably refactor even more of it in a follow up.

r? @remi-stripe I got the idea to do this from a chat we had the other day. I
think it'll tighten up the implementation even a little more and cut quite a
few LOCs.

cc @stripe/api-libraries