### PR TITLE
Upgrade stripe-mock to 0.30.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.27.0
+    - STRIPE_MOCK_VERSION=0.30.0
 
 go:
   - "1.7"

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.27.0"
+	MockMinimumVersion = "0.30.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Now that we've got a few more fixes into stripe-mock, OpenAPI (the
addition of the `object` parameter when listing customer sources), and
in stripe-go's test suite, we're ready to take stripe-mock to 0.30.0.