### PR TITLE
Enable request latency telemetry by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,19 @@ This information is passed along when the library makes calls to the Stripe
 API. Note that while `Name` is always required, `URL` and `Version` are
 optional.
 
+### Request latency telemetry
+
+By default, the library sends request latency telemetry to Stripe. These
+numbers help Stripe improve the overall latency of its API for all users.
+
+You can disable this behavior if you prefer:
+
+```go
+config := &stripe.BackendConfig{
+	EnableTelemetry: false,
+}
+```
+
 ## Development
 
 Pull requests from the community are welcome. If you submit one, please keep

--- a/stripe.go
+++ b/stripe.go
@@ -53,11 +53,11 @@ const (
 // EnableTelemetry is a global override for enabling client telemetry, which
 // sends request performance metrics to Stripe via the `X-Stripe-Client-Telemetry`
 // header. If set to true, all clients will send telemetry metrics. Defaults to
-// false.
+// true.
 //
-// Telemetry can also be enabled on a per-client basis by instead creating a
-// `BackendConfig` with `EnableTelemetry: true`.
-var EnableTelemetry = false
+// Telemetry can also be disabled on a per-client basis by instead creating a
+// `BackendConfig` with `EnableTelemetry: false`.
+var EnableTelemetry = true
 
 // Key is the Stripe API key used globally in the binding.
 var Key string


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries

Cf. https://github.com/stripe/stripe-ruby/pull/800.