### PR TITLE
Change the type of FileUpload's Links fld to FileLinkList

### DIFF
--- a/fileupload.go
+++ b/fileupload.go
@@ -47,7 +47,7 @@ type FileUpload struct {
 	Created  int64             `json:"created"`
 	ID       string            `json:"id"`
 	Filename string            `json:"filename"`
-	Links    []*FileLink       `json:"links"`
+	Links    *FileLinkList     `json:"links"`
 	Purpose  FileUploadPurpose `json:"purpose"`
 	Size     int64             `json:"size"`
 	Type     string            `json:"type"`


### PR DESCRIPTION
The `Links` field of `FileUpload` struct is currently set to `[]*FileLink`.
This can cause an unmarshalling error when calling for example the Create FileUpload method, as the  `FileUpload` object return as response can include a list of file links:
```
{
  id: "file_xxxxxxxx",
  object: "file_upload",
  created: 1533640021,
  filename: "file.jpg",
  links: {
    object: "list",
    data: [ ... ],
    has_more: false,
    url: "/v1/file_links?file=file_xxxxxxxx"
  },
  ....
}
```
This PR attempts to fix this issue by changing the type of FileUpload's Links fld to `FileLinkList`.

r? @ob-stripe @brandur-stripe
cc @stripe/api-libraries 