### PR TITLE
Set `Request.GetBody`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,10 @@ env:
     - STRIPE_MOCK_VERSION=0.33.0
 
 go:
-  - "1.7"
   - "1.8"
   - "1.9"
   - "1.10"
+  - "1.11"
   - tip
 
 language: go


### PR DESCRIPTION
Here we set `Request.GetBody`, which is used under certain circumstances
by the internal `net/http` core like in the case of a redirect. This
will usually not end up being used, but it doesn't hurt to set it in
case it is (it's run lazily, and few additional resources are needed in
case it's not run).

Fixes #710.

r? @remi-stripe
cc @stripe/api-libraries