### PR TITLE
Add support for billing thresholds

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -25,12 +25,13 @@ type InvoiceBillingReason string
 
 // List of values that InvoiceBillingReason can take.
 const (
-	InvoiceBillingReasonManual             InvoiceBillingReason = "manual"
-	InvoiceBillingReasonSubscription       InvoiceBillingReason = "subscription"
-	InvoiceBillingReasonSubscriptionCreate InvoiceBillingReason = "subscription_create"
-	InvoiceBillingReasonSubscriptionCycle  InvoiceBillingReason = "subscription_cycle"
-	InvoiceBillingReasonSubscriptionUpdate InvoiceBillingReason = "subscription_update"
-	InvoiceBillingReasonUpcoming           InvoiceBillingReason = "upcoming"
+	InvoiceBillingReasonManual                InvoiceBillingReason = "manual"
+	InvoiceBillingReasonSubscription          InvoiceBillingReason = "subscription"
+	InvoiceBillingReasonSubscriptionCreate    InvoiceBillingReason = "subscription_create"
+	InvoiceBillingReasonSubscriptionCycle     InvoiceBillingReason = "subscription_cycle"
+	InvoiceBillingReasonSubscriptionThreshold InvoiceBillingReason = "subscription_threshold"
+	InvoiceBillingReasonSubscriptionUpdate    InvoiceBillingReason = "subscription_update"
+	InvoiceBillingReasonUpcoming              InvoiceBillingReason = "upcoming"
 )
 
 // InvoiceBillingStatus is the reason why a given invoice was created
@@ -166,55 +167,69 @@ type InvoiceVoidParams struct {
 // Invoice is the resource representing a Stripe invoice.
 // For more details see https://stripe.com/docs/api#invoice_object.
 type Invoice struct {
-	AmountDue                 int64                 `json:"amount_due"`
-	AmountPaid                int64                 `json:"amount_paid"`
-	AmountRemaining           int64                 `json:"amount_remaining"`
-	ApplicationFee            int64                 `json:"application_fee"`
-	AttemptCount              int64                 `json:"attempt_count"`
-	Attempted                 bool                  `json:"attempted"`
-	AutoAdvance               bool                  `json:"auto_advance"`
-	Billing                   InvoiceBilling        `json:"billing"`
-	BillingReason             InvoiceBillingReason  `json:"billing_reason"`
-	Charge                    *Charge               `json:"charge"`
-	Currency                  Currency              `json:"currency"`
-	CustomFields              []*InvoiceCustomField `json:"custom_fields"`
-	Customer                  *Customer             `json:"customer"`
-	Date                      int64                 `json:"date"`
-	DefaultSource             *PaymentSource        `json:"default_source"`
-	Description               string                `json:"description"`
-	Discount                  *Discount             `json:"discount"`
-	DueDate                   int64                 `json:"due_date"`
-	EndingBalance             int64                 `json:"ending_balance"`
-	FinalizedAt               int64                 `json:"finalized_at"`
-	Footer                    string                `json:"footer"`
-	HostedInvoiceURL          string                `json:"hosted_invoice_url"`
-	ID                        string                `json:"id"`
-	InvoicePDF                string                `json:"invoice_pdf"`
-	Lines                     *InvoiceLineList      `json:"lines"`
-	Livemode                  bool                  `json:"livemode"`
-	Metadata                  map[string]string     `json:"metadata"`
-	NextPaymentAttempt        int64                 `json:"next_payment_attempt"`
-	Number                    string                `json:"number"`
-	Paid                      bool                  `json:"paid"`
-	PeriodEnd                 int64                 `json:"period_end"`
-	PeriodStart               int64                 `json:"period_start"`
-	ReceiptNumber             string                `json:"receipt_number"`
-	StartingBalance           int64                 `json:"starting_balance"`
-	StatementDescriptor       string                `json:"statement_descriptor"`
-	Status                    InvoiceBillingStatus  `json:"status"`
-	Subscription              string                `json:"subscription"`
-	SubscriptionProrationDate int64                 `json:"subscription_proration_date"`
-	Subtotal                  int64                 `json:"subtotal"`
-	Tax                       int64                 `json:"tax"`
-	TaxPercent                float64               `json:"tax_percent"`
-	Total                     int64                 `json:"total"`
-	WebhooksDeliveredAt       int64                 `json:"webhooks_delivered_at"`
+	AmountDue                 int64                   `json:"amount_due"`
+	AmountPaid                int64                   `json:"amount_paid"`
+	AmountRemaining           int64                   `json:"amount_remaining"`
+	ApplicationFee            int64                   `json:"application_fee"`
+	AttemptCount              int64                   `json:"attempt_count"`
+	Attempted                 bool                    `json:"attempted"`
+	AutoAdvance               bool                    `json:"auto_advance"`
+	Billing                   InvoiceBilling          `json:"billing"`
+	BillingReason             InvoiceBillingReason    `json:"billing_reason"`
+	Charge                    *Charge                 `json:"charge"`
+	Currency                  Currency                `json:"currency"`
+	CustomFields              []*InvoiceCustomField   `json:"custom_fields"`
+	Customer                  *Customer               `json:"customer"`
+	Date                      int64                   `json:"date"`
+	DefaultSource             *PaymentSource          `json:"default_source"`
+	Description               string                  `json:"description"`
+	Discount                  *Discount               `json:"discount"`
+	DueDate                   int64                   `json:"due_date"`
+	EndingBalance             int64                   `json:"ending_balance"`
+	FinalizedAt               int64                   `json:"finalized_at"`
+	Footer                    string                  `json:"footer"`
+	HostedInvoiceURL          string                  `json:"hosted_invoice_url"`
+	ID                        string                  `json:"id"`
+	InvoicePDF                string                  `json:"invoice_pdf"`
+	Lines                     *InvoiceLineList        `json:"lines"`
+	Livemode                  bool                    `json:"livemode"`
+	Metadata                  map[string]string       `json:"metadata"`
+	NextPaymentAttempt        int64                   `json:"next_payment_attempt"`
+	Number                    string                  `json:"number"`
+	Paid                      bool                    `json:"paid"`
+	PeriodEnd                 int64                   `json:"period_end"`
+	PeriodStart               int64                   `json:"period_start"`
+	ReceiptNumber             string                  `json:"receipt_number"`
+	StartingBalance           int64                   `json:"starting_balance"`
+	StatementDescriptor       string                  `json:"statement_descriptor"`
+	Status                    InvoiceBillingStatus    `json:"status"`
+	Subscription              string                  `json:"subscription"`
+	SubscriptionProrationDate int64                   `json:"subscription_proration_date"`
+	Subtotal                  int64                   `json:"subtotal"`
+	Tax                       int64                   `json:"tax"`
+	TaxPercent                float64                 `json:"tax_percent"`
+	ThreasholdReason          *InvoiceThresholdReason `json:"threshold_reason"`
+	Total                     int64                   `json:"total"`
+	WebhooksDeliveredAt       int64                   `json:"webhooks_delivered_at"`
 }
 
 // InvoiceCustomField is a structure representing a custom field on an Invoice.
 type InvoiceCustomField struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
+}
+
+// InvoiceThresholdReason is a structure representing a reason for a billing threshold.
+type InvoiceThresholdReason struct {
+	AmountGTE   int64                               `json:"amount_gte"`
+	ItemReasons []*InvoiceThresholdReasonItemReason `json:"item_reasons"`
+}
+
+// InvoiceThresholdReasonItemReason is a structure representing the line items that
+// triggered an invoice.
+type InvoiceThresholdReasonItemReason struct {
+	LineItemIDs []string `json:"line_item_ids"`
+	UsageGTE    int64    `json:"usage_gte"`
 }
 
 // InvoiceList is a list of invoices as retrieved from a list endpoint.

--- a/sub.go
+++ b/sub.go
@@ -32,28 +32,36 @@ const (
 // For more details see https://stripe.com/docs/api#create_subscription and https://stripe.com/docs/api#update_subscription.
 type SubscriptionParams struct {
 	Params                      `form:"*"`
-	ApplicationFeePercent       *float64                   `form:"application_fee_percent"`
-	Billing                     *string                    `form:"billing"`
-	BillingCycleAnchor          *int64                     `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow       *bool                      `form:"-"` // See custom AppendTo
-	BillingCycleAnchorUnchanged *bool                      `form:"-"` // See custom AppendTo
-	CancelAtPeriodEnd           *bool                      `form:"cancel_at_period_end"`
-	Card                        *CardParams                `form:"card"`
-	Coupon                      *string                    `form:"coupon"`
-	Customer                    *string                    `form:"customer"`
-	DaysUntilDue                *int64                     `form:"days_until_due"`
-	DefaultSource               *string                    `form:"default_source"`
-	Items                       []*SubscriptionItemsParams `form:"items"`
-	OnBehalfOf                  *string                    `form:"on_behalf_of"`
-	Plan                        *string                    `form:"plan"`
-	Prorate                     *bool                      `form:"prorate"`
-	ProrationDate               *int64                     `form:"proration_date"`
-	Quantity                    *int64                     `form:"quantity"`
-	TaxPercent                  *float64                   `form:"tax_percent"`
-	TrialEnd                    *int64                     `form:"trial_end"`
-	TrialEndNow                 *bool                      `form:"-"` // See custom AppendTo
-	TrialFromPlan               *bool                      `form:"trial_from_plan"`
-	TrialPeriodDays             *int64                     `form:"trial_period_days"`
+	ApplicationFeePercent       *float64                             `form:"application_fee_percent"`
+	Billing                     *string                              `form:"billing"`
+	BillingCycleAnchor          *int64                               `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       *bool                                `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged *bool                                `form:"-"` // See custom AppendTo
+	BillingThresholds           *SubscriptionBillingThresholdsParams `form:"billing_thresholds"`
+	CancelAtPeriodEnd           *bool                                `form:"cancel_at_period_end"`
+	Card                        *CardParams                          `form:"card"`
+	Coupon                      *string                              `form:"coupon"`
+	Customer                    *string                              `form:"customer"`
+	DaysUntilDue                *int64                               `form:"days_until_due"`
+	DefaultSource               *string                              `form:"default_source"`
+	Items                       []*SubscriptionItemsParams           `form:"items"`
+	OnBehalfOf                  *string                              `form:"on_behalf_of"`
+	Plan                        *string                              `form:"plan"`
+	Prorate                     *bool                                `form:"prorate"`
+	ProrationDate               *int64                               `form:"proration_date"`
+	Quantity                    *int64                               `form:"quantity"`
+	TaxPercent                  *float64                             `form:"tax_percent"`
+	TrialEnd                    *int64                               `form:"trial_end"`
+	TrialEndNow                 *bool                                `form:"-"` // See custom AppendTo
+	TrialFromPlan               *bool                                `form:"trial_from_plan"`
+	TrialPeriodDays             *int64                               `form:"trial_period_days"`
+}
+
+// SubscriptionBillingThresholdsParams is a structure representing the parameters allowed to control
+// billing thresholds for a subscription.
+type SubscriptionBillingThresholdsParams struct {
+	AmountGTE               *int64 `form:"amount_gte"`
+	ResetBillingCycleAnchor *bool  `form:"reset_billing_cycle_anchor"`
 }
 
 // SubscriptionCancelParams is the set of parameters that can be used when canceling a subscription.
@@ -107,30 +115,37 @@ type SubscriptionListParams struct {
 // Subscription is the resource representing a Stripe subscription.
 // For more details see https://stripe.com/docs/api#subscriptions.
 type Subscription struct {
-	ApplicationFeePercent float64               `json:"application_fee_percent"`
-	Billing               SubscriptionBilling   `json:"billing"`
-	BillingCycleAnchor    int64                 `json:"billing_cycle_anchor"`
-	CanceledAt            int64                 `json:"canceled_at"`
-	Created               int64                 `json:"created"`
-	CurrentPeriodEnd      int64                 `json:"current_period_end"`
-	CurrentPeriodStart    int64                 `json:"current_period_start"`
-	Customer              *Customer             `json:"customer"`
-	DaysUntilDue          int64                 `json:"days_until_due"`
-	DefaultSource         *PaymentSource        `json:"default_source"`
-	Discount              *Discount             `json:"discount"`
-	CancelAtPeriodEnd     bool                  `json:"cancel_at_period_end"`
-	EndedAt               int64                 `json:"ended_at"`
-	ID                    string                `json:"id"`
-	Items                 *SubscriptionItemList `json:"items"`
-	Metadata              map[string]string     `json:"metadata"`
-	OnBehalfOf            *Account              `json:"on_behalf_of"`
-	Plan                  *Plan                 `json:"plan"`
-	Quantity              int64                 `json:"quantity"`
-	Start                 int64                 `json:"start"`
-	Status                SubscriptionStatus    `json:"status"`
-	TaxPercent            float64               `json:"tax_percent"`
-	TrialEnd              int64                 `json:"trial_end"`
-	TrialStart            int64                 `json:"trial_start"`
+	ApplicationFeePercent float64                        `json:"application_fee_percent"`
+	Billing               SubscriptionBilling            `json:"billing"`
+	BillingCycleAnchor    int64                          `json:"billing_cycle_anchor"`
+	BillingThresholds     *SubscriptionBillingThresholds `json:"billing_thresholds"`
+	CanceledAt            int64                          `json:"canceled_at"`
+	Created               int64                          `json:"created"`
+	CurrentPeriodEnd      int64                          `json:"current_period_end"`
+	CurrentPeriodStart    int64                          `json:"current_period_start"`
+	Customer              *Customer                      `json:"customer"`
+	DaysUntilDue          int64                          `json:"days_until_due"`
+	DefaultSource         *PaymentSource                 `json:"default_source"`
+	Discount              *Discount                      `json:"discount"`
+	CancelAtPeriodEnd     bool                           `json:"cancel_at_period_end"`
+	EndedAt               int64                          `json:"ended_at"`
+	ID                    string                         `json:"id"`
+	Items                 *SubscriptionItemList          `json:"items"`
+	Metadata              map[string]string              `json:"metadata"`
+	OnBehalfOf            *Account                       `json:"on_behalf_of"`
+	Plan                  *Plan                          `json:"plan"`
+	Quantity              int64                          `json:"quantity"`
+	Start                 int64                          `json:"start"`
+	Status                SubscriptionStatus             `json:"status"`
+	TaxPercent            float64                        `json:"tax_percent"`
+	TrialEnd              int64                          `json:"trial_end"`
+	TrialStart            int64                          `json:"trial_start"`
+}
+
+// SubscriptionBillingThresholds is a structure representing the billing thresholds for a subscription.
+type SubscriptionBillingThresholds struct {
+	AmountGTE               int64 `json:"amount_gte"`
+	ResetBillingCycleAnchor bool  `json:"reset_billing_cycle_anchor"`
 }
 
 // SubscriptionList is a list object for subscriptions.

--- a/subitem.go
+++ b/subitem.go
@@ -3,14 +3,21 @@ package stripe
 // SubscriptionItemParams is the set of parameters that can be used when creating or updating a subscription item.
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
 type SubscriptionItemParams struct {
-	Params        `form:"*"`
-	ID            *string `form:"-"` // Handled in URL
-	Plan          *string `form:"plan"`
-	ClearUsage    *bool   `form:"clear_usage"`
-	Prorate       *bool   `form:"prorate"`
-	ProrationDate *int64  `form:"proration_date"`
-	Quantity      *int64  `form:"quantity"`
-	Subscription  *string `form:"subscription"`
+	Params            `form:"*"`
+	ID                *string                                  `form:"-"` // Handled in URL
+	BillingThresholds *SubscriptionItemBillingThresholdsParams `form:"billing_thresholds"`
+	ClearUsage        *bool                                    `form:"clear_usage"`
+	Plan              *string                                  `form:"plan"`
+	Prorate           *bool                                    `form:"prorate"`
+	ProrationDate     *int64                                   `form:"proration_date"`
+	Quantity          *int64                                   `form:"quantity"`
+	Subscription      *string                                  `form:"subscription"`
+}
+
+// SubscriptionItemBillingThresholdsParams is a structure representing the parameters allowed to
+// control billing thresholds for a subscription item.
+type SubscriptionItemBillingThresholdsParams struct {
+	UsageGTE *int64 `form:"usage_gte"`
 }
 
 // SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.
@@ -23,13 +30,20 @@ type SubscriptionItemListParams struct {
 // SubscriptionItem is the resource representing a Stripe subscription item.
 // For more details see https://stripe.com/docs/api#subscription_items.
 type SubscriptionItem struct {
-	Created      int64             `json:"created"`
-	Deleted      bool              `json:"deleted"`
-	ID           string            `json:"id"`
-	Metadata     map[string]string `json:"metadata"`
-	Plan         *Plan             `json:"plan"`
-	Quantity     int64             `json:"quantity"`
-	Subscription string            `json:"subscription"`
+	BillingThresholds SubscriptionItemBillingThresholds `json:"billing_thresholds"`
+	Created           int64                             `json:"created"`
+	Deleted           bool                              `json:"deleted"`
+	ID                string                            `json:"id"`
+	Metadata          map[string]string                 `json:"metadata"`
+	Plan              *Plan                             `json:"plan"`
+	Quantity          int64                             `json:"quantity"`
+	Subscription      string                            `json:"subscription"`
+}
+
+// SubscriptionItemBillingThresholds is a structure representing the billing thresholds for a
+// subscription item.
+type SubscriptionItemBillingThresholds struct {
+	UsageGTE int64 `form:"usage_gte"`
 }
 
 // SubscriptionItemList is a list of invoice items as retrieved from a list endpoint.


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This one is a bit complex as it's across multiple resources and no specific test was added for it so we need to make sure it matches OpenAPI.

cc @clintonb-stripe Could you double check that I added the right set of properties too and I'm not missing any? (Java only lists properties, not parameters).

Docs: https://stripe.com/docs/billing/subscriptions/metered-billing/thresholds
Internal PR with gate removal: #126799