### PR TITLE
Add non-null params for capture in test

### DIFF
--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestChargeCapture(t *testing.T) {
-	charge, err := Capture("ch_123", nil)
+	charge, err := Capture("ch_123", &stripe.CaptureParams{
+		Amount: stripe.Int64(123),
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)
 }

--- a/paymentintent/client_test.go
+++ b/paymentintent/client_test.go
@@ -17,7 +17,9 @@ func TestPaymentIntentCancel(t *testing.T) {
 }
 
 func TestPaymentIntentCapture(t *testing.T) {
-	intent, err := Capture("pi_123", nil)
+	intent, err := Capture("pi_123", &stripe.PaymentIntentCaptureParams{
+		AmountToCapture: stripe.Int64(123),
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, intent)
 }


### PR DESCRIPTION
- This adds non-null params for capture endpoint to the existing test-suite.
- Capture endpoints for charge/payment intent actually doesn't have any required params, but adding the existing params here allow me to generate the fully-populated params to schema of the params for comparison with OpenAPI. 
- From completeness of test standpoint, I think this PR does add value. Although if people use this for examples, it can be misleading.
r? @remi-stripe 
cc @stripe/api-libraries 
