### PR TITLE
Fix module require line in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ requirement in your `go.mod` along with its current version:
 module github.com/my/package
 
 require (
-    github.com/stripe/stripe-go v55.9.0
+    github.com/stripe/stripe-go/v55 v55.9.0
 )
 ```
 


### PR DESCRIPTION
Annoyingly, the major version has to be included twice in the require line, otherwise you'll get something like this:

```
go: finding github.com/stripe/stripe-go v55.9.0
go: github.com/stripe/stripe-go@v0.0.0-20190115230412-fc4981293b86: go.mod has post-v0 module path "github.com/stripe/stripe-go/v55" at revision fc4981293b86                                                                                                    
go: error loading module requirements
```