### PR TITLE
Introduce `GetBackendWithConfig` and make logging configurable per backend

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -22,13 +22,11 @@ func TestErrorResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	SetBackend("api", &BackendConfiguration{
-		Type:       APIBackend,
-		URL:        ts.URL,
-		HTTPClient: &http.Client{},
+	backend := GetBackendWithConfig(APIBackend, &BackendConfig{
+		URL: ts.URL,
 	})
 
-	err := GetBackend(APIBackend).Call(http.MethodGet, "/v1/account", "sk_test_badKey", nil, nil)
+	err := backend.Call(http.MethodGet, "/v1/account", "sk_test_badKey", nil, nil)
 	assert.Error(t, err)
 
 	stripeErr := err.(*Error)

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestBearerAuth(t *testing.T) {
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 	key := "apiKey"
 
 	req, err := c.NewRequest("", "", key, "", nil, nil)
@@ -25,7 +25,7 @@ func TestBearerAuth(t *testing.T) {
 }
 
 func TestContext(t *testing.T) {
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 	p := &stripe.Params{Context: context.Background()}
 
 	req, err := c.NewRequest("", "", "", "", nil, p)
@@ -35,10 +35,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestContext_Cancel(t *testing.T) {
-	c := &stripe.BackendConfiguration{
-		HTTPClient: &http.Client{},
-		URL:        stripe.APIURL,
-	}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &stripe.Params{Context: ctx}
 
@@ -107,7 +104,7 @@ func TestMultipleAPICalls(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+			c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 			key := "apiKey"
 
 			req, err := c.NewRequest("", "", key, "", nil, nil)
@@ -120,7 +117,7 @@ func TestMultipleAPICalls(t *testing.T) {
 }
 
 func TestIdempotencyKey(t *testing.T) {
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 	p := &stripe.Params{IdempotencyKey: stripe.String("idempotency-key")}
 
 	req, err := c.NewRequest("", "", "", "", nil, p)
@@ -130,7 +127,7 @@ func TestIdempotencyKey(t *testing.T) {
 }
 
 func TestStripeAccount(t *testing.T) {
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 	p := &stripe.Params{}
 	p.SetStripeAccount(TestMerchantID)
 
@@ -141,7 +138,7 @@ func TestStripeAccount(t *testing.T) {
 }
 
 func TestUserAgent(t *testing.T) {
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 
 	req, err := c.NewRequest("", "", "", "", nil, nil)
 	assert.NoError(t, err)
@@ -164,7 +161,7 @@ func TestUserAgentWithAppInfo(t *testing.T) {
 	stripe.SetAppInfo(appInfo)
 	defer stripe.SetAppInfo(nil)
 
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 
 	req, err := c.NewRequest("", "", "", "", nil, nil)
 	assert.NoError(t, err)
@@ -200,7 +197,7 @@ func TestUserAgentWithAppInfo(t *testing.T) {
 }
 
 func TestStripeClientUserAgent(t *testing.T) {
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 
 	req, err := c.NewRequest("", "", "", "", nil, nil)
 	assert.NoError(t, err)
@@ -234,7 +231,7 @@ func TestStripeClientUserAgentWithAppInfo(t *testing.T) {
 	stripe.SetAppInfo(appInfo)
 	defer stripe.SetAppInfo(nil)
 
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 
 	req, err := c.NewRequest("", "", "", "", nil, nil)
 	assert.NoError(t, err)
@@ -253,7 +250,7 @@ func TestStripeClientUserAgentWithAppInfo(t *testing.T) {
 }
 
 func TestResponseToError(t *testing.T) {
-	c := &stripe.BackendConfiguration{URL: stripe.APIURL}
+	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 
 	// A test response that includes a status code and request ID.
 	res := &http.Response{

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -59,11 +59,14 @@ func init() {
 	// Configure a backend for stripe-mock and set it for both the API and
 	// Uploads (unlike the real Stripe API, stripe-mock supports both these
 	// backends).
-	stripeMockBackend := &stripe.BackendConfiguration{
-		Type:       stripe.APIBackend,
-		URL:        "http://localhost:" + port + "/v1",
-		HTTPClient: &http.Client{},
-	}
+	stripeMockBackend := stripe.GetBackendWithConfig(
+		stripe.APIBackend,
+		&stripe.BackendConfig{
+			URL:        "http://localhost:" + port,
+			HTTPClient: &http.Client{},
+			Logger:     stripe.Logger,
+		},
+	)
 	stripe.SetBackend(stripe.APIBackend, stripeMockBackend)
 	stripe.SetBackend(stripe.UploadsBackend, stripeMockBackend)
 }


### PR DESCRIPTION
Introduces a new system for getting backends with a set of custom
configuration that's a little cleaner than adding a new setter for every
option that we add in the future.

`BackendConfig` is introduced a user configurable struct which is then
passed to `GetBackendWithConfig`, which returns a backend configured to
spec. `GetBackend` remains, is backward compatible, and continues to set
a default backend for either type.

A new option on `BackendConfig` is being able to set a per-backend
`Logger` and `LogLevel`. This is the impetus that sparked this change as
documented in #608.

So the unfortunate part is that `BackendConfig` is confusingly named
similarly to the very poorly named `BackendConfiguration`, which is the
final implementation of a backend. I wanted to keep this patch backward
compatible, but I want to make a breaking change in the future to rename
this to `backendImplementation` and make it unexported at the same time
because it shouldn't be needed outside of the core package.

We should also unexport `NewBackends` at the same time. It was
introduced to allow some configuration for backends, but it was a pretty
bad idea.

Fixes #608.

r? @remi-stripe