### PR TITLE
Add `go.mod` to support the new module system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .env
 *.test
 *.coverprofile
+
+
+# Because our only dependencies are test-related, I'm leaving out `go.sum` for
+# the time being. Feel free to revisit this decision in the future if it
+# appears to be causing problems.
+/go.sum

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/stripe/stripe-go


### PR DESCRIPTION
Adds a `go.mod` file to support the new experimental Go module system
which is likely to see full release pretty soon.

See #559 for original context. I originally tried this in #563, but ran
into trouble because Vgo wasn't smart enough to have subpackages in a
module know to use their parent's version, so we'd see problems where
it'd use stripe-go v46 (for example), go on to look at stripe-go/charge,
see that it depended on stripe-go, so it would re-ascend the tree and
default to stripe-go v1 instead of v46! See #563 for details, but it
didn't work at all and I ended up just reverting.

Since then it seems like some major improvements have been made and
subpackages can now resolve their parents version correctly. (I tried
this in a test project and although I'm not 100% sure that it was doing
t he right thing because `go.mod` is not yet in GitHub's master, it
looked like it was working).

Also, the system has improved to the point where the `/v46` path suffix
is no longer needed in `vgo.mod` which means that we don't even have to
updated our build scripts. That's great.

After this lands, I'll make sure to mess around it with a little more to
make sure everything looks like it's doing what expect.

r? @ob-stripe
cc @stripe/api-libraries