### PR TITLE
Enforce linter on all files and packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,64 +9,8 @@ build:
 check-gofmt:
 	scripts/check_gofmt.sh
 
-# We're trying to get linting activated, but there are so many errors that
-# we're doing so incrementally instead of pushing it through as part of one
-# giant patch.
-#
-# As new packages get cleaned up, add them here so that we don't regress. When
-# all packages are here, switch to a `./...` instead of linting every package
-# individually.
 lint:
-	golint -set_exit_status ./account
-	golint -set_exit_status ./applepaydomain
-	golint -set_exit_status ./balance
-	golint -set_exit_status ./bankaccount
-	golint -set_exit_status ./bitcoinreceiver
-	golint -set_exit_status ./bitcointransaction
-	golint -set_exit_status ./card
-	golint -set_exit_status ./charge
-	golint -set_exit_status ./countryspec
-	golint -set_exit_status ./coupon
-	golint -set_exit_status ./customer
-	golint -set_exit_status ./discount
-	golint -set_exit_status ./dispute
-	golint -set_exit_status ./ephemeralkey
-	golint -set_exit_status ./event
-	golint -set_exit_status ./exchangerate
-	golint -set_exit_status ./fee
-	golint -set_exit_status ./feerefund
-	golint -set_exit_status ./fileupload
-	golint -set_exit_status ./invoice
-	golint -set_exit_status ./invoiceitem
-	golint -set_exit_status ./issuerfraudrecord
-	golint -set_exit_status ./issuing/authorization
-	golint -set_exit_status ./issuing/card
-	golint -set_exit_status ./issuing/cardholder
-	golint -set_exit_status ./issuing/dispute
-	golint -set_exit_status ./issuing/transaction
-	golint -set_exit_status ./loginlink
-	golint -set_exit_status ./order
-	golint -set_exit_status ./orderreturn
-	golint -set_exit_status ./paymentintent
-	golint -set_exit_status ./paymentsource
-	golint -set_exit_status ./payout
-	golint -set_exit_status ./plan
-	golint -set_exit_status ./product
-	golint -set_exit_status ./recipient
-	golint -set_exit_status ./recipienttransfer
-	golint -set_exit_status ./refund
-	golint -set_exit_status ./reversal
-	golint -set_exit_status ./sigma/scheduledqueryrun
-	golint -set_exit_status ./sku
-	golint -set_exit_status ./source
-	golint -set_exit_status ./sourcetransaction
-	golint -set_exit_status ./sub
-	golint -set_exit_status ./subitem
-	golint -set_exit_status ./threedsecure
-	golint -set_exit_status ./token
-	golint -set_exit_status ./topup
-	golint -set_exit_status ./transfer
-	golint -set_exit_status ./usagerecord
+	golint -set_exit_status ./...
 
 test:
 	go test -race ./...

--- a/account.go
+++ b/account.go
@@ -205,7 +205,7 @@ type AdditionalOwnerParams struct {
 	Verification     *IdentityVerificationParams `form:"verification"`
 }
 
-// IdentityVerification represents a verification during account creation/updates.
+// IdentityVerificationParams represents a verification during account creation/updates.
 type IdentityVerificationParams struct {
 	Document     *string `form:"document"`
 	DocumentBack *string `form:"document_back"`
@@ -250,6 +250,9 @@ type PayoutScheduleParams struct {
 	WeeklyAnchor     *string `form:"weekly_anchor"`
 }
 
+
+// AppendTo implements custom encoding logic for PayoutScheduleParams
+// so that we can send a special value for `delay_days` field if needed.
 func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
 	if BoolValue(p.DelayDaysMinimum) {
 		body.Add(form.FormatKey(append(keyParts, "delay_days")), "minimum")
@@ -411,7 +414,7 @@ type LegalEntity struct {
 	Verification             *IdentityVerification `json:"verification"`
 }
 
-// Address is the structure for an account address.
+// AccountAddress is the structure for an account address.
 type AccountAddress struct {
 	City       string `json:"city"`
 	Country    string `json:"country"`

--- a/account.go
+++ b/account.go
@@ -45,8 +45,8 @@ const (
 	IdentityVerificationDetailsCodeScanCorrupt               IdentityVerificationDetailsCode = "scan_corrupt"
 	IdentityVerificationDetailsCodeScanFailedGreyscale       IdentityVerificationDetailsCode = "scan_failed_greyscale"
 	IdentityVerificationDetailsCodeScanFailedOther           IdentityVerificationDetailsCode = "scan_failed_other"
-	IdentityVerificationDetailsCodeScanIdCountryNotSupported IdentityVerificationDetailsCode = "scan_id_country_not_supported"
-	IdentityVerificationDetailsCodeScanIdTypeNotSupported    IdentityVerificationDetailsCode = "scan_id_type_not_supported"
+	IdentityVerificationDetailsCodeScanIDCountryNotSupported IdentityVerificationDetailsCode = "scan_id_country_not_supported"
+	IdentityVerificationDetailsCodeScanIDTypeNotSupported    IdentityVerificationDetailsCode = "scan_id_type_not_supported"
 	IdentityVerificationDetailsCodeScanNameMismatch          IdentityVerificationDetailsCode = "scan_name_mismatch"
 	IdentityVerificationDetailsCodeScanNotReadable           IdentityVerificationDetailsCode = "scan_not_readable"
 	IdentityVerificationDetailsCodeScanNotUploaded           IdentityVerificationDetailsCode = "scan_not_uploaded"
@@ -249,7 +249,6 @@ type PayoutScheduleParams struct {
 	MonthlyAnchor    *int64  `form:"monthly_anchor"`
 	WeeklyAnchor     *string `form:"weekly_anchor"`
 }
-
 
 // AppendTo implements custom encoding logic for PayoutScheduleParams
 // so that we can send a special value for `delay_days` field if needed.

--- a/account.go
+++ b/account.go
@@ -232,7 +232,7 @@ type AccountExternalAccountParams struct {
 
 // AppendTo implements custom encoding logic for AccountExternalAccountParams
 // so that we can send the special required `object` field up along with the
-// other specified parameters or the token value
+// other specified parameters or the token value.
 func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.Token != nil {
 		body.Add(form.FormatKey(keyParts), StringValue(p.Token))

--- a/account.go
+++ b/account.go
@@ -9,6 +9,7 @@ import (
 // AccountType is the type of an account.
 type AccountType string
 
+// List of values that AccountType can take.
 const (
 	AccountTypeCustom   AccountType = "custom"
 	AccountTypeExpress  AccountType = "express"
@@ -18,6 +19,7 @@ const (
 // ExternalAccountType is the type of an external account.
 type ExternalAccountType string
 
+// List of values that ExternalAccountType can take.
 const (
 	ExternalAccountTypeBankAccount ExternalAccountType = "bank_account"
 	ExternalAccountTypeCard        ExternalAccountType = "card"
@@ -26,6 +28,7 @@ const (
 // LegalEntityType describes the types for a legal entity.
 type LegalEntityType string
 
+// List of values that LegalEntityType can take.
 const (
 	LegalEntityTypeCompany    LegalEntityType = "company"
 	LegalEntityTypeIndividual LegalEntityType = "individual"
@@ -35,6 +38,7 @@ const (
 // verification state of a legal entity
 type IdentityVerificationDetailsCode string
 
+// List of values that IdentityVerificationDetailsCode can take.
 const (
 	IdentityVerificationDetailsCodeFailedKeyedIdentity       IdentityVerificationDetailsCode = "failed_keyed_identity"
 	IdentityVerificationDetailsCodeFailedOther               IdentityVerificationDetailsCode = "failed_other"
@@ -51,6 +55,7 @@ const (
 // IdentityVerificationDisabledReason describes the valid reason to disable account
 type IdentityVerificationDisabledReason string
 
+// List of values that IdentityVerificationDisabledReason can take.
 const (
 	IdentityVerificationDisabledReasonFieldsNeeded           IdentityVerificationDisabledReason = "fields_needed"
 	IdentityVerificationDisabledReasonListed                 IdentityVerificationDisabledReason = "listed"
@@ -65,15 +70,17 @@ const (
 // IdentityVerificationStatus describes the different statuses for identity verification.
 type IdentityVerificationStatus string
 
+// List of values that IdentityVerificationStatus can take.
 const (
 	IdentityVerificationStatusPending    IdentityVerificationStatus = "pending"
 	IdentityVerificationStatusUnverified IdentityVerificationStatus = "unverified"
 	IdentityVerificationStatusVerified   IdentityVerificationStatus = "verified"
 )
 
-// Interval describes the payout interval.
+// PayoutInterval describes the payout interval.
 type PayoutInterval string
 
+// List of values that PayoutInterval can take.
 const (
 	PayoutIntervalDaily   PayoutInterval = "daily"
 	PayoutIntervalManual  PayoutInterval = "manual"
@@ -84,6 +91,7 @@ const (
 // AccountRejectReason describes the valid reason to reject an account
 type AccountRejectReason string
 
+// List of values that AccountRejectReason can take.
 const (
 	AccountRejectReasonFraud          AccountRejectReason = "fraud"
 	AccountRejectReasonOther          AccountRejectReason = "other"

--- a/address.go
+++ b/address.go
@@ -1,6 +1,6 @@
 package stripe
 
-// Standard address parameters.
+// AddressParams describes the common parameters for an Address.
 type AddressParams struct {
 	City       *string `form:"city"`
 	Country    *string `form:"country"`
@@ -10,7 +10,7 @@ type AddressParams struct {
 	State      *string `form:"state"`
 }
 
-// Standard address resource.
+// Address describes common properties for an Address hash.
 type Address struct {
 	City       string `json:"city"`
 	Country    string `json:"country"`

--- a/application.go
+++ b/application.go
@@ -2,6 +2,7 @@ package stripe
 
 import "encoding/json"
 
+// Application describes the properties for an Application.
 type Application struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/balance.go
+++ b/balance.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // BalanceTransactionStatus is the list of allowed values for the balance transaction's status.
 type BalanceTransactionStatus string
 
+// List of values that BalanceTransactionStatus can take.
 const (
 	BalanceTransactionStatusAvailable BalanceTransactionStatus = "available"
 	BalanceTransactionStatusPending   BalanceTransactionStatus = "pending"
@@ -13,6 +14,7 @@ const (
 // BalanceTransactionType is the list of allowed values for the balance transaction's type.
 type BalanceTransactionType string
 
+// List of values that BalanceTransactionType can take.
 const (
 	BalanceTransactionTypeAdjustment                      BalanceTransactionType = "adjustment"
 	BalanceTransactionTypeApplicationFee                  BalanceTransactionType = "application_fee"
@@ -39,6 +41,7 @@ const (
 // BalanceTransactionSourceType consts represent valid balance transaction sources.
 type BalanceTransactionSourceType string
 
+// List of values that BalanceTransactionSourceType can take.
 const (
 	BalanceTransactionSourceTypeApplicationFee       BalanceTransactionSourceType = "application_fee"
 	BalanceTransactionSourceTypeCharge               BalanceTransactionSourceType = "charge"

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -127,6 +127,9 @@ type BankAccountListParams struct {
 	Customer *string `form:"-"`
 }
 
+// AppendTo implements custom encoding logic for BankAccountListParams
+// so that we can send the special required `object` field up along with the
+// other specified parameters.
 func (p *BankAccountListParams) AppendTo(body *form.Values, keyParts []string) {
 	body.Add(form.FormatKey(append(keyParts, "object")), "bank_account")
 }

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -10,6 +10,7 @@ import (
 // BankAccountStatus is the list of allowed values for the bank account's status.
 type BankAccountStatus string
 
+// List of values that BankAccountStatus can take.
 const (
 	BankAccountStatusErrored            BankAccountStatus = "errored"
 	BankAccountStatusNew                BankAccountStatus = "new"
@@ -21,6 +22,7 @@ const (
 // BankAccountAccountHolderType is the list of allowed values for the bank account holder type.
 type BankAccountAccountHolderType string
 
+// List of values that BankAccountAccountHolderType can take.
 const (
 	BankAccountAccountHolderTypeCompany    BankAccountAccountHolderType = "company"
 	BankAccountAccountHolderTypeIndividual BankAccountAccountHolderType = "individual"

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -41,7 +41,7 @@ type BitcoinReceiver struct {
 	AmountReceived        int64                   `json:"amount_received"`
 	BitcoinAmount         int64                   `json:"bitcoin_amount"`
 	BitcoinAmountReceived int64                   `json:"bitcoin_amount_received"`
-	BitcoinUri            string                  `json:"bitcoin_uri"`
+	BitcoinURI            string                  `json:"bitcoin_uri"`
 	Created               int64                   `json:"created"`
 	Currency              Currency                `json:"currency"`
 	Customer              string                  `json:"customer"`

--- a/card.go
+++ b/card.go
@@ -10,6 +10,7 @@ import (
 // CardBrand is the list of allowed values for the card's brand.
 type CardBrand string
 
+// List of values that CardBrand can take.
 const (
 	CardBrandAmex       CardBrand = "American Express"
 	CardBrandDiscover   CardBrand = "Discover"
@@ -24,6 +25,7 @@ const (
 // CardFunding is the list of allowed values for the card's funding.
 type CardFunding string
 
+// List of values that CardFunding can take.
 const (
 	CardFundingCredit  CardFunding = "credit"
 	CardFundingDebit   CardFunding = "debit"
@@ -34,6 +36,7 @@ const (
 // CardTokenizationMethod is the list of allowed values for the card's tokenization method.
 type CardTokenizationMethod string
 
+// List of values that CardTokenizationMethod can take.
 const (
 	TokenizationMethodAndroidPay CardTokenizationMethod = "android_pay"
 	TokenizationMethodApplePay   CardTokenizationMethod = "apple_pay"
@@ -42,6 +45,7 @@ const (
 // CardVerification is the list of allowed verification responses.
 type CardVerification string
 
+// List of values that CardVerification can take.
 const (
 	CardVerificationFail      CardVerification = "fail"
 	CardVerificationPass      CardVerification = "pass"

--- a/card.go
+++ b/card.go
@@ -172,6 +172,9 @@ type CardListParams struct {
 	Recipient  *string `form:"-"`
 }
 
+// AppendTo implements custom encoding logic for CardListParams
+// so that we can send the special required `object` field up along with the
+// other specified parameters.
 func (p *CardListParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.Account != nil || p.Customer != nil {
 		body.Add(form.FormatKey(append(keyParts, "object")), "card")

--- a/charge.go
+++ b/charge.go
@@ -42,7 +42,6 @@ type ChargeLevel3Params struct {
 }
 
 // ChargeParams is the set of parameters that can be used when creating or updating a charge.
-// For more details see https://stripe.com/docs/api#create_charge and https://stripe.com/docs/api#update_charge.
 type ChargeParams struct {
 	Params              `form:"*"`
 	Amount              *int64                 `form:"amount"`
@@ -80,6 +79,7 @@ func (p *ChargeParams) SetSource(sp interface{}) error {
 	return err
 }
 
+// DestinationParams describes the parameters available for the destination hash when creating a charge.
 type DestinationParams struct {
 	Account *string `form:"account"`
 	Amount  *int64  `form:"amount"`
@@ -91,7 +91,6 @@ type FraudDetailsParams struct {
 }
 
 // ChargeListParams is the set of parameters that can be used when listing charges.
-// For more details see https://stripe.com/docs/api#list_charges.
 type ChargeListParams struct {
 	ListParams    `form:"*"`
 	Created       *int64            `form:"created"`
@@ -101,7 +100,6 @@ type ChargeListParams struct {
 }
 
 // CaptureParams is the set of parameters that can be used when capturing a charge.
-// For more details see https://stripe.com/docs/api#charge_capture.
 type CaptureParams struct {
 	Params              `form:"*"`
 	Amount              *int64   `form:"amount"`
@@ -111,7 +109,7 @@ type CaptureParams struct {
 	StatementDescriptor *string  `form:"statement_descriptor"`
 }
 
-// ChargeLevel3LineItems represents a line item on level III data.
+// ChargeLevel3LineItem represents a line item on level III data.
 // This is in private beta and would be empty for most integrations
 type ChargeLevel3LineItem struct {
 	DiscountAmount     int64  `json:"discount_amount"`
@@ -231,7 +229,7 @@ type ShippingDetails struct {
 	TrackingNumber string   `json:"tracking_number"`
 }
 
-var depth int = -1
+var depth = -1
 
 // UnmarshalJSON handles deserialization of a ChargeOutcomeRule.
 // This custom unmarshaling is needed because the resulting

--- a/charge.go
+++ b/charge.go
@@ -7,6 +7,7 @@ import (
 // ChargeFraudUserReport is the list of allowed values for reporting fraud.
 type ChargeFraudUserReport string
 
+// List of values that ChargeFraudUserReport can take.
 const (
 	ChargeFraudUserReportFraudulent ChargeFraudUserReport = "fraudulent"
 	ChargeFraudUserReportSafe       ChargeFraudUserReport = "safe"
@@ -15,6 +16,7 @@ const (
 // ChargeFraudStripeReport is the list of allowed values for reporting fraud.
 type ChargeFraudStripeReport string
 
+// List of values that ChargeFraudStripeReport can take.
 const (
 	ChargeFraudStripeReportFraudulent ChargeFraudStripeReport = "fraudulent"
 )

--- a/client/api.go
+++ b/client/api.go
@@ -2,7 +2,7 @@
 package client
 
 import (
-	. "github.com/stripe/stripe-go"
+	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/account"
 	"github.com/stripe/stripe-go/applepaydomain"
 	"github.com/stripe/stripe-go/balance"
@@ -155,9 +155,12 @@ type API struct {
 
 // Init initializes the Stripe client with the appropriate secret key
 // as well as providing the ability to override the backend as needed.
-func (a *API) Init(key string, backends *Backends) {
+func (a *API) Init(key string, backends *stripe.Backends) {
 	if backends == nil {
-		backends = &Backends{API: GetBackend(APIBackend), Uploads: GetBackend(UploadsBackend)}
+		backends = &stripe.Backends{
+			API:     stripe.GetBackend(stripe.APIBackend),
+			Uploads: stripe.GetBackend(stripe.UploadsBackend),
+		}
 	}
 
 	a.Account = &account.Client{B: backends.API, Key: key}
@@ -212,7 +215,7 @@ func (a *API) Init(key string, backends *Backends) {
 
 // New creates a new Stripe client with the appropriate secret key
 // as well as providing the ability to override the backends as needed.
-func New(key string, backends *Backends) *API {
+func New(key string, backends *stripe.Backends) *API {
 	api := API{}
 	api.Init(key, backends)
 	return &api

--- a/coupon.go
+++ b/coupon.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // CouponDuration is the list of allowed values for the coupon's duration.
 type CouponDuration string
 
+// List of values that CouponDuration can take.
 const (
 	CouponDurationForever   CouponDuration = "forever"
 	CouponDurationOnce      CouponDuration = "once"

--- a/currency.go
+++ b/currency.go
@@ -4,6 +4,7 @@ package stripe
 // For more details see https://support.stripe.com/questions/which-currencies-does-stripe-support.
 type Currency string
 
+// List of values that Currency can take.
 const (
 	CurrencyAED Currency = "aed" // United Arab Emirates Dirham
 	CurrencyAFN Currency = "afn" // Afghan Afghani

--- a/dispute.go
+++ b/dispute.go
@@ -7,6 +7,7 @@ import (
 // DisputeReason is the list of allowed values for a discount's reason.
 type DisputeReason string
 
+// List of values that DisputeReason can take.
 const (
 	DisputeReasonCreditNotProcessed   DisputeReason = "credit_not_processed"
 	DisputeReasonDuplicate            DisputeReason = "duplicate"
@@ -21,6 +22,7 @@ const (
 // DisputeStatus is the list of allowed values for a discount's status.
 type DisputeStatus string
 
+// List of values that DisputeStatus can take.
 const (
 	DisputeStatusChargeRefunded       DisputeStatus = "charge_refunded"
 	DisputeStatusLost                 DisputeStatus = "lost"

--- a/error.go
+++ b/error.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // ErrorType is the list of allowed values for the error's type.
 type ErrorType string
 
+// List of values that ErrorType can take.
 const (
 	ErrorTypeAPI            ErrorType = "api_error"
 	ErrorTypeAPIConnection  ErrorType = "api_connection_error"
@@ -18,6 +19,7 @@ const (
 // ErrorCode is the list of allowed values for the error's code.
 type ErrorCode string
 
+// List of values that ErrorCode can take.
 const (
 	ErrorCodeCardDeclined       ErrorCode = "card_declined"
 	ErrorCodeExpiredCard        ErrorCode = "expired_card"

--- a/fileupload.go
+++ b/fileupload.go
@@ -10,6 +10,7 @@ import (
 // FileUploadPurpose is the purpose of a particular file upload.
 type FileUploadPurpose string
 
+// List of values that FileUploadPurpose can take.
 const (
 	FileUploadPurposeDisputeEvidence  FileUploadPurpose = "dispute_evidence"
 	FileUploadPurposeIdentityDocument FileUploadPurpose = "identity_document"

--- a/invoice.go
+++ b/invoice.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // InvoiceLineType is the list of allowed values for the invoice line's type.
 type InvoiceLineType string
 
+// List of values that InvoiceLineType can take.
 const (
 	InvoiceLineTypeInvoiceItem  InvoiceLineType = "invoiceitem"
 	InvoiceLineTypeSubscription InvoiceLineType = "subscription"
@@ -13,6 +14,7 @@ const (
 // InvoiceBilling is the type of billing method for this invoice.
 type InvoiceBilling string
 
+// List of values that InvoiceBilling can take.
 const (
 	InvoiceBillingChargeAutomatically InvoiceBilling = "charge_automatically"
 	InvoiceBillingSendInvoice         InvoiceBilling = "send_invoice"
@@ -21,6 +23,7 @@ const (
 // InvoiceBillingReason is the reason why a given invoice was created
 type InvoiceBillingReason string
 
+// List of values that InvoiceBillingReason can take.
 const (
 	InvoiceBillingReasonManual             InvoiceBillingReason = "manual"
 	InvoiceBillingReasonSubscription       InvoiceBillingReason = "subscription"

--- a/issuerfraudrecord.go
+++ b/issuerfraudrecord.go
@@ -3,6 +3,7 @@ package stripe
 // IssuerFraudType are strings that map to the fraud label category from the issuer.
 type IssuerFraudType string
 
+// List of values that IssuerFraudType can take.
 const (
 	IssuerFraudTypeCardNeverReceived         IssuerFraudType = "card_never_received"
 	IssuerFraudTypeFraudulentCardApplication IssuerFraudType = "fraudulent_card_application"

--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -125,7 +125,7 @@ type IssuingMerchantData struct {
 	City       string `json:"city"`
 	Country    string `json:"country"`
 	Name       string `json:"name"`
-	NetworkId  string `json:"network_id"`
+	NetworkID  string `json:"network_id"`
 	PostalCode string `json:"postal_code"`
 	State      string `json:"state"`
 }

--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -6,6 +6,7 @@ import "encoding/json"
 // on an issuing authorization.
 type IssuingAuthorizationAuthorizationMethod string
 
+// List of values that IssuingAuthorizationAuthorizationMethod can take.
 const (
 	IssuingAuthorizationAuthorizationMethodChip        IssuingAuthorizationAuthorizationMethod = "chip"
 	IssuingAuthorizationAuthorizationMethodContactless IssuingAuthorizationAuthorizationMethod = "contactless"
@@ -18,6 +19,7 @@ const (
 // reason on an issuing authorization.
 type IssuingAuthorizationRequestHistoryReason string
 
+// List of values that IssuingAuthorizationRequestHistoryReason can take.
 const (
 	IssuingAuthorizationRequestHistoryReasonAuthorizationControls IssuingAuthorizationRequestHistoryReason = "authorization_controls"
 	IssuingAuthorizationRequestHistoryReasonCardActive            IssuingAuthorizationRequestHistoryReason = "card_active"
@@ -31,6 +33,7 @@ const (
 // IssuingAuthorizationStatus is the possible values for status for an issuing authorization.
 type IssuingAuthorizationStatus string
 
+// List of values that IssuingAuthorizationStatus can take.
 const (
 	IssuingAuthorizationStatusClosed   IssuingAuthorizationStatus = "closed"
 	IssuingAuthorizationStatusPending  IssuingAuthorizationStatus = "pending"
@@ -41,6 +44,7 @@ const (
 // for verification data on an issuing authorization.
 type IssuingAuthorizationVerificationDataCheck string
 
+// List of values that IssuingAuthorizationVerificationDataCheck can take.
 const (
 	IssuingAuthorizationVerificationDataCheckMatch       IssuingAuthorizationVerificationDataCheck = "match"
 	IssuingAuthorizationVerificationDataCheckMismatch    IssuingAuthorizationVerificationDataCheck = "mismatch"

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -6,6 +6,7 @@ import "encoding/json"
 // on an issuing card.
 type IssuingCardShippingStatus string
 
+// List of values that IssuingCardShippingStatus can take.
 const (
 	IssuingCardShippingTypeDelivered IssuingCardShippingStatus = "delivered"
 	IssuingCardShippingTypeFailure   IssuingCardShippingStatus = "failure"
@@ -18,6 +19,7 @@ const (
 // on an issuing card.
 type IssuingCardShippingType string
 
+// List of values that IssuingCardShippingType can take.
 const (
 	IssuingCardShippingTypeBulk       IssuingCardShippingType = "bulk"
 	IssuingCardShippingTypeIndividual IssuingCardShippingType = "individual"
@@ -26,6 +28,7 @@ const (
 // IssuingCardStatus is the list of possible values for status on an issuing card.
 type IssuingCardStatus string
 
+// List of values that IssuingCardStatus can take.
 const (
 	IssuingCardStatusActive   IssuingCardStatus = "active"
 	IssuingCardStatusCanceled IssuingCardStatus = "canceled"
@@ -36,6 +39,7 @@ const (
 // IssuingCardType is the type of an issuing card.
 type IssuingCardType string
 
+// List of values that IssuingCardType can take.
 const (
 	IssuingCardTypePhysical IssuingCardType = "physical"
 	IssuingCardTypeVirtual  IssuingCardType = "virtual"

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // IssuingCardholderStatus is the possible values for status on an issuing cardholder.
 type IssuingCardholderStatus string
 
+// List of values that IssuingCardholderStatus can take.
 const (
 	IssuingCardholderStatusActive   IssuingCardholderStatus = "active"
 	IssuingCardholderStatusInactive IssuingCardholderStatus = "inactive"
@@ -13,6 +14,7 @@ const (
 // IssuingCardholderType is the type of an issuing cardholder.
 type IssuingCardholderType string
 
+// List of values that IssuingCardholderType can take.
 const (
 	IssuingCardholderTypeBusinessEntity IssuingCardholderType = "business_entity"
 	IssuingCardholderTypeIndividual     IssuingCardholderType = "individual"

--- a/issuing_dispute.go
+++ b/issuing_dispute.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // IssuingDisputeReason is the list of possible values for status on an issuing dispute.
 type IssuingDisputeReason string
 
+// List of values that IssuingDisputeReason can take.
 const (
 	IssuingDisputeReasonFraudulent IssuingDisputeReason = "fraudulent"
 	IssuingDisputeReasonOther      IssuingDisputeReason = "other"
@@ -13,6 +14,7 @@ const (
 // IssuingDisputeStatus is the list of possible values for status on an issuing dispute.
 type IssuingDisputeStatus string
 
+// List of values that IssuingDisputeStatus can take.
 const (
 	IssuingDisputeStatusLost        IssuingDisputeStatus = "lost"
 	IssuingDisputeStatusUnderReview IssuingDisputeStatus = "under_review"

--- a/issuing_transaction.go
+++ b/issuing_transaction.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // IssuingTransactionType is the type of an issuing transaction.
 type IssuingTransactionType string
 
+// List of values that IssuingTransactionType can take.
 const (
 	IssuingTransactionTypeCapture        IssuingTransactionType = "capture"
 	IssuingTransactionTypeCashWithdrawal IssuingTransactionType = "cash_withdrawal"

--- a/order.go
+++ b/order.go
@@ -36,6 +36,7 @@ const (
 	OrderItemTypeTax      OrderItemType = "tax"
 )
 
+// OrderParams is the set of parameters that can be used when creating an order.
 type OrderParams struct {
 	Params   `form:"*"`
 	Coupon   *string            `form:"coupon"`
@@ -46,12 +47,15 @@ type OrderParams struct {
 	Shipping *ShippingParams    `form:"shipping"`
 }
 
+// ShippingParams is the set of parameters that can be used for the shipping hash
+// on order creation.
 type ShippingParams struct {
 	Address *AddressParams `form:"address"`
 	Name    *string        `form:"name"`
 	Phone   *string        `form:"phone"`
 }
 
+// OrderUpdateParams is the set of parameters that can be used when updating an order.
 type OrderUpdateParams struct {
 	Params                 `form:"*"`
 	Coupon                 *string                    `form:"coupon"`
@@ -60,18 +64,20 @@ type OrderUpdateParams struct {
 	Status                 *string                    `form:"status"`
 }
 
+// OrderUpdateShippingParams is the set of parameters that can be used for the shipping
+// hash on order update.
 type OrderUpdateShippingParams struct {
 	Carrier        *string `form:"carrier"`
 	TrackingNumber *string `form:"tracking_number"`
 }
 
-// OrderReturnParams is the set of parameters that can be used when returning
-// orders. For more details, see: https://stripe.com/docs/api#return_order.
+// OrderReturnParams is the set of parameters that can be used when returning orders.
 type OrderReturnParams struct {
 	Params `form:"*"`
 	Items  []*OrderItemParams `form:"items,indexed"`
 }
 
+// Shipping describes the shipping hash on an order.
 type Shipping struct {
 	Address        *Address `json:"address"`
 	Carrier        string   `json:"carrier"`
@@ -80,6 +86,7 @@ type Shipping struct {
 	TrackingNumber string   `json:"tracking_number"`
 }
 
+// ShippingMethod describes a shipping method as available on an order.
 type ShippingMethod struct {
 	Amount           int64             `json:"amount"`
 	ID               string            `json:"id"`
@@ -88,6 +95,8 @@ type ShippingMethod struct {
 	Description      string            `json:"description"`
 }
 
+// DeliveryEstimate represent the properties available for a shipping method's
+// estimated delivery.
 type DeliveryEstimate struct {
 	// If Type == Exact
 	Date string `json:"date"`
@@ -97,6 +106,8 @@ type DeliveryEstimate struct {
 	Type     OrderDeliveryEstimateType `json:"type"`
 }
 
+// Order is the resource representing a Stripe charge.
+// For more details see https://stripe.com/docs/api#orders.
 type Order struct {
 	Amount                 int64             `json:"amount"`
 	AmountReturned         int64             `json:"amount_returned"`
@@ -126,9 +137,7 @@ type OrderList struct {
 	Data []*Order `json:"data"`
 }
 
-// OrderListParams is the set of parameters that can be used when
-// listing orders. For more details, see:
-// https://stripe.com/docs/api#list_orders.
+// OrderListParams is the set of parameters that can be used when listing orders.
 type OrderListParams struct {
 	ListParams   `form:"*"`
 	Created      *int64            `form:"created"`
@@ -138,8 +147,7 @@ type OrderListParams struct {
 	Status       *string           `form:"status"`
 }
 
-// StatusTransitions are the timestamps at which the order status was updated
-// https://stripe.com/docs/api#order_object
+// StatusTransitions are the timestamps at which the order status was updated.
 type StatusTransitions struct {
 	Canceled  int64 `json:"canceled"`
 	Fulfilled int64 `json:"fulfiled"`
@@ -147,9 +155,7 @@ type StatusTransitions struct {
 	Returned  int64 `json:"returned"`
 }
 
-// OrderPayParams is the set of parameters that can be used when
-// paying orders. For more details, see:
-// https://stripe.com/docs/api#pay_order.
+// OrderPayParams is the set of parameters that can be used when paying orders.
 type OrderPayParams struct {
 	Params         `form:"*"`
 	ApplicationFee *int64        `form:"application_fee"`
@@ -158,6 +164,7 @@ type OrderPayParams struct {
 	Source         *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 
+// OrderItemParams is the set of parameters describing an order item on order creation or update.
 type OrderItemParams struct {
 	Amount      *int64  `form:"amount"`
 	Currency    *string `form:"currency"`
@@ -167,6 +174,7 @@ type OrderItemParams struct {
 	Type        *string `form:"type"`
 }
 
+// OrderItem is the resource representing an order item.
 type OrderItem struct {
 	Amount      int64         `json:"amount"`
 	Currency    Currency      `json:"currency"`

--- a/order.go
+++ b/order.go
@@ -7,6 +7,7 @@ import (
 // OrderStatus represents the statuses of an order object.
 type OrderStatus string
 
+// List of values that OrderStatus can take.
 const (
 	OrderStatusCanceled  OrderStatus = "canceled"
 	OrderStatusCreated   OrderStatus = "created"
@@ -18,6 +19,7 @@ const (
 // OrderDeliveryEstimateType represents the type of delivery estimate for shipping methods
 type OrderDeliveryEstimateType string
 
+// List of values that OrderDeliveryEstimateType can take.
 const (
 	OrderDeliveryEstimateTypeExact OrderDeliveryEstimateType = "exact"
 	OrderDeliveryEstimateTypeRange OrderDeliveryEstimateType = "range"
@@ -26,6 +28,7 @@ const (
 // OrderItemType represents the type of order item
 type OrderItemType string
 
+// List of values that OrderItemType can take.
 const (
 	OrderItemTypeDiscount OrderItemType = "discount"
 	OrderItemTypeShipping OrderItemType = "shipping"

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -2,6 +2,8 @@ package stripe
 
 import "encoding/json"
 
+// OrderReturn is the resource representing an order return.
+// For more details see https://stripe.com/docs/api#order_returns.
 type OrderReturn struct {
 	Amount   int64        `json:"amount"`
 	Created  int64        `json:"created"`
@@ -13,14 +15,13 @@ type OrderReturn struct {
 	Refund   *Refund      `json:"refund"`
 }
 
-// OrderReturnList is a list of returns as retrieved from a list endpoint.
+// OrderReturnList is a list of order returns as retrieved from a list endpoint.
 type OrderReturnList struct {
 	ListMeta
 	Data []*OrderReturn `json:"data"`
 }
 
-// OrderReturnListParams is the set of parameters that can be used when listing
-// returns. For more details, see: https://stripe.com/docs/api#list_order_returns.
+// OrderReturnListParams is the set of parameters that can be used when listing order returns.
 type OrderReturnListParams struct {
 	ListParams   `form:"*"`
 	Created      *int64            `form:"created"`

--- a/params.go
+++ b/params.go
@@ -16,7 +16,7 @@ import (
 // Public constants
 //
 
-// Describes possible values for type of pagination when using a List API.
+// Contains constants for the names of parameters used for pagination in list APIs.
 const (
 	EndingBefore  = "ending_before"
 	StartingAfter = "starting_after"

--- a/params.go
+++ b/params.go
@@ -16,6 +16,7 @@ import (
 // Public constants
 //
 
+// Describes possible values for type of pagination when using a List API.
 const (
 	EndingBefore  = "ending_before"
 	StartingAfter = "starting_after"

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -6,6 +6,7 @@ import (
 
 type PaymentIntentCaptureMethod string
 
+// List of values that PaymentIntentCaptureMethod can take.
 const (
 	PaymentIntentCaptureMethodAutomatic PaymentIntentCaptureMethod = "automatic"
 	PaymentIntentCaptureMethodManual    PaymentIntentCaptureMethod = "manual"
@@ -13,6 +14,7 @@ const (
 
 type PaymentIntentConfirmationMethod string
 
+// List of values that PaymentIntentConfirmationMethod can take.
 const (
 	PaymentIntentConfirmationMethodPublishable PaymentIntentConfirmationMethod = "publishable"
 	PaymentIntentConfirmationMethodSecret      PaymentIntentConfirmationMethod = "secret"
@@ -20,12 +22,14 @@ const (
 
 type PaymentIntentNextActionType string
 
+// List of values that PaymentIntentNextActionType can take.
 const (
 	PaymentIntentNextActionAuthorizeWithURL PaymentIntentNextActionType = "authorize_with_url"
 )
 
 type PaymentIntentStatus string
 
+// List of values that PaymentIntentStatus can take.
 const (
 	PaymentIntentStatusCanceled             PaymentIntentStatus = "canceled"
 	PaymentIntentStatusProcessing           PaymentIntentStatus = "processing"

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 )
 
+// PaymentIntentCaptureMethod is the list of allowed values for the capture method.
 type PaymentIntentCaptureMethod string
 
 // List of values that PaymentIntentCaptureMethod can take.
@@ -12,6 +13,7 @@ const (
 	PaymentIntentCaptureMethodManual    PaymentIntentCaptureMethod = "manual"
 )
 
+// PaymentIntentConfirmationMethod is the list of allowed values for the confirmation method.
 type PaymentIntentConfirmationMethod string
 
 // List of values that PaymentIntentConfirmationMethod can take.
@@ -20,6 +22,7 @@ const (
 	PaymentIntentConfirmationMethodSecret      PaymentIntentConfirmationMethod = "secret"
 )
 
+// PaymentIntentNextActionType is the list of allowed values for the next action's type.
 type PaymentIntentNextActionType string
 
 // List of values that PaymentIntentNextActionType can take.
@@ -27,6 +30,7 @@ const (
 	PaymentIntentNextActionAuthorizeWithURL PaymentIntentNextActionType = "authorize_with_url"
 )
 
+// PaymentIntentStatus is the list of allowed values for the payment intent's status.
 type PaymentIntentStatus string
 
 // List of values that PaymentIntentStatus can take.
@@ -40,6 +44,7 @@ const (
 	PaymentIntentStatusSucceeded            PaymentIntentStatus = "succeeded"
 )
 
+// PaymentIntentTransferDataParams is the set of parameters allowed for the transfer hash.
 type PaymentIntentTransferDataParams struct {
 	Amount *int64 `form:"amount"`
 }
@@ -72,6 +77,8 @@ type PaymentIntentListParams struct {
 	ListParams `form:"*"`
 }
 
+// PaymentIntentSourceActionAuthorizeWithURL represents the resource for the next action of type
+// "authorize with url".
 type PaymentIntentSourceActionAuthorizeWithURL struct {
 	URL string `json:"url"`
 }
@@ -82,6 +89,7 @@ type PaymentIntentSourceActionValue struct {
 	AuthorizeWithURL *PaymentIntentSourceActionAuthorizeWithURL `json:"-"`
 }
 
+// PaymentIntentSourceAction represents the type of action to take on a payment intent.
 type PaymentIntentSourceAction struct {
 	Type  PaymentIntentNextActionType     `json:"type"`
 	Value *PaymentIntentSourceActionValue `json:"-"`
@@ -116,12 +124,13 @@ func (s *PaymentIntentSourceAction) UnmarshalJSON(data []byte) error {
 	return err
 }
 
+// PaymentIntentTransferData represents the information for the transfer associated with a payment intent.
 type PaymentIntentTransferData struct {
 	Amount int64 `json:"amount"`
 }
 
-// Payout is the resource representing a Stripe payout.
-// For more details see https://stripe.com/docs/api#payouts.
+// PaymentIntent is the resource representing a Stripe payout.
+// For more details see https://stripe.com/docs/api#payment_intents.
 type PaymentIntent struct {
 	AllowedSourceTypes  []string                        `json:"allowed_source_types"`
 	Amount              int64                           `json:"amount"`
@@ -153,7 +162,7 @@ type PaymentIntent struct {
 	TransferGroup       string                          `json:"transfer_group"`
 }
 
-// PayoutList is a list of payouts as retrieved from a list endpoint.
+// PaymentIntentList is a list of payment intents as retrieved from a list endpoint.
 type PaymentIntentList struct {
 	ListMeta
 	Data []*PaymentIntent `json:"data"`

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -26,6 +26,7 @@ type SourceParams struct {
 	Token *string     `form:"source"`
 }
 
+// AppendTo implements custom encoding logic for SourceParams.
 func (p *SourceParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.Card != nil {
 		p.Card.AppendToAsCardSourceOrExternalAccount(body, keyParts)

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -10,6 +10,7 @@ import (
 // PaymentSourceType consts represent valid payment sources.
 type PaymentSourceType string
 
+// List of values that PaymentSourceType can take.
 const (
 	PaymentSourceTypeAccount         PaymentSourceType = "account"
 	PaymentSourceTypeBankAccount     PaymentSourceType = "bank_account"

--- a/payout.go
+++ b/payout.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // PayoutDestinationType consts represent valid payout destinations.
 type PayoutDestinationType string
 
+// List of values that PayoutDestinationType can take.
 const (
 	PayoutDestinationTypeBankAccount PayoutDestinationType = "bank_account"
 	PayoutDestinationTypeCard        PayoutDestinationType = "card"
@@ -13,6 +14,7 @@ const (
 // PayoutFailureCode is the list of allowed values for the payout's failure code.
 type PayoutFailureCode string
 
+// List of values that PayoutFailureCode can take.
 const (
 	PayoutFailureCodeAccountClosed         PayoutFailureCode = "account_closed"
 	PayoutFailureCodeAccountFrozen         PayoutFailureCode = "account_frozen"
@@ -29,6 +31,7 @@ const (
 // PayoutSourceType is the list of allowed values for the payout's source_type field.
 type PayoutSourceType string
 
+// List of values that PayoutSourceType can take.
 const (
 	PayoutSourceTypeAlipayAccount   PayoutSourceType = "alipay_account"
 	PayoutSourceTypeBankAccount     PayoutSourceType = "bank_account"
@@ -39,6 +42,7 @@ const (
 // PayoutStatus is the list of allowed values for the payout's status.
 type PayoutStatus string
 
+// List of values that PayoutStatus can take.
 const (
 	PayoutStatusCanceled  PayoutStatus = "canceled"
 	PayoutStatusFailed    PayoutStatus = "failed"
@@ -50,6 +54,7 @@ const (
 // PayoutType is the list of allowed values for the payout's type.
 type PayoutType string
 
+// List of values that PayoutType can take.
 const (
 	PayoutTypeBank PayoutType = "bank_account"
 	PayoutTypeCard PayoutType = "card"
@@ -58,6 +63,7 @@ const (
 // PayoutMethodType represents the type of payout
 type PayoutMethodType string
 
+// List of values that PayoutMethodType can take.
 const (
 	PayoutMethodInstant  PayoutMethodType = "instant"
 	PayoutMethodStandard PayoutMethodType = "standard"

--- a/plan.go
+++ b/plan.go
@@ -9,6 +9,7 @@ import (
 // PlanInterval is the list of allowed values for a plan's interval.
 type PlanInterval string
 
+// List of values that PlanInterval can take.
 const (
 	PlanIntervalDay   PlanInterval = "day"
 	PlanIntervalWeek  PlanInterval = "week"
@@ -19,6 +20,7 @@ const (
 // PlanBillingScheme is the list of allowed values for a plan's billing scheme.
 type PlanBillingScheme string
 
+// List of values that PlanBillingScheme can take.
 const (
 	PlanBillingSchemePerUnit PlanBillingScheme = "per_unit"
 	PlanBillingSchemeTiered  PlanBillingScheme = "tiered"
@@ -27,6 +29,7 @@ const (
 // PlanUsageType is the list of allowed values for a plan's usage type.
 type PlanUsageType string
 
+// List of values that PlanUsageType can take.
 const (
 	PlanUsageTypeLicensed PlanUsageType = "licensed"
 	PlanUsageTypeMetered  PlanUsageType = "metered"
@@ -35,6 +38,7 @@ const (
 // PlanTiersMode is the list of allowed values for a plan's tiers mode.
 type PlanTiersMode string
 
+// List of values that PlanTiersMode can take.
 const (
 	PlanTiersModeGraduated PlanTiersMode = "graduated"
 	PlanTiersModeVolume    PlanTiersMode = "volume"
@@ -43,6 +47,7 @@ const (
 // PlanTransformUsageRound is the list of allowed values for a plan's transform usage round logic.
 type PlanTransformUsageRound string
 
+// List of values that PlanTransformUsageRound can take.
 const (
 	PlanTransformUsageRoundDown PlanTransformUsageRound = "down"
 	PlanTransformUsageRoundUp   PlanTransformUsageRound = "up"
@@ -51,6 +56,7 @@ const (
 // PlanAggregateUsage is the list of allowed values for a plan's aggregate usage.
 type PlanAggregateUsage string
 
+// List of values that PlanAggregateUsage can take.
 const (
 	PlanAggregateUsageLastDuringPeriod PlanAggregateUsage = "last_during_period"
 	PlanAggregateUsageLastEver         PlanAggregateUsage = "last_ever"

--- a/product.go
+++ b/product.go
@@ -11,8 +11,8 @@ const (
 	ProductTypeService ProductType = "service"
 )
 
-// PackageDimensions represents the dimension of a product or a sku from the
-// perspective of shipping.
+// PackageDimensionsParams represents the set of parameters for the the dimension of a
+// product or a sku from the perspective of shipping .
 type PackageDimensionsParams struct {
 	Height *float64 `form:"height"`
 	Length *float64 `form:"length"`
@@ -20,10 +20,7 @@ type PackageDimensionsParams struct {
 	Width  *float64 `form:"width"`
 }
 
-// ProductParams is the set of parameters that can be used
-// when creating or updating a product.
-// For more details, see https://stripe.com/docs/api#create_product
-// and https://stripe.com/docs/api#update_product.
+// ProductParams is the set of parameters that can be used when creating or updating a product.
 type ProductParams struct {
 	Params              `form:"*"`
 	Active              *bool                    `form:"active"`
@@ -80,9 +77,7 @@ type ProductList struct {
 	Data []*Product `json:"data"`
 }
 
-// ProductListParams is the set of parameters that can be used when
-// listing products. For more details, see:
-// https://stripe.com/docs/api#list_products.
+// ProductListParams is the set of parameters that can be used when listing products.
 type ProductListParams struct {
 	ListParams `form:"*"`
 	Active     *bool     `form:"active"`

--- a/product.go
+++ b/product.go
@@ -12,7 +12,7 @@ const (
 )
 
 // PackageDimensionsParams represents the set of parameters for the the dimension of a
-// product or a sku from the perspective of shipping .
+// product or a SKU from the perspective of shipping .
 type PackageDimensionsParams struct {
 	Height *float64 `form:"height"`
 	Length *float64 `form:"length"`
@@ -39,7 +39,7 @@ type ProductParams struct {
 	URL                 *string                  `form:"url"`
 }
 
-// PackageDimensions represents the dimension of a product or a sku from the
+// PackageDimensions represents the dimension of a product or a SKU from the
 // perspective of shipping.
 type PackageDimensions struct {
 	Height float64 `json:"height"`

--- a/product.go
+++ b/product.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // ProductType is the type of a product.
 type ProductType string
 
+// List of values that ProductType can take.
 const (
 	ProductTypeGood    ProductType = "good"
 	ProductTypeService ProductType = "service"

--- a/recipient.go
+++ b/recipient.go
@@ -9,6 +9,7 @@ import (
 // RecipientType is the list of allowed values for the recipient's type.
 type RecipientType string
 
+// List of values that RecipientType can take.
 const (
 	RecipientTypeIndividual  RecipientType = "individual"
 	RecipientTypeCorporation RecipientType = "corporation"

--- a/recipienttransfer.go
+++ b/recipienttransfer.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // RecipientTransferDestinationType consts represent valid recipient_transfer destinations.
 type RecipientTransferDestinationType string
 
+// List of values that RecipientTransferDestinationType can take.
 const (
 	RecipientTransferDestinationBankAccount RecipientTransferDestinationType = "bank_account"
 	RecipientTransferDestinationCard        RecipientTransferDestinationType = "card"
@@ -13,6 +14,7 @@ const (
 // RecipientTransferFailureCode is the list of allowed values for the recipient_transfer's failure code.
 type RecipientTransferFailureCode string
 
+// List of values that RecipientTransferFailureCode can take.
 const (
 	RecipientTransferFailureCodeAccountClosed         RecipientTransferFailureCode = "account_closed"
 	RecipientTransferFailureCodeAccountFrozen         RecipientTransferFailureCode = "account_frozen"
@@ -29,6 +31,7 @@ const (
 // RecipientTransferSourceType is the list of allowed values for the recipient_transfer's source_type field.
 type RecipientTransferSourceType string
 
+// List of values that RecipientTransferSourceType can take.
 const (
 	RecipientTransferSourceTypeAlipayAccount   RecipientTransferSourceType = "alipay_account"
 	RecipientTransferSourceTypeBankAccount     RecipientTransferSourceType = "bank_account"
@@ -39,6 +42,7 @@ const (
 // RecipientTransferStatus is the list of allowed values for the recipient_transfer's status.
 type RecipientTransferStatus string
 
+// List of values that RecipientTransferStatus can take.
 const (
 	RecipientTransferStatusFailed    RecipientTransferStatus = "failed"
 	RecipientTransferStatusInTransit RecipientTransferStatus = "in_transit"
@@ -49,6 +53,7 @@ const (
 // RecipientTransferType is the list of allowed values for the recipient_transfer's type.
 type RecipientTransferType string
 
+// List of values that RecipientTransferType can take.
 const (
 	RecipientTransferTypeBankAccount RecipientTransferType = "bank_account"
 	RecipientTransferTypeCard        RecipientTransferType = "card"
@@ -57,6 +62,7 @@ const (
 // RecipientTransferMethodType represents the type of recipient_transfer
 type RecipientTransferMethodType string
 
+// List of values that RecipientTransferMethodType can take.
 const (
 	RecipientTransferMethodInstant  RecipientTransferMethodType = "instant"
 	RecipientTransferMethodStandard RecipientTransferMethodType = "standard"

--- a/refund.go
+++ b/refund.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // RefundReason is, if set, the reason the refund is being made
 type RefundReason string
 
+// List of values that RefundReason can take.
 const (
 	RefundReasonDuplicate           RefundReason = "duplicate"
 	RefundReasonFraudulent          RefundReason = "fraudulent"
@@ -14,6 +15,7 @@ const (
 // RefundStatus is the status of the refund.
 type RefundStatus string
 
+// List of values that RefundStatus can take.
 const (
 	RefundStatusCanceled  RefundStatus = "canceled"
 	RefundStatusFailed    RefundStatus = "failed"

--- a/review.go
+++ b/review.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // ReviewReasonType describes the reason why the review is open or closed.
 type ReviewReasonType string
 
+// List of values that ReviewReasonType can take.
 const (
 	ReviewReasonApproved        ReviewReasonType = "approved"
 	ReviewReasonDisputed        ReviewReasonType = "disputed"

--- a/review.go
+++ b/review.go
@@ -15,6 +15,8 @@ const (
 	ReviewReasonRule            ReviewReasonType = "rule"
 )
 
+// Review is the resource representing a Radar review.
+// For more details see https://stripe.com/docs/api#reviews.
 type Review struct {
 	Charge   *Charge          `json:"charge"`
 	Created  int64            `json:"created"`
@@ -24,6 +26,9 @@ type Review struct {
 	Reason   ReviewReasonType `json:"reason"`
 }
 
+// UnmarshalJSON handles deserialization of a Review.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
 func (r *Review) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
 		r.ID = id

--- a/sigma_scheduledqueryrun.go
+++ b/sigma_scheduledqueryrun.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // SigmaScheduledQueryRunStatus is the possible values for status for a scheduled query run.
 type SigmaScheduledQueryRunStatus string
 
+// List of values that SigmaScheduledQueryRunStatus can take.
 const (
 	SigmaScheduledQueryRunStatusCanceled  SigmaScheduledQueryRunStatus = "canceled"
 	SigmaScheduledQueryRunStatusCompleted SigmaScheduledQueryRunStatus = "completed"

--- a/sku.go
+++ b/sku.go
@@ -22,7 +22,7 @@ const (
 	SKUInventoryValueOutOfStock SKUInventoryValue = "out_of_stock"
 )
 
-// InventoryParams is the set of parameters allowed as inventory on a SKU
+// InventoryParams is the set of parameters allowed as inventory on a SKU.
 type InventoryParams struct {
 	Quantity *int64  `form:"quantity"`
 	Type     *string `form:"type"`

--- a/sku.go
+++ b/sku.go
@@ -22,12 +22,14 @@ const (
 	SKUInventoryValueOutOfStock SKUInventoryValue = "out_of_stock"
 )
 
+// InventoryParams is the set of parameters allowed as inventory on a SKU
 type InventoryParams struct {
 	Quantity *int64  `form:"quantity"`
 	Type     *string `form:"type"`
 	Value    *string `form:"value"`
 }
 
+// SKUParams is the set of parameters allowed on SKU creation or update.
 type SKUParams struct {
 	Params            `form:"*"`
 	Active            *bool                    `form:"active"`
@@ -42,12 +44,15 @@ type SKUParams struct {
 	Product           *string                  `form:"product"`
 }
 
+// Inventory represents the inventory options of a SKU.
 type Inventory struct {
 	Quantity int64             `json:"quantity"`
 	Type     SKUInventoryType  `json:"type"`
 	Value    SKUInventoryValue `json:"value"`
 }
 
+// SKU is the resource representing a SKU.
+// For more details see https://stripe.com/docs/api#skus.
 type SKU struct {
 	Active            bool               `json:"active"`
 	Attributes        map[string]string  `json:"attributes"`
@@ -65,11 +70,13 @@ type SKU struct {
 	Updated           int64              `json:"updated"`
 }
 
+// SKUList is a list of SKUs as returned from a list endpoint.
 type SKUList struct {
 	ListMeta
 	Data []*SKU `json:"data"`
 }
 
+// SKUListParams is the set of parameters that can be used when listing SKUs.
 type SKUListParams struct {
 	ListParams `form:"*"`
 	Active     *bool             `form:"active"`
@@ -79,6 +86,9 @@ type SKUListParams struct {
 	Product    *string           `form:"product"`
 }
 
+// UnmarshalJSON handles deserialization of a SKU.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
 func (s *SKU) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
 		s.ID = id

--- a/sku.go
+++ b/sku.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // SKUInventoryType describe's the possible value for inventory type
 type SKUInventoryType string
 
+// List of values that SKUInventoryType can take.
 const (
 	SKUInventoryTypeBucket   SKUInventoryType = "bucket"
 	SKUInventoryTypeFinite   SKUInventoryType = "finite"
@@ -14,6 +15,7 @@ const (
 // SKUInventoryValue describe's the possible value for inventory value
 type SKUInventoryValue string
 
+// List of values that SKUInventoryValue can take.
 const (
 	SKUInventoryValueInStock    SKUInventoryValue = "in_stock"
 	SKUInventoryValueLimited    SKUInventoryValue = "limited"

--- a/source.go
+++ b/source.go
@@ -9,6 +9,7 @@ import (
 // SourceCodeVerificationFlowStatus represents the possible statuses of a code verification flow.
 type SourceCodeVerificationFlowStatus string
 
+// List of values that SourceCodeVerificationFlowStatus can take.
 const (
 	SourceCodeVerificationFlowStatusFailed    SourceCodeVerificationFlowStatus = "failed"
 	SourceCodeVerificationFlowStatusPending   SourceCodeVerificationFlowStatus = "pending"
@@ -18,6 +19,7 @@ const (
 // SourceFlow represents the possible flows of a source object.
 type SourceFlow string
 
+// List of values that SourceFlow can take.
 const (
 	SourceFlowCodeVerification SourceFlow = "code_verification"
 	SourceFlowNone             SourceFlow = "none"
@@ -28,6 +30,7 @@ const (
 // SourceMandateAcceptanceStatus represents the possible failure reasons of a redirect flow.
 type SourceMandateAcceptanceStatus string
 
+// List of values that SourceMandateAcceptanceStatus can take.
 const (
 	SourceMandateAcceptanceStatusAccepted SourceMandateAcceptanceStatus = "accepted"
 	SourceMandateAcceptanceStatusRefused  SourceMandateAcceptanceStatus = "refused"
@@ -36,6 +39,7 @@ const (
 // SourceRedirectFlowFailureReason represents the possible failure reasons of a redirect flow.
 type SourceRedirectFlowFailureReason string
 
+// List of values that SourceRedirectFlowFailureReason can take.
 const (
 	SourceRedirectFlowFailureReasonDeclined        SourceRedirectFlowFailureReason = "declined"
 	SourceRedirectFlowFailureReasonProcessingError SourceRedirectFlowFailureReason = "processing_error"
@@ -45,6 +49,7 @@ const (
 // SourceRedirectFlowStatus represents the possible statuses of a redirect flow.
 type SourceRedirectFlowStatus string
 
+// List of values that SourceRedirectFlowStatus can take.
 const (
 	SourceRedirectFlowStatusFailed      SourceRedirectFlowStatus = "failed"
 	SourceRedirectFlowStatusNotRequired SourceRedirectFlowStatus = "not_required"
@@ -55,6 +60,7 @@ const (
 // SourceRefundAttributesMethod are the possible method to retrieve a receiver's refund attributes.
 type SourceRefundAttributesMethod string
 
+// List of values that SourceRefundAttributesMethod can take.
 const (
 	SourceRefundAttributesMethodEmail  SourceRefundAttributesMethod = "email"
 	SourceRefundAttributesMethodManual SourceRefundAttributesMethod = "manual"
@@ -63,6 +69,7 @@ const (
 // SourceRefundAttributesStatus are the possible status of a receiver's refund attributes.
 type SourceRefundAttributesStatus string
 
+// List of values that SourceRefundAttributesStatus can take.
 const (
 	SourceRefundAttributesStatusAvailable SourceRefundAttributesStatus = "available"
 	SourceRefundAttributesStatusMissing   SourceRefundAttributesStatus = "missing"
@@ -72,6 +79,7 @@ const (
 // SourceStatus represents the possible statuses of a source object.
 type SourceStatus string
 
+// List of values that SourceStatus can take.
 const (
 	SourceStatusCanceled   SourceStatus = "canceled"
 	SourceStatusChargeable SourceStatus = "chargeable"
@@ -83,6 +91,7 @@ const (
 // SourceUsage represents the possible usages of a source object.
 type SourceUsage string
 
+// List of values that SourceUsage can take.
 const (
 	SourceUsageReusable  SourceUsage = "reusable"
 	SourceUsageSingleUse SourceUsage = "single_use"

--- a/source.go
+++ b/source.go
@@ -97,6 +97,8 @@ const (
 	SourceUsageSingleUse SourceUsage = "single_use"
 )
 
+// SourceOwnerParams is the set of parameters allowed for the owner hash on
+// source creation or update.
 type SourceOwnerParams struct {
 	Address *AddressParams `form:"address"`
 	Email   *string        `form:"email"`
@@ -104,10 +106,13 @@ type SourceOwnerParams struct {
 	Phone   *string        `form:"phone"`
 }
 
+// RedirectParams is the set of parameters allowed for the redirect hash on
+// source creation or update.
 type RedirectParams struct {
 	ReturnURL *string `form:"return_url"`
 }
 
+// SourceObjectParams is the set of parameters allowed on source creation or update.
 type SourceObjectParams struct {
 	Params              `form:"*"`
 	Amount              *int64             `form:"amount"`
@@ -131,6 +136,7 @@ type SourceObjectDetachParams struct {
 	Customer *string `form:"-"`
 }
 
+// SourceOwner describes the owner hash on a source.
 type SourceOwner struct {
 	Address         *Address `json:"address,omitempty"`
 	Email           string   `json:"email"`
@@ -142,7 +148,7 @@ type SourceOwner struct {
 	VerifiedPhone   string   `json:"verified_phone"`
 }
 
-// ReceiverFlow informs of the state of a redirect authentication flow.
+// RedirectFlow informs of the state of a redirect authentication flow.
 type RedirectFlow struct {
 	FailureReason SourceRedirectFlowFailureReason `json:"failure_reason"`
 	ReturnURL     string                          `json:"return_url"`
@@ -166,6 +172,7 @@ type CodeVerificationFlow struct {
 	Status            SourceCodeVerificationFlowStatus `json:"status"`
 }
 
+// SourceMandateAcceptance describes a source mandate acceptance state.
 type SourceMandateAcceptance struct {
 	Date      string                        `json:"date"`
 	IP        string                        `json:"ip"`
@@ -173,6 +180,7 @@ type SourceMandateAcceptance struct {
 	UserAgent string                        `json:"user_agent"`
 }
 
+// SourceMandate describes a source mandate.
 type SourceMandate struct {
 	Acceptance         *SourceMandateAcceptance `json:"acceptance"`
 	NotificationMethod string                   `json:"notification_method"`
@@ -180,6 +188,8 @@ type SourceMandate struct {
 	URL                string                   `json:"url"`
 }
 
+// Source is the resource representing a Source.
+// For more details see https://stripe.com/docs/api#sources.
 type Source struct {
 	Amount              int64                 `json:"amount"`
 	ClientSecret        string                `json:"client_secret"`

--- a/stripe.go
+++ b/stripe.go
@@ -196,6 +196,7 @@ func (s *BackendConfiguration) CallMultipart(method, path, key, boundary string,
 	return nil
 }
 
+// CallRaw is the implementation for invoking Stripe APIs internally without a backend.
 func (s *BackendConfiguration) CallRaw(method, path, key string, form *form.Values, params *Params, v interface{}) error {
 	var body io.Reader
 	if form != nil && !form.Empty() {
@@ -252,7 +253,7 @@ func (s *BackendConfiguration) NewRequest(method, path, key, contentType string,
 		if params.IdempotencyKey != nil {
 			idempotencyKey := strings.TrimSpace(*params.IdempotencyKey)
 			if len(idempotencyKey) > 255 {
-				return nil, errors.New("Cannot use an idempotency key longer than 255 characters.")
+				return nil, errors.New("cannot use an idempotency key longer than 255 characters")
 			}
 
 			req.Header.Add("Idempotency-Key", idempotencyKey)
@@ -338,6 +339,7 @@ func (s *BackendConfiguration) Do(req *http.Request, v interface{}) error {
 	return nil
 }
 
+// ResponseToError converts a stripe response to an Error.
 func (s *BackendConfiguration) ResponseToError(res *http.Response, resBody []byte) error {
 	// for some odd reason, the Erro structure doesn't unmarshal
 	// initially I thought it was because it's a struct inside of a struct

--- a/sub.go
+++ b/sub.go
@@ -9,6 +9,7 @@ import (
 // SubscriptionStatus is the list of allowed values for the subscription's status.
 type SubscriptionStatus string
 
+// List of values that SubscriptionStatus can take.
 const (
 	SubscriptionStatusActive   SubscriptionStatus = "active"
 	SubscriptionStatusAll      SubscriptionStatus = "all"
@@ -21,6 +22,7 @@ const (
 // SubscriptionBilling is the type of billing method for this subscription's invoices.
 type SubscriptionBilling string
 
+// List of values that SubscriptionBilling can take.
 const (
 	SubscriptionBillingChargeAutomatically SubscriptionBilling = "charge_automatically"
 	SubscriptionBillingSendInvoice         SubscriptionBilling = "send_invoice"

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -1,9 +1,9 @@
 package stripe
 
+// ThreeDSecureStatus represents the possible statuses of a ThreeDSecure object.
 type ThreeDSecureStatus string
 
 // ThreeDSecureParams is the set of parameters that can be used when creating a 3DS object.
-// For more details see https://stripe.com/docs/api#create_three_d_secure.
 type ThreeDSecureParams struct {
 	Params    `form:"*"`
 	Amount    *int64  `form:"amount"`

--- a/token.go
+++ b/token.go
@@ -3,6 +3,7 @@ package stripe
 // TokenType is the list of allowed values for a token's type.
 type TokenType string
 
+// List of values that TokenType can take.
 const (
 	TokenTypeAccount     TokenType = "account"
 	TokenTypeCard        TokenType = "card"

--- a/transfer.go
+++ b/transfer.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // TransferSourceType is the list of allowed values for the transfer's source_type field.
 type TransferSourceType string
 
+// List of values that TransferSourceType can take.
 const (
 	TransferSourceTypeAlipayAccount   TransferSourceType = "alipay_account"
 	TransferSourceTypeBankAccount     TransferSourceType = "bank_account"

--- a/usage_record.go
+++ b/usage_record.go
@@ -1,5 +1,6 @@
 package stripe
 
+// Possible values for the action parameter on usage record creation.
 const (
 	UsageRecordActionIncrement string = "increment"
 	UsageRecordActionSet       string = "set"

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -15,16 +15,18 @@ import (
 )
 
 const (
-	// Signatures older than this will be rejected by ConstructEvent
+	// DefaultTolerance indicates that signatures older than this will be rejected by ConstructEvent.
 	DefaultTolerance time.Duration = 300 * time.Second
-	signingVersion   string        = "v1"
+	// signingVersion represents the version of the signature we currently use.
+	signingVersion string = "v1"
 )
 
+// This block represents the list of errors that could be raised when using the webhook package.
 var (
-	ErrNotSigned        error = errors.New("Webhook has no Stripe-Signature header")
-	ErrInvalidHeader    error = errors.New("Webhook has invalid Stripe-Signature header")
-	ErrTooOld           error = errors.New("Timestamp wasn't within tolerance")
-	ErrNoValidSignature error = errors.New("Webhook had no valid signature")
+	ErrNotSigned        = errors.New("Webhook has no Stripe-Signature header")
+	ErrInvalidHeader    = errors.New("Webhook has invalid Stripe-Signature header")
+	ErrTooOld           = errors.New("Timestamp wasn't within tolerance")
+	ErrNoValidSignature = errors.New("Webhook had no valid signature")
 )
 
 // Computes a webhook signature using Stripe's v1 signing method. See
@@ -85,8 +87,8 @@ func parseSignatureHeader(header string) (*signedHeader, error) {
 	return sh, nil
 }
 
-// Initializes an Event object from a JSON webhook payload, validating the
-// Stripe-Signature header using the specified signing secret. Returns an error
+// ConstructEvent initializes an Event object from a JSON webhook payload, validating
+// the Stripe-Signature header using the specified signing secret. Returns an error
 // if the body or Stripe-Signature header provided are unreadable, if the
 // signature doesn't match, or if the timestamp for the signature is older than
 // DefaultTolerance.
@@ -99,9 +101,9 @@ func ConstructEvent(payload []byte, header string, secret string) (stripe.Event,
 	return ConstructEventWithTolerance(payload, header, secret, DefaultTolerance)
 }
 
-// Initializes an Event object from a JSON webhook payload, validating the
-// signature in the Stripe-Signature header using the specified signing secret
-// and tolerance window. Returns an error if the body or Stripe-Signature header
+// ConstructEventWithTolerance initializes an Event object from a JSON webhook payload,
+// validating the signature in the Stripe-Signature header using the specified signing
+// secret and tolerance window. Returns an error if the body or Stripe-Signature header
 // provided are unreadable, if the signature doesn't match, or if the timestamp
 // for the signature is older than the specified tolerance.
 //
@@ -113,10 +115,10 @@ func ConstructEventWithTolerance(payload []byte, header string, secret string, t
 	return constructEvent(payload, header, secret, tolerance, true)
 }
 
-// Initializes an Event object from a JSON webhook payload, validating the
-// Stripe-Signature header using the specified signing secret. Returns an error
-// if the body or Stripe-Signature header provided are unreadable or if the
-// signature doesn't match. Does not check the signature's timestamp.
+// ConstructEventIgnoringTolerance initializes an Event object from a JSON webhook
+// payload, validating the Stripe-Signature header using the specified signing secret.
+// Returns an error if the body or Stripe-Signature header provided are unreadable or
+// if the signature doesn't match. Does not check the signature's timestamp.
 //
 // NOTE: Stripe will only send Webhook signing headers after you have retrieved
 // your signing secret from the Stripe dashboard:

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -23,10 +23,10 @@ const (
 
 // This block represents the list of errors that could be raised when using the webhook package.
 var (
-	ErrNotSigned        = errors.New("Webhook has no Stripe-Signature header")
-	ErrInvalidHeader    = errors.New("Webhook has invalid Stripe-Signature header")
-	ErrTooOld           = errors.New("Timestamp wasn't within tolerance")
-	ErrNoValidSignature = errors.New("Webhook had no valid signature")
+	ErrNotSigned        = errors.New("webhook has no Stripe-Signature header")
+	ErrInvalidHeader    = errors.New("webhook has invalid Stripe-Signature header")
+	ErrTooOld           = errors.New("timestamp wasn't within tolerance")
+	ErrNoValidSignature = errors.New("webhook had no valid signature")
 )
 
 // Computes a webhook signature using Stripe's v1 signing method. See


### PR DESCRIPTION
This enforces the linter on all files and packages and fixes all the current errors

* Fix the makefile to run `golint ./...`
* Add comments to all const blocks to describe what they represent
* Fix comments on all structs and exported methods
* A few breaking changes due to naming of properties or variables:
  * `Account` resource where `IdentityVerificationDetailsCodeScanIdCountryNotSupported` is now `IdentityVerificationDetailsCodeScanIDCountryNotSupported`
  * `Account` resource where `IdentityVerificationDetailsCodeScanIdTypeNotSupported` is now `IdentityVerificationDetailsCodeScanIDTypeNotSupported`
  * `BitcointReceiver` resource where `BitcoinUri` is now `BitcoinURI`.
  * `IssuingAuthorization` resource where `NetworkId` is now `NetworkID`

r? @brandur-stripe 
cc @stripe/api-libraries 