### PR TITLE
Add `Quantity` and `UnitAmount` to `InvoiceItemParams`

### DIFF
--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -12,7 +12,9 @@ type InvoiceItemParams struct {
 	Description  *string `form:"description"`
 	Discountable *bool   `form:"discountable"`
 	Invoice      *string `form:"invoice"`
+	Quantity     *int64  `form:"quantity"`
 	Subscription *string `form:"subscription"`
+	UnitAmount   *int64  `form:"unit_amount"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.
@@ -43,6 +45,7 @@ type InvoiceItem struct {
 	Proration    bool              `json:"proration"`
 	Quantity     int64             `json:"quantity"`
 	Subscription *Subscription     `json:"subscription"`
+	UnitAmount   int64             `json:"unit_amount"`
 }
 
 // InvoiceItemList is a list of invoice items as retrieved from a list endpoint.


### PR DESCRIPTION
Both these parameters were missing from the params struct, but are
documented in the API [1]. This patch adds them in.

Fixes #619.

[1] https://stripe.com/docs/api/php#create_invoiceitem

r? @remi-stripe
cc @stripe/api-libraries