### PR TITLE
Integration branch for v53.0.0 release

### DIFF
--- a/countryspec.go
+++ b/countryspec.go
@@ -18,6 +18,7 @@ type CountrySpec struct {
 	SupportedBankAccountCurrencies map[Currency][]Country                      `json:"supported_bank_account_currencies"`
 	SupportedPaymentCurrencies     []Currency                                  `json:"supported_payment_currencies"`
 	SupportedPaymentMethods        []string                                    `json:"supported_payment_methods"`
+	SupportedTransferCountries     []string                                    `json:"supported_transfer_countries"`
 	VerificationFields             map[LegalEntityType]*VerificationFieldsList `json:"verification_fields"`
 }
 

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -26,6 +26,19 @@ func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	return invoice, err
 }
 
+// Del deletes an invoice.
+func Del(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
+	return getC().Del(id, params)
+}
+
+// Del deletes an invoice.
+func (c Client) Del(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, invoice)
+	return invoice, err
+}
+
 // Get returns the details of an invoice.
 func Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	return getC().Get(id, params)
@@ -116,6 +129,58 @@ func (c Client) ListLines(listParams *stripe.InvoiceLineListParams) *LineIter {
 
 		return ret, list.ListMeta, err
 	})}
+}
+
+// FinalizeInvoice finalizes an invoice.
+func FinalizeInvoice(id string, params *stripe.InvoiceFinalizeParams) (*stripe.Invoice, error) {
+	return getC().FinalizeInvoice(id, params)
+}
+
+// FinalizeInvoice finalizes an invoice.
+func (c Client) FinalizeInvoice(id string, params *stripe.InvoiceFinalizeParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s/finalize", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	return invoice, err
+}
+
+// MarkUncollectible marks an invoice as uncollectible.
+func MarkUncollectible(id string, params *stripe.InvoiceMarkUncollectibleParams) (*stripe.Invoice, error) {
+	return getC().MarkUncollectible(id, params)
+}
+
+// MarkUncollectible marks an invoice as uncollectible.
+func (c Client) MarkUncollectible(id string, params *stripe.InvoiceMarkUncollectibleParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s/mark_uncollectible", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	return invoice, err
+}
+
+// SendInvoice sends an invoice.
+func SendInvoice(id string, params *stripe.InvoiceSendParams) (*stripe.Invoice, error) {
+	return getC().SendInvoice(id, params)
+}
+
+// SendInvoice sends an invoice.
+func (c Client) SendInvoice(id string, params *stripe.InvoiceSendParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s/send", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	return invoice, err
+}
+
+// VoidInvoice voids an invoice.
+func VoidInvoice(id string, params *stripe.InvoiceVoidParams) (*stripe.Invoice, error) {
+	return getC().VoidInvoice(id, params)
+}
+
+// VoidInvoice voids an invoice.
+func (c Client) VoidInvoice(id string, params *stripe.InvoiceVoidParams) (*stripe.Invoice, error) {
+	path := stripe.FormatURLPath("/invoices/%s/void", id)
+	invoice := &stripe.Invoice{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	return invoice, err
 }
 
 // Iter is an iterator for invoices.

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -59,3 +59,33 @@ func TestInvoiceUpdate(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)
 }
+
+func TestInvoiceDel(t *testing.T) {
+	invoice, err := Del("in_123", &stripe.InvoiceParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}
+
+func TestInvoiceFinalizeInvoice(t *testing.T) {
+	invoice, err := FinalizeInvoice("in_123", &stripe.InvoiceFinalizeParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}
+
+func TestInvoiceMarkUncollectible(t *testing.T) {
+	invoice, err := MarkUncollectible("in_123", &stripe.InvoiceMarkUncollectibleParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}
+
+func TestInvoiceSendInvoice(t *testing.T) {
+	invoice, err := SendInvoice("in_123", &stripe.InvoiceSendParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}
+
+func TestInvoiceVoidInvoice(t *testing.T) {
+	invoice, err := VoidInvoice("in_123", &stripe.InvoiceVoidParams{})
+	assert.Nil(t, err)
+	assert.NotNil(t, invoice)
+}

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -152,6 +152,7 @@ type PaymentIntent struct {
 	NextSourceAction    *PaymentIntentSourceAction      `json:"next_source_action"`
 	OnBehalfOf          *Account                        `json:"on_behalf_of"`
 	ReceiptEmail        string                          `json:"receipt_email"`
+	Review              *Review                         `json:"review"`
 	Shipping            ShippingDetails                 `json:"shipping"`
 	Source              *PaymentSource                  `json:"source"`
 	StatementDescriptor string                          `json:"statement_descriptor"`

--- a/paymentintent/client.go
+++ b/paymentintent/client.go
@@ -55,12 +55,12 @@ func (c Client) Update(id string, params *stripe.PaymentIntentParams) (*stripe.P
 }
 
 // Cancel cancels a payment intent.
-func Cancel(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
+func Cancel(id string, params *stripe.PaymentIntentCancelParams) (*stripe.PaymentIntent, error) {
 	return getC().Cancel(id, params)
 }
 
 // Cancel cancels a payment intent.
-func (c Client) Cancel(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
+func (c Client) Cancel(id string, params *stripe.PaymentIntentCancelParams) (*stripe.PaymentIntent, error) {
 	path := stripe.FormatURLPath("/payment_intents/%s/cancel", id)
 	intent := &stripe.PaymentIntent{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)
@@ -81,12 +81,12 @@ func (c Client) Capture(id string, params *stripe.PaymentIntentCaptureParams) (*
 }
 
 // Confirm confirms a payment intent.
-func Confirm(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
+func Confirm(id string, params *stripe.PaymentIntentConfirmParams) (*stripe.PaymentIntent, error) {
 	return getC().Confirm(id, params)
 }
 
 // Confirm confirms a payment intent.
-func (c Client) Confirm(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
+func (c Client) Confirm(id string, params *stripe.PaymentIntentConfirmParams) (*stripe.PaymentIntent, error) {
 	path := stripe.FormatURLPath("/payment_intents/%s/confirm", id)
 	intent := &stripe.PaymentIntent{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)

--- a/paymentintent/client_test.go
+++ b/paymentintent/client_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestPaymentIntentCancel(t *testing.T) {
-	intent, err := Cancel("pi_123", nil)
+	intent, err := Cancel("pi_123", &stripe.PaymentIntentCancelParams{
+		CancellationReason: stripe.String(string(stripe.PaymentIntentCancellationReasonRequestedByCustomer)),
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, intent)
 }
@@ -21,7 +23,9 @@ func TestPaymentIntentCapture(t *testing.T) {
 }
 
 func TestPaymentIntentConfirm(t *testing.T) {
-	intent, err := Confirm("pi_123", nil)
+	intent, err := Confirm("pi_123", &stripe.PaymentIntentConfirmParams{
+		ReturnURL: stripe.String("https://stripe.com/return"),
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, intent)
 }

--- a/paymentintent_test.go
+++ b/paymentintent_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestPaymentIntentSourceAction_UnmarshalJSON(t *testing.T) {
 	actionData := map[string]interface{}{
-		"type": "authorize_with_url",
-		"value": map[string]interface{}{
-			"url": "https://stripe.com",
+		"authorize_with_url": map[string]interface{}{
+			"return_url": "https://stripe.com/return",
+			"url":        "https://stripe.com",
 		},
+		"type": "authorize_with_url",
 	}
 
 	bytes, err := json.Marshal(&actionData)
@@ -23,7 +24,8 @@ func TestPaymentIntentSourceAction_UnmarshalJSON(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, PaymentIntentNextActionAuthorizeWithURL, action.Type)
-	assert.Equal(t, "https://stripe.com", action.Value.AuthorizeWithURL.URL)
+	assert.Equal(t, "https://stripe.com", action.AuthorizeWithURL.URL)
+	assert.Equal(t, "https://stripe.com/return", action.AuthorizeWithURL.ReturnURL)
 }
 
 func TestPaymentIntent_UnmarshalJSON(t *testing.T) {

--- a/plan.go
+++ b/plan.go
@@ -128,6 +128,7 @@ type PlanParams struct {
 
 // PlanTier configures tiered pricing
 type PlanTier struct {
+	FlatAmount int64 `json:"flat_amount"`
 	UnitAmount int64 `json:"unit_amount"`
 	UpTo       int64 `json:"up_to"`
 }
@@ -147,6 +148,7 @@ type PlanTransformUsageParams struct {
 // PlanTierParams configures tiered pricing
 type PlanTierParams struct {
 	Params     `form:"*"`
+	FlatAmount *int64 `form:"flat_amount"`
 	UnitAmount *int64 `form:"unit_amount"`
 	UpTo       *int64 `form:"-"` // handled in custom AppendTo
 	UpToInf    *bool  `form:"-"` // handled in custom AppendTo

--- a/stripe.go
+++ b/stripe.go
@@ -794,7 +794,7 @@ func StringValue(v *string) string {
 const apiURL = "https://api.stripe.com"
 
 // apiversion is the currently supported API version
-const apiversion = "2018-09-24"
+const apiversion = "2018-11-08"
 
 // clientversion is the binding version
 const clientversion = "52.1.0"

--- a/sub.go
+++ b/sub.go
@@ -42,6 +42,7 @@ type SubscriptionParams struct {
 	Coupon                      *string                    `form:"coupon"`
 	Customer                    *string                    `form:"customer"`
 	DaysUntilDue                *int64                     `form:"days_until_due"`
+	DefaultSource               *string                    `form:"default_source"`
 	Items                       []*SubscriptionItemsParams `form:"items"`
 	OnBehalfOf                  *string                    `form:"on_behalf_of"`
 	Plan                        *string                    `form:"plan"`
@@ -113,6 +114,7 @@ type Subscription struct {
 	CurrentPeriodStart    int64                 `json:"current_period_start"`
 	Customer              *Customer             `json:"customer"`
 	DaysUntilDue          int64                 `json:"days_until_due"`
+	DefaultSource         *PaymentSource        `json:"default_source"`
 	Discount              *Discount             `json:"discount"`
 	CancelAtPeriodEnd     bool                  `json:"cancel_at_period_end"`
 	EndedAt               int64                 `json:"ended_at"`


### PR DESCRIPTION
Since we are introducing multiple breaking changes to some resources, we are preparing a new branch to group multiple changes into one release.

* [x] Add support for `supported_transfer_countries` on CountrySpec. #718
* [x] Add support for `flat_amount` on Plan tiers. #717
* [x] Ship changes to the Payment Intent resource to match the final layout. #715
* [x] Add support for `review` on Payment Intent. https://github.com/stripe/stripe-go/pull/720
* [x] Ship all changes and new methods for Invoice and latest API version. https://github.com/stripe/stripe-go/pull/707