### PR TITLE
Add support for `transfer_data[amount]` on Charge

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -43,6 +43,7 @@ type ChargeLevel3Params struct {
 
 // ChargeTransferDataParams is the set of parameters allowed for the transfer_data hash.
 type ChargeTransferDataParams struct {
+	Amount      *int64  `form:"amount"`
 	Destination *string `form:"destination"`
 }
 
@@ -145,6 +146,7 @@ type ChargeLevel3 struct {
 
 // ChargeTransferData represents the information for the transfer_data associated with a charge.
 type ChargeTransferData struct {
+	Amount      int64    `form:"amount"`
 	Destination *Account `json:"destination"`
 }
 


### PR DESCRIPTION
We decided to support `transfer_data[amount]` on Charges for 2/19, at least for a few months. We think developers should use `application_fee_amount` instead but many integrations already used `destination[amount]` and would be quite blocked if we removed this.

r? @brandur-stripe 
cc @stripe/api-libraries 