### PR TITLE
Remove racy test in favor of simpler one

### DIFF
--- a/stripe_test.go
+++ b/stripe_test.go
@@ -33,38 +33,10 @@ func TestContext(t *testing.T) {
 	req, err := c.NewRequest("", "", "", "", p)
 	assert.NoError(t, err)
 
+	// We assume that contexts are sufficiently tested in the standard library
+	// and here we just check that the context sent in to `NewRequest` is
+	// indeed properly set on the request that's returned.
 	assert.Equal(t, p.Context, req.Context())
-}
-
-func TestContext_Cancel(t *testing.T) {
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
-	ctx, cancel := context.WithCancel(context.Background())
-	p := &stripe.Params{Context: ctx}
-
-	req, err := c.NewRequest("", "", "", "", p)
-	assert.NoError(t, err)
-
-	assert.Equal(t, ctx, req.Context())
-
-	// Cancel the context before we even try to start the request. This will
-	// cause it to immediately return an error and also avoid any kind of race
-	// condition.
-	cancel()
-
-	var v interface{}
-	err = c.Do(req, nil, &v)
-
-	// Go 1.7 will produce an error message like:
-	//
-	//     Get https://api.stripe.com/v1/: net/http: request canceled while waiting for connection
-	//
-	// 1.8 and later produce something like:
-	//
-	//     Get https://api.stripe.com/v1/: context canceled
-	//
-	// When we drop support for 1.7 we can remove the first case of this
-	// expression.
-	assert.Regexp(t, regexp.MustCompile(`(request canceled|context canceled\z)`), err.Error())
 }
 
 // Tests client retries.


### PR DESCRIPTION
Removes a test that's producing racy results in CI. As noted in #672, it
probably became racy as it started using the new HTTP implementation
in Go's HTTP/2 package.

My justification here is that cancellable contexts are already well
tested in Go's core. What we really want to test is just that the
context supplied by our users does indeed make it into the Go `Request`
that we're about to execute -- from there we can expect Go to do the
right thing. We already have a test that checks that just a few lines
above.

r? @remi-stripe What do you think about this approach?
cc @stripe-internal/api-libraries