### PR TITLE
SubscriptionTaxPercent should be a float64, not int64

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -70,7 +70,7 @@ type InvoiceParams struct {
 	SubscriptionProrate            *bool                             `form:"subscription_prorate"`
 	SubscriptionProrationDate      *int64                            `form:"subscription_proration_date"`
 	SubscriptionQuantity           *int64                            `form:"subscription_quantity"`
-	SubscriptionTaxPercent         *int64                            `form:"subscription_tax_percent"`
+	SubscriptionTaxPercent         *float64                          `form:"subscription_tax_percent"`
 	SubscriptionTrialEnd           *int64                            `form:"subscription_trial_end"`
 	SubscriptionTrialFromPlan      *bool                             `form:"subscription_trial_from_plan"`
 }


### PR DESCRIPTION
The TaxPercent field is a *float64, the SubscriptionTaxPercent field should match, if not it's impossible to apply something like 6.5% tax on a subscription.