### PR TITLE
Changes to the Payment Intent APIs for the next API version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.40.0
+    - STRIPE_MOCK_VERSION=0.44.0
 
 go:
   - "1.9.x"

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -37,7 +37,7 @@ type PaymentIntentNextActionType string
 
 // List of values that PaymentIntentNextActionType can take.
 const (
-	PaymentIntentNextActionAuthorizeWithURL PaymentIntentNextActionType = "authorize_with_url"
+	PaymentIntentNextActionTypeRedirectToURL PaymentIntentNextActionType = "redirect_to_url"
 )
 
 // PaymentIntentStatus is the list of allowed values for the payment intent's status.
@@ -45,13 +45,13 @@ type PaymentIntentStatus string
 
 // List of values that PaymentIntentStatus can take.
 const (
-	PaymentIntentStatusCanceled             PaymentIntentStatus = "canceled"
-	PaymentIntentStatusProcessing           PaymentIntentStatus = "processing"
-	PaymentIntentStatusRequiresCapture      PaymentIntentStatus = "requires_capture"
-	PaymentIntentStatusRequiresConfirmation PaymentIntentStatus = "requires_confirmation"
-	PaymentIntentStatusRequiresSource       PaymentIntentStatus = "requires_source"
-	PaymentIntentStatusRequiresSourceAction PaymentIntentStatus = "requires_source_action"
-	PaymentIntentStatusSucceeded            PaymentIntentStatus = "succeeded"
+	PaymentIntentStatusCanceled              PaymentIntentStatus = "canceled"
+	PaymentIntentStatusProcessing            PaymentIntentStatus = "processing"
+	PaymentIntentStatusRequiresAction        PaymentIntentStatus = "requires_action"
+	PaymentIntentStatusRequiresCapture       PaymentIntentStatus = "requires_capture"
+	PaymentIntentStatusRequiresConfirmation  PaymentIntentStatus = "requires_confirmation"
+	PaymentIntentStatusRequiresPaymentMethod PaymentIntentStatus = "requires_payment_method"
+	PaymentIntentStatusSucceeded             PaymentIntentStatus = "succeeded"
 )
 
 // PaymentIntentCancelParams is the set of parameters that can be used when canceling a payment intent.
@@ -87,7 +87,6 @@ type PaymentIntentTransferDataParams struct {
 // PaymentIntentParams is the set of parameters that can be used when handling a payment intent.
 type PaymentIntentParams struct {
 	Params               `form:"*"`
-	AllowedSourceTypes   []*string                        `form:"allowed_source_types"`
 	Amount               *int64                           `form:"amount"`
 	ApplicationFeeAmount *int64                           `form:"application_fee_amount"`
 	Confirm              *bool                            `form:"confirm"`
@@ -96,6 +95,7 @@ type PaymentIntentParams struct {
 	Customer             *string                          `form:"customer"`
 	Description          *string                          `form:"description"`
 	OnBehalfOf           *string                          `form:"on_behalf_of"`
+	PaymentMethodTypes   []*string                        `form:"payment_method_types"`
 	ReceiptEmail         *string                          `form:"receipt_email"`
 	ReturnURL            *string                          `form:"return_url"`
 	SaveSourceToCustomer *bool                            `form:"save_source_to_customer"`
@@ -124,17 +124,17 @@ type PaymentIntentLastPaymentError struct {
 	Type        ErrorType      `json:"type"`
 }
 
-// PaymentIntentSourceActionAuthorizeWithURL represents the resource for the next action of type
-// "authorize_with_url".
-type PaymentIntentSourceActionAuthorizeWithURL struct {
+// PaymentIntentNextActionRedirectToURL represents the resource for the next action of type
+// "redirect_to_url".
+type PaymentIntentNextActionRedirectToURL struct {
 	ReturnURL string `json:"return_url"`
 	URL       string `json:"url"`
 }
 
-// PaymentIntentSourceAction represents the type of action to take on a payment intent.
-type PaymentIntentSourceAction struct {
-	AuthorizeWithURL *PaymentIntentSourceActionAuthorizeWithURL `json:"authorize_with_url"`
-	Type             PaymentIntentNextActionType                `json:"type"`
+// PaymentIntentNextAction represents the type of action to take on a payment intent.
+type PaymentIntentNextAction struct {
+	RedirectToURL *PaymentIntentNextActionRedirectToURL `json:"redirect_to_url"`
+	Type          PaymentIntentNextActionType           `json:"type"`
 }
 
 // PaymentIntentTransferData represents the information for the transfer associated with a payment intent.
@@ -146,7 +146,6 @@ type PaymentIntentTransferData struct {
 // PaymentIntent is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payment_intents.
 type PaymentIntent struct {
-	AllowedSourceTypes  []string                        `json:"allowed_source_types"`
 	Amount              int64                           `json:"amount"`
 	AmountCapturable    int64                           `json:"amount_capturable"`
 	AmountReceived      int64                           `json:"amount_received"`
@@ -165,8 +164,9 @@ type PaymentIntent struct {
 	Livemode            bool                            `json:"livemode"`
 	ID                  string                          `json:"id"`
 	Metadata            map[string]string               `json:"metadata"`
-	NextSourceAction    *PaymentIntentSourceAction      `json:"next_source_action"`
+	NextAction          *PaymentIntentNextAction        `json:"next_action"`
 	OnBehalfOf          *Account                        `json:"on_behalf_of"`
+	PaymentMethodTypes  []string                        `json:"payment_method_types"`
 	ReceiptEmail        string                          `json:"receipt_email"`
 	Review              *Review                         `json:"review"`
 	Shipping            ShippingDetails                 `json:"shipping"`

--- a/paymentintent/client_test.go
+++ b/paymentintent/client_test.go
@@ -47,11 +47,11 @@ func TestPaymentIntentList(t *testing.T) {
 
 func TestPaymentIntentNew(t *testing.T) {
 	intent, err := New(&stripe.PaymentIntentParams{
-		AllowedSourceTypes: []*string{
-			stripe.String("card"),
-		},
 		Amount:   stripe.Int64(123),
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
+		PaymentMethodTypes: []*string{
+			stripe.String("card"),
+		},
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, intent)

--- a/paymentintent_test.go
+++ b/paymentintent_test.go
@@ -41,34 +41,31 @@ func TestPaymentIntentLastPaymentError_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, "card_123", lastPaymentError.Source.Card.ID)
 }
 
-func TestPaymentIntentSourceAction_UnmarshalJSON(t *testing.T) {
+func TestPaymentIntentNextAction_UnmarshalJSON(t *testing.T) {
 	actionData := map[string]interface{}{
-		"authorize_with_url": map[string]interface{}{
+		"redirect_to_url": map[string]interface{}{
 			"return_url": "https://stripe.com/return",
 			"url":        "https://stripe.com",
 		},
-		"type": "authorize_with_url",
+		"type": "redirect_to_url",
 	}
 
 	bytes, err := json.Marshal(&actionData)
 	assert.NoError(t, err)
 
-	var action PaymentIntentSourceAction
+	var action PaymentIntentNextAction
 	err = json.Unmarshal(bytes, &action)
 	assert.NoError(t, err)
 
-	assert.Equal(t, PaymentIntentNextActionAuthorizeWithURL, action.Type)
-	assert.Equal(t, "https://stripe.com", action.AuthorizeWithURL.URL)
-	assert.Equal(t, "https://stripe.com/return", action.AuthorizeWithURL.ReturnURL)
+	assert.Equal(t, PaymentIntentNextActionTypeRedirectToURL, action.Type)
+	assert.Equal(t, "https://stripe.com", action.RedirectToURL.URL)
+	assert.Equal(t, "https://stripe.com/return", action.RedirectToURL.ReturnURL)
 }
 
 func TestPaymentIntent_UnmarshalJSON(t *testing.T) {
 	intentData := map[string]interface{}{
 		"id":     "pi_123",
 		"object": "payment_intent",
-		"allowed_source_types": []interface{}{
-			"card",
-		},
 		"charges": map[string]interface{}{
 			"object":   "list",
 			"has_more": true,
@@ -83,6 +80,9 @@ func TestPaymentIntent_UnmarshalJSON(t *testing.T) {
 				},
 			},
 		},
+		"payment_method_types": []interface{}{
+			"card",
+		},
 	}
 
 	bytes, err := json.Marshal(&intentData)
@@ -94,6 +94,6 @@ func TestPaymentIntent_UnmarshalJSON(t *testing.T) {
 
 	assert.Equal(t, "pi_123", intent.ID)
 
-	assert.Equal(t, 1, len(intent.AllowedSourceTypes))
 	assert.Equal(t, 2, len(intent.Charges.Data))
+	assert.Equal(t, 1, len(intent.PaymentMethodTypes))
 }

--- a/stripe.go
+++ b/stripe.go
@@ -817,7 +817,7 @@ func StringValue(v *string) string {
 const apiURL = "https://api.stripe.com"
 
 // apiversion is the currently supported API version
-const apiversion = "2018-11-08"
+const apiversion = "2019-02-11"
 
 // clientversion is the binding version
 const clientversion = "55.14.0"

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.40.0"
+	MockMinimumVersion = "0.44.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
We are going to ship some changes to the Payment Intent APIs in the next API version. Though are fairly self-contained and pave the way for future changes. Changes are:

* `status`: remove `require_source` and `require_source_action` and add `requires_payment_method` and `requires_action`
* `next_source_action` renamed to `next_action`
* `allowed_source_types` renamed to `payment_method_types`
* `authorize_with_url` renamed to `redirect_to_url` both in the type of next action and in the hash that describes that next action.

cc @stripe/api-libraries @danwang-stripe 