### PR TITLE
Fix all Get methods to support Params and remove deprecated ones

### DIFF
--- a/charge/client.go
+++ b/charge/client.go
@@ -85,64 +85,6 @@ func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
 	})}
 }
 
-// MarkFraudulent reports the charge as fraudulent.
-func MarkFraudulent(id string) (*stripe.Charge, error) {
-	return getC().MarkFraudulent(id)
-}
-
-func (c Client) MarkFraudulent(id string) (*stripe.Charge, error) {
-	return c.Update(
-		id,
-		&stripe.ChargeParams{
-			FraudDetails: &stripe.FraudDetailsParams{
-				UserReport: stripe.String(string(stripe.ChargeFraudUserReportFraudulent)),
-			},
-		},
-	)
-}
-
-// MarkSafe reports the charge as not-fraudulent.
-func MarkSafe(id string) (*stripe.Charge, error) {
-	return getC().MarkSafe(id)
-}
-
-func (c Client) MarkSafe(id string) (*stripe.Charge, error) {
-	return c.Update(
-		id,
-		&stripe.ChargeParams{
-			FraudDetails: &stripe.FraudDetailsParams{
-				UserReport: stripe.String(string(stripe.ChargeFraudUserReportSafe)),
-			},
-		},
-	)
-}
-
-// Update updates a charge's dispute.
-// For more details see https://stripe.com/docs/api#update_dispute.
-func UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	return getC().UpdateDispute(id, params)
-}
-
-func (c Client) UpdateDispute(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	path := stripe.FormatURLPath("/charges/%s/dispute", id)
-	dispute := &stripe.Dispute{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
-
-	return dispute, err
-}
-
-// Close dismisses a charge's dispute in the customer's favor.
-// For more details see https://stripe.com/docs/api#close_dispute.
-func CloseDispute(id string) (*stripe.Dispute, error) {
-	return getC().CloseDispute(id)
-}
-
-func (c Client) CloseDispute(id string) (*stripe.Dispute, error) {
-	dispute := &stripe.Dispute{}
-	err := c.B.Call(http.MethodPost, stripe.FormatURLPath("/charges/%s/dispute/close", id), c.Key, nil, dispute)
-	return dispute, err
-}
-
 // Iter is an iterator for lists of Charges.
 // The embedded Iter carries methods with it;
 // see its documentation for details.

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -14,12 +14,6 @@ func TestChargeCapture(t *testing.T) {
 	assert.NotNil(t, charge)
 }
 
-func TestChargeCloseDispute(t *testing.T) {
-	charge, err := CloseDispute("ch_123")
-	assert.Nil(t, err)
-	assert.NotNil(t, charge)
-}
-
 func TestChargeGet(t *testing.T) {
 	charge, err := Get("ch_123", nil)
 	assert.Nil(t, err)
@@ -33,12 +27,6 @@ func TestChargeList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Charge())
-}
-
-func TestChargeMarkFraudulent(t *testing.T) {
-	charge, err := MarkFraudulent("ch_123")
-	assert.Nil(t, err)
-	assert.NotNil(t, charge)
 }
 
 func TestChargeNew(t *testing.T) {
@@ -71,25 +59,9 @@ func TestChargeNew_WithSetSource(t *testing.T) {
 	assert.NotNil(t, charge)
 }
 
-func TestChargeMarkSafe(t *testing.T) {
-	charge, err := MarkSafe("ch_123")
-	assert.Nil(t, err)
-	assert.NotNil(t, charge)
-}
-
 func TestChargeUpdate(t *testing.T) {
 	charge, err := Update("ch_123", &stripe.ChargeParams{
 		Description: stripe.String("Updated description"),
-	})
-	assert.Nil(t, err)
-	assert.NotNil(t, charge)
-}
-
-func TestChargeUpdateDispute(t *testing.T) {
-	charge, err := UpdateDispute("ch_123", &stripe.DisputeParams{
-		Evidence: &stripe.DisputeEvidenceParams{
-			ProductDescription: stripe.String("original description"),
-		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)

--- a/countryspec.go
+++ b/countryspec.go
@@ -21,6 +21,11 @@ type CountrySpec struct {
 	VerificationFields             map[LegalEntityType]*VerificationFieldsList `json:"verification_fields"`
 }
 
+// CountrySpecParams are the parameters allowed during CountrySpec retrieval.
+type CountrySpecParams struct {
+	Params `form:"*"`
+}
+
 // CountrySpecList is a list of country specs as retrieved from a list endpoint.
 type CountrySpecList struct {
 	ListMeta

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -16,14 +16,14 @@ type Client struct {
 
 // Get returns a CountrySpec for a given country code
 // For more details see https://stripe.com/docs/api/ruby#retrieve_country_spec
-func Get(country string) (*stripe.CountrySpec, error) {
-	return getC().Get(country)
+func Get(country string, params *stripe.CountrySpecParams) (*stripe.CountrySpec, error) {
+	return getC().Get(country, params)
 }
 
-func (c Client) Get(country string) (*stripe.CountrySpec, error) {
+func (c Client) Get(country string, params *stripe.CountrySpecParams) (*stripe.CountrySpec, error) {
 	path := stripe.FormatURLPath("/country_specs/%s", country)
 	countrySpec := &stripe.CountrySpec{}
-	err := c.B.Call(http.MethodGet, path, c.Key, nil, countrySpec)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, countrySpec)
 	return countrySpec, err
 }
 

--- a/countryspec/client_test.go
+++ b/countryspec/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCountrySpecGet(t *testing.T) {
-	spec, err := Get("US")
+	spec, err := Get("US", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, spec)
 }

--- a/event.go
+++ b/event.go
@@ -38,6 +38,12 @@ type EventData struct {
 	Raw                json.RawMessage        `json:"object"`
 }
 
+// EventParams is the set of parameters that can be used when retrieving events.
+// For more details see https://stripe.com/docs/api#retrieve_events.
+type EventParams struct {
+	Params `form:"*"`
+}
+
 // EventList is a list of events as retrieved from a list endpoint.
 type EventList struct {
 	ListMeta

--- a/event/client.go
+++ b/event/client.go
@@ -16,11 +16,11 @@ type Client struct {
 
 // Get returns the details of an event
 // For more details see https://stripe.com/docs/api#retrieve_event.
-func Get(id string, params *stripe.Params) (*stripe.Event, error) {
+func Get(id string, params *stripe.EventParams) (*stripe.Event, error) {
 	return getC().Get(id, params)
 }
 
-func (c Client) Get(id string, params *stripe.Params) (*stripe.Event, error) {
+func (c Client) Get(id string, params *stripe.EventParams) (*stripe.Event, error) {
 	path := stripe.FormatURLPath("/events/%s", id)
 	event := &stripe.Event{}
 	err := c.B.Call(http.MethodGet, path, c.Key, params, event)

--- a/exchangerate.go
+++ b/exchangerate.go
@@ -7,6 +7,12 @@ type ExchangeRate struct {
 	Rates map[Currency]float64 `json:"rates"`
 }
 
+// ExchangeRateParams is the set of parameters that can be used when retrieving
+// exchange rates.
+type ExchangeRateParams struct {
+	Params `form:"*"`
+}
+
 // ExchangeRateList is a list of exchange rates as retrieved from a list endpoint.
 type ExchangeRateList struct {
 	ListMeta

--- a/exchangerate/client.go
+++ b/exchangerate/client.go
@@ -15,14 +15,14 @@ type Client struct {
 }
 
 // Get returns an ExchangeRate for a given currency
-func Get(currency string) (*stripe.ExchangeRate, error) {
-	return getC().Get(currency)
+func Get(currency string, params *stripe.ExchangeRateParams) (*stripe.ExchangeRate, error) {
+	return getC().Get(currency, params)
 }
 
-func (c Client) Get(currency string) (*stripe.ExchangeRate, error) {
+func (c Client) Get(currency string, params *stripe.ExchangeRateParams) (*stripe.ExchangeRate, error) {
 	path := stripe.FormatURLPath("/exchange_rates/%s", currency)
 	exchangeRate := &stripe.ExchangeRate{}
-	err := c.B.Call(http.MethodGet, path, c.Key, nil, exchangeRate)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, exchangeRate)
 
 	return exchangeRate, err
 }

--- a/exchangerate/client_test.go
+++ b/exchangerate/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestExchangeRateGet(t *testing.T) {
-	rates, err := Get(string(stripe.CurrencyUSD))
+	rates, err := Get(string(stripe.CurrencyUSD), nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, rates)
 }

--- a/issuerfraudrecord.go
+++ b/issuerfraudrecord.go
@@ -18,7 +18,7 @@ const (
 // https://stripe.com/docs#list_issuer_fraud_records.
 type IssuerFraudRecordListParams struct {
 	ListParams `form:"*"`
-	Charge     string `form:"-"`
+	Charge     *string `form:"-"`
 }
 
 // IssuerFraudRecordList is a list of issuer fraud records as retrieved from a

--- a/issuerfraudrecord.go
+++ b/issuerfraudrecord.go
@@ -13,6 +13,13 @@ const (
 	IssuerFraudTypeUnauthorizedUseOfCard     IssuerFraudType = "unauthorized_use_of_card"
 )
 
+// IssuerFraudRecordParams is the set of parameters that can be used when
+// retrieving issuer fraud records. For more details see
+// https://stripe.com/docs#retrieve_issuer_fraud_records.
+type IssuerFraudRecordParams struct {
+	Params `form:"*"`
+}
+
 // IssuerFraudRecordListParams is the set of parameters that can be used when
 // listing issuer fraud records. For more details see
 // https://stripe.com/docs#list_issuer_fraud_records.

--- a/issuerfraudrecord/client.go
+++ b/issuerfraudrecord/client.go
@@ -15,16 +15,16 @@ type Client struct {
 
 // Get returns the details of an issuer fraud record.
 // For more details see https://stripe.com/docs/api#retrieve_issuer_fraud_record.
-func Get(id string) (*stripe.IssuerFraudRecord, error) {
-	return getC().Get(id)
+func Get(id string, params *stripe.IssuerFraudRecordParams) (*stripe.IssuerFraudRecord, error) {
+	return getC().Get(id, params)
 }
 
 // Get returns the details of an issuer fraud record on a client.
 // For more details see https://stripe.com/docs/api#retrieve_issuer_fraud_record.
-func (c Client) Get(id string) (*stripe.IssuerFraudRecord, error) {
+func (c Client) Get(id string, params *stripe.IssuerFraudRecordParams) (*stripe.IssuerFraudRecord, error) {
 	path := stripe.FormatURLPath("/issuer_fraud_records/%s", id)
 	ifr := &stripe.IssuerFraudRecord{}
-	err := c.B.Call(http.MethodGet, path, c.Key, nil, ifr)
+	err := c.B.Call(http.MethodGet, path, c.Key, params, ifr)
 	return ifr, err
 }
 

--- a/issuerfraudrecord/client_test.go
+++ b/issuerfraudrecord/client_test.go
@@ -24,7 +24,9 @@ func TestIssuerFraudRecordList(t *testing.T) {
 }
 
 func TestIssuerFraudRecordListByChargeID(t *testing.T) {
-	i := List(&stripe.IssuerFraudRecordListParams{Charge: "ch_123"})
+	i := List(&stripe.IssuerFraudRecordListParams{
+		Charge: stripe.String("ch_123"),
+	})
 
 	// Verify that we can get at least one issuer fraud record
 	assert.True(t, i.Next())

--- a/issuerfraudrecord/client_test.go
+++ b/issuerfraudrecord/client_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestIssuerFraudRecordGet(t *testing.T) {
-	topup, err := Get("ifr_123")
+	ifr, err := Get("ifr_123", nil)
 	assert.Nil(t, err)
-	assert.NotNil(t, topup)
+	assert.NotNil(t, ifr)
 }
 
 func TestIssuerFraudRecordList(t *testing.T) {

--- a/loginlink.go
+++ b/loginlink.go
@@ -3,6 +3,7 @@ package stripe
 // LoginLinkParams is the set of parameters that can be used when creating a login_link.
 // For more details see https://stripe.com/docs/api#create_login_link.
 type LoginLinkParams struct {
+	Params  `form:"*"`
 	Account *string `form:"-"` // Included in URL
 }
 

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -27,7 +27,7 @@ func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 
 	path := stripe.FormatURLPath("/accounts/%s/login_links", stripe.StringValue(params.Account))
 	loginLink := &stripe.LoginLink{}
-	err := c.B.Call(http.MethodPost, path, c.Key, nil, loginLink)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, loginLink)
 	return loginLink, err
 }
 


### PR DESCRIPTION
* `IssuerFraudRecordListParams` now uses `*string` for `Charge`
* `event.Get()` now takes `EventParams` instead of `Params` to be consistent
* The `Get` method for `countryspec`, `exchangerate`, `issuerfraudrecord` now take an extra parameter to be consistent and allow setting the connected account.
* `charge. MarkFraudulent()` and `charge. MarkSafe()` have been removed. You should use `charge.Update()` instead
* `charge.CloseDispute()` and `charge.UpdateDispute()` have been removed. You should use `dispute.Update()` or `dispute.Close()` instead.
* `loginlink` now properly passes the `params`

This fixes https://github.com/stripe/stripe-go/issues/588

r? @brandur-stripe 
cc @stripe/api-libraries 