### PR TITLE
Use `net/http` constants instead of string literals for HTTP verbs

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -1,6 +1,8 @@
 package account
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -18,7 +20,7 @@ func New(params *stripe.AccountParams) (*stripe.Account, error) {
 
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 	acct := &stripe.Account{}
-	err := c.B.Call("POST", "/accounts", c.Key, params, acct)
+	err := c.B.Call(http.MethodPost, "/accounts", c.Key, params, acct)
 	return acct, err
 }
 
@@ -29,7 +31,7 @@ func Get() (*stripe.Account, error) {
 
 func (c Client) Get() (*stripe.Account, error) {
 	account := &stripe.Account{}
-	err := c.B.Call("GET", "/account", c.Key, nil, account)
+	err := c.B.Call(http.MethodGet, "/account", c.Key, nil, account)
 	return account, err
 }
 
@@ -41,7 +43,7 @@ func GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/accounts/%s", id)
 	account := &stripe.Account{}
-	err := c.B.Call("GET", path, c.Key, params, account)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, account)
 	return account, err
 }
 
@@ -53,7 +55,7 @@ func Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/accounts/%s", id)
 	acct := &stripe.Account{}
-	err := c.B.Call("POST", path, c.Key, params, acct)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -65,7 +67,7 @@ func Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/accounts/%s", id)
 	acct := &stripe.Account{}
-	err := c.B.Call("DELETE", path, c.Key, params, acct)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -77,7 +79,7 @@ func Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, err
 func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/accounts/%s/reject", id)
 	acct := &stripe.Account{}
-	err := c.B.Call("POST", path, c.Key, params, acct)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, acct)
 	return acct, err
 }
 
@@ -89,7 +91,7 @@ func List(params *stripe.AccountListParams) *Iter {
 func (c Client) List(listParams *stripe.AccountListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.AccountList{}
-		err := c.B.CallRaw("GET", "/accounts", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/accounts", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -2,6 +2,8 @@
 package applepaydomain
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -19,7 +21,7 @@ func New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 
 func (c Client) New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("POST", "/apple_pay/domains", c.Key, params, domain)
+	err := c.B.Call(http.MethodPost, "/apple_pay/domains", c.Key, params, domain)
 	return domain, err
 }
 
@@ -31,7 +33,7 @@ func Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 func (c Client) Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	path := stripe.FormatURLPath("/apple_pay/domains/%s", id)
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("GET", path, c.Key, params, domain)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, domain)
 	return domain, err
 }
 
@@ -43,7 +45,7 @@ func Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 func (c Client) Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	path := stripe.FormatURLPath("/apple_pay/domains/%s", id)
 	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call("DELETE", path, c.Key, params, domain)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, domain)
 	return domain, err
 }
 
@@ -55,7 +57,7 @@ func List(params *stripe.ApplePayDomainListParams) *Iter {
 func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplePayDomainList{}
-		err := c.B.CallRaw("GET", "/apple_pay/domains", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/apple_pay/domains", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/balance/client.go
+++ b/balance/client.go
@@ -2,6 +2,8 @@
 package balance
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 
 func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 	balance := &stripe.Balance{}
-	err := c.B.Call("GET", "/balance", c.Key, params, balance)
+	err := c.B.Call(http.MethodGet, "/balance", c.Key, params, balance)
 	return balance, err
 }
 
@@ -33,7 +35,7 @@ func GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (
 func (c Client) GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
 	path := stripe.FormatURLPath("/balance/history/%s", id)
 	balance := &stripe.BalanceTransaction{}
-	err := c.B.Call("GET", path, c.Key, params, balance)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, balance)
 	return balance, err
 }
 
@@ -46,7 +48,7 @@ func List(params *stripe.BalanceTransactionListParams) *Iter {
 func (c Client) List(listParams *stripe.BalanceTransactionListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BalanceTransactionList{}
-		err := c.B.CallRaw("GET", "/balance/history", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/balance/history", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -3,6 +3,7 @@ package bankaccount
 
 import (
 	"errors"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -44,7 +45,7 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 	// make an explicit call using a form and CallRaw instead of the standard
 	// Call (which takes a set of parameters).
 	ba := &stripe.BankAccount{}
-	err := c.B.CallRaw("POST", path, c.Key, body, &params.Params, ba)
+	err := c.B.CallRaw(http.MethodPost, path, c.Key, body, &params.Params, ba)
 	return ba, err
 }
 
@@ -68,7 +69,7 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	}
 
 	ba := &stripe.BankAccount{}
-	err := c.B.Call("GET", path, c.Key, params, ba)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, ba)
 	return ba, err
 }
 
@@ -92,7 +93,7 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 	}
 
 	ba := &stripe.BankAccount{}
-	err := c.B.Call("POST", path, c.Key, params, ba)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, ba)
 	return ba, err
 }
 
@@ -116,7 +117,7 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	}
 
 	ba := &stripe.BankAccount{}
-	err := c.B.Call("DELETE", path, c.Key, params, ba)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, ba)
 	return ba, err
 }
 
@@ -148,7 +149,7 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 			return nil, list.ListMeta, outerErr
 		}
 
-		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -5,6 +5,8 @@
 package bitcoinreceiver
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -23,7 +25,7 @@ func New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) 
 
 func (c Client) New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
 	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call("POST", "/bitcoin/receivers", c.Key, params, receiver)
+	err := c.B.Call(http.MethodPost, "/bitcoin/receivers", c.Key, params, receiver)
 	return receiver, err
 }
 
@@ -36,7 +38,7 @@ func Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiv
 func (c Client) Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
 	path := stripe.FormatURLPath("/bitcoin/receivers/%s", id)
 	bitcoinReceiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call("GET", path, c.Key, params, bitcoinReceiver)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, bitcoinReceiver)
 	return bitcoinReceiver, err
 }
 
@@ -49,7 +51,7 @@ func Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.Bitc
 func (c Client) Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.BitcoinReceiver, error) {
 	path := stripe.FormatURLPath("/bitcoin/receivers/%s", id)
 	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call("POST", path, c.Key, params, receiver)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, receiver)
 	return receiver, err
 }
 
@@ -62,7 +64,7 @@ func List(params *stripe.BitcoinReceiverListParams) *Iter {
 func (c Client) List(listParams *stripe.BitcoinReceiverListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.BitcoinReceiverList{}
-		err := c.B.CallRaw("GET", "/bitcoin/receivers", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/bitcoin/receivers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -2,6 +2,8 @@
 package bitcointransaction
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -23,7 +25,7 @@ func (c Client) List(listParams *stripe.BitcoinTransactionListParams) *Iter {
 		path := stripe.FormatURLPath("/bitcoin/receivers/%s/transactions",
 			stripe.StringValue(listParams.Receiver))
 		list := &stripe.BitcoinTransactionList{}
-		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/card/client.go
+++ b/card/client.go
@@ -3,6 +3,7 @@ package card
 
 import (
 	"errors"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -50,7 +51,7 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	// explicit call using a form and CallRaw instead of the standard Call
 	// (which takes a set of parameters).
 	card := &stripe.Card{}
-	err := c.B.CallRaw("POST", path, c.Key, body, &params.Params, card)
+	err := c.B.CallRaw(http.MethodPost, path, c.Key, body, &params.Params, card)
 	return card, err
 }
 
@@ -80,7 +81,7 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call("GET", path, c.Key, params, card)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, card)
 	return card, err
 }
 
@@ -110,7 +111,7 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call("POST", path, c.Key, params, card)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
 	return card, err
 }
 
@@ -137,7 +138,7 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call("DELETE", path, c.Key, params, card)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, card)
 	return card, err
 }
 
@@ -172,7 +173,7 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 			return nil, list.ListMeta, outerErr
 		}
 
-		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/charge/client.go
+++ b/charge/client.go
@@ -2,6 +2,8 @@
 package charge
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 
 func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 	charge := &stripe.Charge{}
-	err := c.B.Call("POST", "/charges", c.Key, params, charge)
+	err := c.B.Call(http.MethodPost, "/charges", c.Key, params, charge)
 	return charge, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/charges/%s", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call("GET", path, c.Key, params, charge)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/charges/%s", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call("POST", path, c.Key, params, charge)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -59,7 +61,7 @@ func Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 func (c Client) Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/charges/%s/capture", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call("POST", path, c.Key, params, charge)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, charge)
 	return charge, err
 }
 
@@ -72,7 +74,7 @@ func List(params *stripe.ChargeListParams) *Iter {
 func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ChargeList{}
-		err := c.B.CallRaw("GET", "/charges", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/charges", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -124,7 +126,7 @@ func UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, er
 func (c Client) UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/charges/%s/dispute", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", path, c.Key, params, dispute)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
 
 	return dispute, err
 }
@@ -137,7 +139,7 @@ func CloseDispute(id string) (*stripe.Dispute, error) {
 
 func (c Client) CloseDispute(id string) (*stripe.Dispute, error) {
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", stripe.FormatURLPath("/charges/%s/dispute/close", id), c.Key, nil, dispute)
+	err := c.B.Call(http.MethodPost, stripe.FormatURLPath("/charges/%s/dispute/close", id), c.Key, nil, dispute)
 	return dispute, err
 }
 

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -2,6 +2,8 @@
 package countryspec
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -21,7 +23,7 @@ func Get(country string) (*stripe.CountrySpec, error) {
 func (c Client) Get(country string) (*stripe.CountrySpec, error) {
 	path := stripe.FormatURLPath("/country_specs/%s", country)
 	countrySpec := &stripe.CountrySpec{}
-	err := c.B.Call("GET", path, c.Key, nil, countrySpec)
+	err := c.B.Call(http.MethodGet, path, c.Key, nil, countrySpec)
 	return countrySpec, err
 }
 
@@ -33,7 +35,7 @@ func List(params *stripe.CountrySpecListParams) *Iter {
 func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CountrySpecList{}
-		err := c.B.CallRaw("GET", "/country_specs", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/country_specs", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -2,6 +2,8 @@
 package coupon
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 
 func (c Client) New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("POST", "/coupons", c.Key, params, coupon)
+	err := c.B.Call(http.MethodPost, "/coupons", c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("GET", path, c.Key, params, coupon)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("POST", path, c.Key, params, coupon)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -59,7 +61,7 @@ func Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call("DELETE", path, c.Key, params, coupon)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, coupon)
 	return coupon, err
 }
 
@@ -72,7 +74,7 @@ func List(params *stripe.CouponListParams) *Iter {
 func (c Client) List(listParams *stripe.CouponListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CouponList{}
-		err := c.B.CallRaw("GET", "/coupons", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/coupons", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/customer/client.go
+++ b/customer/client.go
@@ -2,6 +2,8 @@
 package customer
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 
 func (c Client) New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 	cust := &stripe.Customer{}
-	err := c.B.Call("POST", "/customers", c.Key, params, cust)
+	err := c.B.Call(http.MethodPost, "/customers", c.Key, params, cust)
 	return cust, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 func (c Client) Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call("GET", path, c.Key, params, cust)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) 
 func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call("POST", path, c.Key, params, cust)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -59,7 +61,7 @@ func Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 func (c Client) Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/customers/%s", id)
 	cust := &stripe.Customer{}
-	err := c.B.Call("DELETE", path, c.Key, params, cust)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, cust)
 	return cust, err
 }
 
@@ -72,7 +74,7 @@ func List(params *stripe.CustomerListParams) *Iter {
 func (c Client) List(listParams *stripe.CustomerListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.CustomerList{}
-		err := c.B.CallRaw("GET", "/customers", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/customers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/discount/client.go
+++ b/discount/client.go
@@ -2,6 +2,8 @@
 package discount
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 )
 
@@ -20,7 +22,7 @@ func Del(customerID string, params *stripe.DiscountParams) (*stripe.Discount, er
 func (c Client) Del(customerID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
 	path := stripe.FormatURLPath("/customers/%s/discount", customerID)
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", path, c.Key, params, discount)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, discount)
 	return discount, err
 }
 
@@ -33,7 +35,7 @@ func DelSubscription(subscriptionID string, params *stripe.DiscountParams) (*str
 func (c Client) DelSub(subscriptionID string, params *stripe.DiscountParams) (*stripe.Discount, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s/discount", subscriptionID)
 	discount := &stripe.Discount{}
-	err := c.B.Call("DELETE", path, c.Key, params, discount)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, discount)
 
 	return discount, err
 }

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -1,6 +1,8 @@
 package dispute
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/disputes/%s", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("GET", path, c.Key, params, dispute)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, dispute)
 	return dispute, err
 }
 
@@ -33,7 +35,7 @@ func List(params *stripe.DisputeListParams) *Iter {
 func (c Client) List(listParams *stripe.DisputeListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.DisputeList{}
-		err := c.B.CallRaw("GET", "/disputes", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/disputes", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -66,7 +68,7 @@ func Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/disputes/%s", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", path, c.Key, params, dispute)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
 	return dispute, err
 }
 
@@ -79,7 +81,7 @@ func Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/disputes/%s/close", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call("POST", path, c.Key, params, dispute)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
 	return dispute, err
 }
 

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -33,7 +33,7 @@ func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 	params.Headers.Add("Stripe-Version", stripe.StringValue(params.StripeVersion))
 
 	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call("POST", "/ephemeral_keys", c.Key, params, ephemeralKey)
+	err := c.B.Call(http.MethodPost, "/ephemeral_keys", c.Key, params, ephemeralKey)
 	return ephemeralKey, err
 }
 
@@ -48,7 +48,7 @@ func Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 func (c Client) Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
 	path := stripe.FormatURLPath("/ephemeral_keys/%s", id)
 	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call("DELETE", path, c.Key, params, ephemeralKey)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, ephemeralKey)
 	return ephemeralKey, err
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -28,7 +28,7 @@ func TestErrorResponse(t *testing.T) {
 		&http.Client{},
 	})
 
-	err := GetBackend(APIBackend).Call("GET", "/v1/account", "sk_test_badKey", nil, nil)
+	err := GetBackend(APIBackend).Call(http.MethodGet, "/v1/account", "sk_test_badKey", nil, nil)
 	assert.Error(t, err)
 
 	stripeErr := err.(*Error)

--- a/event/client.go
+++ b/event/client.go
@@ -2,6 +2,8 @@
 package event
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -21,7 +23,7 @@ func Get(id string, params *stripe.Params) (*stripe.Event, error) {
 func (c Client) Get(id string, params *stripe.Params) (*stripe.Event, error) {
 	path := stripe.FormatURLPath("/events/%s", id)
 	event := &stripe.Event{}
-	err := c.B.Call("GET", path, c.Key, params, event)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, event)
 	return event, err
 }
 
@@ -34,7 +36,7 @@ func List(params *stripe.EventListParams) *Iter {
 func (c Client) List(listParams *stripe.EventListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.EventList{}
-		err := c.B.CallRaw("GET", "/events", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/events", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/exchangerate/client.go
+++ b/exchangerate/client.go
@@ -2,6 +2,8 @@
 package exchangerate
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func Get(currency string) (*stripe.ExchangeRate, error) {
 func (c Client) Get(currency string) (*stripe.ExchangeRate, error) {
 	path := stripe.FormatURLPath("/exchange_rates/%s", currency)
 	exchangeRate := &stripe.ExchangeRate{}
-	err := c.B.Call("GET", path, c.Key, nil, exchangeRate)
+	err := c.B.Call(http.MethodGet, path, c.Key, nil, exchangeRate)
 
 	return exchangeRate, err
 }
@@ -33,7 +35,7 @@ func List(params *stripe.ExchangeRateListParams) *Iter {
 func (c Client) List(listParams *stripe.ExchangeRateListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ExchangeRateList{}
-		err := c.B.CallRaw("GET", "/exchange_rates", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/exchange_rates", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/fee/client.go
+++ b/fee/client.go
@@ -2,6 +2,8 @@
 package fee
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -21,7 +23,7 @@ func Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee
 func (c Client) Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
 	path := stripe.FormatURLPath("/application_fees/%s", id)
 	fee := &stripe.ApplicationFee{}
-	err := c.B.Call("GET", path, c.Key, params, fee)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, fee)
 	return fee, err
 }
 
@@ -34,7 +36,7 @@ func List(params *stripe.ApplicationFeeListParams) *Iter {
 func (c Client) List(listParams *stripe.ApplicationFeeListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ApplicationFeeList{}
-		err := c.B.CallRaw("GET", "/application_fees", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/application_fees", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -3,6 +3,7 @@ package feerefund
 
 import (
 	"fmt"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -31,7 +32,7 @@ func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	path := stripe.FormatURLPath("/application_fees/%s/refunds",
 		stripe.StringValue(params.ApplicationFee))
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", path, c.Key, params, refund)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -52,7 +53,7 @@ func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefun
 	path := stripe.FormatURLPath("/application_fees/%s/refunds/%s",
 		stripe.StringValue(params.ApplicationFee), id)
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("GET", path, c.Key, params, refund)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -73,7 +74,7 @@ func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRe
 	path := stripe.FormatURLPath("/application_fees/%s/refunds/%s",
 		stripe.StringValue(params.ApplicationFee), id)
 	refund := &stripe.FeeRefund{}
-	err := c.B.Call("POST", path, c.Key, params, refund)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, refund)
 
 	return refund, err
 }
@@ -90,7 +91,7 @@ func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
 
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FeeRefundList{}
-		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/fileupload/client.go
+++ b/fileupload/client.go
@@ -4,6 +4,7 @@ package fileupload
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -33,7 +34,7 @@ func (c Client) New(params *stripe.FileUploadParams) (*stripe.FileUpload, error)
 	}
 
 	upload := &stripe.FileUpload{}
-	err = c.B.CallMultipart("POST", "/files", c.Key, boundary, body, &params.Params, upload)
+	err = c.B.CallMultipart(http.MethodPost, "/files", c.Key, boundary, body, &params.Params, upload)
 
 	return upload, err
 }
@@ -48,7 +49,7 @@ func Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error)
 func (c Client) Get(id string, params *stripe.FileUploadParams) (*stripe.FileUpload, error) {
 	path := stripe.FormatURLPath("/files/%s", id)
 	upload := &stripe.FileUpload{}
-	err := c.B.Call("GET", path, c.Key, params, upload)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, upload)
 	return upload, err
 }
 
@@ -61,7 +62,7 @@ func List(params *stripe.FileUploadListParams) *Iter {
 func (c Client) List(listParams *stripe.FileUploadListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.FileUploadList{}
-		err := c.B.CallRaw("GET", "/files", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/files", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -2,6 +2,8 @@
 package invoice
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 
 func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("POST", "/invoices", c.Key, params, invoice)
+	err := c.B.Call(http.MethodPost, "/invoices", c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 func (c Client) Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("GET", path, c.Key, params, invoice)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -46,7 +48,7 @@ func Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 func (c Client) Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/invoices/%s/pay", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("POST", path, c.Key, params, invoice)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -59,7 +61,7 @@ func Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("POST", path, c.Key, params, invoice)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -71,7 +73,7 @@ func GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 
 func (c Client) GetNext(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	invoice := &stripe.Invoice{}
-	err := c.B.Call("GET", "/invoices/upcoming", c.Key, params, invoice)
+	err := c.B.Call(http.MethodGet, "/invoices/upcoming", c.Key, params, invoice)
 	return invoice, err
 }
 
@@ -84,7 +86,7 @@ func List(params *stripe.InvoiceListParams) *Iter {
 func (c Client) List(listParams *stripe.InvoiceListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceList{}
-		err := c.B.CallRaw("GET", "/invoices", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/invoices", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -105,7 +107,7 @@ func (c Client) ListLines(listParams *stripe.InvoiceLineListParams) *LineIter {
 	path := stripe.FormatURLPath("/invoices/%s/lines", stripe.StringValue(listParams.ID))
 	return &LineIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceLineList{}
-		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -2,6 +2,8 @@
 package invoiceitem
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 
 func (c Client) New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call("POST", "/invoiceitems", c.Key, params, invoiceItem)
+	err := c.B.Call(http.MethodPost, "/invoiceitems", c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 func (c Client) Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call("GET", path, c.Key, params, invoiceItem)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, e
 func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call("POST", path, c.Key, params, invoiceItem)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoiceItem)
 	return invoiceItem, err
 }
 
@@ -59,7 +61,7 @@ func Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 func (c Client) Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/invoiceitems/%s", id)
 	ii := &stripe.InvoiceItem{}
-	err := c.B.Call("DELETE", path, c.Key, params, ii)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, ii)
 	return ii, err
 }
 
@@ -72,7 +74,7 @@ func List(params *stripe.InvoiceItemListParams) *Iter {
 func (c Client) List(listParams *stripe.InvoiceItemListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.InvoiceItemList{}
-		err := c.B.CallRaw("GET", "/invoiceitems", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/invoiceitems", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/issuerfraudrecord/client.go
+++ b/issuerfraudrecord/client.go
@@ -1,6 +1,8 @@
 package issuerfraudrecord
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -22,7 +24,7 @@ func Get(id string) (*stripe.IssuerFraudRecord, error) {
 func (c Client) Get(id string) (*stripe.IssuerFraudRecord, error) {
 	path := stripe.FormatURLPath("/issuer_fraud_records/%s", id)
 	ifr := &stripe.IssuerFraudRecord{}
-	err := c.B.Call("GET", path, c.Key, nil, ifr)
+	err := c.B.Call(http.MethodGet, path, c.Key, nil, ifr)
 	return ifr, err
 }
 
@@ -37,7 +39,7 @@ func List(params *stripe.IssuerFraudRecordListParams) *Iter {
 func (c Client) List(listParams *stripe.IssuerFraudRecordListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.IssuerFraudRecordList{}
-		err := c.B.CallRaw("GET", "/issuer_fraud_records", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/issuer_fraud_records", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Values))
 		for i, v := range list.Values {

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -3,6 +3,7 @@ package loginlink
 
 import (
 	"errors"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -26,7 +27,7 @@ func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 
 	path := stripe.FormatURLPath("/accounts/%s/login_links", stripe.StringValue(params.Account))
 	loginLink := &stripe.LoginLink{}
-	err := c.B.Call("POST", path, c.Key, nil, loginLink)
+	err := c.B.Call(http.MethodPost, path, c.Key, nil, loginLink)
 	return loginLink, err
 }
 

--- a/order/client.go
+++ b/order/client.go
@@ -1,6 +1,8 @@
 package order
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -21,7 +23,7 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 // For more details see https://stripe.com/docs/api#create_order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
 	p := &stripe.Order{}
-	err := c.B.Call("POST", "/orders", c.Key, params, p)
+	err := c.B.Call(http.MethodPost, "/orders", c.Key, params, p)
 	return p, err
 }
 
@@ -36,7 +38,7 @@ func Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) 
 func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/orders/%s", id)
 	o := &stripe.Order{}
-	err := c.B.Call("POST", path, c.Key, params, o)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, o)
 	return o, err
 }
 
@@ -51,7 +53,7 @@ func Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/orders/%s/pay", id)
 	o := &stripe.Order{}
-	err := c.B.Call("POST", path, c.Key, params, o)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, o)
 	return o, err
 }
 
@@ -64,7 +66,7 @@ func Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/orders/%s", id)
 	order := &stripe.Order{}
-	err := c.B.Call("GET", path, c.Key, params, order)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, order)
 	return order, err
 }
 
@@ -77,7 +79,7 @@ func List(params *stripe.OrderListParams) *Iter {
 func (c Client) List(listParams *stripe.OrderListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderList{}
-		err := c.B.CallRaw("GET", "/orders", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/orders", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -112,7 +114,7 @@ func Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, e
 func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
 	path := stripe.FormatURLPath("/orders/%s/returns", id)
 	ret := &stripe.OrderReturn{}
-	err := c.B.Call("POST", path, c.Key, params, ret)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, ret)
 	return ret, err
 }
 

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -1,6 +1,8 @@
 package orderreturn
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -19,7 +21,7 @@ func List(params *stripe.OrderReturnListParams) *Iter {
 func (c Client) List(listParams *stripe.OrderReturnListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderReturnList{}
-		err := c.B.CallRaw("GET", "/order_returns", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/order_returns", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -3,6 +3,7 @@ package paymentsource
 
 import (
 	"errors"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -31,7 +32,7 @@ func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 
 	path := stripe.FormatURLPath("/customers/%s/sources", stripe.StringValue(params.Customer))
 	source := &stripe.PaymentSource{}
-	err := s.B.Call("POST", path, s.Key, params, source)
+	err := s.B.Call(http.MethodPost, path, s.Key, params, source)
 	return source, err
 }
 
@@ -52,7 +53,7 @@ func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 
 	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	source := &stripe.PaymentSource{}
-	err := s.B.Call("GET", path, s.Key, params, source)
+	err := s.B.Call(http.MethodGet, path, s.Key, params, source)
 	return source, err
 }
 
@@ -73,7 +74,7 @@ func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.
 
 	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	source := &stripe.PaymentSource{}
-	err := s.B.Call("POST", path, s.Key, params, source)
+	err := s.B.Call(http.MethodPost, path, s.Key, params, source)
 	return source, err
 }
 
@@ -94,7 +95,7 @@ func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 
 	source := &stripe.PaymentSource{}
 	path := stripe.FormatURLPath("/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
-	err := s.B.Call("DELETE", path, s.Key, params, source)
+	err := s.B.Call(http.MethodDelete, path, s.Key, params, source)
 	return source, err
 }
 
@@ -124,7 +125,7 @@ func (s Client) List(listParams *stripe.SourceListParams) *Iter {
 			return nil, list.ListMeta, outerErr
 		}
 
-		err := s.B.CallRaw("GET", path, s.Key, b, p, list)
+		err := s.B.CallRaw(http.MethodGet, path, s.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -157,7 +158,7 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 	}
 
 	source := &stripe.PaymentSource{}
-	err := s.B.Call("POST", path, s.Key, params, source)
+	err := s.B.Call(http.MethodPost, path, s.Key, params, source)
 	return source, err
 }
 

--- a/payout/client.go
+++ b/payout/client.go
@@ -2,6 +2,8 @@
 package payout
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 
 func (c Client) New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 	payout := &stripe.Payout{}
-	err := c.B.Call("POST", "/payouts", c.Key, params, payout)
+	err := c.B.Call(http.MethodPost, "/payouts", c.Key, params, payout)
 	return payout, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call("GET", path, c.Key, params, payout)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call("POST", path, c.Key, params, payout)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -59,7 +61,7 @@ func Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s/cancel", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call("POST", path, c.Key, params, payout)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, payout)
 	return payout, err
 }
 
@@ -72,7 +74,7 @@ func List(params *stripe.PayoutListParams) *Iter {
 func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PayoutList{}
-		err := c.B.CallRaw("GET", "/payouts", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/payouts", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/plan/client.go
+++ b/plan/client.go
@@ -2,6 +2,8 @@
 package plan
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.PlanParams) (*stripe.Plan, error) {
 
 func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
 	plan := &stripe.Plan{}
-	err := c.B.Call("POST", "/plans", c.Key, params, plan)
+	err := c.B.Call(http.MethodPost, "/plans", c.Key, params, plan)
 	return plan, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call("GET", path, c.Key, params, plan)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call("POST", path, c.Key, params, plan)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -59,7 +61,7 @@ func Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call("DELETE", path, c.Key, params, plan)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, plan)
 	return plan, err
 }
 
@@ -72,7 +74,7 @@ func List(params *stripe.PlanListParams) *Iter {
 func (c Client) List(listParams *stripe.PlanListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PlanList{}
-		err := c.B.CallRaw("GET", "/plans", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/plans", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/product/client.go
+++ b/product/client.go
@@ -1,6 +1,8 @@
 package product
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -21,7 +23,7 @@ func New(params *stripe.ProductParams) (*stripe.Product, error) {
 // For more details see https://stripe.com/docs/api#create_product.
 func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
 	p := &stripe.Product{}
-	err := c.B.Call("POST", "/products", c.Key, params, p)
+	err := c.B.Call(http.MethodPost, "/products", c.Key, params, p)
 	return p, err
 }
 
@@ -36,7 +38,7 @@ func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call("POST", path, c.Key, params, p)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, p)
 	return p, err
 }
 
@@ -49,7 +51,7 @@ func Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call("GET", path, c.Key, params, p)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, p)
 	return p, err
 }
 
@@ -62,7 +64,7 @@ func List(params *stripe.ProductListParams) *Iter {
 func (c Client) List(listParams *stripe.ProductListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ProductList{}
-		err := c.B.CallRaw("GET", "/products", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/products", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -97,7 +99,7 @@ func Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
-	err := c.B.Call("DELETE", path, c.Key, params, p)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, p)
 
 	return p, err
 }

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -2,6 +2,8 @@
 package recipient
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -24,7 +26,7 @@ func Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 func (c Client) Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("GET", path, c.Key, params, recipient)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -37,7 +39,7 @@ func Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error
 func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("POST", path, c.Key, params, recipient)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -50,7 +52,7 @@ func Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 func (c Client) Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
-	err := c.B.Call("DELETE", path, c.Key, params, recipient)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, recipient)
 	return recipient, err
 }
 
@@ -63,7 +65,7 @@ func List(params *stripe.RecipientListParams) *Iter {
 func (c Client) List(listParams *stripe.RecipientListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RecipientList{}
-		err := c.B.CallRaw("GET", "/recipients", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/recipients", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/refund/client.go
+++ b/refund/client.go
@@ -2,6 +2,8 @@
 package refund
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.RefundParams) (*stripe.Refund, error) {
 
 func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	refund := &stripe.Refund{}
-	err := c.B.Call("POST", "/refunds", c.Key, params, refund)
+	err := c.B.Call(http.MethodPost, "/refunds", c.Key, params, refund)
 	return refund, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/refunds/%s", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call("GET", path, c.Key, params, refund)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/refunds/%s", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call("POST", path, c.Key, params, refund)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, refund)
 	return refund, err
 }
 
@@ -59,7 +61,7 @@ func List(params *stripe.RefundListParams) *Iter {
 func (c Client) List(listParams *stripe.RefundListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RefundList{}
-		err := c.B.CallRaw("GET", "/refunds", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/refunds", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -3,6 +3,7 @@ package reversal
 
 import (
 	"fmt"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -22,7 +23,7 @@ func New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 func (c Client) New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	path := stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(params.Transfer))
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("POST", path, c.Key, params, reversal)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -39,7 +40,7 @@ func (c Client) Get(id string, params *stripe.ReversalParams) (*stripe.Reversal,
 	path := stripe.FormatURLPath("/transfers/%s/reversals/%s",
 		stripe.StringValue(params.Transfer), id)
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("GET", path, c.Key, params, reversal)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -52,7 +53,7 @@ func (c Client) Update(id string, params *stripe.ReversalParams) (*stripe.Revers
 	path := stripe.FormatURLPath("/transfers/%s/reversals/%s",
 		stripe.StringValue(params.Transfer), id)
 	reversal := &stripe.Reversal{}
-	err := c.B.Call("POST", path, c.Key, params, reversal)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, reversal)
 	return reversal, err
 }
 
@@ -66,7 +67,7 @@ func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
 
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ReversalList{}
-		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/sku/client.go
+++ b/sku/client.go
@@ -1,6 +1,8 @@
 package sku
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -21,7 +23,7 @@ func New(params *stripe.SKUParams) (*stripe.SKU, error) {
 // For more details see https://stripe.com/docs/api#create_sku.
 func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
 	s := &stripe.SKU{}
-	err := c.B.Call("POST", "/skus", c.Key, params, s)
+	err := c.B.Call(http.MethodPost, "/skus", c.Key, params, s)
 	return s, err
 }
 
@@ -36,7 +38,7 @@ func Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call("POST", path, c.Key, params, s)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, s)
 	return s, err
 }
 
@@ -49,7 +51,7 @@ func Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call("GET", path, c.Key, params, s)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, s)
 	return s, err
 }
 
@@ -62,7 +64,7 @@ func List(params *stripe.SKUListParams) *Iter {
 func (c Client) List(listParams *stripe.SKUListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SKUList{}
-		err := c.B.CallRaw("GET", "/skus", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/skus", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {
@@ -97,7 +99,7 @@ func Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
-	err := c.B.Call("DELETE", path, c.Key, params, s)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, s)
 
 	return s, err
 }

--- a/source/client.go
+++ b/source/client.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"errors"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 )
@@ -22,7 +23,7 @@ func New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 // For more details see https://stripe.com/docs/api#create_source.
 func (c Client) New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	p := &stripe.Source{}
-	err := c.B.Call("POST", "/sources", c.Key, params, p)
+	err := c.B.Call(http.MethodPost, "/sources", c.Key, params, p)
 	return p, err
 }
 
@@ -37,7 +38,7 @@ func Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 func (c Client) Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	path := stripe.FormatURLPath("/sources/%s", id)
 	source := &stripe.Source{}
-	err := c.B.Call("GET", path, c.Key, params, source)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, source)
 	return source, err
 }
 
@@ -50,7 +51,7 @@ func Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error
 func (c Client) Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	path := stripe.FormatURLPath("/sources/%s", id)
 	source := &stripe.Source{}
-	err := c.B.Call("POST", path, c.Key, params, source)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, source)
 	return source, err
 }
 
@@ -71,6 +72,6 @@ func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*str
 	path := stripe.FormatURLPath("/customers/%s/sources/%s",
 		stripe.StringValue(params.Customer), id)
 	source := &stripe.Source{}
-	err := c.B.Call("DELETE", path, c.Key, params, source)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, source)
 	return source, err
 }

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -3,6 +3,7 @@ package sourcetransaction
 
 import (
 	"errors"
+	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
@@ -38,7 +39,7 @@ func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 			return nil, list.ListMeta, outerErr
 		}
 
-		err := c.B.CallRaw("GET", path, c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/stripe.go
+++ b/stripe.go
@@ -240,7 +240,7 @@ func (s *BackendConfiguration) CallRaw(method, path, key string, form *form.Valu
 	var body io.Reader
 	if form != nil && !form.Empty() {
 		data := form.Encode()
-		if strings.ToUpper(method) == "GET" {
+		if method == http.MethodGet {
 			path += "?" + data
 		} else {
 			body = bytes.NewBufferString(data)

--- a/sub/client.go
+++ b/sub/client.go
@@ -2,6 +2,8 @@
 package sub
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 
 func (c Client) New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	sub := &stripe.Subscription{}
-	err := c.B.Call("POST", "/subscriptions", c.Key, params, sub)
+	err := c.B.Call(http.MethodPost, "/subscriptions", c.Key, params, sub)
 	return sub, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, er
 func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call("GET", path, c.Key, params, sub)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, sub)
 	return sub, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription,
 func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call("POST", path, c.Key, params, sub)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, sub)
 
 	return sub, err
 }
@@ -60,7 +62,7 @@ func Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscri
 func (c Client) Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
-	err := c.B.Call("DELETE", path, c.Key, params, sub)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, sub)
 	return sub, err
 }
 
@@ -73,7 +75,7 @@ func List(params *stripe.SubscriptionListParams) *Iter {
 func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubscriptionList{}
-		err := c.B.CallRaw("GET", "/subscriptions", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/subscriptions", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -2,6 +2,8 @@
 package subitem
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error
 
 func (c Client) New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call("POST", "/subscription_items", c.Key, params, item)
+	err := c.B.Call(http.MethodPost, "/subscription_items", c.Key, params, item)
 	return item, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call("GET", path, c.Key, params, item)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, item)
 	return item, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscript
 func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	subi := &stripe.SubscriptionItem{}
-	err := c.B.Call("POST", path, c.Key, params, subi)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, subi)
 	return subi, err
 }
 
@@ -59,7 +61,7 @@ func Del(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	item := &stripe.SubscriptionItem{}
-	err := c.B.Call("DELETE", path, c.Key, params, item)
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, item)
 
 	return item, err
 }
@@ -73,7 +75,7 @@ func List(params *stripe.SubscriptionItemListParams) *Iter {
 func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubscriptionItemList{}
-		err := c.B.CallRaw("GET", "/subscription_items", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/subscription_items", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/threedsecure/client.go
+++ b/threedsecure/client.go
@@ -2,6 +2,8 @@
 package threedsecure
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 )
 
@@ -19,7 +21,7 @@ func New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 
 func (c Client) New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 	tds := &stripe.ThreeDSecure{}
-	err := c.B.Call("POST", "/3d_secure", c.Key, params, tds)
+	err := c.B.Call(http.MethodPost, "/3d_secure", c.Key, params, tds)
 	return tds, err
 }
 
@@ -32,7 +34,7 @@ func Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, er
 func (c Client) Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 	path := stripe.FormatURLPath("/3d_secure/%s", id)
 	tds := &stripe.ThreeDSecure{}
-	err := c.B.Call("GET", path, c.Key, params, tds)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, tds)
 
 	return tds, err
 }

--- a/token/client.go
+++ b/token/client.go
@@ -2,6 +2,8 @@
 package token
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 )
 
@@ -19,7 +21,7 @@ func New(params *stripe.TokenParams) (*stripe.Token, error) {
 
 func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
 	tok := &stripe.Token{}
-	err := c.B.Call("POST", "/tokens", c.Key, params, tok)
+	err := c.B.Call(http.MethodPost, "/tokens", c.Key, params, tok)
 	return tok, err
 }
 
@@ -32,7 +34,7 @@ func Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 	path := stripe.FormatURLPath("/tokens/%s", id)
 	token := &stripe.Token{}
-	err := c.B.Call("GET", path, c.Key, params, token)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, token)
 
 	return token, err
 }

--- a/topup/client.go
+++ b/topup/client.go
@@ -1,6 +1,8 @@
 package topup
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -19,7 +21,7 @@ func New(params *stripe.TopupParams) (*stripe.Topup, error) {
 
 func (c Client) New(params *stripe.TopupParams) (*stripe.Topup, error) {
 	topup := &stripe.Topup{}
-	err := c.B.Call("POST", "/topups", c.Key, params, topup)
+	err := c.B.Call(http.MethodPost, "/topups", c.Key, params, topup)
 	return topup, err
 }
 
@@ -32,7 +34,7 @@ func Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 func (c Client) Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/topups/%s", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call("GET", path, c.Key, params, topup)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, topup)
 	return topup, err
 }
 
@@ -45,7 +47,7 @@ func Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/topups/%s", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call("POST", path, c.Key, params, topup)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, topup)
 	return topup, err
 }
 
@@ -58,7 +60,7 @@ func List(params *stripe.TopupListParams) *Iter {
 func (c Client) List(listParams *stripe.TopupListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TopupList{}
-		err := c.B.CallRaw("GET", "/topups", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/topups", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -2,6 +2,8 @@
 package transfer
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/form"
 )
@@ -20,7 +22,7 @@ func New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 
 func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 	transfer := &stripe.Transfer{}
-	err := c.B.Call("POST", "/transfers", c.Key, params, transfer)
+	err := c.B.Call(http.MethodPost, "/transfers", c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -33,7 +35,7 @@ func Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	path := stripe.FormatURLPath("/transfers/%s", id)
 	transfer := &stripe.Transfer{}
-	err := c.B.Call("GET", path, c.Key, params, transfer)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -46,7 +48,7 @@ func Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) 
 func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	path := stripe.FormatURLPath("/transfers/%s", id)
 	transfer := &stripe.Transfer{}
-	err := c.B.Call("POST", path, c.Key, params, transfer)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, transfer)
 	return transfer, err
 }
 
@@ -59,7 +61,7 @@ func List(params *stripe.TransferListParams) *Iter {
 func (c Client) List(listParams *stripe.TransferListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TransferList{}
-		err := c.B.CallRaw("GET", "/transfers", c.Key, b, p, list)
+		err := c.B.CallRaw(http.MethodGet, "/transfers", c.Key, b, p, list)
 
 		ret := make([]interface{}, len(list.Data))
 		for i, v := range list.Data {

--- a/usagerecord/client.go
+++ b/usagerecord/client.go
@@ -2,6 +2,8 @@
 package usagerecord
 
 import (
+	"net/http"
+
 	stripe "github.com/stripe/stripe-go"
 )
 
@@ -21,7 +23,7 @@ func New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
 func (c Client) New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s/usage_records", stripe.StringValue(params.SubscriptionItem))
 	record := &stripe.UsageRecord{}
-	err := c.B.Call("POST", path, c.Key, params, record)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, record)
 	return record, err
 }
 


### PR DESCRIPTION
Switches from string literals like `"GET"` over to their corresponding
constants in `net/http` like `http.MethodGet`. This isn't a huge win,
but seems like slightly better hygiene and slightly reduces the risk of
typos because a mistyped verb will now not compile instead of crashing
on a test or at runtime.

For review: I basically did a project-wide find and replace, so me
accidentally screwing up a verb change is relatively unlikely.

r? @remi-stripe
cc @stripe/api-libraries