### PR TITLE
All `BackendImplementation`s should sleep by default on retries

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -899,11 +899,12 @@ func isHTTPWriteMethod(method string) bool {
 // instead of this function.
 func newBackendImplementation(backendType SupportedBackend, config *BackendConfig) Backend {
 	return &BackendImplementation{
-		HTTPClient:        config.HTTPClient,
-		LogLevel:          config.LogLevel,
-		Logger:            config.Logger,
-		MaxNetworkRetries: config.MaxNetworkRetries,
-		Type:              backendType,
-		URL:               config.URL,
+		HTTPClient:          config.HTTPClient,
+		LogLevel:            config.LogLevel,
+		Logger:              config.Logger,
+		MaxNetworkRetries:   config.MaxNetworkRetries,
+		Type:                backendType,
+		URL:                 config.URL,
+		networkRetriesSleep: true,
 	}
 }


### PR DESCRIPTION
In #648 I introduced a new field on `BackendImplementation` which allows
us to disable sleeping between retries in tests. Unfortunately, I forgot
to set this field to `true` by default, and therefore we weren't
sleeping on retries in production.

Here we make sure to enable sleep when generating a new backend.

Fixes #651.