### PR TITLE
Properly override API version if it's set in the request

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -295,7 +295,8 @@ func (s *BackendImplementation) NewRequest(method, path, key, contentType string
 
 		for k, v := range params.Headers {
 			for _, line := range v {
-				req.Header.Add(k, line)
+				// Use Set to override the default value possibly set before
+				req.Header.Set(k, line)
 			}
 		}
 	}


### PR DESCRIPTION
While testing the `strict-version-check` flag, I discovered that we were incorrectly overriding the version forced in the request creating ephemeral keys.

This fixes the issue by calling `Set` instead of `Add`. I've confirmed it works, but I'm not sure this is the right approach here.

Marking as a breaking change since Ephemeral Keys would suddenly be created with the correct API version, which is what people would likely want, but still a dangerous change. There's also another major version going out anyway.

r? @brandur-stripe 
cc @stripe/api-libraries 