### PR TITLE
Lock before changing field of backends

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -816,7 +816,7 @@ func SetAppInfo(info *AppInfo) {
 func SetBackend(backend SupportedBackend, b Backend) {
 	backends.mu.Lock()
 	defer backends.mu.Unlock()
-	
+
 	switch backend {
 	case APIBackend:
 		backends.API = b

--- a/stripe.go
+++ b/stripe.go
@@ -814,6 +814,9 @@ func SetAppInfo(info *AppInfo) {
 
 // SetBackend sets the backend used in the binding.
 func SetBackend(backend SupportedBackend, b Backend) {
+	backends.mu.Lock()
+	defer backends.mu.Unlock()
+	
 	switch backend {
 	case APIBackend:
 		backends.API = b


### PR DESCRIPTION
Just a minor thing I noticed while trying to update a Stripe client to specify `MaxNetworkRetries`, since the default is 0. Apologies if this is somehow intentional.

---

The `SetBackend` method updates one of the members of the package-level variable `backends`. Since it's a pointer, it's probably safe on most architectures. But the `Backends` struct already has a `sync.RWMutex` field, and earlier in the file the `GetBackend` function goes through the trouble of explicitly acquiring a read and possibly a write lock. See:
https://github.com/stripe/stripe-go/blob/d94ce0ed857fb1571b9b30bd24430bdac3d50c0f/stripe.go#L666

So to be safe, and consistent with the rest of the code, it makes sense to acquire a write lock before updating the `backends` value.