### PR TITLE
missing amount on the IssuingTransaction struct

### DIFF
--- a/issuing_transaction.go
+++ b/issuing_transaction.go
@@ -29,6 +29,7 @@ type IssuingTransactionListParams struct {
 
 // IssuingTransaction is the resource representing a Stripe issuing transaction.
 type IssuingTransaction struct {
+	Amount             int64                  `json:"amount"`
 	Authorization      *IssuingAuthorization  `json:"authorization"`
 	BalanceTransaction *BalanceTransaction    `json:"balance_transaction"`
 	Card               *IssuingCard           `json:"card"`


### PR DESCRIPTION
The amount field of the issuing transaction object is described in the api documentation (https://stripe.com/docs/api/issuing/transactions), returned by the API, but not parsed by this library.