### PR TITLE
Add support for the most recent API version

### DIFF
--- a/coupon.go
+++ b/coupon.go
@@ -15,15 +15,15 @@ const (
 // For more details see https://stripe.com/docs/api#create_coupon.
 type CouponParams struct {
 	Params           `form:"*"`
-	AmountOff        *int64  `form:"amount_off"`
-	Currency         *string `form:"currency"`
-	Duration         *string `form:"duration"`
-	DurationInMonths *int64  `form:"duration_in_months"`
-	ID               *string `form:"id"`
-	MaxRedemptions   *int64  `form:"max_redemptions"`
-	Name             *string `form:"name"`
-	PercentOff       *int64  `form:"percent_off"`
-	RedeemBy         *int64  `form:"redeem_by"`
+	AmountOff        *int64   `form:"amount_off"`
+	Currency         *string  `form:"currency"`
+	Duration         *string  `form:"duration"`
+	DurationInMonths *int64   `form:"duration_in_months"`
+	ID               *string  `form:"id"`
+	MaxRedemptions   *int64   `form:"max_redemptions"`
+	Name             *string  `form:"name"`
+	PercentOff       *float64 `form:"percent_off"`
+	RedeemBy         *int64   `form:"redeem_by"`
 }
 
 // CouponListParams is the set of parameters that can be used when listing coupons.
@@ -48,7 +48,7 @@ type Coupon struct {
 	MaxRedemptions   int64             `json:"max_redemptions"`
 	Metadata         map[string]string `json:"metadata"`
 	Name             string            `json:"name"`
-	PercentOff       int64             `json:"percent_off"`
+	PercentOff       float64           `json:"percent_off"`
 	RedeemBy         int64             `json:"redeem_by"`
 	TimesRedeemed    int64             `json:"times_redeemed"`
 	Valid            bool              `json:"valid"`

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -35,7 +35,7 @@ func TestCouponNew(t *testing.T) {
 		Duration:         stripe.String(string(stripe.CouponDurationRepeating)),
 		DurationInMonths: stripe.Int64(3),
 		ID:               stripe.String("25OFF"),
-		PercentOff:       stripe.Int64(25),
+		PercentOff:       stripe.Float64(12.5),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)

--- a/product.go
+++ b/product.go
@@ -66,7 +66,6 @@ type Product struct {
 	Name                string             `json:"name"`
 	PackageDimensions   *PackageDimensions `json:"package_dimensions"`
 	Shippable           bool               `json:"shippable"`
-	Skus                *SKUList           `json:"skus"`
 	StatementDescriptor string             `json:"statement_descriptor"`
 	Type                ProductType        `json:"type"`
 	UnitLabel           string             `json:"unit_label"`

--- a/stripe.go
+++ b/stripe.go
@@ -688,7 +688,7 @@ func StringValue(v *string) string {
 const apiURL = "https://api.stripe.com"
 
 // apiversion is the currently supported API version
-const apiversion = "2018-02-06"
+const apiversion = "2018-07-27"
 
 // clientversion is the binding version
 const clientversion = "36.3.0"

--- a/sub.go
+++ b/sub.go
@@ -46,7 +46,6 @@ type SubscriptionParams struct {
 	Prorate                     *bool                      `form:"prorate"`
 	ProrationDate               *int64                     `form:"proration_date"`
 	Quantity                    *int64                     `form:"quantity"`
-	Source                      *string                    `form:"source"`
 	TaxPercent                  *float64                   `form:"tax_percent"`
 	TrialEnd                    *int64                     `form:"trial_end"`
 	TrialEndNow                 *bool                      `form:"-"` // See custom AppendTo


### PR DESCRIPTION
This ensures the most recent API version is set in stripe-go as there were a few breaking changes.

* Move to API version 2018-07-27
* Remove SKUs list on the product
* Remove the ability to pass a Source on subscription creation/update
* Change percent_off on the coupon from int to float

r? @brandur-stripe 
cc @stripe/api-libraries 