### PR TITLE
Lint remaining packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,27 @@ lint:
 	golint -set_exit_status ./invoice
 	golint -set_exit_status ./invoiceitem
 	golint -set_exit_status ./issuerfraudrecord
+	golint -set_exit_status ./loginlink
+	golint -set_exit_status ./order
+	golint -set_exit_status ./orderreturn
+	golint -set_exit_status ./paymentsource
+	golint -set_exit_status ./payout
+	golint -set_exit_status ./plan
+	golint -set_exit_status ./product
+	golint -set_exit_status ./recipient
+	golint -set_exit_status ./recipienttransfer
+	golint -set_exit_status ./refund
+	golint -set_exit_status ./reversal
+	golint -set_exit_status ./sku
+	golint -set_exit_status ./source
+	golint -set_exit_status ./sourcetransaction
+	golint -set_exit_status ./sub
+	golint -set_exit_status ./subitem
+	golint -set_exit_status ./threedsecure
+	golint -set_exit_status ./token
+	golint -set_exit_status ./topup
+	golint -set_exit_status ./transfer
+	golint -set_exit_status ./usagerecord
 
 test:
 	go test -race ./...

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -14,12 +14,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs to create a login_link for an account
-// For more details see https://stripe.com/docs/api#create_login_link.
+// New creates a login link for an account.
 func New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 	return getC().New(params)
 }
 
+// New creates a login link for an account.
 func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 	if params.Account == nil {
 		return nil, errors.New("Invalid login link params: Account must be set")

--- a/order/client.go
+++ b/order/client.go
@@ -13,14 +13,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new order.
-// For more details see https://stripe.com/docs/api#create_order.
+// New creates a new order.
 func New(params *stripe.OrderParams) (*stripe.Order, error) {
 	return getC().New(params)
 }
 
-// New POSTs a new order.
-// For more details see https://stripe.com/docs/api#create_order.
+// New creates a new order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
 	p := &stripe.Order{}
 	err := c.B.Call(http.MethodPost, "/orders", c.Key, params, p)
@@ -28,13 +26,11 @@ func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
 }
 
 // Update updates an order's properties.
-// For more details see https://stripe.com/docs/api#update_order.
 func Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) {
 	return getC().Update(id, params)
 }
 
 // Update updates an order's properties.
-// For more details see https://stripe.com/docs/api#update_order.
 func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/orders/%s", id)
 	o := &stripe.Order{}
@@ -42,14 +38,12 @@ func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Ord
 	return o, err
 }
 
-// Pay pays an order
-// For more details see https://stripe.com/docs/api#pay_order.
+// Pay pays an order.
 func Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 	return getC().Pay(id, params)
 }
 
-// Pay pays an order
-// For more details see https://stripe.com/docs/api#pay_order.
+// Pay pays an order.
 func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/orders/%s/pay", id)
 	o := &stripe.Order{}
@@ -57,12 +51,12 @@ func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, er
 	return o, err
 }
 
-// Get returns the details of an order
-// For more details see https://stripe.com/docs/api#retrieve_order.
+// Get returns the details of an order.
 func Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of an order.
 func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/orders/%s", id)
 	order := &stripe.Order{}
@@ -71,11 +65,11 @@ func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error
 }
 
 // List returns a list of orders.
-// For more details see https://stripe.com/docs/api#list_orders
 func List(params *stripe.OrderListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of orders.
 func (c Client) List(listParams *stripe.OrderListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderList{}
@@ -90,27 +84,12 @@ func (c Client) List(listParams *stripe.OrderListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Orders.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
-type Iter struct {
-	*stripe.Iter
-}
-
-// Order returns the most recent Order
-// visited by a call to Next.
-func (i *Iter) Order() *stripe.Order {
-	return i.Current().(*stripe.Order)
-}
-
 // Return returns all or part of an order.
-// For more details see https://stripe.com/docs/api#return_order.
 func Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
 	return getC().Return(id, params)
 }
 
 // Return returns all or part of an order.
-// For more details see https://stripe.com/docs/api#return_order.
 func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
 	path := stripe.FormatURLPath("/orders/%s/returns", id)
 	ret := &stripe.OrderReturn{}
@@ -118,6 +97,15 @@ func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.Ord
 	return ret, err
 }
 
+// Iter is an iterator for orders.
+type Iter struct {
+	*stripe.Iter
+}
+
+// Order returns the order which the iterator is currently pointing to.
+func (i *Iter) Order() *stripe.Order {
+	return i.Current().(*stripe.Order)
+}
 func getC() Client {
 	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
 }

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -13,11 +13,12 @@ type Client struct {
 	Key string
 }
 
-// For more details see https://stripe.com/docs/api#list_orders
+// List returns a list of order returns.
 func List(params *stripe.OrderReturnListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of order returns.
 func (c Client) List(listParams *stripe.OrderReturnListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.OrderReturnList{}
@@ -32,15 +33,12 @@ func (c Client) List(listParams *stripe.OrderReturnListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of OrderReturns.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for order returns.
 type Iter struct {
 	*stripe.Iter
 }
 
-// OrderReturn returns the most recent OrderReturn
-// visited by a call to Next.
+// OrderReturn returns the order return which the iterator is currently pointing to.
 func (i *Iter) OrderReturn() *stripe.OrderReturn {
 	return i.Current().(*stripe.OrderReturn)
 }

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -15,12 +15,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs new sources for a customer.
-// For more details see https://stripe.com/docs/api#create_source.
+// New creates a new source for a customer.
 func New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	return getC().New(params)
 }
 
+// New creates a new source for a customer.
 func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	if params == nil {
 		return nil, errors.New("params should not be nil")
@@ -37,11 +37,11 @@ func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource,
 }
 
 // Get returns the details of a source.
-// For more details see https://stripe.com/docs/api#retrieve_source.
 func Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a source.
 func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	if params == nil {
 		return nil, errors.New("params should not be nil")
@@ -58,11 +58,11 @@ func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 }
 
 // Update updates a source's properties.
-// For more details see https://stripe.com/docs/api#update_source.
 func Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a source's properties.
 func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	if params == nil {
 		return nil, errors.New("params should not be nil")
@@ -79,11 +79,11 @@ func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.
 }
 
 // Del removes a source.
-// For more details see https://stripe.com/docs/api#delete_source.
 func Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	return getC().Del(id, params)
 }
 
+// Del removes a source.
 func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	if params == nil {
 		return nil, errors.New("params should not be nil")
@@ -100,11 +100,11 @@ func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 }
 
 // List returns a list of sources.
-// For more details see https://stripe.com/docs/api#list_sources.
 func List(params *stripe.SourceListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of sources.
 func (s Client) List(listParams *stripe.SourceListParams) *Iter {
 	var outerErr error
 	var path string
@@ -136,12 +136,12 @@ func (s Client) List(listParams *stripe.SourceListParams) *Iter {
 	})}
 }
 
-// Verify verifies a bank account
-// For more details see https://stripe.com/docs/guides/ach-beta
+// Verify verifies a source which is used for bank accounts.
 func Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
 	return getC().Verify(id, params)
 }
 
+// Verify verifies a source which is used for bank accounts.
 func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
 	if params == nil {
 		return nil, errors.New("params should not be nil")
@@ -154,7 +154,7 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 	} else if len(params.Values) > 0 {
 		path = stripe.FormatURLPath("/sources/%s/verify", id)
 	} else {
-		return nil, errors.New("Only customer bank accounts or sources can be verified in this manner.")
+		return nil, errors.New("Only customer bank accounts or sources can be verified in this manner")
 	}
 
 	source := &stripe.PaymentSource{}
@@ -162,15 +162,12 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 	return source, err
 }
 
-// Iter is an iterator for lists of PaymentSources.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for sources.
 type Iter struct {
 	*stripe.Iter
 }
 
-// PaymentSource returns the most recent PaymentSource
-// visited by a call to Next.
+// PaymentSource returns the source which the iterator is currently pointing to.
 func (i *Iter) PaymentSource() *stripe.PaymentSource {
 	return i.Current().(*stripe.PaymentSource)
 }

--- a/payout/client.go
+++ b/payout/client.go
@@ -14,12 +14,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new payout.
-// For more details see https://stripe.com/docs/api#create_payout.
+// New creates a new payout.
 func New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 	return getC().New(params)
 }
 
+// New creates a new payout.
 func (c Client) New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 	payout := &stripe.Payout{}
 	err := c.B.Call(http.MethodPost, "/payouts", c.Key, params, payout)
@@ -27,11 +27,11 @@ func (c Client) New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 }
 
 // Get returns the details of a payout.
-// For more details see https://stripe.com/docs/api#retrieve_payout.
 func Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a payout.
 func (c Client) Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s", id)
 	payout := &stripe.Payout{}
@@ -40,11 +40,11 @@ func (c Client) Get(id string, params *stripe.PayoutParams) (*stripe.Payout, err
 }
 
 // Update updates a payout's properties.
-// For more details see https://stripe.com/docs/api#update_payout.
 func Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a payout's properties.
 func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s", id)
 	payout := &stripe.Payout{}
@@ -53,11 +53,11 @@ func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, 
 }
 
 // Cancel cancels a pending payout.
-// For more details see https://stripe.com/docs/api#cancel_payout.
 func Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	return getC().Cancel(id, params)
 }
 
+// Cancel cancels a pending payout.
 func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/payouts/%s/cancel", id)
 	payout := &stripe.Payout{}
@@ -66,11 +66,11 @@ func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, 
 }
 
 // List returns a list of payouts.
-// For more details see https://stripe.com/docs/api#list_payouts.
 func List(params *stripe.PayoutListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of payouts.
 func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PayoutList{}
@@ -85,15 +85,12 @@ func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Payouts.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for payouts.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Payout returns the most recent Payout
-// visited by a call to Next.
+// Payout returns the payout which the iterator is currently pointing to.
 func (i *Iter) Payout() *stripe.Payout {
 	return i.Current().(*stripe.Payout)
 }

--- a/plan/client.go
+++ b/plan/client.go
@@ -14,12 +14,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new plan.
-// For more details see https://stripe.com/docs/api#create_plan.
+// New creates a new plan.
 func New(params *stripe.PlanParams) (*stripe.Plan, error) {
 	return getC().New(params)
 }
 
+// New creates a new plan.
 func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
 	plan := &stripe.Plan{}
 	err := c.B.Call(http.MethodPost, "/plans", c.Key, params, plan)
@@ -27,11 +27,11 @@ func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
 }
 
 // Get returns the details of a plan.
-// For more details see https://stripe.com/docs/api#retrieve_plan.
 func Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a plan.
 func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
@@ -40,11 +40,11 @@ func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) 
 }
 
 // Update updates a plan's properties.
-// For more details see https://stripe.com/docs/api#update_plan.
 func Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a plan's properties.
 func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
@@ -53,11 +53,11 @@ func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, erro
 }
 
 // Del removes a plan.
-// For more details see https://stripe.com/docs/api#delete_plan.
 func Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	return getC().Del(id, params)
 }
 
+// Del removes a plan.
 func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/plans/%s", id)
 	plan := &stripe.Plan{}
@@ -66,11 +66,11 @@ func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) 
 }
 
 // List returns a list of plans.
-// For more details see https://stripe.com/docs/api#list_plans.
 func List(params *stripe.PlanListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of plans.
 func (c Client) List(listParams *stripe.PlanListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.PlanList{}
@@ -85,15 +85,12 @@ func (c Client) List(listParams *stripe.PlanListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Plans.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for plans.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Plan returns the most recent Plan
-// visited by a call to Next.
+// Plan returns the plan which the iterator is currently pointing to.
 func (i *Iter) Plan() *stripe.Plan {
 	return i.Current().(*stripe.Plan)
 }

--- a/product/client.go
+++ b/product/client.go
@@ -13,14 +13,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new product.
-// For more details see https://stripe.com/docs/api#create_product.
+// New creates a new product.
 func New(params *stripe.ProductParams) (*stripe.Product, error) {
 	return getC().New(params)
 }
 
-// New POSTs a new product.
-// For more details see https://stripe.com/docs/api#create_product.
+// New creates a new product.
 func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
 	p := &stripe.Product{}
 	err := c.B.Call(http.MethodPost, "/products", c.Key, params, p)
@@ -28,13 +26,11 @@ func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
 }
 
 // Update updates a product's properties.
-// For more details see https://stripe.com/docs/api#update_product.
 func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	return getC().Update(id, params)
 }
 
 // Update updates a product's properties.
-// For more details see https://stripe.com/docs/api#update_product.
 func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
@@ -42,12 +38,12 @@ func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product
 	return p, err
 }
 
-// Get returns the details of an product
-// For more details see https://stripe.com/docs/api#retrieve_product.
+// Get returns the details of a product.
 func Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a product.
 func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
@@ -56,11 +52,11 @@ func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, e
 }
 
 // List returns a list of products.
-// For more details see https://stripe.com/docs/api#list_products
 func List(params *stripe.ProductListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of products.
 func (c Client) List(listParams *stripe.ProductListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.ProductList{}
@@ -75,33 +71,28 @@ func (c Client) List(listParams *stripe.ProductListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Products.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
-type Iter struct {
-	*stripe.Iter
-}
-
-// Product returns the most recent Product
-// visited by a call to Next.
-func (i *Iter) Product() *stripe.Product {
-	return i.Current().(*stripe.Product)
-}
-
-// Delete deletes a product
-// For more details see https://stripe.com/docs/api#delete_product.
+// Del deletes a product
 func Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	return getC().Del(id, params)
 }
 
-// Delete deletes a product.
-// For more details see https://stripe.com/docs/api#delete_product.
+// Del deletes a product.
 func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/products/%s", id)
 	p := &stripe.Product{}
 	err := c.B.Call(http.MethodDelete, path, c.Key, params, p)
 
 	return p, err
+}
+
+// Iter is an iterator for products.
+type Iter struct {
+	*stripe.Iter
+}
+
+// Product returns the product which the iterator is currently pointing to.
+func (i *Iter) Product() *stripe.Product {
+	return i.Current().(*stripe.Product)
 }
 
 func getC() Client {

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -18,11 +18,11 @@ type Client struct {
 // For that reason, there isn't a New() method for the Recipient resource.
 
 // Get returns the details of a recipient.
-// For more details see https://stripe.com/docs/api#retrieve_recipient.
 func Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a recipient.
 func (c Client) Get(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
@@ -31,11 +31,11 @@ func (c Client) Get(id string, params *stripe.RecipientParams) (*stripe.Recipien
 }
 
 // Update updates a recipient's properties.
-// For more details see https://stripe.com/docs/api#update_recipient.
 func Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a recipient's properties.
 func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
@@ -44,11 +44,11 @@ func (c Client) Update(id string, params *stripe.RecipientParams) (*stripe.Recip
 }
 
 // Del removes a recipient.
-// For more details see https://stripe.com/docs/api#delete_recipient.
 func Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	return getC().Del(id, params)
 }
 
+// Del removes a recipient.
 func (c Client) Del(id string, params *stripe.RecipientParams) (*stripe.Recipient, error) {
 	path := stripe.FormatURLPath("/recipients/%s", id)
 	recipient := &stripe.Recipient{}
@@ -57,11 +57,11 @@ func (c Client) Del(id string, params *stripe.RecipientParams) (*stripe.Recipien
 }
 
 // List returns a list of recipients.
-// For more details see https://stripe.com/docs/api#list_recipients.
 func List(params *stripe.RecipientListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of recipients.
 func (c Client) List(listParams *stripe.RecipientListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RecipientList{}
@@ -76,15 +76,12 @@ func (c Client) List(listParams *stripe.RecipientListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Recipients.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for recipients.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Recipient returns the most recent Recipient
-// visited by a call to Next.
+// Recipient returns the recipient which the iterator is currently pointing to.
 func (i *Iter) Recipient() *stripe.Recipient {
 	return i.Current().(*stripe.Recipient)
 }

--- a/refund/client.go
+++ b/refund/client.go
@@ -14,12 +14,12 @@ type Client struct {
 	Key string
 }
 
-// New refunds a charge previously created.
-// For more details see https://stripe.com/docs/api#refund_charge.
+// New creates a refund.
 func New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	return getC().New(params)
 }
 
+// New creates a refund.
 func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	refund := &stripe.Refund{}
 	err := c.B.Call(http.MethodPost, "/refunds", c.Key, params, refund)
@@ -27,11 +27,11 @@ func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 }
 
 // Get returns the details of a refund.
-// For more details see https://stripe.com/docs/api#retrieve_refund.
 func Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a refund.
 func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/refunds/%s", id)
 	refund := &stripe.Refund{}
@@ -40,11 +40,11 @@ func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, err
 }
 
 // Update updates a refund's properties.
-// For more details see https://stripe.com/docs/api#update_refund.
 func Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a refund's properties.
 func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/refunds/%s", id)
 	refund := &stripe.Refund{}
@@ -53,11 +53,11 @@ func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, 
 }
 
 // List returns a list of refunds.
-// For more details see https://stripe.com/docs/api#list_refunds.
 func List(params *stripe.RefundListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of refunds.
 func (c Client) List(listParams *stripe.RefundListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.RefundList{}
@@ -72,15 +72,12 @@ func (c Client) List(listParams *stripe.RefundListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Refunds.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for refunds.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Refund returns the most recent Refund
-// visited by a call to Next.
+// Refund returns the refund which the iterator is currently pointing to.
 func (i *Iter) Refund() *stripe.Refund {
 	return i.Current().(*stripe.Refund)
 }

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -15,11 +15,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new transfer reversal.
+// New creates a new transfer reversal.
 func New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	return getC().New(params)
 }
 
+// New creates a new transfer reversal.
 func (c Client) New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	path := stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(params.Transfer))
 	reversal := &stripe.Reversal{}
@@ -32,6 +33,7 @@ func Get(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a transfer reversal.
 func (c Client) Get(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil, and params.Transfer must be set")
@@ -49,6 +51,7 @@ func Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) 
 	return getC().Update(id, params)
 }
 
+// Update updates a transfer reversal's properties.
 func (c Client) Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	path := stripe.FormatURLPath("/transfers/%s/reversals/%s",
 		stripe.StringValue(params.Transfer), id)
@@ -62,6 +65,7 @@ func List(params *stripe.ReversalListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of transfer reversals.
 func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
 	path := stripe.FormatURLPath("/transfers/%s/reversals", stripe.StringValue(listParams.Transfer))
 
@@ -78,15 +82,12 @@ func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Reversals.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for transfer reversals.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Refund returns the most recent Reversals
-// visited by a call to Next.
+// Reversal returns the transfer reversal which the iterator is currently pointing to.
 func (i *Iter) Reversal() *stripe.Reversal {
 	return i.Current().(*stripe.Reversal)
 }

--- a/sku/client.go
+++ b/sku/client.go
@@ -13,14 +13,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new SKU.
-// For more details see https://stripe.com/docs/api#create_sku.
+// New creates a new SKU.
 func New(params *stripe.SKUParams) (*stripe.SKU, error) {
 	return getC().New(params)
 }
 
-// New POSTs a new SKU.
-// For more details see https://stripe.com/docs/api#create_sku.
+// New creates a new SKU.
 func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
 	s := &stripe.SKU{}
 	err := c.B.Call(http.MethodPost, "/skus", c.Key, params, s)
@@ -28,13 +26,11 @@ func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
 }
 
 // Update updates a SKU's properties.
-// For more details see https://stripe.com/docs/api#update_sku.
 func Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	return getC().Update(id, params)
 }
 
 // Update updates a SKU's properties.
-// For more details see https://stripe.com/docs/api#update_sku.
 func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
@@ -42,12 +38,12 @@ func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error)
 	return s, err
 }
 
-// Get returns the details of an sku
-// For more details see https://stripe.com/docs/api#retrieve_sku.
+// Get returns the details of a SKU.
 func Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a SKU.
 func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
@@ -55,12 +51,12 @@ func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	return s, err
 }
 
-// List returns a list of skus.
-// For more details see https://stripe.com/docs/api#list_skus
+// List returns a list of SKUs.
 func List(params *stripe.SKUListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of SKUs.
 func (c Client) List(listParams *stripe.SKUListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SKUList{}
@@ -75,33 +71,28 @@ func (c Client) List(listParams *stripe.SKUListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of SKUs.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
-type Iter struct {
-	*stripe.Iter
-}
-
-// SKU returns the most recent SKU
-// visited by a call to Next.
-func (i *Iter) SKU() *stripe.SKU {
-	return i.Current().(*stripe.SKU)
-}
-
-// Delete destroys a SKU.
-// For more details see https://stripe.com/docs/api#delete_sku.
+// Del removes a SKU.
 func Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	return getC().Del(id, params)
 }
 
-// Delete destroys a SKU.
-// For more details see https://stripe.com/docs/api#delete_sku.
+// Del removes a SKU.
 func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/skus/%s", id)
 	s := &stripe.SKU{}
 	err := c.B.Call(http.MethodDelete, path, c.Key, params, s)
 
 	return s, err
+}
+
+// Iter is an iterator for SKUs.
+type Iter struct {
+	*stripe.Iter
+}
+
+// SKU returns the SKU which the iterator is currently pointing to.
+func (i *Iter) SKU() *stripe.SKU {
+	return i.Current().(*stripe.SKU)
 }
 
 func getC() Client {

--- a/source/client.go
+++ b/source/client.go
@@ -13,28 +13,24 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new source.
-// For more details see https://stripe.com/docs/api#create_source.
+// New creates a new source.
 func New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	return getC().New(params)
 }
 
-// New POSTs a new source.
-// For more details see https://stripe.com/docs/api#create_source.
+// New creates a new source.
 func (c Client) New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	p := &stripe.Source{}
 	err := c.B.Call(http.MethodPost, "/sources", c.Key, params, p)
 	return p, err
 }
 
-// Get returns the details of a source
-// For more details see https://stripe.com/docs/api#retrieve_source.
+// Get returns the details of a source.
 func Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a source
-// For more details see https://stripe.com/docs/api#retrieve_source.
+// Get returns the details of a source.
 func (c Client) Get(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	path := stripe.FormatURLPath("/sources/%s", id)
 	source := &stripe.Source{}
@@ -43,11 +39,11 @@ func (c Client) Get(id string, params *stripe.SourceObjectParams) (*stripe.Sourc
 }
 
 // Update updates a source's properties.
-// For more details see	https://stripe.com/docs/api#update_source.
 func Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a source's properties.
 func (c Client) Update(id string, params *stripe.SourceObjectParams) (*stripe.Source, error) {
 	path := stripe.FormatURLPath("/sources/%s", id)
 	source := &stripe.Source{}
@@ -55,15 +51,12 @@ func (c Client) Update(id string, params *stripe.SourceObjectParams) (*stripe.So
 	return source, err
 }
 
-func getC() Client {
-	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
-}
-
-// Detach detaches the source from its customer object.
+// Detach detaches the source from a customer.
 func Detach(id string, params *stripe.SourceObjectDetachParams) (*stripe.Source, error) {
 	return getC().Detach(id, params)
 }
 
+// Detach detaches the source from a customer.
 func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*stripe.Source, error) {
 	if params.Customer == nil {
 		return nil, errors.New("Invalid source detach params: Customer needs to be set")
@@ -74,4 +67,8 @@ func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*str
 	source := &stripe.Source{}
 	err := c.B.Call(http.MethodDelete, path, c.Key, params, source)
 	return source, err
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
 }

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -16,11 +16,11 @@ type Client struct {
 }
 
 // List returns a list of source transactions.
-// For more details see https://stripe.com/docs/api#retrieve_source.
 func List(params *stripe.SourceTransactionListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of source transactions.
 func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 	var outerErr error
 	var path string
@@ -50,15 +50,12 @@ func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of SourceTransactions.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for source transactions.
 type Iter struct {
 	*stripe.Iter
 }
 
-// SourceTransaction returns the most recent SourceTransaction
-// visited by a call to Next.
+// SourceTransaction returns the source transaction which the iterator is currently pointing to.
 func (i *Iter) SourceTransaction() *stripe.SourceTransaction {
 	return i.Current().(*stripe.SourceTransaction)
 }

--- a/sub/client.go
+++ b/sub/client.go
@@ -14,12 +14,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTS a new subscription for a customer.
-// For more details see https://stripe.com/docs/api#create_subscription.
+// New creates a new subscription.
 func New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().New(params)
 }
 
+// New creates a new subscription.
 func (c Client) New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	sub := &stripe.Subscription{}
 	err := c.B.Call(http.MethodPost, "/subscriptions", c.Key, params, sub)
@@ -27,11 +27,11 @@ func (c Client) New(params *stripe.SubscriptionParams) (*stripe.Subscription, er
 }
 
 // Get returns the details of a subscription.
-// For more details see https://stripe.com/docs/api#retrieve_subscription.
 func Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a subscription.
 func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
@@ -40,11 +40,11 @@ func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subsc
 }
 
 // Update updates a subscription's properties.
-// For more details see https://stripe.com/docs/api#update_subscription.
 func Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a subscription's properties.
 func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
@@ -54,11 +54,11 @@ func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Su
 }
 
 // Cancel removes a subscription.
-// For more details see https://stripe.com/docs/api#cancel_subscription.
 func Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
 	return getC().Cancel(id, params)
 }
 
+// Cancel removes a subscription.
 func (c Client) Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/subscriptions/%s", id)
 	sub := &stripe.Subscription{}
@@ -67,11 +67,11 @@ func (c Client) Cancel(id string, params *stripe.SubscriptionCancelParams) (*str
 }
 
 // List returns a list of subscriptions.
-// For more details see https://stripe.com/docs/api#list_subscriptions.
 func List(params *stripe.SubscriptionListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of subscriptions.
 func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubscriptionList{}
@@ -86,15 +86,12 @@ func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Subs.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for subscriptions.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Subscription returns the most recent Subscription
-// visited by a call to Next.
+// Subscription returns the subscription which the iterator is currently pointing to.
 func (i *Iter) Subscription() *stripe.Subscription {
 	return i.Current().(*stripe.Subscription)
 }

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -14,24 +14,24 @@ type Client struct {
 	Key string
 }
 
-// New POSTS a new subscription for a customer.
-// For more details see https://stripe.com/docs/api#create_subscription_item.
+// New creates a new subscription item.
 func New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().New(params)
 }
 
+// New creates a new subscription item.
 func (c Client) New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	item := &stripe.SubscriptionItem{}
 	err := c.B.Call(http.MethodPost, "/subscription_items", c.Key, params, item)
 	return item, err
 }
 
-// Get returns the details of a subscription.
-// For more details see https://stripe.com/docs/api#retrieve_subscription.
+// Get returns the details of a subscription item.
 func Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a subscription item.
 func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	item := &stripe.SubscriptionItem{}
@@ -39,12 +39,12 @@ func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.S
 	return item, err
 }
 
-// Update updates a subscription's properties.
-// For more details see https://stripe.com/docs/api#update_subscription.
+// Update updates a subscription item's properties.
 func Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a subscription item's properties.
 func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	subi := &stripe.SubscriptionItem{}
@@ -53,11 +53,11 @@ func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*strip
 }
 
 // Del removes a subscription item.
-// For more details see https://stripe.com/docs/api#cancel_subscription.
 func Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	return getC().Del(id, params)
 }
 
+// Del removes a subscription item.
 func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s", id)
 	item := &stripe.SubscriptionItem{}
@@ -67,11 +67,11 @@ func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.S
 }
 
 // List returns a list of subscription items.
-// For more details see https://stripe.com/docs/api#list_subscription_items.
 func List(params *stripe.SubscriptionItemListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of subscription items.
 func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.SubscriptionItemList{}
@@ -86,15 +86,12 @@ func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Subscriptions.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for subscription items.
 type Iter struct {
 	*stripe.Iter
 }
 
-// SubscriptionItem returns the most recent SubscriptionItem
-// visited by a call to Next.
+// SubscriptionItem returns the subscription item which the iterator is currently pointing to.
 func (i *Iter) SubscriptionItem() *stripe.SubscriptionItem {
 	return i.Current().(*stripe.SubscriptionItem)
 }

--- a/threedsecure/client.go
+++ b/threedsecure/client.go
@@ -1,4 +1,7 @@
 // Package threedsecure provides the /3d_secure APIs
+// This package is deprecated and should not be used anymore.
+// It is still here for backwards compatibility for now.
+// To use 3D Secure, please use the source package instead.
 package threedsecure
 
 import (
@@ -12,10 +15,6 @@ type Client struct {
 	B   stripe.Backend
 	Key string
 }
-
-// This package is deprecated and should not be used anymore.
-// It is still here for backwards compatibility for now.
-// To use 3D Secure, please use the source package instead.
 
 // New creates a new 3D Secure object.
 func New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {

--- a/threedsecure/client.go
+++ b/threedsecure/client.go
@@ -13,24 +13,28 @@ type Client struct {
 	Key string
 }
 
-// New POSTs new 3D Secure auths.
-// For more details see https://stripe.com/docs/api#create_three_d_secure.
+// This package is deprecated and should not be used anymore.
+// It is still here for backwards compatibility for now.
+// To use 3D Secure, please use the source package instead.
+
+// New creates a new 3D Secure object.
 func New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 	return getC().New(params)
 }
 
+// New creates a new 3D Secure object.
 func (c Client) New(params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 	tds := &stripe.ThreeDSecure{}
 	err := c.B.Call(http.MethodPost, "/3d_secure", c.Key, params, tds)
 	return tds, err
 }
 
-// Get returns the details of a 3D Secure auth.
-// For more details see https://stripe.com/docs/api#retrieve_three_d_secure.
+// Get returns the details of a 3D Secure object.
 func Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a 3D Secure object.
 func (c Client) Get(id string, params *stripe.ThreeDSecureParams) (*stripe.ThreeDSecure, error) {
 	path := stripe.FormatURLPath("/3d_secure/%s", id)
 	tds := &stripe.ThreeDSecure{}

--- a/token/client.go
+++ b/token/client.go
@@ -13,12 +13,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new card or bank account.
-// For more details see https://stripe.com/docs/api#create_card_Token and https://stripe.com/docs/api#create_bank_account_token.
+// New creates a new token.
 func New(params *stripe.TokenParams) (*stripe.Token, error) {
 	return getC().New(params)
 }
 
+// New creates a new token.
 func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
 	tok := &stripe.Token{}
 	err := c.B.Call(http.MethodPost, "/tokens", c.Key, params, tok)
@@ -26,11 +26,11 @@ func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
 }
 
 // Get returns the details of a token.
-// For more details see https://stripe.com/docs/api#retrieve_token.
 func Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a token.
 func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 	path := stripe.FormatURLPath("/tokens/%s", id)
 	token := &stripe.Token{}

--- a/topup/client.go
+++ b/topup/client.go
@@ -13,12 +13,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs new topups.
-// For more details see https://stripe.com/docs/api#create_topup.
+// New creates a new topup.
 func New(params *stripe.TopupParams) (*stripe.Topup, error) {
 	return getC().New(params)
 }
 
+// New creates a new topup.
 func (c Client) New(params *stripe.TopupParams) (*stripe.Topup, error) {
 	topup := &stripe.Topup{}
 	err := c.B.Call(http.MethodPost, "/topups", c.Key, params, topup)
@@ -26,11 +26,11 @@ func (c Client) New(params *stripe.TopupParams) (*stripe.Topup, error) {
 }
 
 // Get returns the details of a topup.
-// For more details see https://stripe.com/docs/api#retrieve_topup.
 func Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a topup.
 func (c Client) Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/topups/%s", id)
 	topup := &stripe.Topup{}
@@ -39,11 +39,11 @@ func (c Client) Get(id string, params *stripe.TopupParams) (*stripe.Topup, error
 }
 
 // Update updates a topup's properties.
-// For more details see https://stripe.com/docs/api#update_topup.
 func Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a topup's properties.
 func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/topups/%s", id)
 	topup := &stripe.Topup{}
@@ -52,11 +52,11 @@ func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, er
 }
 
 // List returns a list of topups.
-// For more details see https://stripe.com/docs/api#list_topups.
 func List(params *stripe.TopupListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of topups.
 func (c Client) List(listParams *stripe.TopupListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TopupList{}
@@ -71,9 +71,7 @@ func (c Client) List(listParams *stripe.TopupListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Topups.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for topups.
 type Iter struct {
 	*stripe.Iter
 }

--- a/topup/client.go
+++ b/topup/client.go
@@ -76,6 +76,11 @@ type Iter struct {
 	*stripe.Iter
 }
 
+// Topup returns the topup item which the iterator is currently pointing to.
+func (i *Iter) Topup() *stripe.Topup {
+	return i.Current().(*stripe.Topup)
+}
+
 func getC() Client {
 	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
 }

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -14,12 +14,12 @@ type Client struct {
 	Key string
 }
 
-// New POSTs a new transfer.
-// For more details see https://stripe.com/docs/api#create_transfer.
+// New creates a new transfer.
 func New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 	return getC().New(params)
 }
 
+// New creates a new transfer.
 func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 	transfer := &stripe.Transfer{}
 	err := c.B.Call(http.MethodPost, "/transfers", c.Key, params, transfer)
@@ -27,11 +27,11 @@ func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 }
 
 // Get returns the details of a transfer.
-// For more details see https://stripe.com/docs/api#retrieve_transfer.
 func Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	return getC().Get(id, params)
 }
 
+// Get returns the details of a transfer.
 func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	path := stripe.FormatURLPath("/transfers/%s", id)
 	transfer := &stripe.Transfer{}
@@ -40,11 +40,11 @@ func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer,
 }
 
 // Update updates a transfer's properties.
-// For more details see https://stripe.com/docs/api#update_transfer.
 func Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	return getC().Update(id, params)
 }
 
+// Update updates a transfer's properties.
 func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	path := stripe.FormatURLPath("/transfers/%s", id)
 	transfer := &stripe.Transfer{}
@@ -53,11 +53,11 @@ func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transf
 }
 
 // List returns a list of transfers.
-// For more details see https://stripe.com/docs/api#list_transfers.
 func List(params *stripe.TransferListParams) *Iter {
 	return getC().List(params)
 }
 
+// List returns a list of transfers.
 func (c Client) List(listParams *stripe.TransferListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
 		list := &stripe.TransferList{}
@@ -72,15 +72,12 @@ func (c Client) List(listParams *stripe.TransferListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for lists of Transfers.
-// The embedded Iter carries methods with it;
-// see its documentation for details.
+// Iter is an iterator for transfers.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Transfer returns the most recent Transfer
-// visited by a call to Next.
+// Transfer returns the transfer which the iterator is currently pointing to.
 func (i *Iter) Transfer() *stripe.Transfer {
 	return i.Current().(*stripe.Transfer)
 }

--- a/usagerecord/client.go
+++ b/usagerecord/client.go
@@ -1,4 +1,4 @@
-// Package usage_record provides the /subscription_items/{SUBSCRIPTION_ITEM_ID}/usage_records APIs
+// Package usagerecord provides the /subscription_items/{SUBSCRIPTION_ITEM_ID}/usage_records APIs
 package usagerecord
 
 import (
@@ -14,12 +14,11 @@ type Client struct {
 }
 
 // New creates a new usage record.
-// For more details see https://stripe.com/docs/api#usage_records
 func New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
 	return getC().New(params)
 }
 
-// New internal implementation to create a new usage record.
+// New creates a new usage record.
 func (c Client) New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
 	path := stripe.FormatURLPath("/subscription_items/%s/usage_records", stripe.StringValue(params.SubscriptionItem))
 	record := &stripe.UsageRecord{}


### PR DESCRIPTION
This lint the remaining API packages. It also fixes a missing getter in the `topup` package

r? @brandur-stripe 
cc @stripe/api-libraries 