### PR TITLE
Handle unmarshaling OrderItem to account for `parent` expansion

### DIFF
--- a/order.go
+++ b/order.go
@@ -30,11 +30,31 @@ type OrderItemType string
 
 // List of values that OrderItemType can take.
 const (
+	OrderItemTypeCoupon   OrderItemType = "coupon"
 	OrderItemTypeDiscount OrderItemType = "discount"
-	OrderItemTypeShipping OrderItemType = "shipping"
 	OrderItemTypeSKU      OrderItemType = "sku"
+	OrderItemTypeShipping OrderItemType = "shipping"
 	OrderItemTypeTax      OrderItemType = "tax"
 )
+
+// OrderItemParentType represents the type of order item parent
+type OrderItemParentType string
+
+// List of values that OrderItemParentType can take.
+const (
+	OrderItemParentTypeCoupon   OrderItemParentType = "coupon"
+	OrderItemParentTypeDiscount OrderItemParentType = "discount"
+	OrderItemParentTypeSKU      OrderItemParentType = "sku"
+	OrderItemParentTypeShipping OrderItemParentType = "shipping"
+	OrderItemParentTypeTax      OrderItemParentType = "tax"
+)
+
+// OrderItemParent describes the parent of an order item.
+type OrderItemParent struct {
+	ID   string              `json:"id"`
+	SKU  *SKU                `json:"-"`
+	Type OrderItemParentType `json:"object"`
+}
 
 // OrderParams is the set of parameters that can be used when creating an order.
 type OrderParams struct {
@@ -176,12 +196,12 @@ type OrderItemParams struct {
 
 // OrderItem is the resource representing an order item.
 type OrderItem struct {
-	Amount      int64         `json:"amount"`
-	Currency    Currency      `json:"currency"`
-	Description string        `json:"description"`
-	Parent      string        `json:"parent"`
-	Quantity    int64         `json:"quantity"`
-	Type        OrderItemType `json:"type"`
+	Amount      int64            `json:"amount"`
+	Currency    Currency         `json:"currency"`
+	Description string           `json:"description"`
+	Parent      *OrderItemParent `json:"parent"`
+	Quantity    int64            `json:"quantity"`
+	Type        OrderItemType    `json:"type"`
 }
 
 // SetSource adds valid sources to a OrderParams object,
@@ -190,6 +210,37 @@ func (op *OrderPayParams) SetSource(sp interface{}) error {
 	source, err := SourceParamsFor(sp)
 	op.Source = source
 	return err
+}
+
+// UnmarshalJSON handles deserialization of an OrderItemParent.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or a full SKU struct if it was expanded.
+func (p *OrderItemParent) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		p.ID = id
+		return nil
+	}
+
+	type orderItemParent OrderItemParent
+	var v orderItemParent
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	var err error
+	*p = OrderItemParent(v)
+
+	switch p.Type {
+	case OrderItemParentTypeSKU:
+		// Currently only SKUs `parent` is returned as an object when expanded.
+		// For other items only IDs are returned.
+		if err = json.Unmarshal(data, &p.SKU); err != nil {
+			return err
+		}
+		p.ID = p.SKU.ID
+	}
+
+	return nil
 }
 
 // UnmarshalJSON handles deserialization of an Order.

--- a/order_test.go
+++ b/order_test.go
@@ -29,6 +29,81 @@ func TestOrder_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestOrderItem_UnmarshalJSON(t *testing.T) {
+	// Try unmarshaling a SKU order item
+	{
+		orderItemData := map[string]interface{}{
+			"object": "order_item",
+			"amount": 123,
+			"parent": "TEST-SKU-123",
+			"type":   "sku",
+		}
+		bytes, err := json.Marshal(&orderItemData)
+		assert.NoError(t, err)
+
+		var orderItem OrderItem
+		err = json.Unmarshal(bytes, &orderItem)
+		assert.NoError(t, err)
+		assert.Equal(t, "TEST-SKU-123", orderItem.Parent.ID)
+	}
+
+	// Try unmarshaling a SKU order item with parent expanded
+	{
+		orderItemData := map[string]interface{}{
+			"object": "order_item",
+			"amount": 123,
+			"parent": map[string]interface{}{
+				"id":     "TEST-SKU-123",
+				"object": "sku",
+			},
+			"type": "sku",
+		}
+		bytes, err := json.Marshal(&orderItemData)
+		assert.NoError(t, err)
+
+		var orderItem OrderItem
+		err = json.Unmarshal(bytes, &orderItem)
+		assert.NoError(t, err)
+		assert.Equal(t, "TEST-SKU-123", orderItem.Parent.ID)
+		assert.Equal(t, OrderItemParentTypeSKU, orderItem.Parent.Type)
+		assert.Equal(t, "TEST-SKU-123", orderItem.Parent.SKU.ID)
+	}
+
+	// Try unmarshaling a coupon order item
+	{
+		orderItemData := map[string]interface{}{
+			"object": "order_item",
+			"amount": 0,
+			"parent": "TEST-COUPON-123",
+			"type":   "coupon",
+		}
+		bytes, err := json.Marshal(&orderItemData)
+		assert.NoError(t, err)
+
+		var orderItem OrderItem
+		err = json.Unmarshal(bytes, &orderItem)
+		assert.NoError(t, err)
+		assert.Equal(t, "TEST-COUPON-123", orderItem.Parent.ID)
+	}
+
+	// Try unmarshaling a shipping order item
+	{
+		orderItemData := map[string]interface{}{
+			"object": "order_item",
+			"amount": 1000,
+			"parent": "ship_MZmIpV7v14QZLlRR",
+			"type":   "shipping",
+		}
+		bytes, err := json.Marshal(&orderItemData)
+		assert.NoError(t, err)
+
+		var orderItem OrderItem
+		err = json.Unmarshal(bytes, &orderItem)
+		assert.NoError(t, err)
+		assert.Equal(t, "ship_MZmIpV7v14QZLlRR", orderItem.Parent.ID)
+	}
+}
+
 func TestOrderUpdateParams_AppendTo(t *testing.T) {
 	{
 		params := &OrderUpdateParams{


### PR DESCRIPTION
Attempts to fix the unmarshalling error that can occur when expanding `parent` of an Order Item object, when calling `order.List` and expanding on `data.items.parent`. 

r? @brandur-stripe 
cc @stripe/api-libraries 