### PR TITLE
Attempt to fix racy test

### DIFF
--- a/stripe_test.go
+++ b/stripe_test.go
@@ -41,14 +41,16 @@ func TestContext_Cancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &stripe.Params{Context: ctx}
 
-	req, err := c.NewRequest("", "", "", "", p)
+	req, err := c.NewRequest("GET", "/charges", "sk_test_123", "application/x-www-form-urlencoded", p)
 	assert.NoError(t, err)
 
 	assert.Equal(t, ctx, req.Context())
 
-	// Cancel the context before we even try to start the request. This will
-	// cause it to immediately return an error and also avoid any kind of race
-	// condition.
+	// Cancel the context before we even try to start the request.
+	// Unfortunately, this doesn't seem to completely avoid a race condition
+	// even if it seems like it should, so the request we make should be
+	// relatively long lived so that the context cancellation wins (make
+	// stripe-mock do some work by processing a lis at `/v1/charges`t).
 	cancel()
 
 	var v interface{}


### PR DESCRIPTION
We're currently seeing the occasional build failure in CI that looks like this:

```
$ make
go test -race ./...
--- FAIL: TestContext_Cancel (0.00s)
    assertions.go:256:
            Error Trace:    stripe_test.go:67
            Error:          Expect "{"status":401,"message":"Please authenticate by specifying an `Authorization` header with any valid looking testmode secret API key. For example, `Authorization: Bearer sk_test_123`. Authorization was 'Bearer '.","type":"invalid_request_error"}" to match "(request canceled|context canceled\z)"
            Test:           TestContext_Cancel
2018/08/22 20:05:38 Requesting POST 127.0.0.1:35137/v1/hello
2018/08/22 20:05:38 Request completed in 1.519412ms (retry: 0)
2018/08/22 20:05:38 Request failed with: {"error":"Conflict (this should be retried)."} (error: <nil>)
2018/08/22 20:05:38 Initiating retry 1 for request POST 127.0.0.1:35137/v1/hello after sleeping 0s
2018/08/22 20:05:38 Request completed in 948.533µs (retry: 1)
2018/08/22 20:05:38 Response: {"message":"Hello, client."}
FAIL
FAIL    github.com/stripe/stripe-go 0.153s
```

The test seems to be designed to avoid a race by making sure to cancel its
cancellable context even before executing the request, which you'd think
prevent the request from ever happening, but which apparently does not because
you can see the error message above that's being returned from stripe-mock.

This did seem to be non-racy for a very long time so my guess is that Go's
HTTP/2 implementation changed this behavior slightly in that it's now possible
for a request to start executing even if the attached context is already
cancelled. The test became unreliable roughly around the same time we switched
the test suite over to use HTTP/2.

Here I try to "fix" the problem by making sure the request takes longer.
Because we're not passing a key and hitting a non-endpoint right now,
stripe-mock is able to fall through very quickly because it notices the missing
key immediately. Here I change it to pass a key and hit the `/v1/charges`
endpoint, which means that stripe-mock at the very least has to route the
request, look up a fixture, construct a list object, try data replacement, run
post-request filters, etc., all of which should take quite a bit longer
relatively speaking. This should give the cancellable context enough extra time
to kick in.