### PR TITLE
Pin library to API version 2019-05-16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.56.0
+    - STRIPE_MOCK_VERSION=0.57.0
 
 go:
   - "1.9.x"

--- a/stripe.go
+++ b/stripe.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2019-03-14"
+	APIVersion string = "2019-05-16"
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.56.0"
+	MockMinimumVersion = "0.57.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Like https://github.com/stripe/stripe-java/pull/781. I'd rather release this after #862 in order to avoid forcing people to upgrade, but lmk what you prefer.