### PR TITLE
Add test script to check that all clients are included in `client.API`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-all: test bench vet lint check-gofmt
+all: test bench vet lint check-api-clients check-gofmt
 
 bench:
 	go test -race -bench . -run "Benchmark" ./form
 
 build:
 	go build ./...
+
+check-api-clients:
+	go run scripts/check_api_clients/main.go
 
 check-gofmt:
 	scripts/check_gofmt.sh
@@ -13,7 +16,7 @@ lint:
 	golint -set_exit_status ./...
 
 test:
-	go run scripts/test_with_stripe_mock.go -race ./...
+	go run scripts/test_with_stripe_mock/main.go -race ./...
 
 vet:
 	go vet ./...
@@ -21,7 +24,7 @@ vet:
 coverage:
 	# go currently cannot create coverage profiles when testing multiple packages, so we test each package
 	# independently. This issue should be fixed in Go 1.10 (https://github.com/golang/go/issues/6909).
-	go list ./... | xargs -n1 -I {} -P 4 go run scripts/test_with_stripe_mock.go -covermode=count -coverprofile=../../../{}/profile.coverprofile {}
+	go list ./... | xargs -n1 -I {} -P 4 go run scripts/test_with_stripe_mock/main.go -covermode=count -coverprofile=../../../{}/profile.coverprofile {}
 
 clean:
 	find . -name \*.coverprofile -delete

--- a/client/api.go
+++ b/client/api.go
@@ -4,6 +4,7 @@ package client
 import (
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/account"
+	"github.com/stripe/stripe-go/accountlink"
 	"github.com/stripe/stripe-go/applepaydomain"
 	"github.com/stripe/stripe-go/balance"
 	"github.com/stripe/stripe-go/bankaccount"
@@ -40,6 +41,7 @@ import (
 	"github.com/stripe/stripe-go/paymentmethod"
 	"github.com/stripe/stripe-go/paymentsource"
 	"github.com/stripe/stripe-go/payout"
+	"github.com/stripe/stripe-go/person"
 	"github.com/stripe/stripe-go/plan"
 	"github.com/stripe/stripe-go/product"
 	"github.com/stripe/stripe-go/radar/valuelist"
@@ -49,6 +51,7 @@ import (
 	"github.com/stripe/stripe-go/reporting/reportrun"
 	"github.com/stripe/stripe-go/reporting/reporttype"
 	"github.com/stripe/stripe-go/reversal"
+	"github.com/stripe/stripe-go/review"
 	"github.com/stripe/stripe-go/sigma/scheduledqueryrun"
 	"github.com/stripe/stripe-go/sku"
 	"github.com/stripe/stripe-go/source"
@@ -62,6 +65,7 @@ import (
 	terminalconnectiontoken "github.com/stripe/stripe-go/terminal/connectiontoken"
 	terminallocation "github.com/stripe/stripe-go/terminal/location"
 	terminalreader "github.com/stripe/stripe-go/terminal/reader"
+	"github.com/stripe/stripe-go/threedsecure"
 	"github.com/stripe/stripe-go/token"
 	"github.com/stripe/stripe-go/topup"
 	"github.com/stripe/stripe-go/transfer"
@@ -74,6 +78,8 @@ import (
 type API struct {
 	// Account is the client used to invoke /accounts APIs.
 	Account *account.Client
+	// AccountLink is the client used to invoke /account_links APIs.
+	AccountLinks *accountlink.Client
 	// ApplePayDomains is the client used to invoke /apple_pay/domains APIs.
 	ApplePayDomains *applepaydomain.Client
 	// Balance is the client used to invoke /balance and transaction-related APIs.
@@ -146,6 +152,8 @@ type API struct {
 	PaymentSource *paymentsource.Client
 	// Payouts is the client used to invoke /payouts APIs.
 	Payouts *payout.Client
+	// Persons is the client used to invoke /account/persons APIs.
+	Persons *person.Client
 	// Plans is the client used to invoke /plans APIs.
 	Plans *plan.Client
 	// Products is the client used to invoke /products APIs.
@@ -164,6 +172,8 @@ type API struct {
 	ReportTypes *reporttype.Client
 	// Reversals is the client used to invoke /transfers/reversals APIs.
 	Reversals *reversal.Client
+	// Reviews is the client used to invoke /reviews APIs.
+	Reviews *review.Client
 	// SigmaScheduledQueryRuns is the client used to invoke /sigma/scheduled_query_runs APIs.
 	SigmaScheduledQueryRuns *scheduledqueryrun.Client
 	// Skus is the client used to invoke /skus APIs.
@@ -190,6 +200,8 @@ type API struct {
 	TerminalLocations *terminallocation.Client
 	// TerminalReaders is the client used to invoke /terminal/readers related APIs.
 	TerminalReaders *terminalreader.Client
+	// ThreeDSecures is the client used to invoke /3d_secure related APIs.
+	ThreeDSecures *threedsecure.Client
 	// Tokens is the client used to invoke /tokens APIs.
 	Tokens *token.Client
 	// Topups is the client used to invoke /tokens APIs.
@@ -216,6 +228,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 
 	a.Account = &account.Client{B: backends.API, Key: key}
 	a.ApplePayDomains = &applepaydomain.Client{B: backends.API, Key: key}
+	a.AccountLinks = &accountlink.Client{B: backends.API, Key: key}
 	a.Balance = &balance.Client{B: backends.API, Key: key}
 	a.BankAccounts = &bankaccount.Client{B: backends.API, Key: key}
 	a.BitcoinReceivers = &bitcoinreceiver.Client{B: backends.API, Key: key}
@@ -251,6 +264,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.PaymentMethods = &paymentmethod.Client{B: backends.API, Key: key}
 	a.PaymentSource = &paymentsource.Client{B: backends.API, Key: key}
 	a.Payouts = &payout.Client{B: backends.API, Key: key}
+	a.Persons = &person.Client{B: backends.API, Key: key}
 	a.Plans = &plan.Client{B: backends.API, Key: key}
 	a.Products = &product.Client{B: backends.API, Key: key}
 	a.RadarValueLists = &valuelist.Client{B: backends.API, Key: key}
@@ -260,6 +274,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.ReportRuns = &reportrun.Client{B: backends.API, Key: key}
 	a.ReportTypes = &reporttype.Client{B: backends.API, Key: key}
 	a.Reversals = &reversal.Client{B: backends.API, Key: key}
+	a.Reviews = &review.Client{B: backends.API, Key: key}
 	a.SigmaScheduledQueryRuns = &scheduledqueryrun.Client{B: backends.API, Key: key}
 	a.Skus = &sku.Client{B: backends.API, Key: key}
 	a.Sources = &source.Client{B: backends.API, Key: key}
@@ -273,6 +288,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.TerminalConnectionTokens = &terminalconnectiontoken.Client{B: backends.API, Key: key}
 	a.TerminalLocations = &terminallocation.Client{B: backends.API, Key: key}
 	a.TerminalReaders = &terminalreader.Client{B: backends.API, Key: key}
+	a.ThreeDSecures = &threedsecure.Client{B: backends.API, Key: key}
 	a.Tokens = &token.Client{B: backends.API, Key: key}
 	a.Topups = &topup.Client{B: backends.API, Key: key}
 	a.Transfers = &transfer.Client{B: backends.API, Key: key}

--- a/scripts/check_api_clients/main.go
+++ b/scripts/check_api_clients/main.go
@@ -1,0 +1,304 @@
+// A script that tries to make sure that all API clients (structs called
+// `Client`) defined throughout all subpackages are included in the master list
+// as a field on the `client.API` type. Adding a new client to `client.API` has
+// historically been something that's easily forgotten.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func main() {
+	//
+	// DEBUGGING
+	//
+	// As you can see, working with Go ASTs is quite verbose, and made not
+	// great by all the type casting that's going on. The official docs for the
+	// packages provide only the most basic information about how to use them.
+	//
+	// BY FAR the easiest way to debug something is to just print the AST node
+	// you're interested in (it takes in an `interface{}`). The output is
+	// verbose, detailed, and extremely informative. For example:
+	//
+	//     ast.Print(fset, f)
+	//
+
+	fset := token.NewFileSet()
+
+	//
+	// Step 1: See what clients are in `client.API`
+	//
+
+	// Returned as a map to facilitate fast set checking.
+	packagesInClientAPI, err := getClientAPIPackages(fset)
+	if err != nil {
+		exitWithError(err)
+	}
+
+	//
+	// Step 2: See what clients are in `client.API`
+	//
+
+	var packagesWithClient []string
+	err = filepath.Walk(".", func(path string, f os.FileInfo, _ error) error {
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+
+		if strings.HasSuffix(filepath.Base(path), "_test.go") {
+			return nil
+		}
+
+		packageName, err := findClientType(fset, path)
+		if err != nil {
+			exitWithError(err)
+		}
+
+		if packageName == nil {
+			return nil
+		}
+
+		// Prepend a directory so that we know where nested packages are
+		// nested.
+		//
+		// For example, `session` will become `checkout/session`.
+		relativeDir := filepath.Dir(path)
+
+		// We're not interested in the immediate parent directory because that
+		// has the same name as the package itself, so strip that off the end.
+		relativeDir = strings.TrimSuffix(relativeDir, *packageName)
+
+		if relativeDir != "" {
+			relativePackageName := relativeDir + *packageName
+			packageName = &relativePackageName
+		}
+
+		packagesWithClient = append(packagesWithClient, *packageName)
+		return nil
+	})
+	if err != nil {
+		exitWithError(err)
+	}
+
+	if len(packagesWithClient) < 1 {
+		panic("Found no packages with clients; something went wrong " +
+			"(maybe check the working directory?)")
+	}
+
+	sort.Strings(packagesWithClient)
+
+	var anyMissing bool
+	for _, packageName := range packagesWithClient {
+		_, ok := packagesInClientAPI[packageName]
+		if !ok {
+			if !anyMissing {
+				fmt.Fprintf(os.Stderr, "!!! the following clients are missing from client.%s in %s\n",
+					typeNameAPI, clientAPIPath)
+				anyMissing = true
+			}
+
+			fmt.Fprintf(os.Stderr, "%s.Client\n", packageName)
+		}
+	}
+
+	if anyMissing {
+		os.Exit(1)
+	}
+}
+
+//
+// Private
+//
+
+const (
+	// Names of some of the Go types in stripe-go that we're interested in.
+	typeNameAPI    = "API"
+	typeNameClient = "Client"
+
+	// Path to file containing the `API` type.
+	clientAPIPath = "./client/api.go"
+)
+
+func exitWithError(err error) {
+	fmt.Fprintf(os.Stderr, "%v\n", err)
+	os.Exit(1)
+}
+
+// findType looks for a Go type defined in the given AST and returns its
+// specification.
+func findType(f *ast.File, typeName string) *ast.TypeSpec {
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+
+		// We're only looking for `Client` structs which are always `GenDecl`
+		// of type `TYPE`.
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+
+		if len(genDecl.Specs) > 1 {
+			panic("Expected only a single ast.Spec for GenDecl with Tok of Type")
+		}
+
+		typeSpec, ok := genDecl.Specs[0].(*ast.TypeSpec)
+		if !ok {
+			panic("Expected ast.TypeSpec in GenDecl with Tok of Type")
+		}
+
+		if typeSpec.Name.Name != typeName {
+			continue
+		}
+
+		// Type names are unique with packages, so return early.
+		return typeSpec
+	}
+
+	return nil
+}
+
+// findClientType looks for a type called `Client` in the `.go` file at the
+// target path. If found, it returns the name of the file's defined package.
+func findClientType(fset *token.FileSet, path string) (*string, error) {
+	source, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := parser.ParseFile(fset, "", source, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	packageName := f.Name.Name
+
+	typeSpec := findType(f, typeNameClient)
+	if typeSpec == nil {
+		return nil, nil
+	}
+
+	return &packageName, nil
+
+}
+
+// getClientAPIPackages parses the master `API` type found in `client/api.go`,
+// looks for all fields that have a type named `Client`, and returns a map
+// containing the packages of those clients.
+func getClientAPIPackages(fset *token.FileSet) (map[string]struct{}, error) {
+	packagesInClientAPI := make(map[string]struct{})
+
+	source, err := ioutil.ReadFile(clientAPIPath)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := parser.ParseFile(fset, "", source, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// First we need to make a map of any packages that are being imported
+	// in ways that don't map perfectly well with the package paths that we'll
+	// extract by looking for clients in `.go` files.
+	//
+	// The first case are packages imported under aliases. We often do this for
+	// namespaced packages that have a high probability of collision with
+	// something else. For example, `issuing/card` gets imported as
+	// `issuingcard`.
+	//
+	// The second case are nested packages that are referenced are still
+	// referenced by their local package name.  For example,
+	// `reporting/reportrun` might have been aliased as `reportingreportrun` if
+	// things were perfectly consisted, but its package name is already unique
+	// enough that no one bothered to do so.
+	importAliases := make(map[string]string)
+	for _, importSpec := range f.Imports {
+		path := importSpec.Path.Value
+
+		// The import path is quoted, so trim quotes off either ended.
+		path = strings.TrimPrefix(path, `"`)
+		path = strings.TrimSuffix(path, `"`)
+
+		// Trim the fully qualified prefix off the front of the path to make
+		// translation easier for us after.
+		path = strings.TrimPrefix(path, "github.com/stripe/stripe-go/")
+
+		// A non-nil `Name` is an alias. Save the alias to our map with the
+		// relative package path.
+		if importSpec.Name != nil {
+			importAliases[importSpec.Name.Name] = path
+			continue
+		}
+
+		parts := strings.Split(path, "/")
+
+		// A top-level packaage. No need to keep an alias around for it.
+		if len(parts) == 1 {
+			continue
+		}
+
+		// Otherwise, store the alias as the last component of the path keyed
+		// to the entire relative path.
+		importAliases[parts[len(parts)-1]] = path
+	}
+
+	typeSpec := findType(f, typeNameAPI)
+	if typeSpec == nil {
+		return nil, fmt.Errorf("No 'API' type found in '%s'", clientAPIPath)
+	}
+
+	structType, ok := typeSpec.Type.(*ast.StructType)
+	if !ok {
+		panic(fmt.Sprintf("Expected %s type to be a struct", typeNameAPI))
+	}
+
+	for _, field := range structType.Fields.List {
+		// A "StarExpr" is a pointer like `*charge.Client`. The type
+		// `charge.Client` is wrapped within it.
+		//
+		// We expect all clients to be pointers, so skip any defined fields
+		// that aren't one.
+		starExpr, ok := field.Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+
+		selectorExpr, ok := starExpr.X.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+
+		// Only look for fields with types named 'Client'
+		if selectorExpr.Sel.Name != typeNameClient {
+			continue
+		}
+
+		ident, ok := selectorExpr.X.(*ast.Ident)
+		if !ok {
+			return nil, fmt.Errorf("Expected client field with type '%s' in '%s' "+
+				"to be proceeded by an *ast.Ident", typeNameClient, typeNameAPI)
+		}
+
+		packageName := ident.Name
+		packagesInClientAPI[packageName] = struct{}{}
+	}
+
+	for alias, packageName := range importAliases {
+		_, ok := packagesInClientAPI[alias]
+		if !ok {
+			continue
+		}
+
+		delete(packagesInClientAPI, alias)
+		packagesInClientAPI[packageName] = struct{}{}
+	}
+
+	return packagesInClientAPI, nil
+}

--- a/scripts/test_with_stripe_mock/main.go
+++ b/scripts/test_with_stripe_mock/main.go
@@ -5,8 +5,8 @@
 // The script passes all its arguments to a Go's test command, and defaults to
 // `./...`. For example, both of the following are valid invocations:
 //
-//     go run test_with_stripe_mock.go
-//     go run test_with_stripe_mock.go ./charge
+//     go run test_with_stripe_mock/main.go
+//     go run test_with_stripe_mock/main.go ./charge
 //
 // The reason that we need a separate script for this is because Go's testing
 // infrastructure doesn't provide any kind of global hook that we can use to do


### PR DESCRIPTION
When adding a new package with a `Client` struct, it's really easy to
forget to add it to the big list of clients in `client.API`, and we
often have to rely on user reports to tell us that we forgot about it.

Here we add a script to run with CI which looks for packages with a
`Client` and compares that list against what's in `client.API`, then
errors if any are missing from the latter.

Also adds a few clients that were missing from the list.

r? @remi-stripe
cc @stripe/api-libraries

---

A note on design: I wrote the script in Go because (1) it doesn't make a
bad scripting language, (2) we get a lot of typing safety that some Ruby
thing wouldn't give us, and (3) it allowed me to leverage Go's built in
AST parser for its own syntax so we don't have to do as much fuzzy
matching against strings.

By the end of writing it I think it was the right decision because there
are a few cases involved here that make the check non-trivial. For
example, packages can be aliased when imported in `client/api.go`, and
we need to be able to translate those aliases back to real package paths
that we detected earlier.

The final script is a little on the long side (~300 LOC), but it handles
all the corners we've developed, and I think it'll be relatively stable.