### PR TITLE
Add support for API version 2019-02-19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.44.0
+    - STRIPE_MOCK_VERSION=0.45.0
 
 go:
   - "1.9.x"

--- a/account.go
+++ b/account.go
@@ -45,56 +45,28 @@ const (
 	ExternalAccountTypeCard        ExternalAccountType = "card"
 )
 
-// LegalEntityType describes the types for a legal entity.
-type LegalEntityType string
+// AccountBusinessType describes the business type associated with an account.
+type AccountBusinessType string
 
-// List of values that LegalEntityType can take.
+// List of values that AccountBusinessType can take.
 const (
-	LegalEntityTypeCompany    LegalEntityType = "company"
-	LegalEntityTypeIndividual LegalEntityType = "individual"
+	AccountBusinessTypeCompany    AccountBusinessType = "company"
+	AccountBusinessTypeIndividual AccountBusinessType = "individual"
 )
 
-// IdentityVerificationDetailsCode is a machine-readable code specifying the
-// verification state of a legal entity
-type IdentityVerificationDetailsCode string
+// AccountRequirementsDisabledReason describes why an account is disabled.
+type AccountRequirementsDisabledReason string
 
-// List of values that IdentityVerificationDetailsCode can take.
+// List of values that AccountRequirementsDisabledReason can take.
 const (
-	IdentityVerificationDetailsCodeFailedKeyedIdentity       IdentityVerificationDetailsCode = "failed_keyed_identity"
-	IdentityVerificationDetailsCodeFailedOther               IdentityVerificationDetailsCode = "failed_other"
-	IdentityVerificationDetailsCodeScanCorrupt               IdentityVerificationDetailsCode = "scan_corrupt"
-	IdentityVerificationDetailsCodeScanFailedGreyscale       IdentityVerificationDetailsCode = "scan_failed_greyscale"
-	IdentityVerificationDetailsCodeScanFailedOther           IdentityVerificationDetailsCode = "scan_failed_other"
-	IdentityVerificationDetailsCodeScanIDCountryNotSupported IdentityVerificationDetailsCode = "scan_id_country_not_supported"
-	IdentityVerificationDetailsCodeScanIDTypeNotSupported    IdentityVerificationDetailsCode = "scan_id_type_not_supported"
-	IdentityVerificationDetailsCodeScanNameMismatch          IdentityVerificationDetailsCode = "scan_name_mismatch"
-	IdentityVerificationDetailsCodeScanNotReadable           IdentityVerificationDetailsCode = "scan_not_readable"
-	IdentityVerificationDetailsCodeScanNotUploaded           IdentityVerificationDetailsCode = "scan_not_uploaded"
-)
-
-// IdentityVerificationDisabledReason describes the valid reason to disable account
-type IdentityVerificationDisabledReason string
-
-// List of values that IdentityVerificationDisabledReason can take.
-const (
-	IdentityVerificationDisabledReasonFieldsNeeded           IdentityVerificationDisabledReason = "fields_needed"
-	IdentityVerificationDisabledReasonListed                 IdentityVerificationDisabledReason = "listed"
-	IdentityVerificationDisabledReasonOther                  IdentityVerificationDisabledReason = "other"
-	IdentityVerificationDisabledReasonRejectedFraud          IdentityVerificationDisabledReason = "rejected.fraud"
-	IdentityVerificationDisabledReasonRejectedListed         IdentityVerificationDisabledReason = "rejected.listed"
-	IdentityVerificationDisabledReasonRejectedOther          IdentityVerificationDisabledReason = "rejected.other"
-	IdentityVerificationDisabledReasonRejectedTermsOfService IdentityVerificationDisabledReason = "rejected.terms_of_service"
-	IdentityVerificationDisabledReasonUnderReview            IdentityVerificationDisabledReason = "under_review"
-)
-
-// IdentityVerificationStatus describes the different statuses for identity verification.
-type IdentityVerificationStatus string
-
-// List of values that IdentityVerificationStatus can take.
-const (
-	IdentityVerificationStatusPending    IdentityVerificationStatus = "pending"
-	IdentityVerificationStatusUnverified IdentityVerificationStatus = "unverified"
-	IdentityVerificationStatusVerified   IdentityVerificationStatus = "verified"
+	AccountRequirementsDisabledReasonFieldsNeeded           AccountRequirementsDisabledReason = "fields_needed"
+	AccountRequirementsDisabledReasonListed                 AccountRequirementsDisabledReason = "listed"
+	AccountRequirementsDisabledReasonOther                  AccountRequirementsDisabledReason = "other"
+	AccountRequirementsDisabledReasonRejectedFraud          AccountRequirementsDisabledReason = "rejected.fraud"
+	AccountRequirementsDisabledReasonRejectedListed         AccountRequirementsDisabledReason = "rejected.listed"
+	AccountRequirementsDisabledReasonRejectedOther          AccountRequirementsDisabledReason = "rejected.other"
+	AccountRequirementsDisabledReasonRejectedTermsOfService AccountRequirementsDisabledReason = "rejected.terms_of_service"
+	AccountRequirementsDisabledReasonUnderReview            AccountRequirementsDisabledReason = "under_review"
 )
 
 // PayoutInterval describes the payout interval.
@@ -118,66 +90,117 @@ const (
 	AccountRejectReasonTermsOfService AccountRejectReason = "terms_of_service"
 )
 
-// AccountParams are the parameters allowed during account creation/updates.
-type AccountParams struct {
-	Params                    `form:"*"`
-	AccountToken              *string                       `form:"account_token"`
-	BusinessName              *string                       `form:"business_name"`
-	BusinessPrimaryColor      *string                       `form:"business_primary_color"`
-	BusinessURL               *string                       `form:"business_url"`
-	Country                   *string                       `form:"country"`
-	DeclineChargeOn           *AccountDeclineSettingsParams `form:"decline_charge_on"`
-	DebitNegativeBalances     *bool                         `form:"debit_negative_balances"`
-	DefaultCurrency           *string                       `form:"default_currency"`
-	Email                     *string                       `form:"email"`
-	ExternalAccount           *AccountExternalAccountParams `form:"external_account"`
-	FromRecipient             *string                       `form:"from_recipient"`
-	LegalEntity               *LegalEntityParams            `form:"legal_entity"`
-	PayoutSchedule            *PayoutScheduleParams         `form:"payout_schedule"`
-	PayoutStatementDescriptor *string                       `form:"payout_statement_descriptor"`
-	ProductDescription        *string                       `form:"product_description"`
-	RequestedCapabilities     []*string                     `form:"requested_capabilities"`
-	StatementDescriptor       *string                       `form:"statement_descriptor"`
-	SupportEmail              *string                       `form:"support_email"`
-	SupportPhone              *string                       `form:"support_phone"`
-	SupportURL                *string                       `form:"support_url"`
-	TOSAcceptance             *TOSAcceptanceParams          `form:"tos_acceptance"`
-	Type                      *string                       `form:"type"`
+// AccountBusinessProfileParams are the parameters allowed for an account's business information
+type AccountBusinessProfileParams struct {
+	MCC                *string `form:"mcc"`
+	Name               *string `form:"name"`
+	ProductDescription *string `form:"product_description"`
+	SupportEmail       *string `form:"support_email"`
+	SupportPhone       *string `form:"support_phone"`
+	SupportURL         *string `form:"support_url"`
+	URL                *string `form:"url"`
 }
 
-// LegalEntityParams represents a legal_entity during account creation/updates.
-type LegalEntityParams struct {
-	AdditionalOwners []*AdditionalOwnerParams `form:"additional_owners"`
+// AccountCompanyParams are the parameters describing the company associated with the account.
+type AccountCompanyParams struct {
+	Address           *AccountAddressParams `form:"address"`
+	AddressKana       *AccountAddressParams `form:"address_kana"`
+	AddressKanji      *AccountAddressParams `form:"address_kanji"`
+	DirectorsProvided *bool                 `form:"directors_provided"`
+	Name              *string               `form:"name"`
+	NameKana          *string               `form:"name_kana"`
+	NameKanji         *string               `form:"name_kanji"`
+	OwnersProvided    *bool                 `form:"owners_provided"`
+	Phone             *string               `form:"phone"`
+	TaxID             *string               `form:"tax_id"`
+	TaxIDRegistrar    *string               `form:"tax_id_registrar"`
+	VATID             *string               `form:"vat_id"`
+}
 
-	// AdditionalOwnersEmpty can be set to clear a legal entity's additional
-	// owners.
-	AdditionalOwnersEmpty bool `form:"additional_owners,empty"`
+// AccountDeclineSettingsParams represents the parameters allowed for configuring
+// card declines on connected accounts.
+type AccountDeclineSettingsParams struct {
+	AVSFailure *bool `form:"avs_failure"`
+	CVCFailure *bool `form:"cvc_failure"`
+}
 
-	Address              *AccountAddressParams       `form:"address"`
-	AddressKana          *AccountAddressParams       `form:"address_kana"`
-	AddressKanji         *AccountAddressParams       `form:"address_kanji"`
-	BusinessName         *string                     `form:"business_name"`
-	BusinessNameKana     *string                     `form:"business_name_kana"`
-	BusinessNameKanji    *string                     `form:"business_name_kanji"`
-	BusinessTaxID        *string                     `form:"business_tax_id"`
-	BusinessVATID        *string                     `form:"business_vat_id"`
-	DOB                  *DOBParams                  `form:"dob"`
-	FirstName            *string                     `form:"first_name"`
-	FirstNameKana        *string                     `form:"first_name_kana"`
-	FirstNameKanji       *string                     `form:"first_name_kanji"`
-	Gender               *string                     `form:"gender"`
-	LastName             *string                     `form:"last_name"`
-	LastNameKana         *string                     `form:"last_name_kana"`
-	LastNameKanji        *string                     `form:"last_name_kanji"`
-	MaidenName           *string                     `form:"maiden_name"`
-	PersonalAddress      *AccountAddressParams       `form:"personal_address"`
-	PersonalAddressKana  *AccountAddressParams       `form:"personal_address_kana"`
-	PersonalAddressKanji *AccountAddressParams       `form:"personal_address_kanji"`
-	PersonalIDNumber     *string                     `form:"personal_id_number"`
-	PhoneNumber          *string                     `form:"phone_number"`
-	SSNLast4             *string                     `form:"ssn_last_4"`
-	Type                 *string                     `form:"type"`
-	Verification         *IdentityVerificationParams `form:"verification"`
+// AccountSettingsBrandingParams represent allowed parameters to configure settings specific to the
+// account’s branding.
+type AccountSettingsBrandingParams struct {
+	Icon         *string `form:"icon"`
+	Logo         *string `form:"logo"`
+	PrimaryColor *string `form:"primary_color"`
+}
+
+// AccountSettingsCardPaymentsParams represent allowed parameters to configure settings specific to
+// card charging on the account.
+type AccountSettingsCardPaymentsParams struct {
+	DeclineOn                 *AccountDeclineSettingsParams `form:"decline_on"`
+	StatementDescriptorPrefix *string                       `form:"statement_descriptor_prefix"`
+}
+
+// AccountSettingsDashboardParams represent allowed parameters to configure settings for the
+// account's Dashboard.
+type AccountSettingsDashboardParams struct {
+	DisplayName *string `form:"display_name"`
+	Timezone    *string `form:"timezone"`
+}
+
+// AccountSettingsPaymentsParams represent allowed parameters to configure settings  across payment
+// methods for charging on the account.
+type AccountSettingsPaymentsParams struct {
+	StatementDescriptor *string `form:"statement_descriptor"`
+}
+
+// AccountSettingsPayoutsParams represent allowed parameters to configure settings specific to the
+// account’s payouts.
+type AccountSettingsPayoutsParams struct {
+	DebitNegativeBalances *bool                 `form:"debit_negative_balances"`
+	Schedule              *PayoutScheduleParams `form:"schedule"`
+	StatementDescriptor   *string               `form:"statement_descriptor"`
+}
+
+// AccountSettingsParams are the parameters allowed for the account's settings.
+type AccountSettingsParams struct {
+	Branding     *AccountSettingsBrandingParams     `form:"branding"`
+	CardPayments *AccountSettingsCardPaymentsParams `form:"card_payments"`
+	Dashboard    *AccountSettingsDashboardParams    `form:"dashboard"`
+	Payments     *AccountSettingsPaymentsParams     `form:"payments"`
+	Payouts      *AccountSettingsPayoutsParams      `form:"payouts"`
+}
+
+// PayoutScheduleParams are the parameters allowed for payout schedules.
+type PayoutScheduleParams struct {
+	DelayDays        *int64  `form:"delay_days"`
+	DelayDaysMinimum *bool   `form:"-"` // See custom AppendTo
+	Interval         *string `form:"interval"`
+	MonthlyAnchor    *int64  `form:"monthly_anchor"`
+	WeeklyAnchor     *string `form:"weekly_anchor"`
+}
+
+// AppendTo implements custom encoding logic for PayoutScheduleParams
+// so that we can send a special value for `delay_days` field if needed.
+func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
+	if BoolValue(p.DelayDaysMinimum) {
+		body.Add(form.FormatKey(append(keyParts, "delay_days")), "minimum")
+	}
+}
+
+// AccountParams are the parameters allowed during account creation/updates.
+type AccountParams struct {
+	Params                `form:"*"`
+	BusinessProfile       *AccountBusinessProfileParams `form:"business_profile"`
+	BusinessType          *string                       `form:"business_type"`
+	Company               *AccountCompanyParams         `form:"company"`
+	Country               *string                       `form:"country"`
+	DefaultCurrency       *string                       `form:"default_currency"`
+	Email                 *string                       `form:"email"`
+	ExternalAccount       *AccountExternalAccountParams `form:"external_account"`
+	Individual            *PersonParams                 `form:"individual"`
+	RequestedCapabilities []*string                     `form:"requested_capabilities"`
+	Settings              *AccountSettingsParams        `form:"settings"`
+	TOSAcceptance         *AccountTOSAcceptanceParams   `form:"tos_acceptance"`
+	Type                  *string                       `form:"type"`
 }
 
 // AccountAddressParams represents an address during account creation/updates.
@@ -194,47 +217,22 @@ type AccountAddressParams struct {
 	Town *string `form:"town"`
 }
 
-// AccountDeclineSettingsParams represents the parameters allowed for configuring
-// declines on connected accounts.
-type AccountDeclineSettingsParams struct {
-	AVSFailure *bool `form:"avs_failure"`
-	CVCFailure *bool `form:"cvc_failure"`
-}
-
-// DOBParams represents a DOB during account creation/updates.
-type DOBParams struct {
-	Day   *int64 `form:"day"`
-	Month *int64 `form:"month"`
-	Year  *int64 `form:"year"`
-}
-
-// TOSAcceptanceParams represents tos_acceptance during account creation/updates.
-type TOSAcceptanceParams struct {
+// AccountTOSAcceptanceParams represents tos_acceptance during account creation/updates.
+type AccountTOSAcceptanceParams struct {
 	Date      *int64  `form:"date"`
 	IP        *string `form:"ip"`
 	UserAgent *string `form:"user_agent"`
 }
 
-// AdditionalOwnerParams represents an additional owner during account creation/updates.
-type AdditionalOwnerParams struct {
-	Address          *AccountAddressParams       `form:"address"`
-	DOB              *DOBParams                  `form:"dob"`
-	FirstName        *string                     `form:"first_name"`
-	LastName         *string                     `form:"last_name"`
-	MaidenName       *string                     `form:"maiden_name"`
-	PersonalIDNumber *string                     `form:"personal_id_number"`
-	Verification     *IdentityVerificationParams `form:"verification"`
-}
-
-// IdentityVerificationParams represents a verification during account creation/updates.
-type IdentityVerificationParams struct {
-	Document     *string `form:"document"`
-	DocumentBack *string `form:"document_back"`
-}
-
 // AccountListParams are the parameters allowed during account listing.
 type AccountListParams struct {
 	ListParams `form:"*"`
+}
+
+// AccountRejectParams is the structure for the Reject function.
+type AccountRejectParams struct {
+	Params `form:"*"`
+	Reason *string `form:"reason"`
 }
 
 // AccountExternalAccountParams are the parameters allowed to reference an
@@ -262,75 +260,16 @@ func (p *AccountExternalAccountParams) AppendTo(body *form.Values, keyParts []st
 	}
 }
 
-// PayoutScheduleParams are the parameters allowed for payout schedules.
-type PayoutScheduleParams struct {
-	DelayDays        *int64  `form:"delay_days"`
-	DelayDaysMinimum *bool   `form:"-"` // See custom AppendTo
-	Interval         *string `form:"interval"`
-	MonthlyAnchor    *int64  `form:"monthly_anchor"`
-	WeeklyAnchor     *string `form:"weekly_anchor"`
-}
-
-// AppendTo implements custom encoding logic for PayoutScheduleParams
-// so that we can send a special value for `delay_days` field if needed.
-func (p *PayoutScheduleParams) AppendTo(body *form.Values, keyParts []string) {
-	if BoolValue(p.DelayDaysMinimum) {
-		body.Add(form.FormatKey(append(keyParts, "delay_days")), "minimum")
-	}
-}
-
-// Account is the resource representing your Stripe account.
-// For more details see https://stripe.com/docs/api/#account.
-type Account struct {
-	BusinessLogo          string                  `json:"business_logo"`
-	BusinessName          string                  `json:"business_name"`
-	BusinessPrimaryColor  string                  `json:"business_primary_color"`
-	BusinessURL           string                  `json:"business_url"`
-	Capabilities          *AccountCapabilities    `json:"capabilities"`
-	ChargesEnabled        bool                    `json:"charges_enabled"`
-	Country               string                  `json:"country"`
-	Created               int64                   `json:"created"`
-	DeclineChargeOn       *AccountDeclineSettings `json:"decline_charge_on"`
-	DebitNegativeBalances bool                    `json:"debit_negative_balances"`
-	DefaultCurrency       Currency                `json:"default_currency"`
-	Deleted               bool                    `json:"deleted"`
-	DetailsSubmitted      bool                    `json:"details_submitted"`
-	Email                 string                  `json:"email"`
-	ExternalAccounts      *ExternalAccountList    `json:"external_accounts"`
-	ID                    string                  `json:"id"`
-
-	Keys *struct {
-		Publishable string `json:"publishable"`
-		Secret      string `json:"secret"`
-	} `json:"keys"`
-
-	LegalEntity               *LegalEntity      `json:"legal_entity"`
-	Metadata                  map[string]string `json:"metadata"`
-	DisplayName               string            `json:"display_name"`
-	PayoutSchedule            *PayoutSchedule   `json:"payout_schedule"`
-	PayoutStatementDescriptor string            `json:"payout_statement_descriptor"`
-	PayoutsEnabled            bool              `json:"payouts_enabled"`
-	ProductDescription        string            `json:"product_description"`
-	StatementDescriptor       string            `json:"statement_descriptor"`
-	SupportAddress            *Address          `json:"support_address"`
-	SupportEmail              string            `json:"support_email"`
-	SupportPhone              string            `json:"support_phone"`
-	SupportURL                string            `json:"support_url"`
-	Timezone                  string            `json:"timezone"`
-
-	TOSAcceptance *struct {
-		Date      int64  `json:"date"`
-		IP        string `json:"ip"`
-		UserAgent string `json:"user_agent"`
-	} `json:"tos_acceptance"`
-
-	Type AccountType `json:"type"`
-
-	Verification *struct {
-		DisabledReason IdentityVerificationDisabledReason `json:"disabled_reason"`
-		DueBy          int64                              `json:"due_by"`
-		FieldsNeeded   []string                           `json:"fields_needed"`
-	} `json:"verification"`
+// AccountBusinessProfile represents optional information related to the business.
+type AccountBusinessProfile struct {
+	MCC                string   `json:"mcc"`
+	Name               string   `json:"name"`
+	ProductDescription string   `json:"product_description"`
+	SupportAddress     *Address `json:"support_address"`
+	SupportEmail       string   `json:"support_email"`
+	SupportPhone       string   `json:"support_phone"`
+	SupportURL         string   `json:"support_url"`
+	URL                string   `json:"url"`
 }
 
 // AccountCapabilities is the resource representing the capabilities enabled on that account.
@@ -338,6 +277,119 @@ type AccountCapabilities struct {
 	CardPayments     AccountCapabilityStatus `json:"card_payments"`
 	LegacyPayments   AccountCapabilityStatus `json:"legacy_payments"`
 	PlatformPayments AccountCapabilityStatus `json:"platform_payments"`
+}
+
+// AccountCompany represents details about the company or business associated with the account.
+type AccountCompany struct {
+	Address           *AccountAddress `json:"address"`
+	AddressKana       *AccountAddress `json:"address_kana"`
+	AddressKanji      *AccountAddress `json:"address_kanji"`
+	DirectorsProvided bool            `json:"directors_provided"`
+	Name              string          `json:"name"`
+	NameKana          string          `json:"name_kana"`
+	NameKanji         string          `json:"name_kanji"`
+	OwnersProvided    bool            `json:"owners_provided"`
+	Phone             string          `json:"phone"`
+	TaxIDProvided     bool            `json:"tax_id_provided"`
+	TaxIDRegistrar    string          `json:"tax_id_registrar"`
+	VATIDProvided     bool            `json:"vat_id_provided"`
+}
+
+// AccountDeclineOn represents card charges decline behavior for that account.
+type AccountDeclineOn struct {
+	AVSFailure bool `json:"avs_failure"`
+	CVCFailure bool `json:"cvc_failure"`
+}
+
+// AccountPayoutSchedule is the structure for an account's payout schedule.
+type AccountPayoutSchedule struct {
+	DelayDays     int64          `json:"delay_days"`
+	Interval      PayoutInterval `json:"interval"`
+	MonthlyAnchor int64          `json:"monthly_anchor"`
+	WeeklyAnchor  string         `json:"weekly_anchor"`
+}
+
+// AccountRequirements represents information that needs to be collected for an account.
+type AccountRequirements struct {
+	CurrentDeadline int64                             `json:"current_deadline"`
+	CurrentlyDue    []string                          `json:"currently_due"`
+	DisabledReason  AccountRequirementsDisabledReason `json:"disabled_reason"`
+	EventuallyDue   []string                          `json:"eventually_due"`
+	PastDue         []string                          `json:"past_due"`
+}
+
+// AccountSettingsBranding represents settings specific to the account's branding.
+type AccountSettingsBranding struct {
+	Icon         *File  `json:"icon"`
+	Logo         *File  `json:"logo"`
+	PrimaryColor string `json:"primary_color"`
+}
+
+// AccountSettingsCardPayments represents settings specific to card charging on the account.
+type AccountSettingsCardPayments struct {
+	DeclineOn                 *AccountDeclineOn `json:"decline_on"`
+	StatementDescriptorPrefix string            `json:"statement_descriptor_prefix"`
+}
+
+// AccountSettingsDashboard represents settings specific to the account's Dashboard.
+type AccountSettingsDashboard struct {
+	DisplayName string `json:"display_name"`
+	Timezone    string `json:"timezone"`
+}
+
+// AccountSettingsPayments represents settings that apply across payment methods for charging on
+// the account.
+type AccountSettingsPayments struct {
+	StatementDescriptor string `json:"statement_descriptor"`
+}
+
+// AccountSettingsPayouts represents settings specific to the account’s payouts.
+type AccountSettingsPayouts struct {
+	DebitNegativeBalances bool                   `json:"debit_negative_balances"`
+	Schedule              *AccountPayoutSchedule `json:"schedule"`
+	StatementDescriptor   string                 `json:"statement_descriptor"`
+}
+
+// AccountSettings represents options for customizing how the account functions within Stripe.
+type AccountSettings struct {
+	Branding     *AccountSettingsBranding     `json:"branding"`
+	CardPayments *AccountSettingsCardPayments `json:"card_payments"`
+	Dashboard    *AccountSettingsDashboard    `json:"dashboard"`
+	Payments     *AccountSettingsPayments     `json:"payments"`
+	Payouts      *AccountSettingsPayouts      `json:"payouts"`
+}
+
+// AccountTOSAcceptance represents status of acceptance of our terms of services for the account.
+type AccountTOSAcceptance struct {
+	Date      int64  `json:"date"`
+	IP        string `json:"ip"`
+	UserAgent string `json:"user_agent"`
+}
+
+// Account is the resource representing your Stripe account.
+// For more details see https://stripe.com/docs/api/#account.
+type Account struct {
+	BusinessProfile  *AccountBusinessProfile `json:"business_profile"`
+	BusinessType     AccountBusinessType     `json:"business_type"`
+	Capabilities     *AccountCapabilities    `json:"capabilities"`
+	ChargesEnabled   bool                    `json:"charges_enabled"`
+	Company          *AccountCompany         `json:"company"`
+	Country          string                  `json:"country"`
+	Created          int64                   `json:"created"`
+	DefaultCurrency  Currency                `json:"default_currency"`
+	Deleted          bool                    `json:"deleted"`
+	DetailsSubmitted bool                    `json:"details_submitted"`
+	Email            string                  `json:"email"`
+	ExternalAccounts *ExternalAccountList    `json:"external_accounts"`
+	ID               string                  `json:"id"`
+	Individual       *Person                 `json:"individual"`
+	Metadata         map[string]string       `json:"metadata"`
+	Object           string                  `json:"object"`
+	PayoutsEnabled   bool                    `json:"payouts_enabled"`
+	Requirements     *AccountRequirements    `json:"requirements"`
+	Settings         *AccountSettings        `json:"settings"`
+	TOSAcceptance    *AccountTOSAcceptance   `json:"tos_acceptance"`
+	Type             AccountType             `json:"type"`
 }
 
 // UnmarshalJSON handles deserialization of an account.
@@ -412,36 +464,6 @@ func (ea *ExternalAccount) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-// LegalEntity is the structure for properties related to an account's legal state.
-type LegalEntity struct {
-	AdditionalOwners         []*AdditionalOwner    `json:"additional_owners"`
-	Address                  *AccountAddress       `json:"address"`
-	AddressKana              *AccountAddress       `json:"address_kana"`
-	AddressKanji             *AccountAddress       `json:"address_kanji"`
-	BusinessName             string                `json:"business_name"`
-	BusinessNameKana         string                `json:"business_name_kana"`
-	BusinessNameKanji        string                `json:"business_name_kanji"`
-	BusinessTaxIDProvided    bool                  `json:"business_tax_id_provided"`
-	BusinessVATIDProvided    bool                  `json:"business_vat_id_provided"`
-	DOB                      *DOB                  `json:"dob"`
-	FirstName                string                `json:"first_name"`
-	FirstNameKana            string                `json:"first_name_kana"`
-	FirstNameKanji           string                `json:"first_name_kanji"`
-	Gender                   string                `json:"gender"`
-	LastName                 string                `json:"last_name"`
-	LastNameKana             string                `json:"last_name_kana"`
-	LastNameKanji            string                `json:"last_name_kanji"`
-	MaidenName               string                `json:"maiden_name"`
-	PersonalAddress          *AccountAddress       `json:"personal_address"`
-	PersonalAddressKana      *AccountAddress       `json:"personal_address_kana"`
-	PersonalAddressKanji     *AccountAddress       `json:"personal_address_kanji"`
-	PersonalIDNumberProvided bool                  `json:"personal_id_number_provided"`
-	PhoneNumber              string                `json:"phone_number"`
-	SSNLast4Provided         bool                  `json:"ssn_last_4_provided"`
-	Type                     LegalEntityType       `json:"type"`
-	Verification             *IdentityVerification `json:"verification"`
-}
-
 // AccountAddress is the structure for an account address.
 type AccountAddress struct {
 	City       string `json:"city"`
@@ -454,51 +476,4 @@ type AccountAddress struct {
 	// Town/cho-me. Note that this is only used for Kana/Kanji representations
 	// of an address.
 	Town string `json:"town"`
-}
-
-// AccountDeclineSettings is the structure for an account's decline settings.
-type AccountDeclineSettings struct {
-	AVSFailure bool `json:"avs_failure"`
-	CVCFailure bool `json:"cvc_failure"`
-}
-
-// DOB is a structure for an account owner's date of birth.
-type DOB struct {
-	Day   int64 `json:"day"`
-	Month int64 `json:"month"`
-	Year  int64 `json:"year"`
-}
-
-// AdditionalOwner is the structure for an account owner.
-type AdditionalOwner struct {
-	Address                  *AccountAddress      `json:"address"`
-	DOB                      DOB                  `json:"dob"`
-	FirstName                string               `json:"first_name"`
-	LastName                 string               `json:"last_name"`
-	MaidenName               string               `json:"maiden_name"`
-	PersonalIDNumberProvided bool                 `json:"personal_id_number_provided"`
-	Verification             IdentityVerification `json:"verification"`
-}
-
-// IdentityVerification is the structure for an account's verification.
-type IdentityVerification struct {
-	Details      string                          `json:"details"`
-	DetailsCode  IdentityVerificationDetailsCode `json:"details_code"`
-	Document     *File                           `json:"document"`
-	DocumentBack *File                           `json:"document_back"`
-	Status       IdentityVerificationStatus      `json:"status"`
-}
-
-// PayoutSchedule is the structure for an account's payout schedule.
-type PayoutSchedule struct {
-	DelayDays     int64          `json:"delay_days"`
-	Interval      PayoutInterval `json:"interval"`
-	MonthlyAnchor int64          `json:"monthly_anchor"`
-	WeeklyAnchor  string         `json:"weekly_anchor"`
-}
-
-// AccountRejectParams is the structure for the Reject function.
-type AccountRejectParams struct {
-	Params `form:"*"`
-	Reason *string `form:"reason"`
 }

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -37,51 +37,49 @@ func TestAccountList(t *testing.T) {
 
 func TestAccountNew(t *testing.T) {
 	account, err := New(&stripe.AccountParams{
-		Type:                 stripe.String(string(stripe.AccountTypeCustom)),
-		Country:              stripe.String("CA"),
-		BusinessURL:          stripe.String("www.stripe.com"),
-		BusinessName:         stripe.String("Stripe"),
-		BusinessPrimaryColor: stripe.String("#ffffff"),
-		DeclineChargeOn: &stripe.AccountDeclineSettingsParams{
-			AVSFailure: stripe.Bool(true),
-			CVCFailure: stripe.Bool(true),
+		BusinessProfile: &stripe.AccountBusinessProfileParams{
+			Name:         stripe.String("name"),
+			SupportEmail: stripe.String("foo@bar.com"),
+			SupportURL:   stripe.String("www.stripe.com"),
+			SupportPhone: stripe.String("4151234567"),
 		},
-		DebitNegativeBalances: stripe.Bool(true),
-		SupportEmail:          stripe.String("foo@bar.com"),
-		SupportURL:            stripe.String("www.stripe.com"),
-		SupportPhone:          stripe.String("4151234567"),
-		LegalEntity: &stripe.LegalEntityParams{
-			Type:         stripe.String(string(stripe.LegalEntityTypeIndividual)),
-			BusinessName: stripe.String("Stripe Go"),
-			AdditionalOwners: []*stripe.AdditionalOwnerParams{
-				{
-					FirstName: stripe.String("Jane"),
-					LastName:  stripe.String("Doe"),
-					Verification: &stripe.IdentityVerificationParams{
-						Document:     stripe.String("file_345"),
-						DocumentBack: stripe.String("file_567"),
-					},
+		BusinessType: stripe.String(string(stripe.AccountBusinessTypeCompany)),
+		Company: &stripe.AccountCompanyParams{
+			DirectorsProvided: stripe.Bool(true),
+			Name:              stripe.String("company_name"),
+		},
+		Country: stripe.String("CA"),
+		ExternalAccount: &stripe.AccountExternalAccountParams{
+			Token: stripe.String("tok_123"),
+		},
+		RequestedCapabilities: []*string{
+			stripe.String("card_payments"),
+		},
+		Settings: &stripe.AccountSettingsParams{
+			Branding: &stripe.AccountSettingsBrandingParams{
+				Icon: stripe.String("file_123"),
+				Logo: stripe.String("file_234"),
+			},
+			CardPayments: &stripe.AccountSettingsCardPaymentsParams{
+				DeclineOn: &stripe.AccountDeclineSettingsParams{
+					AVSFailure: stripe.Bool(true),
+					CVCFailure: stripe.Bool(true),
 				},
-				{
-					FirstName: stripe.String("John"),
-					LastName:  stripe.String("Doe"),
+				StatementDescriptorPrefix: stripe.String("prefix"),
+			},
+			Payments: &stripe.AccountSettingsPaymentsParams{
+				StatementDescriptor: stripe.String("descriptor"),
+			},
+			Payouts: &stripe.AccountSettingsPayoutsParams{
+				DebitNegativeBalances: stripe.Bool(true),
+				Schedule: &stripe.PayoutScheduleParams{
+					DelayDaysMinimum: stripe.Bool(true),
+					Interval:         stripe.String(string(stripe.PayoutIntervalManual)),
 				},
-			},
-			DOB: &stripe.DOBParams{
-				Day:   stripe.Int64(1),
-				Month: stripe.Int64(2),
-				Year:  stripe.Int64(1990),
-			},
-			Verification: &stripe.IdentityVerificationParams{
-				Document:     stripe.String("file_123"),
-				DocumentBack: stripe.String("file_234"),
+				StatementDescriptor: stripe.String("payout_descriptor"),
 			},
 		},
-		TOSAcceptance: &stripe.TOSAcceptanceParams{
-			IP:        stripe.String("127.0.0.1"),
-			Date:      stripe.Int64(1437578361),
-			UserAgent: stripe.String("Mozilla/5.0"),
-		},
+		Type: stripe.String(string(stripe.AccountTypeCustom)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, account)
@@ -97,7 +95,7 @@ func TestAccountReject(t *testing.T) {
 
 func TestAccountUpdate(t *testing.T) {
 	account, err := Update("acct_123", &stripe.AccountParams{
-		LegalEntity: &stripe.LegalEntityParams{
+		Company: &stripe.AccountCompanyParams{
 			Address: &stripe.AccountAddressParams{
 				Country:    stripe.String("CA"),
 				City:       stripe.String("Montreal"),

--- a/account_test.go
+++ b/account_test.go
@@ -33,13 +33,13 @@ func TestAccountExternalAccountParams_AppendTo(t *testing.T) {
 func TestAccount_Unmarshal(t *testing.T) {
 	accountData := map[string]interface{}{
 		"id": "acct_123",
+		"business_profile": map[string]interface{}{
+			"mcc": "123",
+		},
+		"business_type": "company",
 		"capabilities": map[string]interface{}{
 			"card_payments":     "active",
 			"platform_payments": "inactive",
-		},
-		"decline_charge_on": map[string]interface{}{
-			"avs_failure": true,
-			"cvc_failure": false,
 		},
 		"external_accounts": map[string]interface{}{
 			"object":   "list",
@@ -55,89 +55,46 @@ func TestAccount_Unmarshal(t *testing.T) {
 				},
 			},
 		},
-		"legal_entity": map[string]interface{}{
-			"additional_owners": []map[string]interface{}{
-				{
-					"address": map[string]interface{}{
-						"city":        "city1",
-						"country":     "US",
-						"line1":       "line1",
-						"line2":       "line2",
-						"postal_code": "90210",
-						"state":       "CA",
-					},
-					"dob": map[string]interface{}{
-						"day":   1,
-						"month": 1,
-						"year":  1970,
-					},
-					"first_name":                  "First",
-					"last_name":                   "Last",
-					"maiden_name":                 "Maiden",
-					"personal_id_number_provided": true,
-					"verification": map[string]interface{}{
-						"details":       "details",
-						"details_code":  "failed_other",
-						"document":      "file_123",
-						"document_back": "file_234",
-						"status":        "pending",
-					},
-				},
-				{
-					"address": map[string]interface{}{
-						"city": "city2",
-					},
-					"dob": map[string]interface{}{
-						"day":   1,
-						"month": 1,
-						"year":  1960,
-					},
-					"first_name": "First2",
-				},
-			},
-			"address": map[string]interface{}{
-				"city":        "city-3",
-				"country":     "US",
-				"line1":       "line1-3",
-				"line2":       "line2-3",
-				"postal_code": "91111",
-				"state":       "CA",
-			},
-			"business_tax_id_provided": true,
-			"dob": map[string]interface{}{
-				"day":   1,
-				"month": 1,
-				"year":  1980,
-			},
-			"first_name":  "John",
-			"last_name":   "Doe",
-			"maiden_name": "Maiden",
-			"personal_address": map[string]interface{}{
-				"city":        "personal_city1",
-				"country":     "US",
-				"line1":       "personal_line1",
-				"line2":       "personal_line2",
-				"postal_code": "90210",
-				"state":       "CA",
-			},
-			"personal_id_number_provided": true,
-			"ssn_last_4_provided":         true,
-			"type":                        "company",
-			"verification": map[string]interface{}{
-				"details":       "details",
-				"details_code":  "failed_other",
-				"document":      "file_345",
-				"document_back": "file_456",
-				"status":        "unverified",
-			},
-		},
 		"metadata": map[string]interface{}{
 			"key1": "value1",
 			"key2": "value2",
 		},
-		"payout_schedule": map[string]interface{}{
-			"delay_days": 2,
-			"interval":   "weekly",
+		"object": "account",
+		"requirements": map[string]interface{}{
+			"current_deadline": 1234567890,
+			"currently_due": []interface{}{
+				"tos_acceptance.date",
+				"tos_acceptance.ip",
+			},
+			"disabled_reason": "fields_needed",
+			"eventually_due": []interface{}{
+				"relationship.account_opener",
+			},
+			"past_due": []interface{}{},
+		},
+		"settings": map[string]interface{}{
+			"branding": map[string]interface{}{
+				"icon": "file_123",
+				"logo": "file_234",
+			},
+			"card_payments": map[string]interface{}{
+				"decline_on": map[string]interface{}{
+					"avs_failure": true,
+					"cvc_failure": false,
+				},
+				"statement_descriptor_prefix": "prefix",
+			},
+			"payments": map[string]interface{}{
+				"statement_descriptor": "descriptor",
+			},
+			"payouts": map[string]interface{}{
+				"debit_negative_balances": true,
+				"schedule": map[string]interface{}{
+					"delay_days": 2,
+					"interval":   "weekly",
+				},
+				"statement_descriptor_prefix": "prefix",
+			},
 		},
 		"tos_acceptance": map[string]interface{}{
 			"date":       1528573382,
@@ -145,14 +102,6 @@ func TestAccount_Unmarshal(t *testing.T) {
 			"user_agent": "user agent",
 		},
 		"type": "custom",
-		"verification": map[string]interface{}{
-			"disabled_reason": "fields_needed",
-			"due_by":          1528573382,
-			"fields_needed": []interface{}{
-				"legal_entity.verification.document",
-				"legal_entity.business_name",
-			},
-		},
 	}
 
 	bytes, err := json.Marshal(&accountData)
@@ -164,102 +113,44 @@ func TestAccount_Unmarshal(t *testing.T) {
 
 	assert.Equal(t, "acct_123", account.ID)
 
+	assert.Equal(t, "123", account.BusinessProfile.MCC)
+
 	assert.Equal(t, AccountCapabilityStatusActive, account.Capabilities.CardPayments)
 	assert.Equal(t, AccountCapabilityStatus(""), account.Capabilities.LegacyPayments)
 	assert.Equal(t, AccountCapabilityStatusInactive, account.Capabilities.PlatformPayments)
 
-	assert.Equal(t, true, account.DeclineChargeOn.AVSFailure)
-	assert.Equal(t, false, account.DeclineChargeOn.CVCFailure)
+	assert.Equal(t, AccountBusinessTypeCompany, account.BusinessType)
+
+	// Assert ExternalAccounts are fully deserialized
+	assert.Equal(t, true, account.ExternalAccounts.HasMore)
+	assert.Equal(t, 2, len(account.ExternalAccounts.Data))
+	assert.Equal(t, "ba_123", account.ExternalAccounts.Data[0].ID)
+	assert.Equal(t, "card_123", account.ExternalAccounts.Data[1].ID)
 
 	assert.Equal(t, "value1", account.Metadata["key1"])
 	assert.Equal(t, "value2", account.Metadata["key2"])
 
-	assert.Equal(t, int64(2), account.PayoutSchedule.DelayDays)
-	assert.Equal(t, PayoutIntervalWeekly, account.PayoutSchedule.Interval)
+	assert.Equal(t, int64(1234567890), account.Requirements.CurrentDeadline)
+	assert.Equal(t, 2, len(account.Requirements.CurrentlyDue))
+	assert.Equal(t, AccountRequirementsDisabledReasonFieldsNeeded, account.Requirements.DisabledReason)
+	assert.Equal(t, 1, len(account.Requirements.EventuallyDue))
+	assert.Equal(t, 0, len(account.Requirements.PastDue))
 
-	assert.Equal(t, AccountTypeCustom, account.Type)
+	assert.Equal(t, "file_123", account.Settings.Branding.Icon.ID)
+	assert.Equal(t, "file_234", account.Settings.Branding.Logo.ID)
+	assert.Equal(t, true, account.Settings.CardPayments.DeclineOn.AVSFailure)
+	assert.Equal(t, false, account.Settings.CardPayments.DeclineOn.CVCFailure)
+	assert.Equal(t, "prefix", account.Settings.CardPayments.StatementDescriptorPrefix)
+	assert.Equal(t, "descriptor", account.Settings.Payments.StatementDescriptor)
+	assert.Equal(t, true, account.Settings.Payouts.DebitNegativeBalances)
+	assert.Equal(t, int64(2), account.Settings.Payouts.Schedule.DelayDays)
+	assert.Equal(t, PayoutIntervalWeekly, account.Settings.Payouts.Schedule.Interval)
 
 	assert.Equal(t, int64(1528573382), account.TOSAcceptance.Date)
 	assert.Equal(t, "127.0.0.1", account.TOSAcceptance.IP)
 	assert.Equal(t, "user agent", account.TOSAcceptance.UserAgent)
 
-	assert.Equal(t, IdentityVerificationDisabledReasonFieldsNeeded, account.Verification.DisabledReason)
-	assert.Equal(t, int64(1528573382), account.Verification.DueBy)
-	assert.Equal(t, 2, len(account.Verification.FieldsNeeded))
-	assert.Equal(t, "legal_entity.verification.document", account.Verification.FieldsNeeded[0])
-	assert.Equal(t, "legal_entity.business_name", account.Verification.FieldsNeeded[1])
-
-	// Assert ExternalAccounts are fully deserialized
-	assert.Equal(t, true, account.ExternalAccounts.HasMore)
-
-	assert.Equal(t, 2, len(account.ExternalAccounts.Data))
-	assert.Equal(t, "ba_123", account.ExternalAccounts.Data[0].ID)
-	assert.Equal(t, "card_123", account.ExternalAccounts.Data[1].ID)
-
-	// Ensure LegalEntity is fully deserialized
-	assert.NotNil(t, account.LegalEntity)
-
-	assert.Equal(t, 2, len(account.LegalEntity.AdditionalOwners))
-	assert.Equal(t, "city1", account.LegalEntity.AdditionalOwners[0].Address.City)
-	assert.Equal(t, "US", account.LegalEntity.AdditionalOwners[0].Address.Country)
-	assert.Equal(t, "line1", account.LegalEntity.AdditionalOwners[0].Address.Line1)
-	assert.Equal(t, "line2", account.LegalEntity.AdditionalOwners[0].Address.Line2)
-	assert.Equal(t, "90210", account.LegalEntity.AdditionalOwners[0].Address.PostalCode)
-	assert.Equal(t, "CA", account.LegalEntity.AdditionalOwners[0].Address.State)
-	assert.Equal(t, int64(1), account.LegalEntity.AdditionalOwners[0].DOB.Day)
-	assert.Equal(t, int64(1), account.LegalEntity.AdditionalOwners[0].DOB.Month)
-	assert.Equal(t, int64(1970), account.LegalEntity.AdditionalOwners[0].DOB.Year)
-	assert.Equal(t, "First", account.LegalEntity.AdditionalOwners[0].FirstName)
-	assert.Equal(t, "Last", account.LegalEntity.AdditionalOwners[0].LastName)
-	assert.Equal(t, "Maiden", account.LegalEntity.AdditionalOwners[0].MaidenName)
-	assert.True(t, account.LegalEntity.AdditionalOwners[0].PersonalIDNumberProvided)
-	assert.Equal(t, "details", account.LegalEntity.AdditionalOwners[0].Verification.Details)
-	assert.Equal(t, IdentityVerificationDetailsCodeFailedOther, account.LegalEntity.AdditionalOwners[0].Verification.DetailsCode)
-	assert.Equal(t, "file_123", account.LegalEntity.AdditionalOwners[0].Verification.Document.ID)
-	assert.Equal(t, "file_234", account.LegalEntity.AdditionalOwners[0].Verification.DocumentBack.ID)
-	assert.Equal(t, IdentityVerificationStatusPending, account.LegalEntity.AdditionalOwners[0].Verification.Status)
-
-	assert.Equal(t, "city2", account.LegalEntity.AdditionalOwners[1].Address.City)
-	assert.Equal(t, "First2", account.LegalEntity.AdditionalOwners[1].FirstName)
-
-	assert.Equal(t, "city1", account.LegalEntity.AdditionalOwners[0].Address.City)
-	assert.Equal(t, "US", account.LegalEntity.AdditionalOwners[0].Address.Country)
-	assert.Equal(t, "line1", account.LegalEntity.AdditionalOwners[0].Address.Line1)
-	assert.Equal(t, "line2", account.LegalEntity.AdditionalOwners[0].Address.Line2)
-	assert.Equal(t, "90210", account.LegalEntity.AdditionalOwners[0].Address.PostalCode)
-	assert.Equal(t, "CA", account.LegalEntity.AdditionalOwners[0].Address.State)
-
-	assert.Equal(t, "city-3", account.LegalEntity.Address.City)
-	assert.Equal(t, "US", account.LegalEntity.Address.Country)
-	assert.Equal(t, "line1-3", account.LegalEntity.Address.Line1)
-	assert.Equal(t, "line2-3", account.LegalEntity.Address.Line2)
-	assert.Equal(t, "91111", account.LegalEntity.Address.PostalCode)
-	assert.Equal(t, "CA", account.LegalEntity.Address.State)
-
-	assert.True(t, account.LegalEntity.BusinessTaxIDProvided)
-	assert.Equal(t, int64(1), account.LegalEntity.DOB.Day)
-	assert.Equal(t, int64(1), account.LegalEntity.DOB.Month)
-	assert.Equal(t, int64(1980), account.LegalEntity.DOB.Year)
-	assert.True(t, account.LegalEntity.PersonalIDNumberProvided)
-	assert.Equal(t, "John", account.LegalEntity.FirstName)
-	assert.Equal(t, "Doe", account.LegalEntity.LastName)
-	assert.Equal(t, "Maiden", account.LegalEntity.MaidenName)
-
-	assert.Equal(t, "personal_city1", account.LegalEntity.PersonalAddress.City)
-	assert.Equal(t, "US", account.LegalEntity.PersonalAddress.Country)
-	assert.Equal(t, "personal_line1", account.LegalEntity.PersonalAddress.Line1)
-	assert.Equal(t, "personal_line2", account.LegalEntity.PersonalAddress.Line2)
-	assert.Equal(t, "90210", account.LegalEntity.PersonalAddress.PostalCode)
-	assert.Equal(t, "CA", account.LegalEntity.PersonalAddress.State)
-
-	assert.True(t, account.LegalEntity.PersonalIDNumberProvided)
-	assert.True(t, account.LegalEntity.SSNLast4Provided)
-	assert.Equal(t, LegalEntityTypeCompany, account.LegalEntity.Type)
-
-	assert.Equal(t, IdentityVerificationDetailsCodeFailedOther, account.LegalEntity.Verification.DetailsCode)
-	assert.Equal(t, "file_345", account.LegalEntity.Verification.Document.ID)
-	assert.Equal(t, "file_456", account.LegalEntity.Verification.DocumentBack.ID)
-	assert.Equal(t, IdentityVerificationStatusUnverified, account.LegalEntity.Verification.Status)
+	assert.Equal(t, AccountTypeCustom, account.Type)
 }
 
 func TestAccount_UnmarshalJSON(t *testing.T) {

--- a/countryspec.go
+++ b/countryspec.go
@@ -13,13 +13,13 @@ type VerificationFieldsList struct {
 // CountrySpec is the resource representing the rules required for a Stripe account.
 // For more details see https://stripe.com/docs/api/#country_specs.
 type CountrySpec struct {
-	DefaultCurrency                Currency                                    `json:"default_currency"`
-	ID                             string                                      `json:"id"`
-	SupportedBankAccountCurrencies map[Currency][]Country                      `json:"supported_bank_account_currencies"`
-	SupportedPaymentCurrencies     []Currency                                  `json:"supported_payment_currencies"`
-	SupportedPaymentMethods        []string                                    `json:"supported_payment_methods"`
-	SupportedTransferCountries     []string                                    `json:"supported_transfer_countries"`
-	VerificationFields             map[LegalEntityType]*VerificationFieldsList `json:"verification_fields"`
+	DefaultCurrency                Currency                                        `json:"default_currency"`
+	ID                             string                                          `json:"id"`
+	SupportedBankAccountCurrencies map[Currency][]Country                          `json:"supported_bank_account_currencies"`
+	SupportedPaymentCurrencies     []Currency                                      `json:"supported_payment_currencies"`
+	SupportedPaymentMethods        []string                                        `json:"supported_payment_methods"`
+	SupportedTransferCountries     []string                                        `json:"supported_transfer_countries"`
+	VerificationFields             map[AccountBusinessType]*VerificationFieldsList `json:"verification_fields"`
 }
 
 // CountrySpecParams are the parameters allowed during CountrySpec retrieval.

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -76,9 +76,6 @@ type PaymentIntentConfirmParams struct {
 	SavePaymentMethod *bool                  `form:"save_payment_method"`
 	Shipping          *ShippingDetailsParams `form:"shipping"`
 	Source            *string                `form:"source"`
-
-	// This property is considered deprecated. Prefer using SavePaymentMethod
-	SaveSourceToCustomer *bool `form:"save_source_to_customer"`
 }
 
 // PaymentIntentTransferDataParams is the set of parameters allowed for the transfer hash.
@@ -107,9 +104,6 @@ type PaymentIntentParams struct {
 	StatementDescriptor  *string                          `form:"statement_descriptor"`
 	TransferData         *PaymentIntentTransferDataParams `form:"transfer_data"`
 	TransferGroup        *string                          `form:"transfer_group"`
-
-	// This property is considered deprecated. Prefer using SavePaymentMethod
-	SaveSourceToCustomer *bool `form:"save_source_to_customer"`
 }
 
 // PaymentIntentListParams is the set of parameters that can be used when listing payment intents.

--- a/person.go
+++ b/person.go
@@ -2,45 +2,107 @@ package stripe
 
 import "encoding/json"
 
+// VerificationDocumentDetailsCode is a machine-readable code specifying the verification state of
+// a document associated with a person.
+type VerificationDocumentDetailsCode string
+
+// List of values that IdentityVerificationDetailsCode can take.
+const (
+	VerificationDocumentDetailsCodeDocumentCorrupt               VerificationDocumentDetailsCode = "document_corrupt"
+	VerificationDocumentDetailsCodeDocumentFailedCopy            VerificationDocumentDetailsCode = "document_failed_copy"
+	VerificationDocumentDetailsCodeDocumentFailedGreyscale       VerificationDocumentDetailsCode = "document_failed_greyscale"
+	VerificationDocumentDetailsCodeDocumentFailedOther           VerificationDocumentDetailsCode = "document_failed_other"
+	VerificationDocumentDetailsCodeDocumentFailedTestMode        VerificationDocumentDetailsCode = "document_failed_test_mode"
+	VerificationDocumentDetailsCodeDocumentFraudulent            VerificationDocumentDetailsCode = "document_fraudulent"
+	VerificationDocumentDetailsCodeDocumentIDTypeNotSupported    VerificationDocumentDetailsCode = "document_id_type_not_supported"
+	VerificationDocumentDetailsCodeDocumentIDCountryNotSupported VerificationDocumentDetailsCode = "document_id_country_not_supported"
+	VerificationDocumentDetailsCodeDocumentManipulated           VerificationDocumentDetailsCode = "document_manipulated"
+	VerificationDocumentDetailsCodeDocumentMissingBack           VerificationDocumentDetailsCode = "document_missing_back"
+	VerificationDocumentDetailsCodeDocumentMissingFront          VerificationDocumentDetailsCode = "document_missing_front"
+	VerificationDocumentDetailsCodeDocumentNotReadable           VerificationDocumentDetailsCode = "document_not_readable"
+	VerificationDocumentDetailsCodeDocumentNotUploaded           VerificationDocumentDetailsCode = "document_not_uploaded"
+	VerificationDocumentDetailsCodeDocumentTooLarge              VerificationDocumentDetailsCode = "document_too_large"
+)
+
+// PersonVerificationDetailsCode is a machine-readable code specifying the verification state of a
+// person.
+type PersonVerificationDetailsCode string
+
+// List of values that IdentityVerificationDetailsCode can take.
+const (
+	PersonVerificationDetailsCodeFailedKeyedIdentity PersonVerificationDetailsCode = "failed_keyed_identity"
+	PersonVerificationDetailsCodeFailedOther         PersonVerificationDetailsCode = "failed_other"
+	PersonVerificationDetailsCodeScanNameMismatch    PersonVerificationDetailsCode = "scan_name_mismatch"
+)
+
+// IdentityVerificationStatus describes the different statuses for identity verification.
+type IdentityVerificationStatus string
+
+// List of values that IdentityVerificationStatus can take.
+const (
+	IdentityVerificationStatusPending    IdentityVerificationStatus = "pending"
+	IdentityVerificationStatusUnverified IdentityVerificationStatus = "unverified"
+	IdentityVerificationStatusVerified   IdentityVerificationStatus = "verified"
+)
+
+// DOBParams represents a DOB during account creation/updates.
+type DOBParams struct {
+	Day   *int64 `form:"day"`
+	Month *int64 `form:"month"`
+	Year  *int64 `form:"year"`
+}
+
 // RelationshipParams is used to set the relationship between an account and a person.
 type RelationshipParams struct {
 	AccountOpener    *bool    `form:"account_opener"`
 	Director         *bool    `form:"director"`
-	Executive        *bool    `form:"executive"`
 	Owner            *bool    `form:"owner"`
 	PercentOwnership *float64 `form:"percent_ownership"`
 	Title            *string  `form:"title"`
+}
+
+// PersonVerificationDocumentParams represents the parameters available for the document verifying
+// a person's identity.
+type PersonVerificationDocumentParams struct {
+	Back  *string `form:"back"`
+	Front *string `form:"front"`
+}
+
+// PersonVerificationParams is used to represent parameters associated with a person's verification
+// details.
+type PersonVerificationParams struct {
+	Document *PersonVerificationDocumentParams `form:"document"`
 }
 
 // PersonParams is the set of parameters that can be used when creating or updating a person.
 // For more details see https://stripe.com/docs/api#create_person.
 type PersonParams struct {
 	Params         `form:"*"`
-	Account        *string               `form:"-"` // Included in URL
-	Address        *AccountAddressParams `form:"address"`
-	AddressKana    *AccountAddressParams `form:"address_kana"`
-	AddressKanji   *AccountAddressParams `form:"address_kanji"`
-	DOB            *DOBParams            `form:"dob"`
-	Email          *string               `form:"email"`
-	FirstName      *string               `form:"first_name"`
-	FirstNameKana  *string               `form:"first_name_kana"`
-	FirstNameKanji *string               `form:"first_name_kanji"`
-	Gender         *string               `form:"gender"`
-	IDNumber       *string               `form:"id_number"`
-	LastName       *string               `form:"last_name"`
-	LastNameKana   *string               `form:"last_name_kana"`
-	LastNameKanji  *string               `form:"last_name_kanji"`
-	MaidenName     *string               `form:"maiden_name"`
-	Phone          *string               `form:"phone"`
-	Relationship   *RelationshipParams   `form:"relationship"`
-	SSNLast4       *string               `form:"ssn_last_4"`
+	Account        *string                   `form:"-"` // Included in URL
+	Address        *AccountAddressParams     `form:"address"`
+	AddressKana    *AccountAddressParams     `form:"address_kana"`
+	AddressKanji   *AccountAddressParams     `form:"address_kanji"`
+	DOB            *DOBParams                `form:"dob"`
+	Email          *string                   `form:"email"`
+	FirstName      *string                   `form:"first_name"`
+	FirstNameKana  *string                   `form:"first_name_kana"`
+	FirstNameKanji *string                   `form:"first_name_kanji"`
+	Gender         *string                   `form:"gender"`
+	IDNumber       *string                   `form:"id_number"`
+	LastName       *string                   `form:"last_name"`
+	LastNameKana   *string                   `form:"last_name_kana"`
+	LastNameKanji  *string                   `form:"last_name_kanji"`
+	MaidenName     *string                   `form:"maiden_name"`
+	Phone          *string                   `form:"phone"`
+	Relationship   *RelationshipParams       `form:"relationship"`
+	SSNLast4       *string                   `form:"ssn_last_4"`
+	Verification   *PersonVerificationParams `form:"verification"`
 }
 
 // RelationshipListParams is used to filter persons by the relationship
 type RelationshipListParams struct {
 	AccountOpener *bool `form:"account_opener"`
 	Director      *bool `form:"director"`
-	Executive     *bool `form:"executive"`
 	Owner         *bool `form:"owner"`
 }
 
@@ -52,11 +114,17 @@ type PersonListParams struct {
 	Relationship *RelationshipListParams `form:"relationship"`
 }
 
-// Relationship represents extra information needed for a Person.
+// DOB represents a Person's date of birth.
+type DOB struct {
+	Day   int64 `json:"day"`
+	Month int64 `json:"month"`
+	Year  int64 `json:"year"`
+}
+
+// Relationship represents how the Person relates to the business.
 type Relationship struct {
 	AccountOpener    bool    `json:"account_opener"`
 	Director         bool    `json:"director"`
-	Executive        bool    `json:"executive"`
 	Owner            bool    `json:"owner"`
 	PercentOwnership float64 `json:"percent_ownership"`
 	Title            string  `json:"title"`
@@ -69,33 +137,49 @@ type Requirements struct {
 	PastDue       []string `json:"past_due"`
 }
 
+// PersonVerificationDocument represents the documents associated with a Person.
+type PersonVerificationDocument struct {
+	Back        *File                           `json:"back"`
+	Details     string                          `json:"details"`
+	DetailsCode VerificationDocumentDetailsCode `json:"details_code"`
+	Front       *File                           `json:"front"`
+}
+
+// PersonVerification is the structure for a person's verification details.
+type PersonVerification struct {
+	Details     string                        `json:"details"`
+	DetailsCode PersonVerificationDetailsCode `json:"details_code"`
+	Document    *PersonVerificationDocument   `json:"document"`
+	Status      IdentityVerificationStatus    `json:"status"`
+}
+
 // Person is the resource representing a Stripe person.
 // For more details see https://stripe.com/docs/api#persons.
 type Person struct {
-	Account          string                `json:"account"`
-	Address          *AccountAddress       `json:"address"`
-	AddressKana      *AccountAddress       `json:"address_kana"`
-	AddressKanji     *AccountAddress       `json:"address_kanji"`
-	Deleted          bool                  `json:"deleted"`
-	DOB              *DOB                  `json:"dob"`
-	Email            string                `json:"email"`
-	FirstName        string                `json:"first_name"`
-	FirstNameKana    string                `json:"first_name_kana"`
-	FirstNameKanji   string                `json:"first_name_kanji"`
-	Gender           string                `json:"gender"`
-	ID               string                `json:"id"`
-	IDNumberProvided bool                  `json:"id_number_provided"`
-	LastName         string                `json:"last_name"`
-	LastNameKana     string                `json:"last_name_kana"`
-	LastNameKanji    string                `json:"last_name_kanji"`
-	MaidenName       string                `json:"maiden_name"`
-	Metadata         map[string]string     `json:"metadata"`
-	Object           string                `json:"object"`
-	Phone            string                `json:"phone"`
-	Relationship     *Relationship         `json:"relationship"`
-	Requirements     *Requirements         `json:"requirements"`
-	SSNLast4Provided bool                  `json:"ssn_last_4_provided"`
-	Verification     *IdentityVerification `json:"verification"`
+	Account          string              `json:"account"`
+	Address          *AccountAddress     `json:"address"`
+	AddressKana      *AccountAddress     `json:"address_kana"`
+	AddressKanji     *AccountAddress     `json:"address_kanji"`
+	Deleted          bool                `json:"deleted"`
+	DOB              *DOB                `json:"dob"`
+	Email            string              `json:"email"`
+	FirstName        string              `json:"first_name"`
+	FirstNameKana    string              `json:"first_name_kana"`
+	FirstNameKanji   string              `json:"first_name_kanji"`
+	Gender           string              `json:"gender"`
+	ID               string              `json:"id"`
+	IDNumberProvided bool                `json:"id_number_provided"`
+	LastName         string              `json:"last_name"`
+	LastNameKana     string              `json:"last_name_kana"`
+	LastNameKanji    string              `json:"last_name_kanji"`
+	MaidenName       string              `json:"maiden_name"`
+	Metadata         map[string]string   `json:"metadata"`
+	Object           string              `json:"object"`
+	Phone            string              `json:"phone"`
+	Relationship     *Relationship       `json:"relationship"`
+	Requirements     *Requirements       `json:"requirements"`
+	SSNLast4Provided bool                `json:"ssn_last_4_provided"`
+	Verification     *PersonVerification `json:"verification"`
 }
 
 // PersonList is a list of persons as retrieved from a list endpoint.

--- a/person/client_test.go
+++ b/person/client_test.go
@@ -45,6 +45,12 @@ func TestPersonNew(t *testing.T) {
 		Relationship: &stripe.RelationshipParams{
 			Owner: stripe.Bool(true),
 		},
+		Verification: &stripe.PersonVerificationParams{
+			Document: &stripe.PersonVerificationDocumentParams{
+				Back:  stripe.String("file_123"),
+				Front: stripe.String("file_234"),
+			},
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, person)

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.44.0"
+	MockMinimumVersion = "0.45.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
This PR contains the changes related to the new API version `2019-02-19`:
* Move stripe-go to API version `2019-02-19`
* Change the shape of `Account`
  * The `legal_entity` property on the Account API resource has been replaced with `individual`, `company`, and `business_type`.
  * `LegalEntityType` is now `BusinessType`.
  * The verification hash has been replaced with a requirements hash.
  * Multiple top-level properties were moved to the `settings` hash.
  * The `keys` property on `Account` has been removed. Platforms should authenticate as their connected accounts with their own key via the `Stripe-Account` [header](https://stripe.com/docs/connect/authentication#authentication-via-the-stripe-account-header).
* The `requested_capabilities` property on `Account` creation is now required for accounts in the US.
* Removed deprecated parameter `save_source_to_customer` on `PaymentIntent`. Use `save_payment_method` instead.
r? @brandur-stripe 
cc @stripe/api-libraries 