### PR TITLE
Updating IssuingCardDetails.Number json tag to 'number'

### DIFF
--- a/issuing_card.go
+++ b/issuing_card.go
@@ -93,7 +93,7 @@ type IssuingCardDetails struct {
 	CVC      string       `json:"cvc"`
 	ExpMonth *string      `form:"exp_month"`
 	ExpYear  *string      `form:"exp_year"`
-	Number   string       `json:"type"`
+	Number   string       `json:"number"`
 	Object   string       `json:"object"`
 }
 


### PR DESCRIPTION
Currently the IssuingCardDetails struct returns with a zero value for Number, this is because the json tag in the type declaration is set to 'type' and the API request is returning 'number'.

This pull request simply changes the json tag in the IssuingCardDetails declaration to 'number' to fix this issue.