### PR TITLE
Improve error response unmarshalling

### DIFF
--- a/error.go
+++ b/error.go
@@ -138,3 +138,15 @@ type RateLimitError struct {
 func (e *RateLimitError) Error() string {
 	return e.stripeErr.Error()
 }
+
+// internalErr type so we can get the decline code from the error response
+// used in CardError type, embed the error type because both fields are on the same level
+type internalErr struct {
+	*Error
+	DC *string `json:"decline_code,omitempty"`
+}
+
+// rawErr - used to unmarshal error response into Error type without the map nonsense
+type rawErr struct {
+	E *internalErr `json:"error,omitempty"`
+}

--- a/error.go
+++ b/error.go
@@ -139,14 +139,15 @@ func (e *RateLimitError) Error() string {
 	return e.stripeErr.Error()
 }
 
-// internalErr type so we can get the decline code from the error response
-// used in CardError type, embed the error type because both fields are on the same level
-type internalErr struct {
-	*Error
-	DC *string `json:"decline_code,omitempty"`
+// rawError deserializes the outer JSON object returned in an error response from the API.
+type rawError struct {
+	E *rawErrorInternal `json:"error,omitempty"`
 }
 
-// rawErr - used to unmarshal error response into Error type without the map nonsense
-type rawErr struct {
-	E *internalErr `json:"error,omitempty"`
+// rawErrorInternal embeds Error to deserialize all the standard error fields,
+// but also adds other fields that may or may not be present depending on error
+// type to help with deserialization. (e.g. Declinecode)
+type rawErrorInternal struct {
+	*Error
+	DeclineCode *string `json:"decline_code,omitempty"`
 }

--- a/stripe.go
+++ b/stripe.go
@@ -414,81 +414,50 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 
 // ResponseToError converts a stripe response to an Error.
 func (s *BackendImplementation) ResponseToError(res *http.Response, resBody []byte) error {
-	// for some odd reason, the Erro structure doesn't unmarshal
-	// initially I thought it was because it's a struct inside of a struct
-	// but even after trying that, it still didn't work
-	// so unmarshalling to a map for now and parsing the results manually
-	// but should investigate later
-	var errMap map[string]interface{}
-
-	err := json.Unmarshal(resBody, &errMap)
-	if err != nil {
+	var raw rawErr
+	if err := json.Unmarshal(resBody, &raw); err != nil {
 		return err
 	}
-
-	e, ok := errMap["error"]
-	if !ok {
+	// no error in resBody
+	if raw.E == nil {
 		err := errors.New(string(resBody))
 		if s.LogLevel > 0 {
 			s.Logger.Printf("Unparsable error returned from Stripe: %v\n", err)
 		}
 		return err
 	}
+	raw.E.HTTPStatusCode = res.StatusCode
+	raw.E.RequestID = res.Header.Get("Request-Id")
 
-	root := e.(map[string]interface{})
-
-	stripeErr := &Error{
-		Type:           ErrorType(root["type"].(string)),
-		Msg:            root["message"].(string),
-		HTTPStatusCode: res.StatusCode,
-		RequestID:      res.Header.Get("Request-Id"),
-	}
-
-	if code, ok := root["code"]; ok {
-		stripeErr.Code = ErrorCode(code.(string))
-	}
-
-	if param, ok := root["param"]; ok {
-		stripeErr.Param = param.(string)
-	}
-
-	if charge, ok := root["charge"]; ok {
-		stripeErr.ChargeID = charge.(string)
-	}
-
-	switch stripeErr.Type {
+	// they all implement the error interface, so assign in switch...
+	var tErr error
+	switch raw.E.Type {
 	case ErrorTypeAPI:
-		stripeErr.Err = &APIError{stripeErr: stripeErr}
-
+		tErr = &APIError{stripeErr: raw.E.Error}
 	case ErrorTypeAPIConnection:
-		stripeErr.Err = &APIConnectionError{stripeErr: stripeErr}
-
+		tErr = &APIConnectionError{stripeErr: raw.E.Error}
 	case ErrorTypeAuthentication:
-		stripeErr.Err = &AuthenticationError{stripeErr: stripeErr}
-
+		tErr = &AuthenticationError{stripeErr: raw.E.Error}
 	case ErrorTypeCard:
-		cardErr := &CardError{stripeErr: stripeErr}
-		stripeErr.Err = cardErr
-
-		if declineCode, ok := root["decline_code"]; ok {
-			cardErr.DeclineCode = declineCode.(string)
+		cardErr := &CardError{stripeErr: raw.E.Error}
+		if raw.E.DC != nil {
+			cardErr.DeclineCode = *raw.E.DC
 		}
-
+		tErr = cardErr
 	case ErrorTypeInvalidRequest:
-		stripeErr.Err = &InvalidRequestError{stripeErr: stripeErr}
-
+		tErr = &InvalidRequestError{stripeErr: raw.E.Error}
 	case ErrorTypePermission:
-		stripeErr.Err = &PermissionError{stripeErr: stripeErr}
-
+		tErr = &PermissionError{stripeErr: raw.E.Error}
 	case ErrorTypeRateLimit:
-		stripeErr.Err = &RateLimitError{stripeErr: stripeErr}
+		tErr = &RateLimitError{stripeErr: raw.E.Error}
 	}
+	// ... then assign to the Error object
+	raw.E.Err = tErr
 
 	if s.LogLevel > 0 {
-		s.Logger.Printf("Error encountered from Stripe: %v\n", stripeErr)
+		s.Logger.Printf("Error encountered from Stripe: %v\n", raw.E.Error)
 	}
-
-	return stripeErr
+	return raw.E.Error
 }
 
 // SetMaxNetworkRetries sets max number of retries on failed requests


### PR DESCRIPTION
Looking through some of the code, I noticed errors were manually unmarshalled using a ton of type assertions and maps. That's not good. The problem was that the error types don't export their underlying `stripeErr` fields. `json.Unmarshal` uses reflection and tags to find fields that are exported (otherwise it can't set values). I've created an un-exported `rawErr` type that can be used for unmarshalling, and a further type `internalError` that embeds the Error type as it is, and adds the `decline_code` field at the same level (to correspond to the error format).

Ideally, the `decline_code` field should be a part of the main `Error` type, so we don't need that second internal type. The type of `decline_code` was (and is) `string`. I've left it as is to not break any existing code, but if a field is tagged as `omitempty`, a pointer type should be used.

Tests all pass, no behavioural changes. The code is just a bit less verbose, more readable, easier to maintain, less error-prone, and possibly faster (though I didn't write a Bench test).