### PR TITLE
Add `last_payment_error` on PaymentIntent and fix broken tests

### DIFF
--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -33,30 +33,7 @@ func TestChargeNew(t *testing.T) {
 	charge, err := New(&stripe.ChargeParams{
 		Amount:   stripe.Int64(11700),
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
-		Level3: &stripe.ChargeLevel3Params{
-			LineItems: []*stripe.ChargeLevel3LineItemsParams{
-				{
-					DiscountAmount:     stripe.Int64(200),
-					ProductCode:        stripe.String("1234"),
-					ProductDescription: stripe.String("description 1"),
-					Quantity:           stripe.Int64(2),
-					TaxAmount:          stripe.Int64(200),
-					UnitCost:           stripe.Int64(1000),
-				},
-				{
-					DiscountAmount:     stripe.Int64(300),
-					ProductCode:        stripe.String("1235"),
-					ProductDescription: stripe.String("description 2"),
-					Quantity:           stripe.Int64(3),
-					TaxAmount:          stripe.Int64(300),
-					UnitCost:           stripe.Int64(3000),
-				},
-			},
-			MerchantReference:  stripe.String("123"),
-			ShippingAddressZip: stripe.String("94110"),
-			ShippingAmount:     stripe.Int64(700),
-		},
-		Source: &stripe.SourceParams{Token: stripe.String("src_123")},
+		Source:   &stripe.SourceParams{Token: stripe.String("src_123")},
 		Shipping: &stripe.ShippingDetailsParams{
 			Address: &stripe.AddressParams{
 				Line1: stripe.String("line1"),

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -53,8 +53,11 @@ func TestInvoicePay(t *testing.T) {
 
 func TestInvoiceUpdate(t *testing.T) {
 	invoice, err := Update("in_123", &stripe.InvoiceParams{
-		Forgiven: stripe.Bool(true),
-		Closed:   stripe.Bool(true),
+		Params: stripe.Params{
+			Metadata: map[string]string{
+				"foo": "bar",
+			},
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, invoice)

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -110,6 +110,18 @@ type PaymentIntentListParams struct {
 	ListParams `form:"*"`
 }
 
+// PaymentIntentLastPaymentError represents the last error happening on a payment intent.
+type PaymentIntentLastPaymentError struct {
+	Charge      string         `json:"charge"`
+	Code        string         `json:"code"`
+	DeclineCode string         `json:"decline_code"`
+	DocURL      string         `json:"doc_url"`
+	Message     string         `json:"message"`
+	Param       string         `json:"param"`
+	Source      *PaymentSource `json:"source"`
+	Type        ErrorType      `json:"type"`
+}
+
 // PaymentIntentSourceActionAuthorizeWithURL represents the resource for the next action of type
 // "authorize_with_url".
 type PaymentIntentSourceActionAuthorizeWithURL struct {
@@ -146,6 +158,7 @@ type PaymentIntent struct {
 	Currency            string                          `json:"currency"`
 	Customer            *Customer                       `json:"customer"`
 	Description         string                          `json:"description"`
+	LastPaymentError    *PaymentIntentLastPaymentError  `json:"last_payment_error"`
 	Livemode            bool                            `json:"livemode"`
 	ID                  string                          `json:"id"`
 	Metadata            map[string]string               `json:"metadata"`

--- a/paymentintent_test.go
+++ b/paymentintent_test.go
@@ -7,6 +7,40 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
+func TestPaymentIntentLastPaymentError_UnmarshalJSON(t *testing.T) {
+	errorData := map[string]interface{}{
+		"charge":       "ch_123",
+		"code":         "card_declined",
+		"decline_code": "generic_decline",
+		"doc_url":      "https://stripe.com/docs/error-codes/card-declined",
+		"message":      "Your card was declined.",
+		"source": map[string]interface{}{
+			"id":          "card_123",
+			"object":      "card",
+			"brand":       "Visa",
+			"country":     "US",
+			"customer":    "cus_123",
+			"exp_month":   9,
+			"exp_year":    2019,
+			"fingerprint": "fingerprint",
+			"last4":       "0341",
+		},
+		"type": "card_error",
+	}
+	bytes, err := json.Marshal(&errorData)
+	assert.NoError(t, err)
+
+	var lastPaymentError PaymentIntentLastPaymentError
+	err = json.Unmarshal(bytes, &lastPaymentError)
+	assert.NoError(t, err)
+
+	assert.Equal(t, ErrorTypeCard, lastPaymentError.Type)
+	assert.Equal(t, "ch_123", lastPaymentError.Charge)
+	assert.Equal(t, "https://stripe.com/docs/error-codes/card-declined", lastPaymentError.DocURL)
+	assert.Equal(t, PaymentSourceTypeCard, lastPaymentError.Source.Type)
+	assert.Equal(t, "card_123", lastPaymentError.Source.Card.ID)
+}
+
 func TestPaymentIntentSourceAction_UnmarshalJSON(t *testing.T) {
 	actionData := map[string]interface{}{
 		"authorize_with_url": map[string]interface{}{


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @kelvin-stripe