### PR TITLE
Add support for new properties and params on Invoice and Subscription

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -72,24 +72,30 @@ type InvoiceCustomFieldParams struct {
 	Value *string `form:"value"`
 }
 
+// InvoiceTransferDataParams is the set of parameters allowed for the transfer_data hash.
+type InvoiceTransferDataParams struct {
+	Destination *string `form:"destination"`
+}
+
 // InvoiceParams is the set of parameters that can be used when creating or updating an invoice.
 // For more details see https://stripe.com/docs/api#create_invoice, https://stripe.com/docs/api#update_invoice.
 type InvoiceParams struct {
-	Params              `form:"*"`
-	AutoAdvance         *bool                       `form:"auto_advance"`
-	ApplicationFee      *int64                      `form:"application_fee"`
-	Billing             *string                     `form:"billing"`
-	CustomFields        []*InvoiceCustomFieldParams `form:"custom_fields"`
-	Customer            *string                     `form:"customer"`
-	DaysUntilDue        *int64                      `form:"days_until_due"`
-	DefaultSource       *string                     `form:"default_source"`
-	Description         *string                     `form:"description"`
-	DueDate             *int64                      `form:"due_date"`
-	Footer              *string                     `form:"footer"`
-	Paid                *bool                       `form:"paid"`
-	StatementDescriptor *string                     `form:"statement_descriptor"`
-	Subscription        *string                     `form:"subscription"`
-	TaxPercent          *float64                    `form:"tax_percent"`
+	Params               `form:"*"`
+	AutoAdvance          *bool                       `form:"auto_advance"`
+	ApplicationFeeAmount *int64                      `form:"application_fee_amount"`
+	Billing              *string                     `form:"billing"`
+	CustomFields         []*InvoiceCustomFieldParams `form:"custom_fields"`
+	Customer             *string                     `form:"customer"`
+	DaysUntilDue         *int64                      `form:"days_until_due"`
+	DefaultSource        *string                     `form:"default_source"`
+	Description          *string                     `form:"description"`
+	DueDate              *int64                      `form:"due_date"`
+	Footer               *string                     `form:"footer"`
+	Paid                 *bool                       `form:"paid"`
+	StatementDescriptor  *string                     `form:"statement_descriptor"`
+	Subscription         *string                     `form:"subscription"`
+	TaxPercent           *float64                    `form:"tax_percent"`
+	TransferData         *InvoiceTransferDataParams  `form:"transfer_data"`
 
 	// These are all for exclusive use by GetNext.
 
@@ -105,6 +111,9 @@ type InvoiceParams struct {
 	SubscriptionTaxPercent         *float64                          `form:"subscription_tax_percent"`
 	SubscriptionTrialEnd           *int64                            `form:"subscription_trial_end"`
 	SubscriptionTrialFromPlan      *bool                             `form:"subscription_trial_from_plan"`
+
+	// This parameter is considered deprecated. Prefer using ApplicationFeeAmount
+	ApplicationFee *int64 `form:"application_fee"`
 }
 
 // InvoiceListParams is the set of parameters that can be used when listing invoices.
@@ -170,7 +179,7 @@ type Invoice struct {
 	AmountDue                 int64                   `json:"amount_due"`
 	AmountPaid                int64                   `json:"amount_paid"`
 	AmountRemaining           int64                   `json:"amount_remaining"`
-	ApplicationFee            int64                   `json:"application_fee"`
+	ApplicationFeeAmount      int64                   `json:"application_fee_amount"`
 	AttemptCount              int64                   `json:"attempt_count"`
 	Attempted                 bool                    `json:"attempted"`
 	AutoAdvance               bool                    `json:"auto_advance"`
@@ -210,7 +219,11 @@ type Invoice struct {
 	TaxPercent                float64                 `json:"tax_percent"`
 	ThreasholdReason          *InvoiceThresholdReason `json:"threshold_reason"`
 	Total                     int64                   `json:"total"`
+	TransferData              *InvoiceTransferData    `json:"transfer_data"`
 	WebhooksDeliveredAt       int64                   `json:"webhooks_delivered_at"`
+
+	// This property is considered deprecated. Prefer using ApplicationFeeAmount
+	ApplicationFee int64 `json:"application_fee"`
 }
 
 // InvoiceCustomField is a structure representing a custom field on an Invoice.
@@ -255,6 +268,11 @@ type InvoiceLine struct {
 	Subscription     string            `json:"subscription"`
 	SubscriptionItem string            `json:"subscription_item"`
 	Type             InvoiceLineType   `json:"type"`
+}
+
+// InvoiceTransferData represents the information for the transfer_data associated with an invoice.
+type InvoiceTransferData struct {
+	Destination *Account `json:"destination"`
 }
 
 // Period is a structure representing a start and end dates.

--- a/sub.go
+++ b/sub.go
@@ -28,6 +28,11 @@ const (
 	SubscriptionBillingSendInvoice         SubscriptionBilling = "send_invoice"
 )
 
+// SubscriptionTransferDataParams is the set of parameters allowed for the transfer_data hash.
+type SubscriptionTransferDataParams struct {
+	Destination *string `form:"destination"`
+}
+
 // SubscriptionParams is the set of parameters that can be used when creating or updating a subscription.
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubscriptionParams struct {
@@ -52,6 +57,7 @@ type SubscriptionParams struct {
 	Quantity                    *int64                               `form:"quantity"`
 	TaxPercent                  *float64                             `form:"tax_percent"`
 	TrialEnd                    *int64                               `form:"trial_end"`
+	TransferData                *SubscriptionTransferDataParams      `form:"transfer_data"`
 	TrialEndNow                 *bool                                `form:"-"` // See custom AppendTo
 	TrialFromPlan               *bool                                `form:"trial_from_plan"`
 	TrialPeriodDays             *int64                               `form:"trial_period_days"`
@@ -112,6 +118,11 @@ type SubscriptionListParams struct {
 	Status       string            `form:"status"`
 }
 
+// SubscriptionTransferData represents the information for the transfer_data associated with a subscription.
+type SubscriptionTransferData struct {
+	Destination *Account `json:"destination"`
+}
+
 // Subscription is the resource representing a Stripe subscription.
 // For more details see https://stripe.com/docs/api#subscriptions.
 type Subscription struct {
@@ -138,6 +149,7 @@ type Subscription struct {
 	Start                 int64                          `json:"start"`
 	Status                SubscriptionStatus             `json:"status"`
 	TaxPercent            float64                        `json:"tax_percent"`
+	TransferData          *SubscriptionTransferData      `json:"transfer_data"`
 	TrialEnd              int64                          `json:"trial_end"`
 	TrialStart            int64                          `json:"trial_start"`
 }


### PR DESCRIPTION
* Add `transfer_data[destination]` to both `Invoice` and `Subscription`
* Add `application_fee_amount` to `Invoice` and deprecate `application_fee`

cc @stripe/api-libraries 

NOT asking for review yet as I want to double check that we don't need `on_behalf_of` for now.