### PR TITLE
Switch to port 12112 as default stripe-mock port for HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
       tar -zxf "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}_linux_amd64.tar.gz" -C "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/"
     fi
   - |
-    stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock -https > /dev/null &
+    stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock -https-port 12112 > /dev/null &
     STRIPE_MOCK_PID=$!
 
 cache:
@@ -30,7 +30,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.20.1
+    - STRIPE_MOCK_VERSION=0.21.1
 
 go:
   - "1.7"

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.20.1"
+	MockMinimumVersion = "0.21.1"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.
@@ -39,7 +39,7 @@ func init() {
 
 	port := os.Getenv("STRIPE_MOCK_PORT")
 	if port == "" {
-		port = "12111"
+		port = "12112"
 	}
 
 	// stripe-mock's certificate for localhost is self-signed so configure a


### PR DESCRIPTION
See stripe/stripe-mock#84 for context, but I'm going to switch to port
`12112` as the new default for stripe-mock running HTTPS. This will
allow us to have a setup where we can run API libraries that use HTTP
and those that use HTTPS with just a single instance of stripe-mock.

Depends on stripe/stripe-mock#84 being merged first, and a new
stripe-mock release being cut.

r? @ob-stripe
cc @stripe/api-libraries