### PR TITLE
Fix invoice's `PaymentIntent` to its JSON tag uses snakecase

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -226,7 +226,7 @@ type Invoice struct {
 	NextPaymentAttempt           int64                    `json:"next_payment_attempt"`
 	Number                       string                   `json:"number"`
 	Paid                         bool                     `json:"paid"`
-	PaymentIntent                *PaymentIntent           `json:"paymentIntent"`
+	PaymentIntent                *PaymentIntent           `json:"payment_intent"`
 	PeriodEnd                    int64                    `json:"period_end"`
 	PeriodStart                  int64                    `json:"period_start"`
 	PostPaymentCreditNotesAmount int64                    `json:"post_payment_credit_notes_amount"`


### PR DESCRIPTION
Just through bad copy/paste this ended up using camelcase instead of
snakecase.

Fixes #856.