### PR TITLE
Fix payment intent parameters

### DIFF
--- a/paymentintent.go
+++ b/paymentintent.go
@@ -44,6 +44,14 @@ const (
 	PaymentIntentStatusSucceeded            PaymentIntentStatus = "succeeded"
 )
 
+// PaymentIntentCaptureParams is the set of parameters that can be used when capturing a payment intent.
+type PaymentIntentCaptureParams struct {
+	Params               `form:"*"`
+	AmountToCapture      *int64                           `form:"amount_to_capture"`
+	ApplicationFeeAmount *int64                           `form:"application_fee_amount"`
+	TransferData         *PaymentIntentTransferDataParams `form:"transfer_data"`
+}
+
 // PaymentIntentTransferDataParams is the set of parameters allowed for the transfer hash.
 type PaymentIntentTransferDataParams struct {
 	Amount *int64 `form:"amount"`
@@ -52,23 +60,22 @@ type PaymentIntentTransferDataParams struct {
 // PaymentIntentParams is the set of parameters that can be used when handling a payment intent.
 type PaymentIntentParams struct {
 	Params               `form:"*"`
-	AllowedSourceTypes   []*string                        `form:"allowed_source_types"`
-	Amount               *int64                           `form:"amount"`
-	ApplicationFee       *int64                           `form:"application_fee"`
-	AttemptConfirmation  *bool                            `form:"attempt_confirmation"`
-	CaptureMethod        *string                          `form:"capture_method"`
-	Currency             *string                          `form:"currency"`
-	Customer             *string                          `form:"customer"`
-	Description          *string                          `form:"description"`
-	OnBehalfOf           *string                          `form:"on_behalf_of"`
-	ReceiptEmail         *string                          `form:"receipt_email"`
-	ReturnURL            *string                          `form:"return_url"`
-	SaveSourceToCustomer *bool                            `form:"save_source_to_customer"`
-	Shipping             *ShippingDetailsParams           `form:"shipping"`
-	Source               *string                          `form:"source"`
-	StatementDescriptor  *string                          `form:"statement_descriptor"`
-	TransferData         *PaymentIntentTransferDataParams `form:"transfer_data"`
-	TransferGroup        *string                          `form:"transfer_group"`
+	AllowedSourceTypes   []*string              `form:"allowed_source_types"`
+	Amount               *int64                 `form:"amount"`
+	ApplicationFeeAmount *int64                 `form:"application_fee_amount"`
+	AttemptConfirmation  *bool                  `form:"attempt_confirmation"`
+	CaptureMethod        *string                `form:"capture_method"`
+	Currency             *string                `form:"currency"`
+	Customer             *string                `form:"customer"`
+	Description          *string                `form:"description"`
+	OnBehalfOf           *string                `form:"on_behalf_of"`
+	ReceiptEmail         *string                `form:"receipt_email"`
+	ReturnURL            *string                `form:"return_url"`
+	SaveSourceToCustomer *bool                  `form:"save_source_to_customer"`
+	Shipping             *ShippingDetailsParams `form:"shipping"`
+	Source               *string                `form:"source"`
+	StatementDescriptor  *string                `form:"statement_descriptor"`
+	TransferGroup        *string                `form:"transfer_group"`
 }
 
 // PaymentIntentListParams is the set of parameters that can be used when listing payment intents.

--- a/paymentintent/client.go
+++ b/paymentintent/client.go
@@ -68,12 +68,12 @@ func (c Client) Cancel(id string, params *stripe.PaymentIntentParams) (*stripe.P
 }
 
 // Capture captures a payment intent.
-func Capture(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
+func Capture(id string, params *stripe.PaymentIntentCaptureParams) (*stripe.PaymentIntent, error) {
 	return getC().Capture(id, params)
 }
 
 // Capture captures a payment intent.
-func (c Client) Capture(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
+func (c Client) Capture(id string, params *stripe.PaymentIntentCaptureParams) (*stripe.PaymentIntent, error) {
 	path := stripe.FormatURLPath("/payment_intents/%s/capture", id)
 	intent := &stripe.PaymentIntent{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)


### PR DESCRIPTION
* Capture takes a different set of parameters
* application_fee is now called application_fee_amount

r? @brandur-stripe 
cc @stripe/api-libraries 

(Flagging the latest stripe-mock broke the test suite so also going to fix that in a separate PR in a few minutes)