### PR TITLE
Fix legal_entity[additional_owners][][verification] to be a struct

### DIFF
--- a/account.go
+++ b/account.go
@@ -396,13 +396,13 @@ type DOB struct {
 
 // AdditionalOwner is the structure for an account owner.
 type AdditionalOwner struct {
-	Address                  *AccountAddress `json:"address"`
-	DOB                      DOB             `json:"dob"`
-	FirstName                string          `json:"first_name"`
-	LastName                 string          `json:"last_name"`
-	MaidenName               string          `json:"maiden_name"`
-	PersonalIDNumberProvided bool            `json:"personal_id_number_provided"`
-	Verification             string          `json:"verification"`
+	Address                  *AccountAddress      `json:"address"`
+	DOB                      DOB                  `json:"dob"`
+	FirstName                string               `json:"first_name"`
+	LastName                 string               `json:"last_name"`
+	MaidenName               string               `json:"maiden_name"`
+	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided"`
+	Verification             IdentityVerification `json:"verification"`
 }
 
 // IdentityVerification is the structure for an account's verification.


### PR DESCRIPTION
When retrieving a Custom account with additional owners, the legal entity was not deserialized property and was empty. The issue was that `legal_entity[additional_owners][][verification]` is not a string but is instead a hash with various properties. Because of this, the entire deserialization of `LegalEntity` failed and it was just `nil`.

This fixes https://github.com/stripe/stripe-go/issues/580

r? @brandur-stripe 
cc @stripe/api-libraries 

I tried to add a test for this but stripe-mock returns no `legal_entity` at all so that did not work.