### PR TITLE
Add `unavailable` as possible value on `CardVerification`

### DIFF
--- a/card.go
+++ b/card.go
@@ -56,9 +56,10 @@ type CardVerification string
 
 // List of values that CardVerification can take.
 const (
-	CardVerificationFail      CardVerification = "fail"
-	CardVerificationPass      CardVerification = "pass"
-	CardVerificationUnchecked CardVerification = "unchecked"
+	CardVerificationFail        CardVerification = "fail"
+	CardVerificationPass        CardVerification = "pass"
+	CardVerificationUnavailable CardVerification = "unavailable"
+	CardVerificationUnchecked   CardVerification = "unchecked"
 )
 
 // cardSource is a string that's used to build card form parameters. It's a


### PR DESCRIPTION
This is supported https://stripe.com/docs/api/cards/object#card_object-address_zip_check but was missing

r? @brandur-stripe 
cc @stripe/api-libraries 