### PR TITLE
Encode `Params` in `AppendToAsSourceOrExternalAccount`

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -71,6 +71,11 @@ type BankAccountParams struct {
 // because the bank accounts endpoint is a little unusual. There is one other
 // resource like it, which is cards.
 func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values) {
+	// Rather than being called in addition to `AppendTo`, this function
+	// *replaces* `AppendTo`, so we must also make sure to handle the encoding
+	// of `Params` so metadata and the like is included in the encoded payload.
+	form.AppendTo(body, a.Params)
+
 	isCustomer := a.Customer != nil
 
 	var sourceType string

--- a/bankaccount_test.go
+++ b/bankaccount_test.go
@@ -79,6 +79,21 @@ func TestBankAccountParams_AppendToAsSourceOrExternalAccount(t *testing.T) {
 		assert.Equal(t, []string{"individual"}, body.Get("external_account[account_holder_type]"))
 	}
 
+	// Includes Params
+	{
+		params := &BankAccountParams{
+			Params: Params{
+				Metadata: map[string]string{
+					"foo": "bar",
+				},
+			},
+		}
+		body := &form.Values{}
+		params.AppendToAsSourceOrExternalAccount(body)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"bar"}, body.Get("metadata[foo]"))
+	}
+
 	// Does not include account_holder_name if empty
 	{
 		params := &BankAccountParams{}

--- a/card.go
+++ b/card.go
@@ -108,6 +108,9 @@ type CardParams struct {
 // because the cards endpoint is a little unusual. There is one other resource
 // like it, which is bank account.
 func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, keyParts []string) {
+	// Rather than being called in addition to `AppendTo`, this function
+	// *replaces* `AppendTo`, so we must also make sure to handle the encoding
+	// of `Params` so metadata and the like is included in the encoded payload.
 	form.AppendToPrefixed(body, c.Params, keyParts)
 
 	if c.DefaultForCurrency != nil {

--- a/card_test.go
+++ b/card_test.go
@@ -58,3 +58,41 @@ func TestCard_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, "card_123", v.ID)
 	}
 }
+
+func TestCardParams_AppendToAsCardSourceOrExternalAccount(t *testing.T) {
+	// We should add more tests for all the various corner cases here ...
+
+	// Includes number and object
+	{
+		params := &CardParams{Number: String("1234")}
+		body := &form.Values{}
+		params.AppendToAsCardSourceOrExternalAccount(body, nil)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"1234"}, body.Get("source[number]"))
+		assert.Equal(t, []string{"card"}, body.Get("source[object]"))
+	}
+
+	// Includes Params
+	{
+		params := &CardParams{
+			Params: Params{
+				Metadata: map[string]string{
+					"foo": "bar",
+				},
+			},
+		}
+		body := &form.Values{}
+		params.AppendToAsCardSourceOrExternalAccount(body, nil)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"bar"}, body.Get("metadata[foo]"))
+	}
+
+	// It takes key parts for deeper embedding
+	{
+		params := &CardParams{Number: String("1234")}
+		body := &form.Values{}
+		params.AppendToAsCardSourceOrExternalAccount(body, []string{"prefix1", "prefix2"})
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"1234"}, body.Get("prefix1[prefix2][source][number]"))
+	}
+}


### PR DESCRIPTION
`BankAccount` has a special encoding function that's invoked from its
`New` called `AppendToAsSourceOrExternalAccount`. It works quite a bit
differently from any other resource (with the exception of card) because
this special encoding is invoked then the function uses a `CallRaw`
instead of a `Call`, so no general `AppendTo` is ever used.

As described in #685, this caused a problem whereby the standard set of
fields in `Params` were not being included because the function didn't
have any consideration for them (although strangely, we *were* handling
them from card's equivalent). Here we add an allowance for `Params` and
a test to make sure that metadata is being encoded correctly.

Fixes #685.

r? @remi-stripe
cc @stripe/api-libraries