### PR TITLE
Fix subscription item listing test

### DIFF
--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -21,7 +21,9 @@ func TestSubscriptionItemGet(t *testing.T) {
 }
 
 func TestSubscriptionItemList(t *testing.T) {
-	i := List(&stripe.SubscriptionItemListParams{})
+	i := List(&stripe.SubscriptionItemListParams{
+		Subscription: stripe.String("sub_123"),
+	})
 
 	// Verify that we can get at least one item
 	assert.True(t, i.Next())


### PR DESCRIPTION
When listing subscription items a subscription ID is required. Our test
wasn't previously doing that, so here we add one in.

Caught while testing against a newer version of stripe-mock that
validates query parameters.