### PR TITLE
Remove editable bitcoin receiver actions

### DIFF
--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -13,26 +13,6 @@ type BitcoinReceiverListParams struct {
 	UncapturedFunds *bool `form:"uncaptured_funds"`
 }
 
-// BitcoinReceiverParams is the set of parameters that can be used when creating a BitcoinReceiver.
-// For more details see https://stripe.com/docs/api/#create_bitcoin_receiver.
-type BitcoinReceiverParams struct {
-	Params      `form:"*"`
-	Amount      *int64  `form:"amount"`
-	Currency    *string `form:"currency"`
-	Description *string `form:"description"`
-	Email       *string `form:"email"`
-}
-
-// BitcoinReceiverUpdateParams is the set of parameters that can be used when
-// updating a BitcoinReceiver. For more details see
-// https://stripe.com/docs/api/#update_bitcoin_receiver.
-type BitcoinReceiverUpdateParams struct {
-	Params        `form:"*"`
-	Description   *string `form:"description"`
-	Email         *string `form:"email"`
-	RefundAddress *string `form:"refund_address"`
-}
-
 // BitcoinReceiver is the resource representing a Stripe bitcoin receiver.
 // For more details see https://stripe.com/docs/api/#bitcoin_receivers
 type BitcoinReceiver struct {

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -17,42 +17,17 @@ type Client struct {
 	Key string
 }
 
-// New creates a new bitcoin receiver.
-func New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
-	return getC().New(params)
-}
-
-// New creates a new bitcoin receiver.
-func (c Client) New(params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
-	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call(http.MethodPost, "/bitcoin/receivers", c.Key, params, receiver)
-	return receiver, err
+// Get returns the details of a bitcoin receiver.
+func Get(id string) (*stripe.BitcoinReceiver, error) {
+	return getC().Get(id)
 }
 
 // Get returns the details of a bitcoin receiver.
-func Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
-	return getC().Get(id, params)
-}
-
-// Get returns the details of a bitcoin receiver.
-func (c Client) Get(id string, params *stripe.BitcoinReceiverParams) (*stripe.BitcoinReceiver, error) {
+func (c Client) Get(id string) (*stripe.BitcoinReceiver, error) {
 	path := stripe.FormatURLPath("/bitcoin/receivers/%s", id)
 	bitcoinReceiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, bitcoinReceiver)
+	err := c.B.Call(http.MethodGet, path, c.Key, nil, bitcoinReceiver)
 	return bitcoinReceiver, err
-}
-
-// Update updates a bitcoin receiver's properties.
-func Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.BitcoinReceiver, error) {
-	return getC().Update(id, params)
-}
-
-// Update updates a bitcoin receiver's properties.
-func (c Client) Update(id string, params *stripe.BitcoinReceiverUpdateParams) (*stripe.BitcoinReceiver, error) {
-	path := stripe.FormatURLPath("/bitcoin/receivers/%s", id)
-	receiver := &stripe.BitcoinReceiver{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, receiver)
-	return receiver, err
 }
 
 // List returns a list of bitcoin receivers.

--- a/bitcoinreceiver/client_test.go
+++ b/bitcoinreceiver/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBitcoinReceiverGet(t *testing.T) {
-	receiver, err := Get("btcrcv_123", nil)
+	receiver, err := Get("btcrcv_123")
 	assert.Nil(t, err)
 	assert.NotNil(t, receiver)
 }


### PR DESCRIPTION
Removes the ability to use `New` and `Update` for bitcoin receivers. Tests pass!

```
» go test ./...
ok  	github.com/stripe/stripe-go	0.176s
ok  	github.com/stripe/stripe-go/account	0.081s
ok  	github.com/stripe/stripe-go/applepaydomain	(cached)
ok  	github.com/stripe/stripe-go/balance	0.106s
ok  	github.com/stripe/stripe-go/bankaccount	0.129s
ok  	github.com/stripe/stripe-go/bitcoinreceiver	0.086s
ok  	github.com/stripe/stripe-go/bitcointransaction	(cached)
ok  	github.com/stripe/stripe-go/card	0.267s
ok  	github.com/stripe/stripe-go/charge	0.089s
ok  	github.com/stripe/stripe-go/client	0.035s
ok  	github.com/stripe/stripe-go/countryspec	(cached)
ok  	github.com/stripe/stripe-go/coupon	(cached)
ok  	github.com/stripe/stripe-go/customer	0.085s
ok  	github.com/stripe/stripe-go/discount	(cached)
ok  	github.com/stripe/stripe-go/dispute	0.072s
ok  	github.com/stripe/stripe-go/ephemeralkey	(cached)
ok  	github.com/stripe/stripe-go/event	(cached)
ok  	github.com/stripe/stripe-go/exchangerate	(cached)
ok  	github.com/stripe/stripe-go/fee	0.092s
ok  	github.com/stripe/stripe-go/feerefund	0.123s
ok  	github.com/stripe/stripe-go/filelink	(cached)
ok  	github.com/stripe/stripe-go/fileupload	(cached)
ok  	github.com/stripe/stripe-go/form	(cached)
ok  	github.com/stripe/stripe-go/invoice	0.127s
ok  	github.com/stripe/stripe-go/invoiceitem	0.074s
ok  	github.com/stripe/stripe-go/issuerfraudrecord	0.134s
ok  	github.com/stripe/stripe-go/issuing/authorization	0.162s
ok  	github.com/stripe/stripe-go/issuing/card	(cached)
ok  	github.com/stripe/stripe-go/issuing/cardholder	(cached)
ok  	github.com/stripe/stripe-go/issuing/dispute	0.160s
ok  	github.com/stripe/stripe-go/issuing/transaction	0.123s
ok  	github.com/stripe/stripe-go/loginlink	(cached)
ok  	github.com/stripe/stripe-go/order	0.157s
ok  	github.com/stripe/stripe-go/orderreturn	0.111s
ok  	github.com/stripe/stripe-go/paymentintent	0.131s
ok  	github.com/stripe/stripe-go/paymentsource	0.099s
ok  	github.com/stripe/stripe-go/payout	0.078s
ok  	github.com/stripe/stripe-go/plan	(cached)
ok  	github.com/stripe/stripe-go/product	(cached)
ok  	github.com/stripe/stripe-go/recipient	0.095s
ok  	github.com/stripe/stripe-go/recipienttransfer	(cached) [no tests to run]
ok  	github.com/stripe/stripe-go/refund	0.076s
ok  	github.com/stripe/stripe-go/reversal	0.089s
ok  	github.com/stripe/stripe-go/sigma/scheduledqueryrun	(cached)
ok  	github.com/stripe/stripe-go/sku	(cached)
ok  	github.com/stripe/stripe-go/source	(cached)
ok  	github.com/stripe/stripe-go/sourcetransaction	(cached)
ok  	github.com/stripe/stripe-go/sub	0.121s
ok  	github.com/stripe/stripe-go/subitem	(cached)
ok  	github.com/stripe/stripe-go/testing	(cached)
ok  	github.com/stripe/stripe-go/threedsecure	0.067s
ok  	github.com/stripe/stripe-go/token	0.081s
ok  	github.com/stripe/stripe-go/topup	0.062s
ok  	github.com/stripe/stripe-go/transfer	0.056s
ok  	github.com/stripe/stripe-go/usagerecord	(cached)
ok  	github.com/stripe/stripe-go/webhook	(cached)
```