### PR TITLE
Update Error.Err field explanation.

### DIFF
--- a/error.go
+++ b/error.go
@@ -45,8 +45,8 @@ type Error struct {
 
 	// Err contains an internal error with an additional level of granularity
 	// that can be used in some cases to get more detailed information about
-	// what went wrong. For example, Err may hold a ChargeError that indicates
-	// exactly what went wrong during a charge.
+	// what went wrong. For example, Err may hold a CardError that indicates
+	// exactly what went wrong during charging a card.
 	Err error `json:"-"`
 
 	HTTPStatusCode int       `json:"status,omitempty"`


### PR DESCRIPTION
Since there is no such thing as ChargeError, the comment on Error.Err is misleading.