### PR TITLE
Add support for authorization_code on the Charge resource

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -138,6 +138,7 @@ type Charge struct {
 	AmountRefunded      int64               `json:"amount_refunded"`
 	Application         *Application        `json:"application"`
 	ApplicationFee      *ApplicationFee     `json:"application_fee"`
+	AuthorizationCode   string              `json:"authorization_code"`
 	BalanceTransaction  *BalanceTransaction `json:"balance_transaction"`
 	Captured            bool                `json:"captured"`
 	Created             int64               `json:"created"`


### PR DESCRIPTION
Note that this property is internal and not usually returned in the API.

r? @brandur-stripe 
cc @stripe/api-libraries 