### PR TITLE
Fix `spending_limits` to be a slice as there

### DIFF
--- a/issuing/card/client_test.go
+++ b/issuing/card/client_test.go
@@ -33,10 +33,22 @@ func TestIssuingCardList(t *testing.T) {
 }
 
 func TestIssuingCardNew(t *testing.T) {
-	card, err := New(&stripe.IssuingCardParams{
+	params := &stripe.IssuingCardParams{
+		AuthorizationControls: &stripe.AuthorizationControlsParams{
+			SpendingLimits: []*stripe.IssuingAuthorizationControlsSpendingLimitsParams{
+				{
+					Amount: stripe.Int64(1000),
+					Categories: []*string{
+						stripe.String("financial_institutions"),
+					},
+					Interval: stripe.String(string(stripe.IssuingSpendingLimitIntervalAllTime)),
+				},
+			},
+		},
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
 		Type:     stripe.String(string(stripe.IssuingCardTypeVirtual)),
-	})
+	}
+	card, err := New(params)
 	assert.Nil(t, err)
 	assert.NotNil(t, card)
 	assert.Equal(t, "issuing.card", card.Object)

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -69,9 +69,9 @@ type IssuingAuthorizationControlsSpendingLimitsParams struct {
 
 // AuthorizationControlsParams is the set of parameters that can be used for the shipping parameter.
 type AuthorizationControlsParams struct {
-	AllowedCategories []*string                                         `form:"allowed_categories"`
-	BlockedCategories []*string                                         `form:"blocked_categories"`
-	SpendingLimits    *IssuingAuthorizationControlsSpendingLimitsParams `form:"spending_limits"`
+	AllowedCategories []*string                                           `form:"allowed_categories"`
+	BlockedCategories []*string                                           `form:"blocked_categories"`
+	SpendingLimits    []*IssuingAuthorizationControlsSpendingLimitsParams `form:"spending_limits"`
 
 	// The following parameters are considered deprecated and only apply to issuing cards
 	MaxAmount    *int64 `form:"max_amount"`
@@ -134,9 +134,9 @@ type IssuingAuthorizationControlsSpendingLimits struct {
 // IssuingCardAuthorizationControls is the resource representing authorization controls on an issuing card.
 // TODO: Rename to IssuingAuthorizationControls in the next major
 type IssuingCardAuthorizationControls struct {
-	AllowedCategories []string                                    `json:"allowed_categories"`
-	BlockedCategories []string                                    `json:"blocked_categories"`
-	SpendingLimits    *IssuingAuthorizationControlsSpendingLimits `json:"spending_limits"`
+	AllowedCategories []string                                      `json:"allowed_categories"`
+	BlockedCategories []string                                      `json:"blocked_categories"`
+	SpendingLimits    []*IssuingAuthorizationControlsSpendingLimits `json:"spending_limits"`
 
 	// The properties below are considered deprecated and can only be used for an issuing card.
 	Currency     Currency `json:"currency"`


### PR DESCRIPTION
This fixes an issue where `spending_limits` was assumed to be a struct instead of a slice of structs as documented [here|https://stripe.com/docs/api/issuing/cards/object#issuing_card_object-authorization_controls-spending_limits]

r? @brandur-stripe 
cc @stripe/api-libraries 
cc @zacht-stripe