### PR TITLE
Separate NextAction as its own for SetupIntent

### DIFF
--- a/setupintent.go
+++ b/setupintent.go
@@ -15,6 +15,14 @@ const (
 	SetupIntentCancellationReasonRequestedByCustomer SetupIntentCancellationReason = "requested_by_customer"
 )
 
+// SetupIntentNextActionType is the list of allowed values for the next action's type.
+type SetupIntentNextActionType string
+
+// List of values that SetupIntentNextActionType can take.
+const (
+	SetupIntentNextActionTypeRedirectToURL SetupIntentNextActionType = "redirect_to_url"
+)
+
 // SetupIntentStatus is the list of allowed values for the setup intent's status.
 type SetupIntentStatus string
 
@@ -71,6 +79,19 @@ type SetupIntentListParams struct {
 	PaymentMethod *string           `form:"payment_method"`
 }
 
+// SetupIntentNextActionRedirectToURL represents the resource for the next action of type
+// "redirect_to_url".
+type SetupIntentNextActionRedirectToURL struct {
+	ReturnURL string `json:"return_url"`
+	URL       string `json:"url"`
+}
+
+// SetupIntentNextAction represents the type of action to take on a setup intent.
+type SetupIntentNextAction struct {
+	RedirectToURL *SetupIntentNextActionRedirectToURL `json:"redirect_to_url"`
+	Type          SetupIntentNextActionType           `json:"type"`
+}
+
 // SetupIntent is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payment_intents.
 type SetupIntent struct {
@@ -84,7 +105,7 @@ type SetupIntent struct {
 	LastSetupError     *Error                        `json:"last_setup_error"`
 	Livemode           bool                          `json:"livemode"`
 	Metadata           map[string]string             `json:"metadata"`
-	NextAction         *PaymentIntentNextAction      `json:"next_action"`
+	NextAction         *SetupIntentNextAction        `json:"next_action"`
 	Object             string                        `json:"object"`
 	OnBehalfOf         *Account                      `json:"on_behalf_of"`
 	PaymentMethod      *PaymentMethod                `json:"payment_method"`

--- a/setupintent_test.go
+++ b/setupintent_test.go
@@ -1,0 +1,29 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestSetupIntentNextAction_UnmarshalJSON(t *testing.T) {
+	actionData := map[string]interface{}{
+		"redirect_to_url": map[string]interface{}{
+			"return_url": "https://stripe.com/return",
+			"url":        "https://stripe.com",
+		},
+		"type": "redirect_to_url",
+	}
+
+	bytes, err := json.Marshal(&actionData)
+	assert.NoError(t, err)
+
+	var action SetupIntentNextAction
+	err = json.Unmarshal(bytes, &action)
+	assert.NoError(t, err)
+
+	assert.Equal(t, SetupIntentNextActionTypeRedirectToURL, action.Type)
+	assert.Equal(t, "https://stripe.com", action.RedirectToURL.URL)
+	assert.Equal(t, "https://stripe.com/return", action.RedirectToURL.ReturnURL)
+}


### PR DESCRIPTION
Quick fix as `NextAction` is its own resource on `SetupIntent`.

r? @remi-stripe (going to self-approve as we need to release)
cc @stripe/api-libraries 