### PR TITLE
Add support for file_link_data in file creation requests

### DIFF
--- a/file/client_test.go
+++ b/file/client_test.go
@@ -50,6 +50,14 @@ func TestFileNew(t *testing.T) {
 		Purpose:    stripe.String(string(stripe.FilePurposeDisputeEvidence)),
 		FileReader: f,
 		Filename:   stripe.String(f.Name()),
+		FileLinkData: &stripe.FileFileLinkDataParams{
+			Params: stripe.Params{
+				Metadata: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Create: stripe.Bool(true),
+		},
 	}
 
 	file, err := New(fileParams)

--- a/file_test.go
+++ b/file_test.go
@@ -38,6 +38,9 @@ func TestFileParams_GetBody(t *testing.T) {
 	p := &FileParams{
 		FileReader: f,
 		Filename:   String(f.Name()),
+		FileLinkData: &FileFileLinkDataParams{
+			Create: Bool(true),
+		},
 	}
 
 	buffer, boundary, err := p.GetBody()


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Add support for [`file_link_data`](https://stripe.com/docs/api/files/create#create_file-file_link_data) in file creation requests.

The implementation is a bit of a hack: it uses `form` to flatten and stringify the contents of `file_link_data`, then parses the resulting query string to add the key/value pairs to the multipart buffer.

I've manually checked the contents of the request:
```
--554f676cf198d9e32740e881eb8cf161d311586da9b3cceaea7fcbe06135
Content-Disposition: form-data; name="purpose"

dispute_evidence
--554f676cf198d9e32740e881eb8cf161d311586da9b3cceaea7fcbe06135
Content-Disposition: form-data; name="file"; filename="test_data.pdf"
Content-Type: application/octet-stream

<snip>

--554f676cf198d9e32740e881eb8cf161d311586da9b3cceaea7fcbe06135
Content-Disposition: form-data; name="file_link_data[metadata][foo]"

bar
--554f676cf198d9e32740e881eb8cf161d311586da9b3cceaea7fcbe06135
Content-Disposition: form-data; name="file_link_data[create]"

true
--554f676cf198d9e32740e881eb8cf161d311586da9b3cceaea7fcbe06135--
```