### PR TITLE
Add section in README on Go modules + simplify lead-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,45 @@
 [![Build Status](https://travis-ci.org/stripe/stripe-go.svg?branch=master)](https://travis-ci.org/stripe/stripe-go)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-go/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-go?branch=master)
 
-## Summary
-
 The official [Stripe][stripe] Go client library.
-
-## Versioning
-
-Each revision of the binding is tagged and the version is updated accordingly.
-
-Given Go's lack of built-in versioning, it is highly recommended you use a
-[package management tool][package-management] in order to ensure a newer
-version of the binding does not affect backwards compatibility.
-
-To see the list of past versions, run `git tag`. To manually get an older
-version of the client, clone this repo, checkout the specific tag and build the
-library:
-
-```sh
-git clone https://github.com/stripe/stripe-go.git
-cd stripe-go
-git checkout api_version_tag
-make build
-```
-
-For more details on changes between versions, see the [binding
-changelog](CHANGELOG.md) and [API changelog][api-changelog].
 
 ## Installation
 
+Install stripe-go with:
+
 ```sh
-go get github.com/stripe/stripe-go
+go get -u github.com/stripe/stripe-go
+```
+
+Then, import it using:
+
+``` go
+import (
+    "github.com/stripe/stripe-go"
+    "github.com/stripe/stripe-go/customer"
+)
+```
+
+### Go Module Support
+
+The library supports Go's [experimental modules][modules]. Add stripe-go as a
+requirement in your `go.mod` along with its current version:
+
+``` go
+module github.com/my/package
+
+require (
+    github.com/stripe/stripe-go v55.8.0
+)
+```
+
+Imports should contain the major version as a virtual component of each path:
+
+``` go
+import (
+    "github.com/stripe/stripe-go/v55"
+    "github.com/stripe/stripe-go/v55/customer"
+)
 ```
 
 ## Documentation
@@ -316,6 +325,7 @@ pull request][pulls].
 [connect]: https://stripe.com/docs/connect/authentication
 [godoc]: http://godoc.org/github.com/stripe/stripe-go
 [issues]: https://github.com/stripe/stripe-go/issues/new
+[modules]: https://github.com/golang/go/wiki/Modules
 [package-management]: https://code.google.com/p/go-wiki/wiki/PackageManagementTools
 [pulls]: https://github.com/stripe/stripe-go/pulls
 [stripe]: https://stripe.com


### PR DESCRIPTION
Modifies the intro of the README to add explicit instructions on how to
use stripe-go with and without Go modules, including commands that need
to be run and what imports should look like.

I've also removed the "versioning" section because I don't think this
information is that all that novel, and certainly isn't useful enough to
occupy prime real estate at the front of the file.

[Link to rendered version](https://github.com/stripe/stripe-go/blob/brandur-readme-modules/README.md).

r? @remi (Going to wait a little longer before merge just in case I have
to revert the Go modules PR, but this should be reviewable now.)