### PR TITLE
Add new invoice methods and fixes to the Issuing Cardholder resource

### DIFF
--- a/invoice/client.go
+++ b/invoice/client.go
@@ -26,6 +26,19 @@ func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	return invoice, err
 }
 
+// Del deletes an invoice.
+func Del(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
+	return getC().Del(id, params)
+}
+
+// Del deletes an invoice.
+func (c Client) Del(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, invoice)
+	return invoice, err
+}
+
 // Get returns the details of an invoice.
 func Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	return getC().Get(id, params)
@@ -116,6 +129,58 @@ func (c Client) ListLines(listParams *stripe.InvoiceLineListParams) *LineIter {
 
 		return ret, list.ListMeta, err
 	})}
+}
+
+// FinalizeInvoice finalizes an invoice.
+func FinalizeInvoice(id string, params *stripe.InvoiceFinalizeParams) (*stripe.Invoice, error) {
+	return getC().FinalizeInvoice(id, params)
+}
+
+// FinalizeInvoice finalizes an invoice.
+func (c Client) FinalizeInvoice(id string, params *stripe.InvoiceFinalizeParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s/finalize", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	return invoice, err
+}
+
+// MarkUncollectible marks an invoice as uncollectible.
+func MarkUncollectible(id string, params *stripe.InvoiceMarkUncollectibleParams) (*stripe.Invoice, error) {
+	return getC().MarkUncollectible(id, params)
+}
+
+// MarkUncollectible marks an invoice as uncollectible.
+func (c Client) MarkUncollectible(id string, params *stripe.InvoiceMarkUncollectibleParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s/mark_uncollectible", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	return invoice, err
+}
+
+// SendInvoice sends an invoice.
+func SendInvoice(id string, params *stripe.InvoiceSendParams) (*stripe.Invoice, error) {
+	return getC().SendInvoice(id, params)
+}
+
+// SendInvoice sends an invoice.
+func (c Client) SendInvoice(id string, params *stripe.InvoiceSendParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s/send", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	return invoice, err
+}
+
+// VoidInvoice voids an invoice.
+func VoidInvoice(id string, params *stripe.InvoiceVoidParams) (*stripe.Invoice, error) {
+	return getC().VoidInvoice(id, params)
+}
+
+// VoidInvoice voids an invoice.
+func (c Client) VoidInvoice(id string, params *stripe.InvoiceVoidParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s/void", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	return invoice, err
 }
 
 // Iter is an iterator for invoices.

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -59,3 +59,33 @@ func TestInvoiceUpdate(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)
 }
+
+func TestInvoiceDel(t *testing.T) {
+	invoice, err := Del("in_123", &stripe.InvoiceParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}
+
+func TestInvoiceFinalizeInvoice(t *testing.T) {
+	invoice, err := FinalizeInvoice("in_123", &stripe.InvoiceFinalizeParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}
+
+func TestInvoiceMarkUncollectible(t *testing.T) {
+	invoice, err := MarkUncollectible("in_123", &stripe.InvoiceMarkUncollectibleParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}
+
+func TestInvoiceSendInvoice(t *testing.T) {
+	invoice, err := SendInvoice("in_123", &stripe.InvoiceSendParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}
+
+func TestInvoiceVoidInvoice(t *testing.T) {
+	invoice, err := VoidInvoice("in_123", &stripe.InvoiceVoidParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}

--- a/stripe.go
+++ b/stripe.go
@@ -794,7 +794,7 @@ func StringValue(v *string) string {
 const apiURL = "https://api.stripe.com"
 
 // apiversion is the currently supported API version
-const apiversion = "2018-09-24"
+const apiversion = "2018-11-08"
 
 // clientversion is the binding version
 const clientversion = "52.1.0"

--- a/sub.go
+++ b/sub.go
@@ -42,6 +42,7 @@ type SubscriptionParams struct {
 	Coupon                      *string                    `form:"coupon"`
 	Customer                    *string                    `form:"customer"`
 	DaysUntilDue                *int64                     `form:"days_until_due"`
+	DefaultSource               *string                    `form:"default_source"`
 	Items                       []*SubscriptionItemsParams `form:"items"`
 	OnBehalfOf                  *string                    `form:"on_behalf_of"`
 	Plan                        *string                    `form:"plan"`
@@ -113,6 +114,7 @@ type Subscription struct {
 	CurrentPeriodStart    int64                 `json:"current_period_start"`
 	Customer              *Customer             `json:"customer"`
 	DaysUntilDue          int64                 `json:"days_until_due"`
+	DefaultSource         *PaymentSource        `json:"default_source"`
 	Discount              *Discount             `json:"discount"`
 	CancelAtPeriodEnd     bool                  `json:"cancel_at_period_end"`
 	EndedAt               int64                 `json:"ended_at"`


### PR DESCRIPTION
This PR ships multiple breaking changes
* Move to `2018-11-08` as the new API version
* Updates the Invoice resource to support new properties, parameters and methods
* Add support for `default_source` on Subscription.

cc @stripe/api-libraries 

