### PR TITLE
Add Stripe client telemetry to request headers

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -165,8 +165,8 @@ type BackendImplementation struct {
 	// See also SetNetworkRetriesSleep.
 	networkRetriesSleep bool
 
-	enableTelemetry    bool
-	prevRequestMetrics chan requestMetrics
+	enableTelemetry      bool
+	requestMetricsBuffer *ringBuffer
 }
 
 // Call is the Backend.Call implementation for invoking Stripe APIs.
@@ -303,7 +303,7 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 
 	if s.enableTelemetry {
 		select {
-		case metrics := <-s.prevRequestMetrics:
+		case metrics := <-s.requestMetricsBuffer.outputChannel:
 			metricsJSON, err := json.Marshal(&requestTelemetry{LastRequestMetrics: metrics})
 			if err == nil {
 				req.Header.Set("X-Stripe-Client-Telemetry", string(metricsJSON))
@@ -425,11 +425,7 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 				RequestDurationMS: requestDurationMS,
 			}
 
-			select {
-			case s.prevRequestMetrics <- metrics:
-			default:
-				// buffer is full, discard.
-			}
+			s.requestMetricsBuffer.inputChannel <- metrics
 		}
 	}
 
@@ -866,6 +862,11 @@ type requestTelemetry struct {
 	LastRequestMetrics requestMetrics `json:"last_request_metrics"`
 }
 
+// ringBuffer is a circular buffer of requestMetrics.
+type ringBuffer struct {
+	inputChannel, outputChannel chan requestMetrics
+}
+
 //
 // Private variables
 //
@@ -939,24 +940,47 @@ func isHTTPWriteMethod(method string) bool {
 // The vast majority of the time you should be calling GetBackendWithConfig
 // instead of this function.
 func newBackendImplementation(backendType SupportedBackend, config *BackendConfig) Backend {
-	var requestMetricsBuffer chan requestMetrics
+	var requestMetricsBuffer *ringBuffer
 
 	// only allocate the requestMetrics buffer if client telemetry is enabled.
 	if config.EnableTelemetry {
-		requestMetricsBuffer = make(chan requestMetrics, telemetryBufferSize)
+		requestMetricsBuffer = &ringBuffer{
+			// inputChannel does not need to be buffered because ringBuffer#run()
+			// is always pulling objects off inputChannel and putting them in
+			// outputChannel.
+			inputChannel:  make(chan requestMetrics),
+			outputChannel: make(chan requestMetrics, telemetryBufferSize),
+		}
+
+		go requestMetricsBuffer.run()
 	}
 
 	return &BackendImplementation{
-		HTTPClient:          config.HTTPClient,
-		LogLevel:            config.LogLevel,
-		Logger:              config.Logger,
-		MaxNetworkRetries:   config.MaxNetworkRetries,
-		Type:                backendType,
-		URL:                 config.URL,
-		networkRetriesSleep: true,
-		enableTelemetry:     config.EnableTelemetry,
-		prevRequestMetrics:  requestMetricsBuffer,
+		HTTPClient:           config.HTTPClient,
+		LogLevel:             config.LogLevel,
+		Logger:               config.Logger,
+		MaxNetworkRetries:    config.MaxNetworkRetries,
+		Type:                 backendType,
+		URL:                  config.URL,
+		networkRetriesSleep:  true,
+		enableTelemetry:      config.EnableTelemetry,
+		requestMetricsBuffer: requestMetricsBuffer,
 	}
+}
+
+// This is the bookkeeping method for ringBuffer, which should be run as a
+// seperate goroutine.
+func (r *ringBuffer) run() {
+	for v := range r.inputChannel {
+		select {
+		case r.outputChannel <- v:
+		default:
+			<-r.outputChannel
+			r.outputChannel <- v
+		}
+	}
+
+	close(r.outputChannel)
 }
 
 func normalizeURL(url string) string {

--- a/stripe.go
+++ b/stripe.go
@@ -305,10 +305,7 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 	}
 
 	if EnableTelemetry && s.lastRequestMetrics != nil {
-		metricsJSON, err := json.Marshal(s.lastRequestMetrics)
-		if err != nil {
-			panic(err) // TODO handle silently
-		}
+		metricsJSON, _ := json.Marshal(s.lastRequestMetrics)
 		payload := fmt.Sprintf(`{"last_request_metrics":%s}`, metricsJSON)
 		req.Header.Set("X-Stripe-Client-Telemetry", payload)
 	}

--- a/stripe.go
+++ b/stripe.go
@@ -153,7 +153,7 @@ type RequestMetrics struct {
 }
 
 // RequestTelemetry contains the payload sent in the
-// `X-Stripe-Client-Telemetry` header when stripe.EnableTelemetry = true.
+// `X-Stripe-Client-Telemetry` header when BackendConfig#EnableTelemetry = true.
 type RequestTelemetry struct {
 	LastRequestMetrics RequestMetrics `json:"last_request_metrics"`
 }

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -251,6 +251,7 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 		case 1:
 			// the first request should not receive any metrics
 			assert.Equal(t, telemetryStr, "")
+			time.Sleep(21 * time.Millisecond)
 		case 2:
 			assert.True(t, len(telemetryStr) > 0, "telemetryStr should not be empty")
 
@@ -261,7 +262,8 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 
 			// the second request should include the metrics for the first request
 			assert.Equal(t, telemetry.LastRequestMetrics.RequestID, "req_1")
-			assert.True(t, telemetry.LastRequestMetrics.RequestDurationMS > 0)
+			assert.True(t, telemetry.LastRequestMetrics.RequestDurationMS > 20,
+				"request_duration_ms should be > 20ms")
 		default:
 			assert.Fail(t, "Should not have reached request %v", requestNum)
 		}

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -310,7 +310,7 @@ func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 	}
 
 	message := "Hello, client."
-	var requestNum int32 = 0
+	var requestNum int32
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqID := atomic.AddInt32(&requestNum, 1)

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -249,6 +249,8 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 			// the first request should not receive any metrics
 			assert.Equal(t, telemetryStr, "")
 		case 2:
+			assert.True(t, len(telemetryStr) > 0, "telemetryStr should not be empty")
+
 			// the telemetry should properly unmarshal into stripe.RequestTelemetry
 			var telemetry requestTelemetry
 			err := json.Unmarshal([]byte(telemetryStr), &telemetry)

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -228,6 +228,15 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 		Message string `json:"message"`
 	}
 
+	type requestMetrics struct {
+		RequestID         string `json:"request_id"`
+		RequestDurationMS int    `json:"request_duration_ms"`
+	}
+
+	type requestTelemetry struct {
+		LastRequestMetrics requestMetrics `json:"last_request_metrics"`
+	}
+
 	message := "Hello, client."
 	requestNum := 0
 
@@ -242,7 +251,7 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 			assert.Contains(t, telemetryStr, `"request_id":"req_0"`)
 
 			// the telemetry should properly unmarshal into stripe.RequestTelemetry
-			var telemetry stripe.RequestTelemetry
+			var telemetry requestTelemetry
 			err := json.Unmarshal([]byte(telemetryStr), &telemetry)
 			assert.NoError(t, err)
 		default:

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -200,6 +200,9 @@ func TestDo_TelemetryDisabled(t *testing.T) {
 		},
 	).(*stripe.BackendImplementation)
 
+	// When telemetry is enabled, the metrics for a request are sent with the
+	// _next_ request via the `X-Stripe-Client-Telemetry header`. To test that
+	// metrics aren't being sent, we need to fire off two requests in sequence.
 	for i := 0; i < 2; i++ {
 		request, err := backend.NewRequest(
 			http.MethodGet,
@@ -258,6 +261,7 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 
 			// the second request should include the metrics for the first request
 			assert.Equal(t, telemetry.LastRequestMetrics.RequestID, "req_1")
+			assert.True(t, telemetry.LastRequestMetrics.RequestDurationMS > 0)
 		default:
 			assert.Fail(t, "Should not have reached request %v", requestNum)
 		}

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -334,7 +334,7 @@ func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 		},
 	).(*stripe.BackendImplementation)
 
-	times := 16
+	times := 20 // 20 > telemetryBufferSize, so some metrics could be discarded
 	done := make(chan struct{})
 
 	for i := 0; i < times; i++ {
@@ -362,7 +362,7 @@ func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 		<-done
 	}
 
-	assert.Equal(t, int32(16), requestNum)
+	assert.Equal(t, int32(times), requestNum)
 }
 
 func TestFormatURLPath(t *testing.T) {

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -308,6 +308,10 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 	assert.Equal(t, 2, requestNum)
 }
 
+// This test does not perform any super valuable assertions - instead, it checks
+// that our logic for buffering requestMetrics when EnableTelemetry = true does
+// not trigger any data races. This test should pass when the -race flag is
+// passed to `go test`.
 func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 	type testServerResponse struct {
 		Message string `json:"message"`

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -224,17 +224,8 @@ func TestDo_TelemetryDisabled(t *testing.T) {
 // Test that telemetry metrics are sent on subsequent requests when
 // stripe.EnableTelemetry = true.
 func TestDo_TelemetryEnabled(t *testing.T) {
-	stripe.EnableTelemetry = true
-	defer func() {
-		stripe.EnableTelemetry = false
-	}()
-
 	type testServerResponse struct {
 		Message string `json:"message"`
-	}
-
-	type clientTelemetry struct {
-		LastRequestMetrics stripe.RequestMetrics `json:"last_request_metrics"`
 	}
 
 	message := "Hello, client."
@@ -250,8 +241,8 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 			// the second request should include the metrics for the first request
 			assert.Contains(t, telemetryStr, `"request_id":"req_0"`)
 
-			// the telemetry should properly unmarshal into stripe.RequestMetrics
-			var telemetry clientTelemetry
+			// the telemetry should properly unmarshal into stripe.RequestTelemetry
+			var telemetry stripe.RequestTelemetry
 			err := json.Unmarshal([]byte(telemetryStr), &telemetry)
 			assert.NoError(t, err)
 		default:
@@ -277,6 +268,7 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 			LogLevel:          3,
 			MaxNetworkRetries: 0,
 			URL:               testServer.URL,
+			EnableTelemetry:   true,
 		},
 	).(*stripe.BackendImplementation)
 


### PR DESCRIPTION
Follows https://github.com/stripe/stripe-ruby/pull/696, https://github.com/stripe/stripe-php/pull/549, and https://github.com/stripe/stripe-python/pull/518 in adding telemetry metadata to request headers. 

The telemetry is disabled by default, and can be enabled per-client like so:

```go
backend := stripe.GetBackendWithConfig(
	stripe.APIBackend,
	&stripe.BackendConfig{
		URL: "https://api.stripe.com/v1",
		EnableTelemetry: true,
	},
)
```

or globally by setting

```go
stripe.EnableTelemetry = true
```

cc @dcarney-stripe @bobby-stripe