### PR TITLE
Add support for TaxRate

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -57,6 +57,7 @@ import (
 	"github.com/stripe/stripe-go/subschedule"
 	"github.com/stripe/stripe-go/subschedulerevision"
 	"github.com/stripe/stripe-go/taxid"
+	"github.com/stripe/stripe-go/taxrate"
 	terminalconnectiontoken "github.com/stripe/stripe-go/terminal/connectiontoken"
 	terminallocation "github.com/stripe/stripe-go/terminal/location"
 	terminalreader "github.com/stripe/stripe-go/terminal/reader"
@@ -178,6 +179,8 @@ type API struct {
 	SubscriptionScheduleRevisions *subschedulerevision.Client
 	// TaxIDs is the client used to invoke /tax_ids APIs.
 	TaxIDs *taxid.Client
+	// TaxRates is the client used to invoke /tax_rates APIs.
+	TaxRates *taxrate.Client
 	// TerminalConnectionTokens is the client used to invoke /terminal/connectiontokens related APIs.
 	TerminalConnectionTokens *terminalconnectiontoken.Client
 	// TerminalLocations is the client used to invoke /terminal/locations related APIs.
@@ -262,6 +265,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.SubscriptionSchedules = &subschedule.Client{B: backends.API, Key: key}
 	a.SubscriptionScheduleRevisions = &subschedulerevision.Client{B: backends.API, Key: key}
 	a.TaxIDs = &taxid.Client{B: backends.API, Key: key}
+	a.TaxRates = &taxrate.Client{B: backends.API, Key: key}
 	a.TerminalConnectionTokens = &terminalconnectiontoken.Client{B: backends.API, Key: key}
 	a.TerminalLocations = &terminallocation.Client{B: backends.API, Key: key}
 	a.TerminalReaders = &terminalreader.Client{B: backends.API, Key: key}

--- a/customer.go
+++ b/customer.go
@@ -4,6 +4,16 @@ import (
 	"encoding/json"
 )
 
+// CustomerTaxExempt is the type of tax exemption associated with a customer.
+type CustomerTaxExempt string
+
+// List of values that CustomerTaxInfoType can take.
+const (
+	CustomerTaxExemptExempt  CustomerTaxExempt = "exempt"
+	CustomerTaxExemptNone    CustomerTaxExempt = "none"
+	CustomerTaxExemptReverse CustomerTaxExempt = "reverse"
+)
+
 // CustomerTaxInfoType is the type of tax info associated with a customer.
 type CustomerTaxInfoType string
 
@@ -37,18 +47,21 @@ type CustomerParams struct {
 	Name             *string                        `form:"name"`
 	PaymentMethod    *string                        `form:"payment_method"`
 	Phone            *string                        `form:"phone"`
-	Plan             *string                        `form:"plan"`
 	PreferredLocales []*string                      `form:"preferred_locales"`
-	Quantity         *int64                         `form:"quantity"`
 	Shipping         *CustomerShippingDetailsParams `form:"shipping"`
 	Source           *SourceParams                  `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxExempt        *string                        `form:"tax_exempt"`
 	TaxIDData        []*CustomerTaxIDDataParams     `form:"tax_id_data"`
-	TaxPercent       *float64                       `form:"tax_percent"`
 	Token            *string                        `form:"-"` // This doesn't seem to be used?
-	TrialEnd         *int64                         `form:"trial_end"`
 
 	// The following parameter is deprecated. Use TaxIDData instead.
 	TaxInfo *CustomerTaxInfoParams `form:"tax_info"`
+
+	// The parameters below are considered deprecated. Consider creating a Subscription separately instead.
+	Plan       *string  `form:"plan"`
+	Quantity   *int64   `form:"quantity"`
+	TaxPercent *float64 `form:"tax_percent"`
+	TrialEnd   *int64   `form:"trial_end"`
 }
 
 // CustomerInvoiceCustomFieldParams represents the parameters associated with one custom field on
@@ -125,6 +138,7 @@ type Customer struct {
 	Shipping         *CustomerShippingDetails `json:"shipping"`
 	Sources          *SourceList              `json:"sources"`
 	Subscriptions    *SubscriptionList        `json:"subscriptions"`
+	TaxExempt        CustomerTaxExempt        `json:"tax_exempt"`
 	TaxIDs           *TaxIDList               `json:"tax_ids"`
 
 	// The following properties are deprecated. Use TaxIds instead.

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -15,6 +15,7 @@ type InvoiceItemParams struct {
 	Period       *InvoiceItemPeriodParams `form:"period"`
 	Quantity     *int64                   `form:"quantity"`
 	Subscription *string                  `form:"subscription"`
+	TaxRates     []*string                `form:"tax_rates"`
 	UnitAmount   *int64                   `form:"unit_amount"`
 }
 
@@ -54,6 +55,7 @@ type InvoiceItem struct {
 	Proration    bool              `json:"proration"`
 	Quantity     int64             `json:"quantity"`
 	Subscription *Subscription     `json:"subscription"`
+	TaxRates     []*TaxRate        `json:"tax_rates"`
 	UnitAmount   int64             `json:"unit_amount"`
 }
 

--- a/sub.go
+++ b/sub.go
@@ -54,18 +54,21 @@ type SubscriptionParams struct {
 	DaysUntilDue                *int64                               `form:"days_until_due"`
 	DefaultPaymentMethod        *string                              `form:"default_payment_method"`
 	DefaultSource               *string                              `form:"default_source"`
+	DefaultTaxRates             []*string                            `form:"default_tax_rates"`
 	Items                       []*SubscriptionItemsParams           `form:"items"`
 	OnBehalfOf                  *string                              `form:"on_behalf_of"`
 	Plan                        *string                              `form:"plan"`
 	Prorate                     *bool                                `form:"prorate"`
 	ProrationDate               *int64                               `form:"proration_date"`
 	Quantity                    *int64                               `form:"quantity"`
-	TaxPercent                  *float64                             `form:"tax_percent"`
 	TrialEnd                    *int64                               `form:"trial_end"`
 	TransferData                *SubscriptionTransferDataParams      `form:"transfer_data"`
 	TrialEndNow                 *bool                                `form:"-"` // See custom AppendTo
 	TrialFromPlan               *bool                                `form:"trial_from_plan"`
 	TrialPeriodDays             *int64                               `form:"trial_period_days"`
+
+	// This parameter is deprecated and we recommend that you use TaxRates instead.
+	TaxPercent *float64 `form:"tax_percent"`
 }
 
 // SubscriptionBillingThresholdsParams is a structure representing the parameters allowed to control
@@ -110,6 +113,7 @@ type SubscriptionItemsParams struct {
 	ID                *string                                  `form:"id"`
 	Plan              *string                                  `form:"plan"`
 	Quantity          *int64                                   `form:"quantity"`
+	TaxRates          []*string                                `form:"tax_rates"`
 }
 
 // SubscriptionListParams is the set of parameters that can be used when listing active subscriptions.
@@ -150,6 +154,7 @@ type Subscription struct {
 	DaysUntilDue          int64                          `json:"days_until_due"`
 	DefaultPaymentMethod  *PaymentMethod                 `json:"default_payment_method"`
 	DefaultSource         *PaymentSource                 `json:"default_source"`
+	DefaultTaxRates       []*TaxRate                     `json:"default_tax_rates"`
 	Discount              *Discount                      `json:"discount"`
 	EndedAt               int64                          `json:"ended_at"`
 	ID                    string                         `json:"id"`
@@ -163,10 +168,12 @@ type Subscription struct {
 	Quantity              int64                          `json:"quantity"`
 	Start                 int64                          `json:"start"`
 	Status                SubscriptionStatus             `json:"status"`
-	TaxPercent            float64                        `json:"tax_percent"`
 	TransferData          *SubscriptionTransferData      `json:"transfer_data"`
 	TrialEnd              int64                          `json:"trial_end"`
 	TrialStart            int64                          `json:"trial_start"`
+
+	// This field is deprecated and we recommend that you use TaxRates instead.
+	TaxPercent float64 `json:"tax_percent"`
 }
 
 // SubscriptionBillingThresholds is a structure representing the billing thresholds for a subscription.

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -46,7 +46,6 @@ func TestSubscriptionNew(t *testing.T) {
 				Quantity: stripe.Int64(20),
 			},
 		},
-		TaxPercent:         stripe.Float64(20.0),
 		BillingCycleAnchor: stripe.Int64(time.Now().AddDate(0, 0, 12).Unix()),
 		Billing:            stripe.String(string(stripe.SubscriptionBillingSendInvoice)),
 		DaysUntilDue:       stripe.Int64(30),
@@ -71,8 +70,7 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 
 func TestSubscriptionUpdate(t *testing.T) {
 	subscription, err := Update("sub_123", &stripe.SubscriptionParams{
-		Prorate:    stripe.Bool(true),
-		TaxPercent: stripe.Float64(0),
+		Prorate: stripe.Bool(true),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)

--- a/subitem.go
+++ b/subitem.go
@@ -12,6 +12,7 @@ type SubscriptionItemParams struct {
 	ProrationDate     *int64                                   `form:"proration_date"`
 	Quantity          *int64                                   `form:"quantity"`
 	Subscription      *string                                  `form:"subscription"`
+	TaxRates          []*string                                `form:"tax_rates"`
 }
 
 // SubscriptionItemBillingThresholdsParams is a structure representing the parameters allowed to
@@ -38,6 +39,7 @@ type SubscriptionItem struct {
 	Plan              *Plan                             `json:"plan"`
 	Quantity          int64                             `json:"quantity"`
 	Subscription      string                            `json:"subscription"`
+	TaxRates          []*TaxRate                        `json:"tax_rates"`
 }
 
 // SubscriptionItemBillingThresholds is a structure representing the billing thresholds for a

--- a/subschedule.go
+++ b/subschedule.go
@@ -38,6 +38,7 @@ type SubscriptionSchedulePhaseItemParams struct {
 	BillingThresholds *SubscriptionItemBillingThresholdsParams `form:"billing_thresholds"`
 	Plan              *string                                  `form:"plan"`
 	Quantity          *int64                                   `form:"quantity"`
+	TaxRates          []*string                                `form:"tax_rates"`
 }
 
 // SubscriptionSchedulePhaseParams is a structure representing the parameters allowed to control
@@ -45,13 +46,16 @@ type SubscriptionSchedulePhaseItemParams struct {
 type SubscriptionSchedulePhaseParams struct {
 	ApplicationFeePercent *int64                                 `form:"application_fee_percent"`
 	Coupon                *string                                `form:"coupon"`
+	DefaultTaxRates       []*string                              `form:"default_tax_rates"`
 	EndDate               *int64                                 `form:"end_date"`
 	Iterations            *int64                                 `form:"iterations"`
 	Plans                 []*SubscriptionSchedulePhaseItemParams `form:"plans"`
 	StartDate             *int64                                 `form:"start_date"`
-	TaxPercent            *float64                               `form:"tax_percent"`
 	Trial                 *bool                                  `form:"trial"`
 	TrialEnd              *int64                                 `form:"trial_end"`
+
+	// This parameter is deprecated and we recommend that you use TaxRates instead.
+	TaxPercent *float64 `form:"tax_percent"`
 }
 
 // SubscriptionScheduleRenewalIntervalParams is a structure representing the renewal interval
@@ -125,17 +129,21 @@ type SubscriptionSchedulePhaseItem struct {
 	BillingThresholds *SubscriptionItemBillingThresholds `json:"billing_thresholds"`
 	Plan              *Plan                              `json:"plan"`
 	Quantity          int64                              `json:"quantity"`
+	TaxRates          []*TaxRate                         `json:"tax_rates"`
 }
 
 // SubscriptionSchedulePhase is a structure a phase of a subscription schedule.
 type SubscriptionSchedulePhase struct {
 	ApplicationFeePercent float64                          `json:"application_fee_percent"`
 	Coupon                *Coupon                          `json:"coupon"`
+	DefaultTaxRates       []*TaxRate                       `json:"default_tax_rates"`
 	EndDate               int64                            `json:"end_date"`
 	Plans                 []*SubscriptionSchedulePhaseItem `json:"plans"`
 	StartDate             int64                            `json:"start_date"`
-	TaxPercent            float64                          `json:"tax_percent"`
 	TrialEnd              int64                            `json:"trial_end"`
+
+	// This field is deprecated and we recommend that you use TaxRates instead.
+	TaxPercent float64 `json:"tax_percent"`
 }
 
 // SubscriptionScheduleRenewalInterval represents the interval and duration of a schedule.

--- a/taxrate.go
+++ b/taxrate.go
@@ -1,0 +1,74 @@
+package stripe
+
+import "encoding/json"
+
+// TaxRateParams is the set of parameters that can be used when creating a tax rate.
+// For more details see https://stripe.com/docs/api/tax_rates/create.
+type TaxRateParams struct {
+	Params       `form:"*"`
+	Active       *bool    `form:"active"`
+	Description  *string  `form:"description"`
+	DisplayName  *string  `form:"display_name"`
+	Inclusive    *bool    `form:"inclusive"`
+	Jurisdiction *string  `form:"jurisdiction"`
+	Percentage   *float64 `form:"percentage"`
+}
+
+// TaxRatePercentageRangeQueryParams are used to filter tax rates by specific percentage values.
+type TaxRatePercentageRangeQueryParams struct {
+	GreaterThan        float64 `form:"gt"`
+	GreaterThanOrEqual float64 `form:"gte"`
+	LesserThan         float64 `form:"lt"`
+	LesserThanOrEqual  float64 `form:"lte"`
+}
+
+// TaxRateListParams is the set of parameters that can be used when listing tax rates.
+// For more detail see https://stripe.com/docs/api/tax_rates/list.
+type TaxRateListParams struct {
+	ListParams       `form:"*"`
+	Active           *bool                              `form:"active"`
+	Created          *int64                             `form:"created"`
+	CreatedRange     *RangeQueryParams                  `form:"created"`
+	Inclusive        *bool                              `form:"inclusive"`
+	Percentage       *float64                           `form:"percentage"`
+	PercentageRanger *TaxRatePercentageRangeQueryParams `form:"percentage"`
+}
+
+// TaxRate is the resource representing a Stripe tax rate.
+// For more details see https://stripe.com/docs/api/tax_rates/object.
+type TaxRate struct {
+	Active       bool              `json:"active"`
+	Created      int64             `json:"created"`
+	Description  string            `json:"description"`
+	DisplayName  string            `json:"display_name"`
+	ID           string            `json:"id"`
+	Jurisdiction string            `json:"jurisdiction"`
+	Livemode     bool              `json:"livemode"`
+	Metadata     map[string]string `json:"metadata"`
+	Percentage   float64           `json:"percent_off"`
+}
+
+// TaxRateList is a list of tax rates as retrieved from a list endpoint.
+type TaxRateList struct {
+	ListMeta
+	Data []*TaxRate `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TaxRate.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (c *TaxRate) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		c.ID = id
+		return nil
+	}
+
+	type taxrate TaxRate
+	var v taxrate
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*c = TaxRate(v)
+	return nil
+}

--- a/taxrate.go
+++ b/taxrate.go
@@ -25,13 +25,13 @@ type TaxRatePercentageRangeQueryParams struct {
 // TaxRateListParams is the set of parameters that can be used when listing tax rates.
 // For more detail see https://stripe.com/docs/api/tax_rates/list.
 type TaxRateListParams struct {
-	ListParams       `form:"*"`
-	Active           *bool                              `form:"active"`
-	Created          *int64                             `form:"created"`
-	CreatedRange     *RangeQueryParams                  `form:"created"`
-	Inclusive        *bool                              `form:"inclusive"`
-	Percentage       *float64                           `form:"percentage"`
-	PercentageRanger *TaxRatePercentageRangeQueryParams `form:"percentage"`
+	ListParams      `form:"*"`
+	Active          *bool                              `form:"active"`
+	Created         *int64                             `form:"created"`
+	CreatedRange    *RangeQueryParams                  `form:"created"`
+	Inclusive       *bool                              `form:"inclusive"`
+	Percentage      *float64                           `form:"percentage"`
+	PercentageRange *TaxRatePercentageRangeQueryParams `form:"percentage"`
 }
 
 // TaxRate is the resource representing a Stripe tax rate.
@@ -42,10 +42,12 @@ type TaxRate struct {
 	Description  string            `json:"description"`
 	DisplayName  string            `json:"display_name"`
 	ID           string            `json:"id"`
+	Inclusive    bool              `json:"inclusive"`
 	Jurisdiction string            `json:"jurisdiction"`
 	Livemode     bool              `json:"livemode"`
 	Metadata     map[string]string `json:"metadata"`
-	Percentage   float64           `json:"percent_off"`
+	Object       string            `json:"object"`
+	Percentage   float64           `json:"percentage"`
 }
 
 // TaxRateList is a list of tax rates as retrieved from a list endpoint.

--- a/taxrate/client.go
+++ b/taxrate/client.go
@@ -1,0 +1,100 @@
+// Package taxrate provides the /tax_rates APIs
+package taxrate
+
+import (
+	"net/http"
+
+	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
+)
+
+// Client is used to invoke /tax_rates APIs.
+type Client struct {
+	B   stripe.Backend
+	Key string
+}
+
+// New creates a new tr.
+func New(params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
+	return getC().New(params)
+}
+
+// New creates a new tr.
+func (c Client) New(params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
+	tr := &stripe.TaxRate{}
+	err := c.B.Call(http.MethodPost, "/v1/tax_rates", c.Key, params, tr)
+	return tr, err
+}
+
+// Get returns the details of a tax rate.
+func Get(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
+	return getC().Get(id, params)
+}
+
+// Get returns the details of a tax rate.
+func (c Client) Get(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
+	path := stripe.FormatURLPath("/v1/tax_rates/%s", id)
+	tr := &stripe.TaxRate{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, tr)
+	return tr, err
+}
+
+// Update updates a tax rate's properties.
+func Update(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
+	return getC().Update(id, params)
+}
+
+// Update updates a tax rate's properties.
+func (c Client) Update(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
+	path := stripe.FormatURLPath("/v1/tax_rates/%s", id)
+	tr := &stripe.TaxRate{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, tr)
+	return tr, err
+}
+
+// Del removes a tax rate.
+func Del(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
+	return getC().Del(id, params)
+}
+
+// Del removes a tax rate.
+func (c Client) Del(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
+	path := stripe.FormatURLPath("/v1/tax_rates/%s", id)
+	tr := &stripe.TaxRate{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, tr)
+	return tr, err
+}
+
+// List returns a list of trs.
+func List(params *stripe.TaxRateListParams) *Iter {
+	return getC().List(params)
+}
+
+// List returns a list of trs.
+func (c Client) List(listParams *stripe.TaxRateListParams) *Iter {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+		list := &stripe.TaxRateList{}
+		err := c.B.CallRaw(http.MethodGet, "/v1/tax_rates", c.Key, b, p, list)
+
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
+			ret[i] = v
+		}
+
+		return ret, list.ListMeta, err
+	})}
+}
+
+// Iter is an iterator for trs.
+type Iter struct {
+	*stripe.Iter
+}
+
+// TaxRate returns the tr which the iterator is currently pointing to.
+func (i *Iter) TaxRate() *stripe.TaxRate {
+	return i.Current().(*stripe.TaxRate)
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
+}

--- a/taxrate/client_test.go
+++ b/taxrate/client_test.go
@@ -1,0 +1,46 @@
+package taxrate
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go"
+	_ "github.com/stripe/stripe-go/testing"
+)
+
+func TestTaxRateGet(t *testing.T) {
+	tr, err := Get("txr_123", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestTaxRateList(t *testing.T) {
+	i := List(&stripe.TaxRateListParams{})
+
+	// Verify that we can get at least one tr
+	assert.True(t, i.Next())
+	assert.Nil(t, i.Err())
+	assert.NotNil(t, i.TaxRate())
+}
+
+func TestTaxRateNew(t *testing.T) {
+	tr, err := New(&stripe.TaxRateParams{
+		DisplayName: stripe.String("name"),
+		Inclusive:   stripe.Bool(false),
+		Percentage:  stripe.Float64(10.15),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestTaxRateUpdate(t *testing.T) {
+	tr, err := Update("txr_123", &stripe.TaxRateParams{
+		Params: stripe.Params{
+			Metadata: map[string]string{
+				"foo": "bar",
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, tr)
+}


### PR DESCRIPTION
This PR adds support for the `TaxRate` resource and APIs. It also modifies all relevant objects that are impacted by this new ship.

cc @stripe/api-libraries 
cc @vihari-stripe @george-stripe 