### PR TITLE
Add basic fields in Charge's PMD 3DS field

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -225,6 +225,8 @@ type ChargePaymentMethodDetailsCardChecks struct {
 // ChargePaymentMethodDetailsCardThreeDSecure represents details about 3DS associated with the
 // charge's PaymentMethod.
 type ChargePaymentMethodDetailsCardThreeDSecure struct {
+	Succeeded bool   `json:"succeeded"`
+	Version   string `json:"version"`
 }
 
 // ChargePaymentMethodDetailsCardWalletAmexExpressCheckout represents the details of the Amex


### PR DESCRIPTION
This PR adds the fields we just approved for the `payment_method_details[card][three_d_secure]` hash on `Charge`. In the future we will add more information but we want to get those out quickly for users to be able to identify 3DS-based Charges on PaymentMethod.

r? @brandur-stripe 
cc @stripe/api-libraries @asolove-stripe