### PR TITLE
Fix two issues with List tests

### DIFF
--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -37,7 +37,7 @@ func TestBankAccountGet_ByCustomer(t *testing.T) {
 }
 
 func TestBankAccountList_ByAccount(t *testing.T) {
-	i := List(&stripe.BankAccountListParams{Customer: stripe.String("acct_123")})
+	i := List(&stripe.BankAccountListParams{Account: stripe.String("acct_123")})
 
 	// Verify that we can get at least one bank account
 	assert.True(t, i.Next())

--- a/usagerecordsummary.go
+++ b/usagerecordsummary.go
@@ -15,7 +15,7 @@ type UsageRecordSummary struct {
 // UsageRecordSummaryListParams is the set of parameters that can be used when listing charges.
 type UsageRecordSummaryListParams struct {
 	ListParams       `form:"*"`
-	SubscriptionItem *string `form:"subscription_item"`
+	SubscriptionItem *string `form:"-"` // Sent in with the URL
 }
 
 // UsageRecordSummaryList is a list of usage record summaries as retrieved from a list endpoint.

--- a/usagerecordsummary/client_test.go
+++ b/usagerecordsummary/client_test.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestUsageRecordList(t *testing.T) {
+func TestUsageRecordSummaryList(t *testing.T) {
 	params := &stripe.UsageRecordSummaryListParams{
 		SubscriptionItem: stripe.String("si_123"),
 	}


### PR DESCRIPTION
* Ensure that `subscription_item` is not sent as a parameter when listing usage record summaries
* Update the test for usage record summary
* Fix the bank account list test for Accounts to pass the right parameter

r? @brandur-stripe 
cc @stripe/api-libraries 