### PR TITLE
Add support for API version 2019-03-14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
       tar -zxf "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}_linux_amd64.tar.gz" -C "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/"
     fi
   - |
-    stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock -https-port 12112 > /dev/null &
+    stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock -https-port 12112 -strict-version-check > /dev/null &
     STRIPE_MOCK_PID=$!
 
   # stripe-mock must be in PATH for `scripts/test_with_stripe_mock.go` to work.

--- a/charge.go
+++ b/charge.go
@@ -436,6 +436,7 @@ type Charge struct {
 	OnBehalfOf           *Account                    `json:"on_behalf_of"`
 	Outcome              *ChargeOutcome              `json:"outcome"`
 	Paid                 bool                        `json:"paid"`
+	PaymentIntent        string                      `json:"payment_intent"`
 	PaymentMethod        string                      `json:"payment_method"`
 	PaymentMethodDetails *ChargePaymentMethodDetails `json:"payment_method_details"`
 	ReceiptEmail         string                      `json:"receipt_email"`

--- a/ephemeralkey/client_test.go
+++ b/ephemeralkey/client_test.go
@@ -17,7 +17,7 @@ func TestEphemeralKeyDel(t *testing.T) {
 func TestEphemeralKeyNew(t *testing.T) {
 	key, err := New(&stripe.EphemeralKeyParams{
 		Customer:      stripe.String("cus_123"),
-		StripeVersion: stripe.String("2018-02-06"),
+		StripeVersion: stripe.String(stripe.APIVersion),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, key)

--- a/invoice.go
+++ b/invoice.go
@@ -126,10 +126,6 @@ type InvoiceListParams struct {
 	CreatedRange *RangeQueryParams `form:"created_range"`
 	DueDate      *int64            `form:"due_date"`
 	Subscription *string           `form:"subscription"`
-
-	// Those parameters are deprecated. Prefer using Created or CreatedRange
-	Date      *int64            `form:"date"`
-	DateRange *RangeQueryParams `form:"date"`
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.
@@ -199,7 +195,6 @@ type Invoice struct {
 	Discount                  *Discount                `json:"discount"`
 	DueDate                   int64                    `json:"due_date"`
 	EndingBalance             int64                    `json:"ending_balance"`
-	FinalizedAt               int64                    `json:"finalized_at"`
 	Footer                    string                   `json:"footer"`
 	HostedInvoiceURL          string                   `json:"hosted_invoice_url"`
 	ID                        string                   `json:"id"`
@@ -226,12 +221,6 @@ type Invoice struct {
 	Total                     int64                    `json:"total"`
 	TransferData              *InvoiceTransferData     `json:"transfer_data"`
 	WebhooksDeliveredAt       int64                    `json:"webhooks_delivered_at"`
-
-	// This property is considered deprecated. Prefer using ApplicationFeeAmount
-	ApplicationFee int64 `json:"application_fee"`
-
-	// This property is considered deprecated. Prefer using created
-	Date int64 `json:"date"`
 }
 
 // InvoiceCustomField is a structure representing a custom field on an Invoice.

--- a/stripe.go
+++ b/stripe.go
@@ -28,6 +28,9 @@ import (
 //
 
 const (
+	// APIVersion is the currently supported API version
+	APIVersion string = "2019-03-14"
+
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"
 
@@ -269,7 +272,7 @@ func (s *BackendImplementation) NewRequest(method, path, key, contentType string
 
 	req.Header.Add("Authorization", authorization)
 	req.Header.Add("Content-Type", contentType)
-	req.Header.Add("Stripe-Version", apiversion)
+	req.Header.Add("Stripe-Version", APIVersion)
 	req.Header.Add("User-Agent", encodedUserAgent)
 	req.Header.Add("X-Stripe-Client-User-Agent", encodedStripeUserAgent)
 
@@ -815,9 +818,6 @@ func StringValue(v *string) string {
 //
 
 const apiURL = "https://api.stripe.com"
-
-// apiversion is the currently supported API version
-const apiversion = "2019-02-19"
 
 // clientversion is the binding version
 const clientversion = "57.8.0"

--- a/sub.go
+++ b/sub.go
@@ -11,12 +11,14 @@ type SubscriptionStatus string
 
 // List of values that SubscriptionStatus can take.
 const (
-	SubscriptionStatusActive   SubscriptionStatus = "active"
-	SubscriptionStatusAll      SubscriptionStatus = "all"
-	SubscriptionStatusCanceled SubscriptionStatus = "canceled"
-	SubscriptionStatusPastDue  SubscriptionStatus = "past_due"
-	SubscriptionStatusTrialing SubscriptionStatus = "trialing"
-	SubscriptionStatusUnpaid   SubscriptionStatus = "unpaid"
+	SubscriptionStatusActive            SubscriptionStatus = "active"
+	SubscriptionStatusAll               SubscriptionStatus = "all"
+	SubscriptionStatusCanceled          SubscriptionStatus = "canceled"
+	SubscriptionStatusIncomplete        SubscriptionStatus = "incomplete"
+	SubscriptionStatusIncompleteExpired SubscriptionStatus = "incomplete_expired"
+	SubscriptionStatusPastDue           SubscriptionStatus = "past_due"
+	SubscriptionStatusTrialing          SubscriptionStatus = "trialing"
+	SubscriptionStatusUnpaid            SubscriptionStatus = "unpaid"
 )
 
 // SubscriptionBilling is the type of billing method for this subscription's invoices.


### PR DESCRIPTION
The changes in the library itself look minor. But this API version changes the behavior of Subscriptions entirely under the hood. If the charge fails, you still get a Subscription back instead of an exception and it's on you to check the Subscription status.

This is now fully ready to be reviewed. It also changes the `apiversion` internal-only constant to a public one.

r? @brandur-stripe 
cc @stripe/api-libraries 

Related to https://github.com/stripe/stripe-dotnet/pull/1552