### PR TITLE
Move to API version 2018-08-23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.26.0
+    - STRIPE_MOCK_VERSION=0.27.0
 
 go:
   - "1.7"

--- a/customer.go
+++ b/customer.go
@@ -9,7 +9,6 @@ import (
 type CustomerParams struct {
 	Params         `form:"*"`
 	AccountBalance *int64                         `form:"account_balance"`
-	BusinessVATID  *string                        `form:"business_vat_id"`
 	Coupon         *string                        `form:"coupon"`
 	DefaultSource  *string                        `form:"default_source"`
 	Description    *string                        `form:"description"`
@@ -50,7 +49,6 @@ type CustomerListParams struct {
 // For more details see https://stripe.com/docs/api#customers.
 type Customer struct {
 	AccountBalance int64                    `json:"account_balance"`
-	BusinessVATID  string                   `json:"business_vat_id"`
 	Created        int64                    `json:"created"`
 	Currency       Currency                 `json:"currency"`
 	DefaultSource  *PaymentSource           `json:"default_source"`

--- a/customer.go
+++ b/customer.go
@@ -4,6 +4,24 @@ import (
 	"encoding/json"
 )
 
+// CustomerTaxInfoType is the type of tax info associated with a customer.
+type CustomerTaxInfoType string
+
+// List of values that CustomerTaxInfoType can take.
+const (
+	CustomerTaxInfoTypeVAT CustomerTaxInfoType = "vat"
+)
+
+// CustomerTaxInfoVerificationStatus is the type of tax info associated with a customer.
+type CustomerTaxInfoVerificationStatus string
+
+// List of values that CustomerTaxInfoType can take.
+const (
+	CustomerTaxInfoVerificationStatusPending    CustomerTaxInfoVerificationStatus = "pending"
+	CustomerTaxInfoVerificationStatusUnverified CustomerTaxInfoVerificationStatus = "unverified"
+	CustomerTaxInfoVerificationStatusVerified   CustomerTaxInfoVerificationStatus = "verified"
+)
+
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
@@ -17,6 +35,7 @@ type CustomerParams struct {
 	Quantity       *int64                         `form:"quantity"`
 	Shipping       *CustomerShippingDetailsParams `form:"shipping"`
 	Source         *SourceParams                  `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxInfo        *CustomerTaxInfoParams         `form:"tax_info"`
 	TaxPercent     *float64                       `form:"tax_percent"`
 	Token          *string                        `form:"-"` // This doesn't seem to be used?
 	TrialEnd       *int64                         `form:"trial_end"`
@@ -27,6 +46,12 @@ type CustomerShippingDetailsParams struct {
 	Address *AddressParams `form:"address"`
 	Name    *string        `form:"name"`
 	Phone   *string        `form:"phone"`
+}
+
+// CustomerTaxInfoParams is the structure containing tax information for the customer.
+type CustomerTaxInfoParams struct {
+	TaxId *string `form:"tax_id"`
+	Type  *string `form:"type"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,
@@ -76,6 +101,18 @@ type CustomerShippingDetails struct {
 	Address Address `json:"address"`
 	Name    string  `json:"name"`
 	Phone   string  `json:"phone"`
+}
+
+// CustomerTaxInfo is the structure containing tax information for the customer.
+type CustomerTaxInfo struct {
+	TaxId string              `json:"tax_info"`
+	Type  CustomerTaxInfoType `json:"type"`
+}
+
+// CustomerTaxInfo is the structure containing tax verification for the customer.
+type CustomerTaxInfoVerification struct {
+	Status       CustomerTaxInfoVerificationStatus `json:"status"`
+	VerifiedName string                            `json:"verified_name"`
 }
 
 // UnmarshalJSON handles deserialization of a Customer.

--- a/customer.go
+++ b/customer.go
@@ -50,7 +50,7 @@ type CustomerShippingDetailsParams struct {
 
 // CustomerTaxInfoParams is the structure containing tax information for the customer.
 type CustomerTaxInfoParams struct {
-	TaxId *string `form:"tax_id"`
+	TaxID *string `form:"tax_id"`
 	Type  *string `form:"type"`
 }
 
@@ -73,21 +73,23 @@ type CustomerListParams struct {
 // Customer is the resource representing a Stripe customer.
 // For more details see https://stripe.com/docs/api#customers.
 type Customer struct {
-	AccountBalance int64                    `json:"account_balance"`
-	Created        int64                    `json:"created"`
-	Currency       Currency                 `json:"currency"`
-	DefaultSource  *PaymentSource           `json:"default_source"`
-	Deleted        bool                     `json:"deleted"`
-	Delinquent     bool                     `json:"delinquent"`
-	Description    string                   `json:"description"`
-	Discount       *Discount                `json:"discount"`
-	Email          string                   `json:"email"`
-	ID             string                   `json:"id"`
-	Livemode       bool                     `json:"livemode"`
-	Metadata       map[string]string        `json:"metadata"`
-	Shipping       *CustomerShippingDetails `json:"shipping"`
-	Sources        *SourceList              `json:"sources"`
-	Subscriptions  *SubscriptionList        `json:"subscriptions"`
+	AccountBalance      int64                        `json:"account_balance"`
+	Created             int64                        `json:"created"`
+	Currency            Currency                     `json:"currency"`
+	DefaultSource       *PaymentSource               `json:"default_source"`
+	Deleted             bool                         `json:"deleted"`
+	Delinquent          bool                         `json:"delinquent"`
+	Description         string                       `json:"description"`
+	Discount            *Discount                    `json:"discount"`
+	Email               string                       `json:"email"`
+	ID                  string                       `json:"id"`
+	Livemode            bool                         `json:"livemode"`
+	Metadata            map[string]string            `json:"metadata"`
+	Shipping            *CustomerShippingDetails     `json:"shipping"`
+	Sources             *SourceList                  `json:"sources"`
+	Subscriptions       *SubscriptionList            `json:"subscriptions"`
+	TaxInfo             *CustomerTaxInfo             `json:"tax_info"`
+	TaxInfoVerification *CustomerTaxInfoVerification `json:"tax_info_verification"`
 }
 
 // CustomerList is a list of customers as retrieved from a list endpoint.
@@ -105,11 +107,11 @@ type CustomerShippingDetails struct {
 
 // CustomerTaxInfo is the structure containing tax information for the customer.
 type CustomerTaxInfo struct {
-	TaxId string              `json:"tax_info"`
+	TaxID string              `json:"tax_info"`
 	Type  CustomerTaxInfoType `json:"type"`
 }
 
-// CustomerTaxInfo is the structure containing tax verification for the customer.
+// CustomerTaxInfoVerification is the structure containing tax verification for the customer.
 type CustomerTaxInfoVerification struct {
 	Status       CustomerTaxInfoVerificationStatus `json:"status"`
 	VerifiedName string                            `json:"verified_name"`

--- a/plan.go
+++ b/plan.go
@@ -128,8 +128,8 @@ type PlanParams struct {
 
 // PlanTier configures tiered pricing
 type PlanTier struct {
-	Amount int64 `json:"amount"`
-	UpTo   int64 `json:"up_to"`
+	UnitAmount int64 `json:"unit_amount"`
+	UpTo       int64 `json:"up_to"`
 }
 
 // PlanTransformUsage represents the bucket billing configuration.
@@ -146,10 +146,10 @@ type PlanTransformUsageParams struct {
 
 // PlanTierParams configures tiered pricing
 type PlanTierParams struct {
-	Params  `form:"*"`
-	Amount  *int64 `form:"amount"`
-	UpTo    *int64 `form:"-"` // handled in custom AppendTo
-	UpToInf *bool  `form:"-"` // handled in custom AppendTo
+	Params     `form:"*"`
+	UnitAmount *int64 `form:"unit_amount"`
+	UpTo       *int64 `form:"-"` // handled in custom AppendTo
+	UpToInf    *bool  `form:"-"` // handled in custom AppendTo
 }
 
 // AppendTo implements custom up_to serialisation logic for tiers configuration

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -42,11 +42,11 @@ func TestPlanNew(t *testing.T) {
 			StatementDescriptor: stripe.String("statement descriptor"),
 		},
 		Tiers: []*stripe.PlanTierParams{
-			{Amount: stripe.Int64(500), UpTo: stripe.Int64(5)},
-			{Amount: stripe.Int64(400), UpTo: stripe.Int64(10)},
-			{Amount: stripe.Int64(300), UpTo: stripe.Int64(15)},
-			{Amount: stripe.Int64(200), UpTo: stripe.Int64(20)},
-			{Amount: stripe.Int64(200), UpToInf: stripe.Bool(true)},
+			{UnitAmount: stripe.Int64(500), UpTo: stripe.Int64(5)},
+			{UnitAmount: stripe.Int64(400), UpTo: stripe.Int64(10)},
+			{UnitAmount: stripe.Int64(300), UpTo: stripe.Int64(15)},
+			{UnitAmount: stripe.Int64(200), UpTo: stripe.Int64(20)},
+			{UnitAmount: stripe.Int64(200), UpToInf: stripe.Bool(true)},
 		},
 	})
 	assert.Nil(t, err)

--- a/plan_test.go
+++ b/plan_test.go
@@ -45,8 +45,8 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		StatementDescriptor: String("SAPPHIRE"),
 	}
 	tiers := []*PlanTierParams{
-		{Amount: Int64(123), UpTo: Int64(321)},
-		{Amount: Int64(123), UpToInf: Bool(true)}}
+		{UnitAmount: Int64(123), UpTo: Int64(321)},
+		{UnitAmount: Int64(123), UpToInf: Bool(true)}}
 	testCases := []struct {
 		field  string
 		params *PlanParams
@@ -62,9 +62,9 @@ func TestPlanParams_AppendTo(t *testing.T) {
 		{"product[name]", &PlanParams{Product: &productParams}, "Sapphire Elite"},
 		{"product[statement_descriptor]", &PlanParams{Product: &productParams}, "SAPPHIRE"},
 		{"product", &PlanParams{ProductID: String("prod_123abc")}, "prod_123abc"}, {"tiers_mode", &PlanParams{TiersMode: String(string(PlanTiersModeVolume))}, "volume"},
-		{"tiers[0][amount]", &PlanParams{Tiers: tiers}, strconv.FormatUint(123, 10)},
+		{"tiers[0][unit_amount]", &PlanParams{Tiers: tiers}, strconv.FormatUint(123, 10)},
 		{"tiers[0][up_to]", &PlanParams{Tiers: tiers}, strconv.FormatUint(321, 10)},
-		{"tiers[1][amount]", &PlanParams{Tiers: tiers}, strconv.FormatUint(123, 10)},
+		{"tiers[1][unit_amount]", &PlanParams{Tiers: tiers}, strconv.FormatUint(123, 10)},
 		{"tiers[1][up_to]", &PlanParams{Tiers: tiers}, "inf"},
 		{"transform_usage[divide_by]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: Int64(123), Round: String("round_up")}}, strconv.FormatUint(123, 10)},
 		{"transform_usage[round]", &PlanParams{TransformUsage: &PlanTransformUsageParams{DivideBy: Int64(123), Round: String("round_up")}}, "round_up"},

--- a/stripe.go
+++ b/stripe.go
@@ -782,7 +782,7 @@ func StringValue(v *string) string {
 const apiURL = "https://api.stripe.com"
 
 // apiversion is the currently supported API version
-const apiversion = "2018-07-27"
+const apiversion = "2018-08-23"
 
 // clientversion is the binding version
 const clientversion = "42.3.0"

--- a/sub.go
+++ b/sub.go
@@ -58,8 +58,7 @@ type SubscriptionParams struct {
 // SubscriptionCancelParams is the set of parameters that can be used when canceling a subscription.
 // For more details see https://stripe.com/docs/api#cancel_subscription
 type SubscriptionCancelParams struct {
-	Params      `form:"*"`
-	AtPeriodEnd *bool `form:"at_period_end"`
+	Params `form:"*"`
 }
 
 // AppendTo implements custom encoding logic for SubscriptionParams so that the special

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func TestSubscriptionCancel(t *testing.T) {
-	subscription, err := Cancel("sub_123", &stripe.SubscriptionCancelParams{
-		AtPeriodEnd: stripe.Bool(true),
-	})
+	subscription, err := Cancel("sub_123", &stripe.SubscriptionCancelParams{})
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
 }

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.26.0"
+	MockMinimumVersion = "0.27.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
This PR has multiple major changes due to the move to the latest API version and some new properties/breaking changes.

* Add support for `tax_info` and `tax_info_verification` on the customer
* Remove `business_vat_id` on the Customer
* Rename `amount` to `unit_amount` on Plan's tiers
* Remove the ability to call Cancel on a Subscription with `at_period_end`.

r? @brandur-stripe 
cc @stripe/api-libraries 

(Flagging that we need a new stripe-mock for tests to pass because of the change to `amount` on Tiers)