### PR TITLE
Add support for payment_intent on invoice and default_payment_method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.49.0
+    - STRIPE_MOCK_VERSION=0.52.0
 
 go:
   - "1.9.x"

--- a/customer.go
+++ b/customer.go
@@ -53,8 +53,9 @@ type CustomerInvoiceCustomFieldParams struct {
 // CustomerInvoiceSettingsParams is the structure containing the default settings for invoices
 // associated with this customer.
 type CustomerInvoiceSettingsParams struct {
-	CustomFields []*CustomerInvoiceCustomFieldParams `form:"custom_fields"`
-	Footer       *string                             `form:"footer"`
+	CustomFields         []*CustomerInvoiceCustomFieldParams `form:"custom_fields"`
+	DefaultPaymentMethod *string                             `form:"default_payment_method"`
+	Footer               *string                             `form:"footer"`
 }
 
 // CustomerShippingDetailsParams is the structure containing shipping information.
@@ -108,6 +109,20 @@ type Customer struct {
 	Subscriptions       *SubscriptionList            `json:"subscriptions"`
 	TaxInfo             *CustomerTaxInfo             `json:"tax_info"`
 	TaxInfoVerification *CustomerTaxInfoVerification `json:"tax_info_verification"`
+}
+
+// CustomerInvoiceCustomField represents a custom field associated with the customer's invoices.
+type CustomerInvoiceCustomField struct {
+	Name  *string `form:"name"`
+	Value *string `form:"value"`
+}
+
+// CustomerInvoiceSettings is the structure containing the default settings for invoices associated
+// with this customer.
+type CustomerInvoiceSettings struct {
+	CustomFields         []*CustomerInvoiceCustomField `json:"custom_fields"`
+	DefaultPaymentMethod *PaymentMethod                `json:"default_payment_method"`
+	Footer               string                        `json:"footer"`
 }
 
 // CustomerList is a list of customers as retrieved from a list endpoint.

--- a/invoice.go
+++ b/invoice.go
@@ -87,6 +87,7 @@ type InvoiceParams struct {
 	CustomFields         []*InvoiceCustomFieldParams `form:"custom_fields"`
 	Customer             *string                     `form:"customer"`
 	DaysUntilDue         *int64                      `form:"days_until_due"`
+	DefaultPaymentMethod *string                     `form:"default_payment_method"`
 	DefaultSource        *string                     `form:"default_source"`
 	Description          *string                     `form:"description"`
 	DueDate              *int64                      `form:"due_date"`
@@ -161,6 +162,7 @@ type InvoicePayParams struct {
 	Params        `form:"*"`
 	Forgive       *bool   `form:"forgive"`
 	PaidOutOfBand *bool   `form:"paid_out_of_band"`
+	PaymentMethod *string `form:"payment_method"`
 	Source        *string `form:"source"`
 }
 
@@ -191,6 +193,7 @@ type Invoice struct {
 	Currency                  Currency                 `json:"currency"`
 	CustomFields              []*InvoiceCustomField    `json:"custom_fields"`
 	Customer                  *Customer                `json:"customer"`
+	DefaultPaymentMethod      *PaymentMethod           `json:"default_payment_method"`
 	DefaultSource             *PaymentSource           `json:"default_source"`
 	Description               string                   `json:"description"`
 	Discount                  *Discount                `json:"discount"`
@@ -206,6 +209,7 @@ type Invoice struct {
 	NextPaymentAttempt        int64                    `json:"next_payment_attempt"`
 	Number                    string                   `json:"number"`
 	Paid                      bool                     `json:"paid"`
+	PaymentIntent             *PaymentIntent           `json:"paymentIntent"`
 	PeriodEnd                 int64                    `json:"period_end"`
 	PeriodStart               int64                    `json:"period_start"`
 	ReceiptNumber             string                   `json:"receipt_number"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -166,6 +166,7 @@ type PaymentIntent struct {
 	Currency            string                          `json:"currency"`
 	Customer            *Customer                       `json:"customer"`
 	Description         string                          `json:"description"`
+	Invoice             *Invoice                        `json:"invoice"`
 	LastPaymentError    *PaymentIntentLastPaymentError  `json:"last_payment_error"`
 	Livemode            bool                            `json:"livemode"`
 	ID                  string                          `json:"id"`

--- a/sub.go
+++ b/sub.go
@@ -52,6 +52,7 @@ type SubscriptionParams struct {
 	Coupon                      *string                              `form:"coupon"`
 	Customer                    *string                              `form:"customer"`
 	DaysUntilDue                *int64                               `form:"days_until_due"`
+	DefaultPaymentMethod        *string                              `form:"default_payment_method"`
 	DefaultSource               *string                              `form:"default_source"`
 	Items                       []*SubscriptionItemsParams           `form:"items"`
 	OnBehalfOf                  *string                              `form:"on_behalf_of"`
@@ -147,6 +148,7 @@ type Subscription struct {
 	CurrentPeriodStart    int64                          `json:"current_period_start"`
 	Customer              *Customer                      `json:"customer"`
 	DaysUntilDue          int64                          `json:"days_until_due"`
+	DefaultPaymentMethod  *PaymentMethod                 `json:"default_payment_method"`
 	DefaultSource         *PaymentSource                 `json:"default_source"`
 	Discount              *Discount                      `json:"discount"`
 	EndedAt               int64                          `json:"ended_at"`

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.49.0"
+	MockMinimumVersion = "0.52.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
This is now ready to be released. Those fields will be public later this week and are stable. Having this out ahead of time is likely the best approach.

r? @mickjermsurawong-stripe 
cc @stripe/api-libraries 
