### PR TITLE
Adds support for 'partner_id' to 'SetAppInfo'

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -72,9 +72,10 @@ var Logger Printfer
 // to. This should be reserved for plugins that wish to identify themselves
 // with Stripe.
 type AppInfo struct {
-	Name    string `json:"name"`
-	URL     string `json:"url"`
-	Version string `json:"version"`
+	Name      string `json:"name"`
+	PartnerId string `json:"partner_id"`
+	URL       string `json:"url"`
+	Version   string `json:"version"`
 }
 
 // formatUserAgent formats an AppInfo in a way that's suitable to be appended

--- a/stripe.go
+++ b/stripe.go
@@ -73,7 +73,7 @@ var Logger Printfer
 // with Stripe.
 type AppInfo struct {
 	Name      string `json:"name"`
-	PartnerId string `json:"partner_id"`
+	PartnerID string `json:"partner_id"`
 	URL       string `json:"url"`
 	Version   string `json:"version"`
 }

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -157,7 +157,7 @@ func TestUserAgent(t *testing.T) {
 func TestUserAgentWithAppInfo(t *testing.T) {
 	appInfo := &stripe.AppInfo{
 		Name:      "MyAwesomePlugin",
-		PartnerId: "partner_1234",
+		PartnerID: "partner_1234",
 		URL:       "https://myawesomeplugin.info",
 		Version:   "1.2.34",
 	}

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -196,6 +196,7 @@ func TestUserAgentWithAppInfo(t *testing.T) {
 	assert.Equal(t, "MyAwesomePlugin", application["name"])
 	assert.Equal(t, "https://myawesomeplugin.info", application["url"])
 	assert.Equal(t, "1.2.34", application["version"])
+	assert.Equal(t, "partner_1234", application["partner_id"])
 }
 
 func TestStripeClientUserAgent(t *testing.T) {

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -156,9 +156,10 @@ func TestUserAgent(t *testing.T) {
 
 func TestUserAgentWithAppInfo(t *testing.T) {
 	appInfo := &stripe.AppInfo{
-		Name:    "MyAwesomePlugin",
-		URL:     "https://myawesomeplugin.info",
-		Version: "1.2.34",
+		Name:      "MyAwesomePlugin",
+		PartnerId: "partner_1234",
+		URL:       "https://myawesomeplugin.info",
+		Version:   "1.2.34",
 	}
 	stripe.SetAppInfo(appInfo)
 	defer stripe.SetAppInfo(nil)


### PR DESCRIPTION
This adds support for an optional partner_id attribute in the SetAppInfo hash.