### PR TITLE
Add ClearUsage param to SubscriptionItemParams

### DIFF
--- a/subitem.go
+++ b/subitem.go
@@ -6,6 +6,7 @@ type SubscriptionItemParams struct {
 	Params        `form:"*"`
 	ID            *string `form:"-"` // Handled in URL
 	Plan          *string `form:"plan"`
+	ClearUsage    *bool   `form:"clear_usage"`
 	Prorate       *bool   `form:"prorate"`
 	ProrationDate *int64  `form:"proration_date"`
 	Quantity      *int64  `form:"quantity"`


### PR DESCRIPTION
Accoring with the [documentation](https://stripe.com/docs/api/subscription_items/delete?lang=go), we need a ClearUsage parameter.

Right now is not possible to delete subscription items due to error:

> Error encountered from Stripe: {"status":400,"message":"When deleting the subscription item ITEM_ID with a metered plan, all related usage records must be cleared too by setting `clear_usage=true`.","request_id":"REQ_ID","type":"invalid_request_error"}