### PR TITLE
Fix uploads API when using NewBackends

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -689,10 +689,11 @@ func Int64Value(v *int64) int64 {
 // NewBackends creates a new set of backends with the given HTTP client. You
 // should only need to use this for testing purposes or on App Engine.
 func NewBackends(httpClient *http.Client) *Backends {
-	config := &BackendConfig{HTTPClient: httpClient}
+	apiConfig := &BackendConfig{HTTPClient: httpClient}
+	uploadConfig := &BackendConfig{HTTPClient: httpClient}
 	return &Backends{
-		API:     GetBackendWithConfig(APIBackend, config),
-		Uploads: GetBackendWithConfig(UploadsBackend, config),
+		API:     GetBackendWithConfig(APIBackend, apiConfig),
+		Uploads: GetBackendWithConfig(UploadsBackend, uploadConfig),
 	}
 }
 


### PR DESCRIPTION
When testing uploading files using an API client, I found that it would fail consistently with a strange error:

```go
{"code":"invalid_utf8_in_post_body","status":400,"message":"Invalid UTF-8 characters found in POST body: \"application/octet-stream\".  For assistance, please contact support@stripe.com.","type":"invalid_request_error"}
```

Adding some log statements to the `backendImplementation.Do` function, I found that it was trying to send a `files.New` request to `https://api.stripe.com/v1/v1/files`

Eventually I tracked the problem down to the `NewBackends` function. It reused the config object when creating the api and uploads backends. The `GetBackendWithConfig` function then modified the config object. So when it was called again with the same config object, it would already have the URL field filled out.

Simply put, we need two copies of the config object to avoid causing problems with the modified config object.
