### PR TITLE
Use `travis_retry` helper when using `go get` for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 before_install:
+  # Install various build dependencies. We use `travis_retry` because `go get`
+  # will occasionally fail intermittently.
+
   # The testify require framework is used for assertions in the test suite
-  - go get -u github.com/stretchr/testify/require
+  - travis_retry go get -u github.com/stretchr/testify/require
 
   # Install lint / code coverage / coveralls tooling
-  - go get -u golang.org/x/lint/golint
-  - go get -u golang.org/x/tools/cmd/cover
-  - go get -u github.com/modocache/gover
-  - go get -u github.com/mattn/goveralls
+  - travis_retry go get -u golang.org/x/lint/golint
+  - travis_retry go get -u golang.org/x/tools/cmd/cover
+  - travis_retry go get -u github.com/modocache/gover
+  - travis_retry go get -u github.com/mattn/goveralls
 
   # Unpack and start the Stripe API stub so that the test suite can talk to it
   - |


### PR DESCRIPTION
Our resolved dependencies aren't cached and we occasionally see
intermittent failures as `go get` runs and temporarily fails to get one
of our dependencies. This fails the build, and someone has to go in and
restart it.

It turns out that Travis provides a handy `travis_retry` helper [1]
which will retry a command up to three times if it returns a non-zero
exit code. I've added it in for all dependency resolution, and we'll see
if it helps.

[1] https://docs.travis-ci.com/user/common-build-problems/#travis_retry

r? @remi-stripe 