### PR TITLE
Add helper to go from []T to []*T for string, int64, float64, bool

### DIFF
--- a/account/client_test.go
+++ b/account/client_test.go
@@ -52,9 +52,9 @@ func TestAccountNew(t *testing.T) {
 		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Token: stripe.String("tok_123"),
 		},
-		RequestedCapabilities: []*string{
-			stripe.String("card_payments"),
-		},
+		RequestedCapabilities: stripe.StringSlice([]string{
+			"card_payments",
+		}),
 		Settings: &stripe.AccountSettingsParams{
 			Branding: &stripe.AccountSettingsBrandingParams{
 				Icon: stripe.String("file_123"),

--- a/checkout/session/client_test.go
+++ b/checkout/session/client_test.go
@@ -23,9 +23,9 @@ func TestCheckoutSessionNew(t *testing.T) {
 				Amount:      stripe.Int64(1234),
 				Currency:    stripe.String(string(stripe.CurrencyUSD)),
 				Description: stripe.String("description"),
-				Images: []*string{
-					stripe.String("https://stripe.com/image1"),
-				},
+				Images: stripe.StringSlice([]string{
+					"https://stripe.com/image1",
+				}),
 				Name:     stripe.String("name"),
 				Quantity: stripe.Int64(2),
 			},
@@ -41,9 +41,9 @@ func TestCheckoutSessionNew(t *testing.T) {
 				Name:    stripe.String("name"),
 			},
 		},
-		PaymentMethodTypes: []*string{
-			stripe.String("card"),
-		},
+		PaymentMethodTypes: stripe.StringSlice([]string{
+			"card",
+		}),
 		SuccessURL: stripe.String("https://stripe.com/success"),
 	})
 	assert.Nil(t, err)

--- a/issuing/card/client_test.go
+++ b/issuing/card/client_test.go
@@ -38,9 +38,9 @@ func TestIssuingCardNew(t *testing.T) {
 			SpendingLimits: []*stripe.IssuingAuthorizationControlsSpendingLimitsParams{
 				{
 					Amount: stripe.Int64(1000),
-					Categories: []*string{
-						stripe.String("financial_institutions"),
-					},
+					Categories: stripe.StringSlice([]string{
+						"financial_institutions",
+					}),
 					Interval: stripe.String(string(stripe.IssuingSpendingLimitIntervalAllTime)),
 				},
 			},

--- a/paymentintent/client_test.go
+++ b/paymentintent/client_test.go
@@ -51,9 +51,9 @@ func TestPaymentIntentNew(t *testing.T) {
 	intent, err := New(&stripe.PaymentIntentParams{
 		Amount:   stripe.Int64(123),
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
-		PaymentMethodTypes: []*string{
-			stripe.String("card"),
-		},
+		PaymentMethodTypes: stripe.StringSlice([]string{
+			"card",
+		}),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, intent)

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -60,10 +60,10 @@ func TestSourceVerify(t *testing.T) {
 
 func TestSourceObjectVerify(t *testing.T) {
 	source, err := Verify("src_123", &stripe.SourceVerifyParams{
-		Values: []*string{
-			stripe.String("32"),
-			stripe.String("45"),
-		},
+		Values: stripe.StringSlice([]string{
+			"32",
+			"45",
+		}),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, source)

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -35,10 +35,10 @@ func TestProductNew(t *testing.T) {
 		Name:        stripe.String("Test Name"),
 		Description: stripe.String("This is a description"),
 		Caption:     stripe.String("This is a caption"),
-		Attributes: []*string{
-			stripe.String("Attr1"),
-			stripe.String("Attr2"),
-		},
+		Attributes: stripe.StringSlice([]string{
+			"Attr1",
+			"Attr2",
+		}),
 		URL:       stripe.String("http://example.com"),
 		Shippable: stripe.Bool(true),
 		PackageDimensions: &stripe.PackageDimensionsParams{

--- a/stripe.go
+++ b/stripe.go
@@ -816,6 +816,15 @@ func StringValue(v *string) string {
 	return ""
 }
 
+// StringSlice returns a slice of string pointers given a slice of strings
+func StringSlice(v []string) []*string {
+	out := make([]*string, len(v))
+	for i := range v {
+		out[i] = &v[i]
+	}
+	return out
+}
+
 //
 // Private constants
 //

--- a/stripe.go
+++ b/stripe.go
@@ -606,6 +606,15 @@ func BoolValue(v *bool) bool {
 	return false
 }
 
+// BoolSlice returns a slice of bool pointers given a slice of bools.
+func BoolSlice(v []bool) []*bool {
+	out := make([]*bool, len(v))
+	for i := range v {
+		out[i] = &v[i]
+	}
+	return out
+}
+
 // Float64 returns a pointer to the float64 value passed in.
 func Float64(v float64) *float64 {
 	return &v
@@ -618,6 +627,15 @@ func Float64Value(v *float64) float64 {
 		return *v
 	}
 	return 0
+}
+
+// Float64Slice returns a slice of float64 pointers given a slice of float64s.
+func Float64Slice(v []float64) []*float64 {
+	out := make([]*float64, len(v))
+	for i := range v {
+		out[i] = &v[i]
+	}
+	return out
 }
 
 // FormatURLPath takes a format string (of the kind used in the fmt package)
@@ -741,6 +759,15 @@ func Int64Value(v *int64) int64 {
 	return 0
 }
 
+// Int64Slice returns a slice of int64 pointers given a slice of int64s.
+func Int64Slice(v []int64) []*int64 {
+	out := make([]*int64, len(v))
+	for i := range v {
+		out[i] = &v[i]
+	}
+	return out
+}
+
 // NewBackends creates a new set of backends with the given HTTP client. You
 // should only need to use this for testing purposes or on App Engine.
 func NewBackends(httpClient *http.Client) *Backends {
@@ -816,7 +843,7 @@ func StringValue(v *string) string {
 	return ""
 }
 
-// StringSlice returns a slice of string pointers given a slice of strings
+// StringSlice returns a slice of string pointers given a slice of strings.
 func StringSlice(v []string) []*string {
 	out := make([]*string, len(v))
 	for i := range v {

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -744,6 +744,15 @@ func TestResponseToError(t *testing.T) {
 	assert.Equal(t, expectedDeclineCode, cardErr.DeclineCode)
 }
 
+func TestStringSlice(t *testing.T) {
+	input := []string{"a", "b", "c"}
+	result := stripe.StringSlice(input)
+
+	assert.Equal(t, "a", *result[0])
+	assert.Equal(t, "b", *result[1])
+	assert.Equal(t, "c", *result[2])
+}
+
 //
 // ---
 //

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -751,6 +751,42 @@ func TestStringSlice(t *testing.T) {
 	assert.Equal(t, "a", *result[0])
 	assert.Equal(t, "b", *result[1])
 	assert.Equal(t, "c", *result[2])
+
+	assert.Equal(t, 0, len(stripe.StringSlice(nil)))
+}
+
+func TestInt64Slice(t *testing.T) {
+	input := []int64{8, 7, 6}
+	result := stripe.Int64Slice(input)
+
+	assert.Equal(t, int64(8), *result[0])
+	assert.Equal(t, int64(7), *result[1])
+	assert.Equal(t, int64(6), *result[2])
+
+	assert.Equal(t, 0, len(stripe.Int64Slice(nil)))
+}
+
+func TestFloat64Slice(t *testing.T) {
+	input := []float64{8, 7, 6}
+	result := stripe.Float64Slice(input)
+
+	assert.Equal(t, float64(8), *result[0])
+	assert.Equal(t, float64(7), *result[1])
+	assert.Equal(t, float64(6), *result[2])
+
+	assert.Equal(t, 0, len(stripe.Float64Slice(nil)))
+}
+
+func TestBoolSlice(t *testing.T) {
+	input := []bool{true, false, true, false}
+	result := stripe.BoolSlice(input)
+
+	assert.Equal(t, true, *result[0])
+	assert.Equal(t, false, *result[1])
+	assert.Equal(t, true, *result[2])
+	assert.Equal(t, false, *result[3])
+
+	assert.Equal(t, 0, len(stripe.BoolSlice(nil)))
 }
 
 //

--- a/webhookendpoint/client_test.go
+++ b/webhookendpoint/client_test.go
@@ -31,9 +31,9 @@ func TestWebhookEndpointList(t *testing.T) {
 
 func TestWebhookEndpointNew(t *testing.T) {
 	endpoint, err := New(&stripe.WebhookEndpointParams{
-		EnabledEvents: []*string{
-			stripe.String("charge.succeeded"),
-		},
+		EnabledEvents: stripe.StringSlice([]string{
+			"charge.succeeded",
+		}),
 		URL: stripe.String("https://stripe.com"),
 	})
 	assert.Nil(t, err)
@@ -42,9 +42,9 @@ func TestWebhookEndpointNew(t *testing.T) {
 
 func TestWebhookEndpointUpdate(t *testing.T) {
 	endpoint, err := Update("we_123", &stripe.WebhookEndpointParams{
-		EnabledEvents: []*string{
-			stripe.String("charge.succeeded"),
-		},
+		EnabledEvents: stripe.StringSlice([]string{
+			"charge.succeeded",
+		}),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, endpoint)


### PR DESCRIPTION
I ran into a [common mistake in golang](https://developmentality.wordpress.com/2014/02/25/go-gotcha-0-why-taking-the-address-of-an-iterated-variable-is-wrong/) when writing my own code to go from a `[]string` to `[]*string` for use in the `PaymentMethodTypes` field.

This adds a helper function to do it correctly. If we want to merge this PR, I also think that we should update the examples in the documentation to use it.