### PR TITLE
Alphabetize more things in `stripe.go`

### DIFF
--- a/stripe_test.go
+++ b/stripe_test.go
@@ -232,8 +232,8 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 	}
 
 	type requestMetrics struct {
-		RequestID         string `json:"request_id"`
 		RequestDurationMS int    `json:"request_duration_ms"`
+		RequestID         string `json:"request_id"`
 	}
 
 	type requestTelemetry struct {


### PR DESCRIPTION
Alphabetizes a few more lists of things in `stripe.go` and
`stripe_test.go`. This is just for cleanliness and produces no
functional changes.

r? @brandur (Very minor change.)