### PR TITLE
Fix API version which should be pinned to 2019-02-19 instead

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -817,7 +817,7 @@ func StringValue(v *string) string {
 const apiURL = "https://api.stripe.com"
 
 // apiversion is the currently supported API version
-const apiversion = "2019-02-11"
+const apiversion = "2019-02-19"
 
 // clientversion is the binding version
 const clientversion = "57.0.0"


### PR DESCRIPTION
Something went wrong on https://github.com/stripe/stripe-go/pull/782 and the API version was never upgraded, making that version broken unfortunately.

r? @brandur-stripe 
cc @stripe/api-libraries 