### PR TITLE
Mark OperatorAccount as deprecated across Terminal endpoints

### DIFF
--- a/terminal_connectiontoken.go
+++ b/terminal_connectiontoken.go
@@ -2,7 +2,9 @@ package stripe
 
 // TerminalConnectionTokenParams is the set of parameters that can be used when creating a terminal connection token.
 type TerminalConnectionTokenParams struct {
-	Params          `form:"*"`
+	Params `form:"*"`
+
+	// This feature has been deprecated and should not be used anymore.
 	OperatorAccount *string `form:"operator_account"`
 }
 

--- a/terminal_location.go
+++ b/terminal_location.go
@@ -2,15 +2,19 @@ package stripe
 
 // TerminalLocationParams is the set of parameters that can be used when creating or updating a terminal location.
 type TerminalLocationParams struct {
-	Params          `form:"*"`
-	Address         *AccountAddressParams `form:"address"`
-	DisplayName     *string               `form:"display_name"`
-	OperatorAccount *string               `form:"operator_account"`
+	Params      `form:"*"`
+	Address     *AccountAddressParams `form:"address"`
+	DisplayName *string               `form:"display_name"`
+
+	// This feature has been deprecated and should not be used anymore.
+	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalLocationListParams is the set of parameters that can be used when listing temrinal locations.
 type TerminalLocationListParams struct {
-	ListParams      `form:"*"`
+	ListParams `form:"*"`
+
+	// This feature has been deprecated and should not be used anymore.
 	OperatorAccount *string `form:"operator_account"`
 }
 

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -5,22 +5,28 @@ type TerminalReaderParams struct {
 	Params           `form:"*"`
 	Label            *string `form:"label"`
 	Location         *string `form:"location"`
-	OperatorAccount  *string `form:"operator_account"`
 	RegistrationCode *string `form:"registration_code"`
+
+	// This feature has been deprecated and should not be used anymore.
+	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalReaderGetParams is the set of parameters that can be used to get a terminal reader.
 type TerminalReaderGetParams struct {
-	Params          `form:"*"`
+	Params `form:"*"`
+
+	// This feature has been deprecated and should not be used anymore.
 	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalReaderListParams is the set of parameters that can be used when listing temrinal readers.
 type TerminalReaderListParams struct {
-	ListParams      `form:"*"`
-	Location        *string `form:"location"`
+	ListParams `form:"*"`
+	Location   *string `form:"location"`
+	Status     *string `form:"status"`
+
+	// This feature has been deprecated and should not be used anymore.
 	OperatorAccount *string `form:"operator_account"`
-	Status          *string `form:"status"`
 }
 
 // TerminalReader is the resource representing a Stripe terminal reader.


### PR DESCRIPTION
Same as https://github.com/stripe/stripe-dotnet/pull/1610

r? @mickjermsurawong-stripe 
cc @stripe/api-libraries @daz-stripe 