### PR TITLE
`Do` function panics when HTTPClient returns a nil response

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -362,10 +362,10 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 				if s.LogLevel > 0 {
 					s.Logger.Printf("Cannot read response: %v\n", err)
 				}
-				return err
-			}
-			if s.LogLevel > 0 {
-				s.Logger.Printf("Request failed with body: %s (status: %v)\n", string(resBody), res.StatusCode)
+			} else {
+				if s.LogLevel > 0 {
+					s.Logger.Printf("Request failed with body: %s (status: %v)\n", string(resBody), res.StatusCode)
+				}
 			}
 		}
 

--- a/stripe.go
+++ b/stripe.go
@@ -351,13 +351,21 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 			break
 		}
 
-		resBody, err := ioutil.ReadAll(res.Body)
-		res.Body.Close()
-		if err != nil {
-			if s.LogLevel > 0 {
-				s.Logger.Printf("Cannot read response: %v\n", err)
+		var (
+			resBody []byte
+			err error
+		)
+		// Checking res instead of err because s.HTTPClient.Do(req) has one special case for Go 1 compatibility
+		// when both the response and an error are returned
+		if res != nil {
+			resBody, err = ioutil.ReadAll(res.Body)
+			res.Body.Close()
+			if err != nil {
+				if s.LogLevel > 0 {
+					s.Logger.Printf("Cannot read response: %v\n", err)
+				}
+				return err
 			}
-			return err
 		}
 
 		if s.LogLevel > 0 {

--- a/stripe.go
+++ b/stripe.go
@@ -365,7 +365,7 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 				return err
 			}
 			if s.LogLevel > 0 {
-				s.Logger.Printf("Request failed with: %s (error: %v)\n", string(resBody), err)
+				s.Logger.Printf("Request failed with body: %s (status: %v)\n", string(resBody), res.StatusCode)
 			}
 		}
 

--- a/stripe.go
+++ b/stripe.go
@@ -351,12 +351,8 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 			break
 		}
 
-		var (
-			resBody []byte
-			err     error
-		)
-		// Checking res instead of err because s.HTTPClient.Do(req) has one special case for Go 1 compatibility
-		// when both the response and an error are returned
+		var resBody []byte
+
 		if res != nil {
 			resBody, err = ioutil.ReadAll(res.Body)
 			res.Body.Close()
@@ -389,6 +385,7 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 		}
 		return err
 	}
+
 	defer res.Body.Close()
 
 	resBody, err := ioutil.ReadAll(res.Body)

--- a/stripe.go
+++ b/stripe.go
@@ -351,10 +351,12 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 			break
 		}
 
-		var resBody []byte
-
-		if res != nil {
-			resBody, err = ioutil.ReadAll(res.Body)
+		if err != nil {
+			if s.LogLevel > 0 {
+				s.Logger.Printf("Request failed with error: %v\n", err)
+			}
+		} else {
+			resBody, err := ioutil.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				if s.LogLevel > 0 {
@@ -362,10 +364,9 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 				}
 				return err
 			}
-		}
-
-		if s.LogLevel > 0 {
-			s.Logger.Printf("Request failed with: %s (error: %v)\n", string(resBody), err)
+			if s.LogLevel > 0 {
+				s.Logger.Printf("Request failed with: %s (error: %v)\n", string(resBody), err)
+			}
 		}
 
 		sleepDuration := s.sleepTime(retry)

--- a/stripe.go
+++ b/stripe.go
@@ -353,7 +353,7 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 
 		var (
 			resBody []byte
-			err error
+			err     error
 		)
 		// Checking res instead of err because s.HTTPClient.Do(req) has one special case for Go 1 compatibility
 		// when both the response and an error are returned

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -137,7 +137,6 @@ func (s *SafeCounter) Get() int {
 	return s.requestNum
 }
 
-// Tests client retries when HTTP returns timeout.
 func TestDo_RetryOnTimeout(t *testing.T) {
 	type testServerResponse struct {
 		Message string `json:"message"`

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	assert "github.com/stretchr/testify/require"
-	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go"
 	. "github.com/stripe/stripe-go/testing"
 )
 
@@ -119,10 +119,9 @@ func TestDo_Retry(t *testing.T) {
 	assert.Equal(t, 2, requestNum)
 }
 
-
 // Types for TestDo_RetryOnTimeout test
 type SafeCounter struct {
-	mux sync.Mutex
+	mux        sync.Mutex
 	requestNum int
 }
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	assert "github.com/stretchr/testify/require"
-	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go"
 	. "github.com/stripe/stripe-go/testing"
 )
 
@@ -153,7 +153,7 @@ func TestDo_RetryOnTimeout(t *testing.T) {
 			LogLevel:          3,
 			MaxNetworkRetries: 2,
 			URL:               testServer.URL,
-			HTTPClient:  &http.Client{Timeout: timeout},
+			HTTPClient:        &http.Client{Timeout: timeout},
 		},
 	).(*stripe.BackendImplementation)
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	assert "github.com/stretchr/testify/require"
-	"github.com/stripe/stripe-go"
+	stripe "github.com/stripe/stripe-go"
 	. "github.com/stripe/stripe-go/testing"
 )
 
@@ -178,7 +178,7 @@ func TestDo_RetryOnTimeout(t *testing.T) {
 	}()
 	err = backend.Do(request, body, &response)
 
-	// there should an error returned
+	// there should be an error returned
 	assert.Error(t, err)
 	// timeout should not prevent retry
 	assert.Equal(t, 2, requestNum)


### PR DESCRIPTION
This PR covers the scenario when `res, err = s.HTTPClient.Do(req)` results in `res` that is `nil` (https://github.com/stripe/stripe-go/blob/master/stripe.go#L341 ). This can happen for example in case of timeout.

* a test was added to verify no panic in case of timeout
* in the `Do` function an additional check was added to prevent panic

Closes #713

---
[EDIT] Initial motivation:

Integration tests in the codebase I'm working on are randomly failing with the following stack trace:
```
error_cause=runtime error: invalid memory address or nil pointer dereference 
stack_trace=[
  {
  "function": "runtime.call32",
  "location": "/usr/local/go/src/runtime/asm_amd64.s:573"
  },
  {
  "function": "runtime.gopanic",
  "location": "/usr/local/go/src/runtime/panic.go:503"
  },
  {
  "function": "runtime.panicmem",
  "location": "/usr/local/go/src/runtime/panic.go:63"
  },
  {
  "function": "runtime.sigpanic",
  "location": "/usr/local/go/src/runtime/signal_unix.go:388"
  },
  {
  "function": "github.com/newstore/newstore/vendor/github.com/stripe/stripe-go.(*BackendImplementation).Do",
  "location": "/go/src/github.com/newstore/newstore/vendor/github.com/stripe/stripe-go/stripe.go:342"
  },
  {
  "function": "github.com/newstore/newstore/vendor/github.com/stripe/stripe-go.(*BackendImplementation).CallRaw",
  "location": "/go/src/github.com/newstore/newstore/vendor/github.com/stripe/stripe-go/stripe.go:224"
  },
  {
  "function": "github.com/newstore/newstore/vendor/github.com/stripe/stripe-go.(*BackendImplementation).Call",
  "location": "/go/src/github.com/newstore/newstore/vendor/github.com/stripe/stripe-go/stripe.go:186"
  },
  {
  "function": "github.com/newstore/newstore/vendor/github.com/stripe/stripe-go/customer.Client.Get",
  "location": "/go/src/github.com/newstore/newstore/vendor/github.com/stripe/stripe-go/customer/client.go:38"
  },
  ...
```

In this PR I'm trying to capture the situation in which this panic can happen in client.go:38. The best hypothesis was that res is nil, and so the attempt to access res.Body causes a panic. 

The goal in the test was to simulate the scenario where HttpClient.Do() function returns nil response. 

The timeout scenario for the test was chosen simply because, given the infrastructure used for testing stripe-go, it was the easiest to simulate. 