### PR TITLE
Organize core files alphabetically and into sections

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -6,8 +6,9 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
-// Query is the function used to get a page listing.
-type Query func(*Params, *form.Values) ([]interface{}, ListMeta, error)
+//
+// Public types
+//
 
 // Iter provides a convenient interface
 // for iterating over the elements
@@ -26,6 +27,67 @@ type Iter struct {
 	query      Query
 	values     []interface{}
 }
+
+// Current returns the most recent item
+// visited by a call to Next.
+func (it *Iter) Current() interface{} {
+	return it.cur
+}
+
+// Err returns the error, if any,
+// that caused the Iter to stop.
+// It must be inspected
+// after Next returns false.
+func (it *Iter) Err() error {
+	return it.err
+}
+
+// Meta returns the list metadata.
+func (it *Iter) Meta() *ListMeta {
+	return &it.meta
+}
+
+// Next advances the Iter to the next item in the list,
+// which will then be available
+// through the Current method.
+// It returns false when the iterator stops
+// at the end of the list.
+func (it *Iter) Next() bool {
+	if len(it.values) == 0 && it.meta.HasMore && !it.listParams.Single {
+		// determine if we're moving forward or backwards in paging
+		if it.listParams.EndingBefore != nil {
+			it.listParams.EndingBefore = String(listItemID(it.cur))
+			it.formValues.Set(EndingBefore, *it.listParams.EndingBefore)
+		} else {
+			it.listParams.StartingAfter = String(listItemID(it.cur))
+			it.formValues.Set(StartingAfter, *it.listParams.StartingAfter)
+		}
+		it.getPage()
+	}
+	if len(it.values) == 0 {
+		return false
+	}
+	it.cur = it.values[0]
+	it.values = it.values[1:]
+	return true
+}
+
+func (it *Iter) getPage() {
+	it.values, it.meta, it.err = it.query(it.listParams.GetParams(), it.formValues)
+
+	if it.listParams.EndingBefore != nil {
+		// We are moving backward,
+		// but items arrive in forward order.
+		reverse(it.values)
+	}
+}
+
+// Query is the function used to get a page listing.
+type Query func(*Params, *form.Values) ([]interface{}, ListMeta, error)
+
+//
+// Public functions
+//
 
 // GetIter returns a new Iter for a given query and its options.
 func GetIter(container ListParamsContainer, query Query) *Iter {
@@ -56,59 +118,9 @@ func GetIter(container ListParamsContainer, query Query) *Iter {
 	return iter
 }
 
-func (it *Iter) getPage() {
-	it.values, it.meta, it.err = it.query(it.listParams.GetParams(), it.formValues)
-
-	if it.listParams.EndingBefore != nil {
-		// We are moving backward,
-		// but items arrive in forward order.
-		reverse(it.values)
-	}
-}
-
-// Next advances the Iter to the next item in the list,
-// which will then be available
-// through the Current method.
-// It returns false when the iterator stops
-// at the end of the list.
-func (it *Iter) Next() bool {
-	if len(it.values) == 0 && it.meta.HasMore && !it.listParams.Single {
-		// determine if we're moving forward or backwards in paging
-		if it.listParams.EndingBefore != nil {
-			it.listParams.EndingBefore = String(listItemID(it.cur))
-			it.formValues.Set(EndingBefore, *it.listParams.EndingBefore)
-		} else {
-			it.listParams.StartingAfter = String(listItemID(it.cur))
-			it.formValues.Set(StartingAfter, *it.listParams.StartingAfter)
-		}
-		it.getPage()
-	}
-	if len(it.values) == 0 {
-		return false
-	}
-	it.cur = it.values[0]
-	it.values = it.values[1:]
-	return true
-}
-
-// Current returns the most recent item
-// visited by a call to Next.
-func (it *Iter) Current() interface{} {
-	return it.cur
-}
-
-// Err returns the error, if any,
-// that caused the Iter to stop.
-// It must be inspected
-// after Next returns false.
-func (it *Iter) Err() error {
-	return it.err
-}
-
-// Meta returns the list metadata.
-func (it *Iter) Meta() *ListMeta {
-	return &it.meta
-}
+//
+// Private functions
+//
 
 func listItemID(x interface{}) string {
 	return reflect.ValueOf(x).Elem().FieldByName("ID").String()

--- a/params.go
+++ b/params.go
@@ -12,16 +12,134 @@ import (
 	"github.com/stripe/stripe-go/form"
 )
 
+//
+// Public constants
+//
+
 const (
 	EndingBefore  = "ending_before"
 	StartingAfter = "starting_after"
 )
 
-// ParamsContainer is a general interface for which all parameter structs
-// should comply. They achieve this by embedding a Params struct and inheriting
-// its implementation of this interface.
-type ParamsContainer interface {
-	GetParams() *Params
+//
+// Public types
+//
+
+// ExtraValues are extra parameters that are attached to an API request.
+// They're implemented as a custom type so that they can have their own
+// AppendTo implementation.
+type ExtraValues struct {
+	url.Values `form:"-"` // See custom AppendTo implementation
+}
+
+// AppendTo implements custom form encoding for extra parameter values.
+func (v ExtraValues) AppendTo(body *form.Values, keyParts []string) {
+	for k, vs := range v.Values {
+		for _, v := range vs {
+			body.Add(form.FormatKey(append(keyParts, k)), v)
+		}
+	}
+}
+
+// Filters is a structure that contains a collection of filters for list-related APIs.
+type Filters struct {
+	f []*filter `form:"-"` // See custom AppendTo implementation
+}
+
+// AddFilter adds a new filter with a given key, op and value.
+func (f *Filters) AddFilter(key, op, value string) {
+	filter := &filter{Key: key, Op: op, Val: value}
+	f.f = append(f.f, filter)
+}
+
+// AppendTo implements custom form encoding for filters.
+func (f Filters) AppendTo(body *form.Values, keyParts []string) {
+	if len(f.f) > 0 {
+		for _, v := range f.f {
+			if len(v.Op) > 0 {
+				body.Add(form.FormatKey(append(keyParts, v.Key, v.Op)), v.Val)
+			} else {
+				body.Add(form.FormatKey(append(keyParts, v.Key)), v.Val)
+			}
+		}
+	}
+}
+
+// ListMeta is the structure that contains the common properties
+// of List iterators. The Count property is only populated if the
+// total_count include option is passed in (see tests for example).
+type ListMeta struct {
+	HasMore    bool   `json:"has_more"`
+	TotalCount uint32 `json:"total_count"`
+	URL        string `json:"url"`
+}
+
+// ListParams is the structure that contains the common properties
+// of any *ListParams structure.
+type ListParams struct {
+	// Context used for request. It may carry deadlines, cancelation signals,
+	// and other request-scoped values across API boundaries and between
+	// processes.
+	//
+	// Note that a cancelled or timed out context does not provide any
+	// guarantee whether the operation was or was not completed on Stripe's API
+	// servers. For certainty, you must either retry with the same idempotency
+	// key or query the state of the API.
+	Context context.Context `form:"-"`
+
+	EndingBefore *string   `form:"ending_before"`
+	Expand       []*string `form:"expand"`
+	Filters      Filters   `form:"*"`
+	Limit        *int64    `form:"limit"`
+
+	// Single specifies whether this is a single page iterator. By default,
+	// listing through an iterator will automatically grab additional pages as
+	// the query progresses. To change this behavior and just load a single
+	// page, set this to true.
+	Single bool `form:"-"` // Not an API parameter
+
+	StartingAfter *string `form:"starting_after"`
+
+	// StripeAccount may contain the ID of a connected account. By including
+	// this field, the request is made as if it originated from the connected
+	// account instead of under the account of the owner of the configured
+	// Stripe key.
+	StripeAccount *string `form:"-"` // Passed as header
+}
+
+// AddExpand appends a new field to expand.
+func (p *ListParams) AddExpand(f string) {
+	p.Expand = append(p.Expand, &f)
+}
+
+// GetListParams returns a ListParams struct (itself). It exists because any
+// structs that embed ListParams will inherit it, and thus implement the
+// ListParamsContainer interface.
+func (p *ListParams) GetListParams() *ListParams {
+	return p
+}
+
+// GetParams returns ListParams as a Params struct. It exists because any
+// structs that embed Params will inherit it, and thus implement the
+// ParamsContainer interface.
+func (p *ListParams) GetParams() *Params {
+	return p.ToParams()
+}
+
+// SetStripeAccount sets a value for the Stripe-Account header.
+func (p *ListParams) SetStripeAccount(val string) {
+	p.StripeAccount = &val
+}
+
+// ToParams converts a ListParams to a Params by moving over any fields that
+// have valid targets in the new type. This is useful because fields in
+// Params can be injected directly into an http.Request while generally
+// ListParams is only used to build a set of parameters.
+func (p *ListParams) ToParams() *Params {
+	return &Params{
+		Context:       p.Context,
+		StripeAccount: p.StripeAccount,
+	}
 }
 
 // ListParamsContainer is a general interface for which all list parameter
@@ -60,6 +178,29 @@ type Params struct {
 	StripeAccount *string `form:"-"` // Passed as header
 }
 
+// AddExpand appends a new field to expand.
+func (p *Params) AddExpand(f string) {
+	p.Expand = append(p.Expand, &f)
+}
+
+// AddExtra adds a new arbitrary key-value pair to the request data
+func (p *Params) AddExtra(key, value string) {
+	if p.Extra == nil {
+		p.Extra = &ExtraValues{Values: make(url.Values)}
+	}
+
+	p.Extra.Add(key, value)
+}
+
+// AddMetadata adds a new key-value pair to the Metadata.
+func (p *Params) AddMetadata(key, value string) {
+	if p.Metadata == nil {
+		p.Metadata = make(map[string]string)
+	}
+
+	p.Metadata[key] = value
+}
+
 // GetParams returns a Params struct (itself). It exists because any structs
 // that embed Params will inherit it, and thus implement the ParamsContainer
 // interface.
@@ -67,62 +208,21 @@ func (p *Params) GetParams() *Params {
 	return p
 }
 
-// ExtraValues are extra parameters that are attached to an API request.
-// They're implemented as a custom type so that they can have their own
-// AppendTo implementation.
-type ExtraValues struct {
-	url.Values `form:"-"` // See custom AppendTo implementation
+// SetIdempotencyKey sets a value for the Idempotency-Key header.
+func (p *Params) SetIdempotencyKey(val string) {
+	p.IdempotencyKey = &val
 }
 
-// AppendTo implements custom form encoding for extra parameter values.
-func (v ExtraValues) AppendTo(body *form.Values, keyParts []string) {
-	for k, vs := range v.Values {
-		for _, v := range vs {
-			body.Add(form.FormatKey(append(keyParts, k)), v)
-		}
-	}
+// SetStripeAccount sets a value for the Stripe-Account header.
+func (p *Params) SetStripeAccount(val string) {
+	p.StripeAccount = &val
 }
 
-// ListParams is the structure that contains the common properties
-// of any *ListParams structure.
-type ListParams struct {
-	// Context used for request. It may carry deadlines, cancelation signals,
-	// and other request-scoped values across API boundaries and between
-	// processes.
-	//
-	// Note that a cancelled or timed out context does not provide any
-	// guarantee whether the operation was or was not completed on Stripe's API
-	// servers. For certainty, you must either retry with the same idempotency
-	// key or query the state of the API.
-	Context context.Context `form:"-"`
-
-	EndingBefore *string   `form:"ending_before"`
-	Expand       []*string `form:"expand"`
-	Filters      Filters   `form:"*"`
-	Limit        *int64    `form:"limit"`
-
-	// Single specifies whether this is a single page iterator. By default,
-	// listing through an iterator will automatically grab additional pages as
-	// the query progresses. To change this behavior and just load a single
-	// page, set this to true.
-	Single bool `form:"-"` // Not an API parameter
-
-	StartingAfter *string `form:"starting_after"`
-
-	// StripeAccount may contain the ID of a connected account. By including
-	// this field, the request is made as if it originated from the connected
-	// account instead of under the account of the owner of the configured
-	// Stripe key.
-	StripeAccount *string `form:"-"` // Passed as header
-}
-
-// ListMeta is the structure that contains the common properties
-// of List iterators. The Count property is only populated if the
-// total_count include option is passed in (see tests for example).
-type ListMeta struct {
-	HasMore    bool   `json:"has_more"`
-	TotalCount uint32 `json:"total_count"`
-	URL        string `json:"url"`
+// ParamsContainer is a general interface for which all parameter structs
+// should comply. They achieve this by embedding a Params struct and inheriting
+// its implementation of this interface.
+type ParamsContainer interface {
+	GetParams() *Params
 }
 
 // RangeQueryParams are a set of generic request parameters that are used on
@@ -144,35 +244,9 @@ type RangeQueryParams struct {
 	LesserThanOrEqual int64 `form:"lte"`
 }
 
-// Filters is a structure that contains a collection of filters for list-related APIs.
-type Filters struct {
-	f []*filter `form:"-"` // See custom AppendTo implementation
-}
-
-// AddFilter adds a new filter with a given key, op and value.
-func (f *Filters) AddFilter(key, op, value string) {
-	filter := &filter{Key: key, Op: op, Val: value}
-	f.f = append(f.f, filter)
-}
-
-// AppendTo implements custom form encoding for filters.
-func (f Filters) AppendTo(body *form.Values, keyParts []string) {
-	if len(f.f) > 0 {
-		for _, v := range f.f {
-			if len(v.Op) > 0 {
-				body.Add(form.FormatKey(append(keyParts, v.Key, v.Op)), v.Val)
-			} else {
-				body.Add(form.FormatKey(append(keyParts, v.Key)), v.Val)
-			}
-		}
-	}
-}
-
-// filter is the structure that contains a filter for list-related APIs.
-// It ends up passing query string parameters in the format key[op]=value.
-type filter struct {
-	Key, Op, Val string
-}
+//
+// Public functions
+//
 
 // NewIdempotencyKey generates a new idempotency key that
 // can be used on a request.
@@ -183,70 +257,12 @@ func NewIdempotencyKey() string {
 	return fmt.Sprintf("%v_%v", now, base64.URLEncoding.EncodeToString(buf)[:6])
 }
 
-// SetIdempotencyKey sets a value for the Idempotency-Key header.
-func (p *Params) SetIdempotencyKey(val string) {
-	p.IdempotencyKey = &val
-}
+//
+// Private types
+//
 
-// SetStripeAccount sets a value for the Stripe-Account header.
-func (p *Params) SetStripeAccount(val string) {
-	p.StripeAccount = &val
-}
-
-// AddExpand appends a new field to expand.
-func (p *Params) AddExpand(f string) {
-	p.Expand = append(p.Expand, &f)
-}
-
-// AddMetadata adds a new key-value pair to the Metadata.
-func (p *Params) AddMetadata(key, value string) {
-	if p.Metadata == nil {
-		p.Metadata = make(map[string]string)
-	}
-
-	p.Metadata[key] = value
-}
-
-// AddExtra adds a new arbitrary key-value pair to the request data
-func (p *Params) AddExtra(key, value string) {
-	if p.Extra == nil {
-		p.Extra = &ExtraValues{Values: make(url.Values)}
-	}
-
-	p.Extra.Add(key, value)
-}
-
-// AddExpand appends a new field to expand.
-func (p *ListParams) AddExpand(f string) {
-	p.Expand = append(p.Expand, &f)
-}
-
-// GetListParams returns a ListParams struct (itself). It exists because any
-// structs that embed ListParams will inherit it, and thus implement the
-// ListParamsContainer interface.
-func (p *ListParams) GetListParams() *ListParams {
-	return p
-}
-
-// GetParams returns ListParams as a Params struct. It exists because any
-// structs that embed Params will inherit it, and thus implement the
-// ParamsContainer interface.
-func (p *ListParams) GetParams() *Params {
-	return p.ToParams()
-}
-
-// SetStripeAccount sets a value for the Stripe-Account header.
-func (p *ListParams) SetStripeAccount(val string) {
-	p.StripeAccount = &val
-}
-
-// ToParams converts a ListParams to a Params by moving over any fields that
-// have valid targets in the new type. This is useful because fields in
-// Params can be injected directly into an http.Request while generally
-// ListParams is only used to build a set of parameters.
-func (p *ListParams) ToParams() *Params {
-	return &Params{
-		Context:       p.Context,
-		StripeAccount: p.StripeAccount,
-	}
+// filter is the structure that contains a filter for list-related APIs.
+// It ends up passing query string parameters in the format key[op]=value.
+type filter struct {
+	Key, Op, Val string
 }


### PR DESCRIPTION
This patch organizes some of library's core files (`stripe.go`,
`params.go`, `iter.go`) alphabetically and into sections. Here are the
key changes:

* Introduces "sections" of codes, these are (in order how they actually
  appear in the file too):

    ```
    // Public constants
    // Public variables
    // Public types
    // Public functions
    // Private constants
    // Private variables
    // Private types
    // Private functions
    ```

    The premise is that symbols which are intended to be more widely
    used (because they're exported out of the package) are at the top of
    the file for easier access, while unexported symbols are organized
    closer to the bottom.

* Within each section, all symbols are organized alphabetically.
* All type-specific functions (e.g. `func (p *Params) GetParams`) are
  arranged below the type they're attached to, and organized
  alphabetically within their type. Unexported functions are arranged
  below exported functions because that's better, also because lowercase
  letters lexically sort after uppercase letters (`A` > `a`).

And a few other minor opportunistic changes that are somewhat unrelated:

* I dropped the `TotalBackends` constant because it wasn't referenced
  anywhere (this could technically be considered a breaking change, but
  because I don't think there was any sane reason to use it, I don't
  think I'll bump the major version).
* I changed `sleepTime` from a type-specific field to one that's not
  (i.e., `func sleepTime`) because it doesn't depend on any state within
  the struct it was attached to.

I kind of want to get this in because some of these files are turning
into a huge mess and it's a good time because we have no other
outstanding pull requests.

r? @remi-stripe Sorry this diff is a giant mess, but I listed everything that
changed above so it might be better/easier just to read that and let me know if
you agree with the decisions or not. I think there's even more organization 
that we can get out too, but I want to break this up a little bit.