### PR TITLE
Add support for invoice_now and prorate on subscription cancelation

### DIFF
--- a/sub.go
+++ b/sub.go
@@ -59,7 +59,9 @@ type SubscriptionParams struct {
 // SubscriptionCancelParams is the set of parameters that can be used when canceling a subscription.
 // For more details see https://stripe.com/docs/api#cancel_subscription
 type SubscriptionCancelParams struct {
-	Params `form:"*"`
+	Params     `form:"*"`
+	InvoiceNow *bool `form:"invoice_now"`
+	Prorate    *bool `form:"prorate"`
 }
 
 // AppendTo implements custom encoding logic for SubscriptionParams so that the special

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -10,7 +10,10 @@ import (
 )
 
 func TestSubscriptionCancel(t *testing.T) {
-	subscription, err := Cancel("sub_123", &stripe.SubscriptionCancelParams{})
+	subscription, err := Cancel("sub_123", &stripe.SubscriptionCancelParams{
+		InvoiceNow: stripe.Bool(true),
+		Prorate:    stripe.Bool(true),
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 