### PR TITLE
Add resource_missing error code

### DIFF
--- a/error.go
+++ b/error.go
@@ -34,6 +34,7 @@ const (
 	ErrorCodeMissing            ErrorCode = "missing"
 	ErrorCodeProcessingError    ErrorCode = "processing_error"
 	ErrorCodeRateLimit          ErrorCode = "rate_limit"
+	ErrorCodeResourceMissing    ErrorCode = "resource_missing"
 )
 
 // Error is the response returned when a call is unsuccessful.


### PR DESCRIPTION
Not urgent, but noticed this missing when I was trying to isolate 404s looking up plans.