### PR TITLE
Allow stripe-mock to be suppressed with `STRIPE_MOCK_AUTOSTART=false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ instructions for installing via Homebrew and other methods):
 
 Run all tests:
 
-    go test ./...
+    make test
 
 Run tests for one package:
 

--- a/testing/openapi/README.md
+++ b/testing/openapi/README.md
@@ -7,3 +7,6 @@ and `fixtures3.json` respectively.
 If those files are present, the test suite will start its own stripe-mock
 process on a random available port. In order for this to work, `stripe-mock`
 must be on the `PATH` in the environment used to run the test suite.
+
+Having stripe-mock start automatically can be disabled by passing
+`STRIPE_MOCK_AUTOSTART=false` in the environment when running the test suite.


### PR DESCRIPTION
Allows stripe-mock startup to be disabled by passing
`STRIPE_MOCK_AUTOSTART` in the env with a value of `false` or `0`. This
may be useful for debugging problems where the automatically started
stripe-mock is not showing logging.

~~Allows stripe-mock startup to be disabled by passing
`STRIPE_MOCK_DISABLE` in the env with any value. This may be useful for
debugging problems where the automatically started stripe-mock is not
showing logging.~~

r? @ob-stripe Thoughts on this?