### PR TITLE
Wire an `http.Client` from `NewBackends` through to backends

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -610,9 +610,10 @@ func Int64Value(v *int64) int64 {
 // NewBackends creates a new set of backends with the given HTTP client. You
 // should only need to use this for testing purposes or on App Engine.
 func NewBackends(httpClient *http.Client) *Backends {
+	config := &BackendConfig{HTTPClient: httpClient}
 	return &Backends{
-		API:     GetBackend(APIBackend),
-		Uploads: GetBackend(UploadsBackend),
+		API:     GetBackendWithConfig(APIBackend, config),
+		Uploads: GetBackendWithConfig(UploadsBackend, config),
 	}
 }
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -126,6 +126,13 @@ func TestIdempotencyKey(t *testing.T) {
 	assert.Equal(t, "idempotency-key", req.Header.Get("Idempotency-Key"))
 }
 
+func TestNewBackends(t *testing.T) {
+	httpClient := &http.Client{}
+	backends := stripe.NewBackends(httpClient)
+	assert.Equal(t, httpClient, backends.API.(*stripe.BackendConfiguration).HTTPClient)
+	assert.Equal(t, httpClient, backends.Uploads.(*stripe.BackendConfiguration).HTTPClient)
+}
+
 func TestStripeAccount(t *testing.T) {
 	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendConfiguration)
 	p := &stripe.Params{}


### PR DESCRIPTION
In #611 I accidentally introduced a regression in the `NewBackends`
function in that an `http.Client` passed into the function isn't
actually wired through to the new backends.

Here we fix that problem by changing the invocations to use
`GetBackendWithConfig` like they were supposed to.

Fixes #626.