### PR TITLE
Doc changes for Collection Method

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -11,7 +11,7 @@ const (
 	InvoiceLineTypeSubscription InvoiceLineType = "subscription"
 )
 
-// InvoiceBilling is the type of billing method for this invoice.
+// InvoiceBilling is the type of collection method for this invoice.
 // This is considered deprecated. Use InvoiceCollectionMethod instead.
 type InvoiceBilling string
 
@@ -47,10 +47,10 @@ const (
 	InvoiceBillingStatusVoid          InvoiceBillingStatus = "void"
 )
 
-// InvoiceCollectionMethod is the type of billing method for this invoice.
+// InvoiceCollectionMethod is the type of collection method for this invoice.
 type InvoiceCollectionMethod string
 
-// List of values that InvoiceBilling can take.
+// List of values that InvoiceCollectionMethod can take.
 const (
 	InvoiceCollectionMethodChargeAutomatically InvoiceCollectionMethod = "charge_automatically"
 	InvoiceCollectionMethodSendInvoice         InvoiceCollectionMethod = "send_invoice"

--- a/sub.go
+++ b/sub.go
@@ -21,7 +21,7 @@ const (
 	SubscriptionStatusUnpaid            SubscriptionStatus = "unpaid"
 )
 
-// SubscriptionBilling is the type of billing method for this subscription's invoices.
+// SubscriptionBilling is the type of collection method for this subscription's invoices.
 // This is considered deprecated. Use SubscriptionCollectionMethod instead.
 type SubscriptionBilling string
 
@@ -31,10 +31,10 @@ const (
 	SubscriptionBillingSendInvoice         SubscriptionBilling = "send_invoice"
 )
 
-// SubscriptionCollectionMethod is the type of billing method for this subscription's invoices.
+// SubscriptionCollectionMethod is the type of collection method for this subscription's invoices.
 type SubscriptionCollectionMethod string
 
-// List of values that SubscriptionBilling can take.
+// List of values that SubscriptionCollectionMethod can take.
 const (
 	SubscriptionCollectionMethodChargeAutomatically SubscriptionCollectionMethod = "charge_automatically"
 	SubscriptionCollectionMethodSendInvoice         SubscriptionCollectionMethod = "send_invoice"


### PR DESCRIPTION
* Slight modifications to documentation for the `collection_method` field (replaces `billing`).

r? @remi-stripe
cc @stripe/api-libraries