### PR TITLE
Add support for VoidedAt on CreditNote

### DIFF
--- a/creditnote.go
+++ b/creditnote.go
@@ -76,6 +76,7 @@ type CreditNote struct {
 	Refund                     *Refund                     `json:"refund"`
 	Status                     CreditNoteStatus            `json:"status"`
 	Type                       CreditNoteType              `json:"type"`
+	VoidedAt                   int64                       `json:"voided_at"`
 }
 
 // CreditNoteList is a list of credit notes as retrieved from a list endpoint.


### PR DESCRIPTION
This adds `VoidedAt` on `CreditNote`

r? @ob-stripe 
cc @stripe/api-libraries 