### PR TITLE
Integer-index encode all arrays

### DIFF
--- a/account.go
+++ b/account.go
@@ -126,7 +126,7 @@ type AccountParams struct {
 
 // LegalEntityParams represents a legal_entity during account creation/updates.
 type LegalEntityParams struct {
-	AdditionalOwners []*AdditionalOwnerParams `form:"additional_owners,indexed"`
+	AdditionalOwners []*AdditionalOwnerParams `form:"additional_owners"`
 
 	// AdditionalOwnersEmpty can be set to clear a legal entity's additional
 	// owners.

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -56,10 +56,15 @@ func TestAccountNew(t *testing.T) {
 			AdditionalOwners: []*stripe.AdditionalOwnerParams{
 				{
 					FirstName: stripe.String("Jane"),
+					LastName:  stripe.String("Doe"),
 					Verification: &stripe.IdentityVerificationParams{
 						Document:     stripe.String("file_345"),
 						DocumentBack: stripe.String("file_567"),
 					},
+				},
+				{
+					FirstName: stripe.String("John"),
+					LastName:  stripe.String("Doe"),
 				},
 			},
 			DOB: &stripe.DOBParams{

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -24,9 +24,6 @@ type testStruct struct {
 	Array    [3]string  `form:"array"`
 	ArrayPtr *[3]string `form:"array_ptr"`
 
-	ArrayIndexed    [3]string  `form:"array_indexed,indexed"`
-	ArrayIndexedPtr *[3]string `form:"array_indexed_ptr,indexed"`
-
 	Bool    bool  `form:"bool"`
 	BoolPtr *bool `form:"bool_ptr"`
 
@@ -58,9 +55,6 @@ type testStruct struct {
 
 	String    string  `form:"string"`
 	StringPtr *string `form:"string_ptr"`
-
-	SliceIndexed    []string  `form:"slice_indexed,indexed"`
-	SliceIndexedPtr *[]string `form:"slice_indexed_ptr,indexed"`
 
 	SubStruct    testSubStruct  `form:"substruct"`
 	SubStructPtr *testSubStruct `form:"substruct_ptr"`
@@ -176,7 +170,7 @@ func TestAppendTo(t *testing.T) {
 	}{
 		{"appender", &testStruct{Appender: &testAppender{String: "123"}}, "123"},
 
-		{"array_indexed[2]", &testStruct{ArrayIndexed: arrayVal}, "3"},
+		{"array[2]", &testStruct{Array: arrayVal}, "3"},
 
 		{"bool", &testStruct{Bool: boolValT}, "true"},
 		{"bool_ptr", &testStruct{}, ""},
@@ -248,7 +242,7 @@ func TestAppendTo(t *testing.T) {
 			"baz",
 		},
 
-		{"slice_indexed[2]", &testStruct{SliceIndexed: sliceVal}, "3"},
+		{"slice[2]", &testStruct{Slice: sliceVal}, "3"},
 
 		{"string", &testStruct{String: stringVal}, stringVal},
 		{"string_ptr", &testStruct{StringPtr: &stringVal}, stringVal},
@@ -291,44 +285,6 @@ func TestAppendTo(t *testing.T) {
 			values := form.ToValues()
 			t.Logf("values = %+v", values)
 			assert.Equal(t, tc.want, values.Get(tc.field))
-		})
-	}
-}
-
-func TestAppendTo_DuplicatedNames(t *testing.T) {
-	arrayVal := [3]string{"1", "2", "3"}
-	sliceVal := []string{"1", "2", "3"}
-
-	testCases := []struct {
-		field string
-		data  *testStruct
-		want  interface{}
-	}{
-		{"array[]", &testStruct{Array: arrayVal}, sliceVal},
-		{"array_ptr[]", &testStruct{ArrayPtr: &arrayVal}, sliceVal},
-		{"slice[]", &testStruct{Slice: sliceVal}, sliceVal},
-		{"slice_ptr[]", &testStruct{SlicePtr: &sliceVal}, sliceVal},
-
-		// Tests slice nested inside of map nested inside of another map
-		{
-			"map[foo][bar][]",
-			&testStruct{Map: map[string]interface{}{
-				"foo": map[string]interface{}{"bar": sliceVal},
-			}},
-			sliceVal,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.field, func(t *testing.T) {
-			form := &Values{}
-			AppendTo(form, tc.data)
-			values := form.ToValues()
-			//fmt.Printf("values = %+v", values)
-
-			// This is the only difference between this test case and the one
-			// above: we used square brackets to grab a []string instead of
-			// just a single value.
-			assert.Equal(t, tc.want, values[tc.field])
 		})
 	}
 }
@@ -405,7 +361,6 @@ func TestParseTag(t *testing.T) {
 	}{
 		{"id", "id", nil},
 		{"id,empty", "id", &formOptions{Empty: true}},
-		{"id,indexed", "id", &formOptions{IndexedArray: true}},
 		{"id,zero", "id", &formOptions{Zero: true}},
 
 		// invalid invocations

--- a/invoice.go
+++ b/invoice.go
@@ -65,7 +65,7 @@ type InvoiceParams struct {
 	Coupon                         *string                           `form:"coupon"`
 	InvoiceItems                   *InvoiceUpcomingInvoiceItemParams `form:"invoice_items"`
 	SubscriptionBillingCycleAnchor *int64                            `form:"subscription_billing_cycle_anchor"`
-	SubscriptionItems              []*SubscriptionItemsParams        `form:"subscription_items,indexed"`
+	SubscriptionItems              []*SubscriptionItemsParams        `form:"subscription_items"`
 	SubscriptionPlan               *string                           `form:"subscription_plan"`
 	SubscriptionProrate            *bool                             `form:"subscription_prorate"`
 	SubscriptionProrationDate      *int64                            `form:"subscription_proration_date"`

--- a/order.go
+++ b/order.go
@@ -43,7 +43,7 @@ type OrderParams struct {
 	Currency *string            `form:"currency"`
 	Customer *string            `form:"customer"`
 	Email    *string            `form:"email"`
-	Items    []*OrderItemParams `form:"items,indexed"`
+	Items    []*OrderItemParams `form:"items"`
 	Shipping *ShippingParams    `form:"shipping"`
 }
 
@@ -74,7 +74,7 @@ type OrderUpdateShippingParams struct {
 // OrderReturnParams is the set of parameters that can be used when returning orders.
 type OrderReturnParams struct {
 	Params `form:"*"`
-	Items  []*OrderItemParams `form:"items,indexed"`
+	Items  []*OrderItemParams `form:"items"`
 }
 
 // Shipping describes the shipping hash on an order.

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -30,6 +30,10 @@ func TestOrderList(t *testing.T) {
 func TestOrderNew(t *testing.T) {
 	order, err := New(&stripe.OrderParams{
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
+		Items: []*stripe.OrderItemParams{
+			{Amount: stripe.Int64(1), Description: stripe.String("Item 1")},
+			{Amount: stripe.Int64(1), Description: stripe.String("Item 2")},
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, order)
@@ -44,7 +48,12 @@ func TestOrderPay(t *testing.T) {
 }
 
 func TestOrderReturn(t *testing.T) {
-	order, err := Return("or_123", &stripe.OrderReturnParams{})
+	order, err := Return("or_123", &stripe.OrderReturnParams{
+		Items: []*stripe.OrderItemParams{
+			{Amount: stripe.Int64(1), Description: stripe.String("Item 1")},
+			{Amount: stripe.Int64(1), Description: stripe.String("Item 2")},
+		},
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, order)
 }

--- a/params_test.go
+++ b/params_test.go
@@ -196,7 +196,7 @@ func TestListParams_Expand(t *testing.T) {
 		{
 			InitialBody:  [][2]string{{"foo", "bar"}, {"foo", "baz"}},
 			Expand:       []string{"data", "data.foo"},
-			ExpectedBody: [][2]string{{"foo", "bar"}, {"foo", "baz"}, {"expand[]", "data"}, {"expand[]", "data.foo"}},
+			ExpectedBody: [][2]string{{"foo", "bar"}, {"foo", "baz"}, {"expand[0]", "data"}, {"expand[1]", "data.foo"}},
 		},
 	}
 

--- a/plan.go
+++ b/plan.go
@@ -119,7 +119,7 @@ type PlanParams struct {
 	Nickname        *string                   `form:"nickname"`
 	Product         *PlanProductParams        `form:"product"`
 	ProductID       *string                   `form:"product"`
-	Tiers           []*PlanTierParams         `form:"tiers,indexed"`
+	Tiers           []*PlanTierParams         `form:"tiers"`
 	TiersMode       *string                   `form:"tiers_mode"`
 	TransformUsage  *PlanTransformUsageParams `form:"transform_usage"`
 	TrialPeriodDays *int64                    `form:"trial_period_days"`

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -31,14 +31,22 @@ func TestPlanList(t *testing.T) {
 
 func TestPlanNew(t *testing.T) {
 	plan, err := New(&stripe.PlanParams{
-		Amount:   stripe.Int64(1),
-		Currency: stripe.String(string(stripe.CurrencyUSD)),
-		ID:       stripe.String("sapphire-elite"),
-		Interval: stripe.String(string(stripe.PlanIntervalMonth)),
+		Amount:        stripe.Int64(1),
+		BillingScheme: stripe.String(string(stripe.PlanBillingSchemeTiered)),
+		Currency:      stripe.String(string(stripe.CurrencyUSD)),
+		ID:            stripe.String("sapphire-elite"),
+		Interval:      stripe.String(string(stripe.PlanIntervalMonth)),
 		Product: &stripe.PlanProductParams{
 			ID:                  stripe.String("plan_id"),
 			Name:                stripe.String("Sapphire Elite"),
 			StatementDescriptor: stripe.String("statement descriptor"),
+		},
+		Tiers: []*stripe.PlanTierParams{
+			{Amount: stripe.Int64(500), UpTo: stripe.Int64(5)},
+			{Amount: stripe.Int64(400), UpTo: stripe.Int64(10)},
+			{Amount: stripe.Int64(300), UpTo: stripe.Int64(15)},
+			{Amount: stripe.Int64(200), UpTo: stripe.Int64(20)},
+			{Amount: stripe.Int64(200), UpToInf: stripe.Bool(true)},
 		},
 	})
 	assert.Nil(t, err)

--- a/sub.go
+++ b/sub.go
@@ -42,7 +42,7 @@ type SubscriptionParams struct {
 	Coupon                      *string                    `form:"coupon"`
 	Customer                    *string                    `form:"customer"`
 	DaysUntilDue                *int64                     `form:"days_until_due"`
-	Items                       []*SubscriptionItemsParams `form:"items,indexed"`
+	Items                       []*SubscriptionItemsParams `form:"items"`
 	OnBehalfOf                  *string                    `form:"on_behalf_of"`
 	Plan                        *string                    `form:"plan"`
 	Prorate                     *bool                      `form:"prorate"`

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -40,6 +40,10 @@ func TestSubscriptionNew(t *testing.T) {
 				Plan:     stripe.String("plan_123"),
 				Quantity: stripe.Int64(10),
 			},
+			{
+				Plan:     stripe.String("plan_456"),
+				Quantity: stripe.Int64(20),
+			},
 		},
 		TaxPercent:         stripe.Float64(20.0),
 		BillingCycleAnchor: stripe.Int64(time.Now().AddDate(0, 0, 12).Unix()),


### PR DESCRIPTION
Changes all arrays from classic Rack encoding:

``` sh
arr[]=...&arr[]=...&arr[]=...
```

To integer-indexed encoding:

``` sh
arr[0]=...&arr[1]=...&arr[2]=...
```

See some additional background in: https://github.com/stripe/stripe-ruby/pull/674

cc @stevene-stripe @zanker-stripe