### PR TITLE
Remove hack to skip Golint on old versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,26 +10,7 @@ before_install:
   - travis_retry go get -u golang.org/x/tools/cmd/cover
   - travis_retry go get -u github.com/modocache/gover
   - travis_retry go get -u github.com/mattn/goveralls
-
-  # Go only officially supports two major versions back from Today's release,
-  # and unfortunately for its users, aren't afraid to break old versions by
-  # aggressively using new features. Here we conditionally fetch Golint if
-  # we're on a version that we know supports it. 
-  #
-  # `Makefile` checks `SKIP_GOLINT` and skips it if necessary.
-  - |
-    GOLINT_BROKEN_GO_VERSION="1.8"
-
-    # Needed because we can't lexically compare versions.
-    version_gt() {
-      test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
-    }
-
-    if version_gt "$TRAVIS_GO_VERSION" "$GOLINT_BROKEN_GO_VERSION"; then
-      travis_retry go get -u golang.org/x/lint/golint
-    else
-      export SKIP_GOLINT=1
-    fi
+  - travis_retry go get -u golang.org/x/lint/golint
 
   # Unpack and start the Stripe API stub so that the test suite can talk to it
   - |

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,7 @@ check-gofmt:
 	scripts/check_gofmt.sh
 
 lint:
-# Golint won't run on some Go versions. See `.travis.yml`.
-ifndef SKIP_GOLINT
 	golint -set_exit_status ./...
-else
-	# No Golint. Skipping Linting.
-endif
 
 test:
 	go test -race ./...


### PR DESCRIPTION
We needed to add this hack so that we could build on Go 1.8 which is no
longer supported by Golint. A while after that we dropped support for Go
1.8 in the build matrix though, so this hack isn't needed any longer.