### PR TITLE
Remove File in favor of FileUpload

### DIFF
--- a/dispute.go
+++ b/dispute.go
@@ -118,33 +118,33 @@ type EvidenceDetails struct {
 // Almost all fields are strings since there structures (i.e. address)
 // do not typically get parsed by anyone and are thus presented as-received.
 type DisputeEvidence struct {
-	AccessActivityLog            string `json:"access_activity_log"`
-	BillingAddress               string `json:"billing_address"`
-	CancellationPolicy           *File  `json:"cancellation_policy"`
-	CancellationPolicyDisclosure string `json:"cancellation_policy_disclosure"`
-	CancellationRebuttal         string `json:"cancellation_rebuttal"`
-	CustomerCommunication        *File  `json:"customer_communication"`
-	CustomerEmailAddress         string `json:"customer_email_address"`
-	CustomerName                 string `json:"customer_name"`
-	CustomerPurchaseIP           string `json:"customer_purchase_ip"`
-	CustomerSignature            *File  `json:"customer_signature"`
-	DuplicateChargeDocumentation *File  `json:"duplicate_charge_documentation"`
-	DuplicateChargeExplanation   string `json:"duplicate_charge_explanation"`
-	DuplicateChargeID            string `json:"duplicate_charge_id"`
-	ProductDescription           string `json:"product_description"`
-	Receipt                      *File  `json:"receipt"`
-	RefundPolicy                 *File  `json:"refund_policy"`
-	RefundPolicyDisclosure       string `json:"refund_policy_disclosure"`
-	RefundRefusalExplanation     string `json:"refund_refusal_explanation"`
-	ServiceDate                  string `json:"service_date"`
-	ServiceDocumentation         *File  `json:"service_documentation"`
-	ShippingAddress              string `json:"shipping_address"`
-	ShippingCarrier              string `json:"shipping_carrier"`
-	ShippingDate                 string `json:"shipping_date"`
-	ShippingDocumentation        *File  `json:"shipping_documentation"`
-	ShippingTrackingNumber       string `json:"shipping_tracking_number"`
-	UncategorizedFile            *File  `json:"uncategorized_file"`
-	UncategorizedText            string `json:"uncategorized_text"`
+	AccessActivityLog            string      `json:"access_activity_log"`
+	BillingAddress               string      `json:"billing_address"`
+	CancellationPolicy           *FileUpload `json:"cancellation_policy"`
+	CancellationPolicyDisclosure string      `json:"cancellation_policy_disclosure"`
+	CancellationRebuttal         string      `json:"cancellation_rebuttal"`
+	CustomerCommunication        *FileUpload `json:"customer_communication"`
+	CustomerEmailAddress         string      `json:"customer_email_address"`
+	CustomerName                 string      `json:"customer_name"`
+	CustomerPurchaseIP           string      `json:"customer_purchase_ip"`
+	CustomerSignature            *FileUpload `json:"customer_signature"`
+	DuplicateChargeDocumentation *FileUpload `json:"duplicate_charge_documentation"`
+	DuplicateChargeExplanation   string      `json:"duplicate_charge_explanation"`
+	DuplicateChargeID            string      `json:"duplicate_charge_id"`
+	ProductDescription           string      `json:"product_description"`
+	Receipt                      *FileUpload `json:"receipt"`
+	RefundPolicy                 *FileUpload `json:"refund_policy"`
+	RefundPolicyDisclosure       string      `json:"refund_policy_disclosure"`
+	RefundRefusalExplanation     string      `json:"refund_refusal_explanation"`
+	ServiceDate                  string      `json:"service_date"`
+	ServiceDocumentation         *FileUpload `json:"service_documentation"`
+	ShippingAddress              string      `json:"shipping_address"`
+	ShippingCarrier              string      `json:"shipping_carrier"`
+	ShippingDate                 string      `json:"shipping_date"`
+	ShippingDocumentation        *FileUpload `json:"shipping_documentation"`
+	ShippingTrackingNumber       string      `json:"shipping_tracking_number"`
+	UncategorizedFile            *FileUpload `json:"uncategorized_file"`
+	UncategorizedText            string      `json:"uncategorized_text"`
 }
 
 // UnmarshalJSON handles deserialization of a Dispute.

--- a/fileupload.go
+++ b/fileupload.go
@@ -15,38 +15,6 @@ const (
 	FileUploadPurposeIdentityDocument FileUploadPurpose = "identity_document"
 )
 
-// File represents a link to downloadable content.
-//
-// This is an earlier incarnation of FileUpload, and they'll eventually be
-// merged into the same struct.
-type File struct {
-	Created  int64  `json:"created"`
-	ID       string `json:"id"`
-	MIMEType string `json:"mime_type"`
-	Purpose  string `json:"purpose"`
-	Size     int64  `json:"size"`
-	URL      string `json:"url"`
-}
-
-// UnmarshalJSON handles deserialization of a File.
-// This custom unmarshaling is needed because the resulting
-// property may be an id or the full struct if it was expanded.
-func (f *File) UnmarshalJSON(data []byte) error {
-	if id, ok := ParseID(data); ok {
-		f.ID = id
-		return nil
-	}
-
-	type file File
-	var v file
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-
-	*f = File(v)
-	return nil
-}
-
 // FileUploadParams is the set of parameters that can be used when creating a
 // file upload.
 // For more details see https://stripe.com/docs/api#create_file_upload.

--- a/fileupload_test.go
+++ b/fileupload_test.go
@@ -7,27 +7,6 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestFile_UnmarshalJSON(t *testing.T) {
-	// Unmarshals from a JSON string
-	{
-		var v File
-		err := json.Unmarshal([]byte(`"file_123"`), &v)
-		assert.NoError(t, err)
-		assert.Equal(t, "file_123", v.ID)
-	}
-
-	// Unmarshals from a JSON object
-	{
-		v := File{ID: "file_123"}
-		data, err := json.Marshal(&v)
-		assert.NoError(t, err)
-
-		err = json.Unmarshal(data, &v)
-		assert.NoError(t, err)
-		assert.Equal(t, "file_123", v.ID)
-	}
-}
-
 func TestFileUpload_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{


### PR DESCRIPTION
As we discussed in #578, here we unify the `File` and `FileUpload`
models into a single type. We do this by removing `File`, and changing
all instances where it was referenced to `FileUpload`.

These two structs were almost identical already, with the exception of
the `MIMEType` field on `File`, which is called `Type` on `FileUpload`.
Aside from that, the rename should cause very minimal breakage because
most users would have been accessing members without referencing the
struct's name directly like `dispute.Evidence.CustomerSignature.URL`.

Also, just examining the server-side resources, I'm pretty sure that
`MIMEType` didn't even work because it looks like the field is actually
called `Type` for both files and file uploads. So even if a user has
referenced the property, they should fix their use anyway.

r? @remi-stripe
cc @stripe/api-libraries