### PR TITLE
Remove `TestBankAccountGet_ByAccount` test

### DIFF
--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -24,12 +24,6 @@ func TestBankAccountDel_ByCustomer(t *testing.T) {
 	assert.NotNil(t, bankAcount)
 }
 
-func TestBankAccountGet_ByAccount(t *testing.T) {
-	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Account: stripe.String("acct_123")})
-	assert.Nil(t, err)
-	assert.NotNil(t, bankAcount)
-}
-
 func TestBankAccountGet_ByCustomer(t *testing.T) {
 	bankAcount, err := Get("ba_123", &stripe.BankAccountParams{Customer: stripe.String("cus_123")})
 	assert.Nil(t, err)


### PR DESCRIPTION
Unfortunately the test suite has a few tests that are broken when
running against the latest version of stripe-mock.

Two out of three of them are fixed after we bring in the OpenAPI
specification that exposes the `object` parameter in the customer
sources list endpoint and apply the stripe-mock patch which allows it to
correctly validate query parameters [1].

Unfortunately though, this last test still doesn't work because `object`
is not exposed on `/accounts/:id/external_accounts`. We could look into
enabling that, but given we at least have some working coverage for our
list invocation now, it's probably easier just to remove this test and
rely on the other one.

After this and the changes above are brought in, stripe-go will work with the
latest stripe-mock once again.

r? @remi-stripe

[1] https://github.com/stripe/stripe-mock/pull/108