### PR TITLE
Add support for the `SetupIntent` resource and APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.59.0
+    - STRIPE_MOCK_VERSION=0.60.0
 
 go:
   - "1.9.x"

--- a/client/api.go
+++ b/client/api.go
@@ -55,6 +55,7 @@ import (
 	"github.com/stripe/stripe-go/reporting/reporttype"
 	"github.com/stripe/stripe-go/reversal"
 	"github.com/stripe/stripe-go/review"
+	"github.com/stripe/stripe-go/setupintent"
 	"github.com/stripe/stripe-go/sigma/scheduledqueryrun"
 	"github.com/stripe/stripe-go/sku"
 	"github.com/stripe/stripe-go/source"
@@ -183,6 +184,8 @@ type API struct {
 	Reversals *reversal.Client
 	// Reviews is the client used to invoke /reviews APIs.
 	Reviews *review.Client
+	// SetupIntents is the client used to invoke /setup_intents APIs.
+	SetupIntents *setupintent.Client
 	// SigmaScheduledQueryRuns is the client used to invoke /sigma/scheduled_query_runs APIs.
 	SigmaScheduledQueryRuns *scheduledqueryrun.Client
 	// Skus is the client used to invoke /skus APIs.
@@ -287,6 +290,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.ReportTypes = &reporttype.Client{B: backends.API, Key: key}
 	a.Reversals = &reversal.Client{B: backends.API, Key: key}
 	a.Reviews = &review.Client{B: backends.API, Key: key}
+	a.SetupIntents = &setupintent.Client{B: backends.API, Key: key}
 	a.SigmaScheduledQueryRuns = &scheduledqueryrun.Client{B: backends.API, Key: key}
 	a.Skus = &sku.Client{B: backends.API, Key: key}
 	a.Sources = &source.Client{B: backends.API, Key: key}

--- a/error.go
+++ b/error.go
@@ -55,6 +55,7 @@ type Error struct {
 	PaymentIntent  *PaymentIntent `json:"payment_intent,omitempty"`
 	PaymentMethod  *PaymentMethod `json:"payment_method,omitempty"`
 	RequestID      string         `json:"request_id,omitempty"`
+	SetupIntent    *SetupIntent   `json:"setup_intent,omitempty"`
 	Source         *PaymentSource `json:"source,omitempty"`
 	Type           ErrorType      `json:"type"`
 }

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -7,7 +7,7 @@ import (
 // PaymentIntentCancellationReason is the list of allowed values for the cancelation reason.
 type PaymentIntentCancellationReason string
 
-// List of values that PaymentIntentCaptureMethod can take.
+// List of values that PaymentIntentCancellationReason can take.
 const (
 	PaymentIntentCancellationReasonAbandoned           PaymentIntentCancellationReason = "abandoned"
 	PaymentIntentCancellationReasonAutomatic           PaymentIntentCancellationReason = "automatic"
@@ -54,6 +54,15 @@ type PaymentIntentOffSession string
 const (
 	PaymentIntentOffSessionOneOff    PaymentIntentOffSession = "one_off"
 	PaymentIntentOffSessionRecurring PaymentIntentOffSession = "recurring"
+)
+
+// PaymentIntentSetupFutureUsage is the list of allowed values for SetupFutureUsage.
+type PaymentIntentSetupFutureUsage string
+
+// List of values that PaymentIntentSetupFutureUsage can take.
+const (
+	PaymentIntentSetupFutureUsageOffSession PaymentIntentSetupFutureUsage = "off_session"
+	PaymentIntentSetupFutureUsageOnSession  PaymentIntentSetupFutureUsage = "on_session"
 )
 
 // PaymentIntentStatus is the list of allowed values for the payment intent's status.
@@ -120,6 +129,7 @@ type PaymentIntentParams struct {
 	ReceiptEmail         *string                          `form:"receipt_email"`
 	ReturnURL            *string                          `form:"return_url"`
 	SavePaymentMethod    *bool                            `form:"save_payment_method"`
+	SetupFutureUsage     *string                          `form:"setup_future_usage"`
 	Shipping             *ShippingDetailsParams           `form:"shipping"`
 	Source               *string                          `form:"source"`
 	StatementDescriptor  *string                          `form:"statement_descriptor"`
@@ -198,6 +208,7 @@ type PaymentIntent struct {
 	PaymentMethodTypes  []string                        `json:"payment_method_types"`
 	ReceiptEmail        string                          `json:"receipt_email"`
 	Review              *Review                         `json:"review"`
+	SetupFutureUsage    PaymentIntentSetupFutureUsage   `json:"setup_future_usage"`
 	Shipping            ShippingDetails                 `json:"shipping"`
 	Source              *PaymentSource                  `json:"source"`
 	StatementDescriptor string                          `json:"statement_descriptor"`

--- a/paymentintent/client_test.go
+++ b/paymentintent/client_test.go
@@ -60,7 +60,7 @@ func TestPaymentIntentNew(t *testing.T) {
 }
 
 func TestPaymentIntentUpdate(t *testing.T) {
-	intent, err := Update("tr_123", &stripe.PaymentIntentParams{
+	intent, err := Update("pi_123", &stripe.PaymentIntentParams{
 		Params: stripe.Params{
 			Metadata: map[string]string{
 				"foo": "bar",

--- a/setupintent.go
+++ b/setupintent.go
@@ -1,0 +1,119 @@
+package stripe
+
+import (
+	"encoding/json"
+)
+
+// SetupIntentCancellationReason is the list of allowed values for the cancelation reason.
+type SetupIntentCancellationReason string
+
+// List of values that SetupIntentCancellationReason can take.
+const (
+	SetupIntentCancellationReasonAbandoned           SetupIntentCancellationReason = "abandoned"
+	SetupIntentCancellationReasonFailedInvoice       SetupIntentCancellationReason = "failed_invoice"
+	SetupIntentCancellationReasonFraudulent          SetupIntentCancellationReason = "fraudulent"
+	SetupIntentCancellationReasonRequestedByCustomer SetupIntentCancellationReason = "requested_by_customer"
+)
+
+// SetupIntentStatus is the list of allowed values for the setup intent's status.
+type SetupIntentStatus string
+
+// List of values that SetupIntentStatus can take.
+const (
+	SetupIntentStatusCanceled              SetupIntentStatus = "canceled"
+	SetupIntentStatusProcessing            SetupIntentStatus = "processing"
+	SetupIntentStatusRequiresAction        SetupIntentStatus = "requires_action"
+	SetupIntentStatusRequiresConfirmation  SetupIntentStatus = "requires_confirmation"
+	SetupIntentStatusRequiresPaymentMethod SetupIntentStatus = "requires_payment_method"
+	SetupIntentStatusSucceeded             SetupIntentStatus = "succeeded"
+)
+
+// SetupIntentUsage is the list of allowed values for the setup intent's usage.
+type SetupIntentUsage string
+
+// List of values that SetupIntentUsage can take.
+const (
+	SetupIntentUsageOffSession SetupIntentUsage = "off_session"
+	SetupIntentUsageOnSession  SetupIntentUsage = "on_session"
+)
+
+// SetupIntentCancelParams is the set of parameters that can be used when canceling a setup intent.
+type SetupIntentCancelParams struct {
+	Params             `form:"*"`
+	CancellationReason *string `form:"cancellation_reason"`
+}
+
+// SetupIntentConfirmParams is the set of parameters that can be used when confirming a setup intent.
+type SetupIntentConfirmParams struct {
+	Params        `form:"*"`
+	PaymentMethod *string `form:"payment_method"`
+	ReturnURL     *string `form:"return_url"`
+}
+
+// SetupIntentParams is the set of parameters that can be used when handling a setup intent.
+type SetupIntentParams struct {
+	Params             `form:"*"`
+	Customer           *string   `form:"customer"`
+	Description        *string   `form:"description"`
+	OnBehalfOf         *string   `form:"on_behalf_of"`
+	PaymentMethod      *string   `form:"payment_method"`
+	PaymentMethodTypes []*string `form:"payment_method_types"`
+	Usage              *string   `form:"usage"`
+}
+
+// SetupIntentListParams is the set of parameters that can be used when listing setup intents.
+// For more details see https://stripe.com/docs/api#list_payouts.
+type SetupIntentListParams struct {
+	ListParams    `form:"*"`
+	Created       *int64            `form:"created"`
+	CreatedRange  *RangeQueryParams `form:"created"`
+	Customer      *string           `form:"customer"`
+	PaymentMethod *string           `form:"payment_method"`
+}
+
+// SetupIntent is the resource representing a Stripe payout.
+// For more details see https://stripe.com/docs/api#payment_intents.
+type SetupIntent struct {
+	Application        *Application                  `json:"application"`
+	CancellationReason SetupIntentCancellationReason `json:"cancellation_reason"`
+	ClientSecret       string                        `json:"client_secret"`
+	Created            int64                         `json:"created"`
+	Customer           *Customer                     `json:"customer"`
+	Description        string                        `json:"description"`
+	ID                 string                        `json:"id"`
+	LastSetupError     *Error                        `json:"last_setup_error"`
+	Livemode           bool                          `json:"livemode"`
+	Metadata           map[string]string             `json:"metadata"`
+	NextAction         *PaymentIntentNextAction      `json:"next_action"`
+	Object             string                        `json:"object"`
+	OnBehalfOf         *Account                      `json:"on_behalf_of"`
+	PaymentMethod      *PaymentMethod                `json:"payment_method"`
+	PaymentMethodTypes []string                      `json:"payment_method_types"`
+	Status             SetupIntentStatus             `json:"status"`
+	Usage              SetupIntentUsage              `json:"usage"`
+}
+
+// SetupIntentList is a list of setup intents as retrieved from a list endpoint.
+type SetupIntentList struct {
+	ListMeta
+	Data []*SetupIntent `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a SetupIntent.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (p *SetupIntent) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		p.ID = id
+		return nil
+	}
+
+	type setupIntent SetupIntent
+	var v setupIntent
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*p = SetupIntent(v)
+	return nil
+}

--- a/setupintent/client.go
+++ b/setupintent/client.go
@@ -1,0 +1,115 @@
+// Package setupintent provides API functions related to setup intents.
+//
+// For more details, see: https://stripe.com/docs/api/go#setup_intents.
+package setupintent
+
+import (
+	"net/http"
+
+	stripe "github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/form"
+)
+
+// Client is used to invoke APIs related to setup intents.
+type Client struct {
+	B   stripe.Backend
+	Key string
+}
+
+// New creates a setup intent.
+func New(params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
+	return getC().New(params)
+}
+
+// New creates a setup intent.
+func (c Client) New(params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
+	intent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodPost, "/v1/setup_intents", c.Key, params, intent)
+	return intent, err
+}
+
+// Get retrieves a setup intent.
+func Get(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
+	return getC().Get(id, params)
+}
+
+// Get retrieves a setup intent.
+func (c Client) Get(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
+	path := stripe.FormatURLPath("/v1/setup_intents/%s", id)
+	intent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, intent)
+	return intent, err
+}
+
+// Update updates a setup intent.
+func Update(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
+	return getC().Update(id, params)
+}
+
+// Update updates a setup intent.
+func (c Client) Update(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
+	path := stripe.FormatURLPath("/v1/setup_intents/%s", id)
+	intent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)
+	return intent, err
+}
+
+// Cancel cancels a setup intent.
+func Cancel(id string, params *stripe.SetupIntentCancelParams) (*stripe.SetupIntent, error) {
+	return getC().Cancel(id, params)
+}
+
+// Cancel cancels a setup intent.
+func (c Client) Cancel(id string, params *stripe.SetupIntentCancelParams) (*stripe.SetupIntent, error) {
+	path := stripe.FormatURLPath("/v1/setup_intents/%s/cancel", id)
+	intent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)
+	return intent, err
+}
+
+// Confirm confirms a setup intent.
+func Confirm(id string, params *stripe.SetupIntentConfirmParams) (*stripe.SetupIntent, error) {
+	return getC().Confirm(id, params)
+}
+
+// Confirm confirms a setup intent.
+func (c Client) Confirm(id string, params *stripe.SetupIntentConfirmParams) (*stripe.SetupIntent, error) {
+	path := stripe.FormatURLPath("/v1/setup_intents/%s/confirm", id)
+	intent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)
+	return intent, err
+}
+
+// List returns a list of setup intents.
+func List(params *stripe.SetupIntentListParams) *Iter {
+	return getC().List(params)
+}
+
+// List returns a list of setup intents.
+func (c Client) List(listParams *stripe.SetupIntentListParams) *Iter {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+		list := &stripe.SetupIntentList{}
+		err := c.B.CallRaw(http.MethodGet, "/v1/setup_intents", c.Key, b, p, list)
+
+		ret := make([]interface{}, len(list.Data))
+		for i, v := range list.Data {
+			ret[i] = v
+		}
+
+		return ret, list.ListMeta, err
+	})}
+}
+
+// Iter is an iterator for setup intents.
+type Iter struct {
+	*stripe.Iter
+}
+
+// SetupIntent returns the setup intent which the iterator is currently pointing to.
+func (i *Iter) SetupIntent() *stripe.SetupIntent {
+	return i.Current().(*stripe.SetupIntent)
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
+}

--- a/setupintent/client_test.go
+++ b/setupintent/client_test.go
@@ -1,0 +1,63 @@
+package setupintent
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go"
+	_ "github.com/stripe/stripe-go/testing"
+)
+
+func TestSetupIntentCancel(t *testing.T) {
+	intent, err := Cancel("seti_123", &stripe.SetupIntentCancelParams{
+		CancellationReason: stripe.String(string(stripe.SetupIntentCancellationReasonRequestedByCustomer)),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, intent)
+}
+
+func TestSetupIntentConfirm(t *testing.T) {
+	intent, err := Confirm("seti_123", &stripe.SetupIntentConfirmParams{
+		ReturnURL: stripe.String("https://stripe.com/return"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, intent)
+}
+
+func TestSetupIntentGet(t *testing.T) {
+	intent, err := Get("seti_123", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, intent)
+}
+
+func TestSetupIntentList(t *testing.T) {
+	i := List(&stripe.SetupIntentListParams{})
+
+	// Verify that we can get at least one setup intent
+	assert.True(t, i.Next())
+	assert.Nil(t, i.Err())
+	assert.NotNil(t, i.SetupIntent())
+}
+
+func TestSetupIntentNew(t *testing.T) {
+	intent, err := New(&stripe.SetupIntentParams{
+		Customer: stripe.String("cus_123"),
+		PaymentMethodTypes: stripe.StringSlice([]string{
+			"card",
+		}),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, intent)
+}
+
+func TestSetupIntentUpdate(t *testing.T) {
+	intent, err := Update("seti_123", &stripe.SetupIntentParams{
+		Params: stripe.Params{
+			Metadata: map[string]string{
+				"foo": "bar",
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, intent)
+}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.59.0"
+	MockMinimumVersion = "0.60.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
New attempt at adding `SetupIntent` to stripe-go

r? @brandur-stripe 
cc @stripe/api-libraries 