### PR TITLE
Add support for `location` on `ConnectionToken`

### DIFF
--- a/terminal_connectiontoken.go
+++ b/terminal_connectiontoken.go
@@ -2,7 +2,8 @@ package stripe
 
 // TerminalConnectionTokenParams is the set of parameters that can be used when creating a terminal connection token.
 type TerminalConnectionTokenParams struct {
-	Params `form:"*"`
+	Params   `form:"*"`
+	Location string `form:"location"`
 
 	// This feature has been deprecated and should not be used anymore.
 	OperatorAccount *string `form:"operator_account"`
@@ -10,6 +11,7 @@ type TerminalConnectionTokenParams struct {
 
 // TerminalConnectionToken is the resource representing a Stripe terminal connection token.
 type TerminalConnectionToken struct {
-	Object string `json:"object"`
-	Secret string `json:"secret"`
+	Location string `json:"location"`
+	Object   string `json:"object"`
+	Secret   string `json:"secret"`
 }


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 