### PR TITLE
Add support for Klarna and SourceOrders

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -359,31 +359,6 @@ type ChargePaymentMethodDetailsIdeal struct {
 // ChargePaymentMethodDetailsKlarna represents details for the Klarna
 // PaymentMethod.
 type ChargePaymentMethodDetailsKlarna struct {
-	BackgroundImageURL              string `json:"background_image_url"`
-	ClientToken                     string `json:"client_token"`
-	FirstName                       string `json:"first_name"`
-	LastName                        string `json:"last_name"`
-	Locale                          string `json:"locale"`
-	LogoURL                         string `json:"logo_url"`
-	PageTitle                       string `json:"page_title"`
-	PayLaterAssetURLsDescriptive    string `json:"pay_later_asset_urls_descriptive"`
-	PayLaterAssetURLsStandard       string `json:"pay_later_asset_urls_standard"`
-	PayLaterName                    string `json:"pay_later_name"`
-	PayLaterRedirectURL             string `json:"pay_later_redirect_url"`
-	PayNowAssetURLsDescriptive      string `json:"pay_now_asset_urls_descriptive"`
-	PayNowAssetURLsStandard         string `json:"pay_now_asset_urls_standard"`
-	PayNowName                      string `json:"pay_now_name"`
-	PayNowRedirectURL               string `json:"pay_now_redirect_url"`
-	PayOverTimeAssetURLsDescriptive string `json:"pay_over_time_asset_urls_descriptive"`
-	PayOverTimeAssetURLsStandard    string `json:"pay_over_time_asset_urls_standard"`
-	PayOverTimeName                 string `json:"pay_over_time_name"`
-	PayOverTimeRedirectURL          string `json:"pay_over_time_redirect_url"`
-	PaymentMethodCategories         string `json:"payment_method_categories"`
-	PurchaseCountry                 string `json:"purchase_country"`
-	PurchaseType                    string `json:"purchase_type"`
-	RedirectURL                     string `json:"redirect_url"`
-	ShippingFirstName               string `json:"shipping_first_name"`
-	ShippingLastName                string `json:"shipping_last_name"`
 }
 
 // ChargePaymentMethodDetailsMultibanco represents details about the Multibanco PaymentMethod.

--- a/charge.go
+++ b/charge.go
@@ -38,6 +38,7 @@ const (
 	ChargePaymentMethodDetailsTypeEps               ChargePaymentMethodDetailsType = "eps"
 	ChargePaymentMethodDetailsTypeGiropay           ChargePaymentMethodDetailsType = "giropay"
 	ChargePaymentMethodDetailsTypeIdeal             ChargePaymentMethodDetailsType = "ideal"
+	ChargePaymentMethodDetailsTypeKlarna            ChargePaymentMethodDetailsType = "klarna"
 	ChargePaymentMethodDetailsTypeMultibanco        ChargePaymentMethodDetailsType = "multibanco"
 	ChargePaymentMethodDetailsTypeP24               ChargePaymentMethodDetailsType = "p24"
 	ChargePaymentMethodDetailsTypeSepaDebit         ChargePaymentMethodDetailsType = "sepa_debit"
@@ -355,6 +356,36 @@ type ChargePaymentMethodDetailsIdeal struct {
 	VerifiedName string `json:"verified_name"`
 }
 
+// ChargePaymentMethodDetailsKlarna represents details for the Klarna
+// PaymentMethod.
+type ChargePaymentMethodDetailsKlarna struct {
+	BackgroundImageURL              string `json:"background_image_url"`
+	ClientToken                     string `json:"client_token"`
+	FirstName                       string `json:"first_name"`
+	LastName                        string `json:"last_name"`
+	Locale                          string `json:"locale"`
+	LogoURL                         string `json:"logo_url"`
+	PageTitle                       string `json:"page_title"`
+	PayLaterAssetURLsDescriptive    string `json:"pay_later_asset_urls_descriptive"`
+	PayLaterAssetURLsStandard       string `json:"pay_later_asset_urls_standard"`
+	PayLaterName                    string `json:"pay_later_name"`
+	PayLaterRedirectURL             string `json:"pay_later_redirect_url"`
+	PayNowAssetURLsDescriptive      string `json:"pay_now_asset_urls_descriptive"`
+	PayNowAssetURLsStandard         string `json:"pay_now_asset_urls_standard"`
+	PayNowName                      string `json:"pay_now_name"`
+	PayNowRedirectURL               string `json:"pay_now_redirect_url"`
+	PayOverTimeAssetURLsDescriptive string `json:"pay_over_time_asset_urls_descriptive"`
+	PayOverTimeAssetURLsStandard    string `json:"pay_over_time_asset_urls_standard"`
+	PayOverTimeName                 string `json:"pay_over_time_name"`
+	PayOverTimeRedirectURL          string `json:"pay_over_time_redirect_url"`
+	PaymentMethodCategories         string `json:"payment_method_categories"`
+	PurchaseCountry                 string `json:"purchase_country"`
+	PurchaseType                    string `json:"purchase_type"`
+	RedirectURL                     string `json:"redirect_url"`
+	ShippingFirstName               string `json:"shipping_first_name"`
+	ShippingLastName                string `json:"shipping_last_name"`
+}
+
 // ChargePaymentMethodDetailsMultibanco represents details about the Multibanco PaymentMethod.
 type ChargePaymentMethodDetailsMultibanco struct {
 	Entity    string `json:"entity"`
@@ -407,6 +438,7 @@ type ChargePaymentMethodDetails struct {
 	Eps               *ChargePaymentMethodDetailsEps               `json:"eps"`
 	Giropay           *ChargePaymentMethodDetailsGiropay           `json:"giropay"`
 	Ideal             *ChargePaymentMethodDetailsIdeal             `json:"ideal"`
+	Klarna            *ChargePaymentMethodDetailsKlarna            `json:"klarna"`
 	Multibanco        *ChargePaymentMethodDetailsMultibanco        `json:"multibanco"`
 	P24               *ChargePaymentMethodDetailsP24               `json:"p24"`
 	SepaDebit         *ChargePaymentMethodDetailsSepaDebit         `json:"sepa_debit"`

--- a/source.go
+++ b/source.go
@@ -46,6 +46,17 @@ const (
 	SourceMandateNotificationMethodNone   SourceMandateNotificationMethod = "none"
 )
 
+// SourceSourceOrderItemType describes the type of source order items on source
+// orders for sources.
+type SourceSourceOrderItemType string
+
+// The list of possible values for source order item types.
+const (
+	SourceSourceOrderItemTypeSKU      SourceSourceOrderItemType = "sku"
+	SourceSourceOrderItemTypeShipping SourceSourceOrderItemType = "shipping"
+	SourceSourceOrderItemTypeTax      SourceSourceOrderItemType = "tax"
+)
+
 // SourceRedirectFlowFailureReason represents the possible failure reasons of a redirect flow.
 type SourceRedirectFlowFailureReason string
 
@@ -122,6 +133,45 @@ type RedirectParams struct {
 	ReturnURL *string `form:"return_url"`
 }
 
+// SourceOrderShippingAddressParams is the set of parameters allowed for the
+// shipping address for source order shipping details.
+type SourceOrderShippingAddressParams struct {
+	City       *string `form:"city"`
+	Country    *string `form:"country"`
+	Line1      *string `form:"line1"`
+	Line2      *string `form:"line2"`
+	PostalCode *string `form:"postal_code"`
+	State      *string `form:"state"`
+}
+
+// SourceOrderShippingParams is the set of parameters allowed for the shipping
+// details on source order items.
+type SourceOrderShippingParams struct {
+	Address        *SourceOrderShippingAddressParams `form:"address"`
+	Carrier        *string                           `form:"carrier"`
+	Name           *string                           `form:"name"`
+	Phone          *string                           `form:"carrier"`
+	TrackingNumber *string                           `form:"carrier"`
+}
+
+// SourceOrderItemsParams is the set of parameters allowed for the items on a
+// source order for a source.
+type SourceOrderItemsParams struct {
+	Amount      *int64  `form:"amount"`
+	Currency    *string `form:"currency"`
+	Description *string `form:"description"`
+	Parent      *string `form:"parent"`
+	Quantity    *int64  `form:"quantity"`
+	Type        *string `form:"type"`
+}
+
+// SourceOrderParams is the set of parameters allowed for the source order of a
+// source.
+type SourceOrderParams struct {
+	Items    []*SourceOrderItemsParams  `form:"items"`
+	Shipping *SourceOrderShippingParams `form:"shipping"`
+}
+
 // SourceObjectParams is the set of parameters allowed on source creation or update.
 type SourceObjectParams struct {
 	Params              `form:"*"`
@@ -134,6 +184,7 @@ type SourceObjectParams struct {
 	Owner               *SourceOwnerParams    `form:"owner"`
 	Receiver            *SourceReceiverParams `form:"receiver"`
 	Redirect            *RedirectParams       `form:"redirect"`
+	SourceOrder         *SourceOrderParams    `form:"source_order"`
 	StatementDescriptor *string               `form:"statement_descriptor"`
 	Token               *string               `form:"token"`
 	Type                *string               `form:"type"`
@@ -222,6 +273,45 @@ type SourceMandate struct {
 	URL                string                          `json:"url"`
 }
 
+// SourceSourceOrderShippingAddress describes the Address for source orders on
+// sources.
+type SourceSourceOrderShippingAddress struct {
+	City       string `json:"city"`
+	Country    string `json:"country"`
+	Line1      string `json:"line1"`
+	Line2      string `json:"line2"`
+	PostalCode string `json:"postal_code"`
+	State      string `json:"state"`
+}
+
+// SourceSourceOrderItems describes the items on source orders for sources.
+type SourceSourceOrderItems struct {
+	Amount      int64                     `json:"amount"`
+	Currency    Currency                  `json:"currency"`
+	Description string                    `json:"description"`
+	Quantity    int64                     `json:"quantity"`
+	Type        SourceSourceOrderItemType `json:"type"`
+}
+
+// SourceSourceOrderShipping describes the shipping options for source orders on
+// sources.
+type SourceSourceOrderShipping struct {
+	Address        SourceSourceOrderShippingAddress `json:"address"`
+	Carrier        string                           `json:"carrier"`
+	Name           string                           `json:"name"`
+	Phone          string                           `json:"phone"`
+	TrackingNumber string                           `json:"tracking_number"`
+}
+
+// SourceSourceOrder describes a source order for a source.
+type SourceSourceOrder struct {
+	Amount   int64                     `json:"amount"`
+	Currency Currency                  `json:"currency"`
+	Email    string                    `json:"email"`
+	Items    SourceSourceOrderItems    `json:"items"`
+	Shipping SourceSourceOrderShipping `json:"shipping"`
+}
+
 // Source is the resource representing a Source.
 // For more details see https://stripe.com/docs/api#sources.
 type Source struct {
@@ -240,6 +330,7 @@ type Source struct {
 	Receiver            *ReceiverFlow         `json:"receiver,omitempty"`
 	Redirect            *RedirectFlow         `json:"redirect,omitempty"`
 	StatementDescriptor string                `json:"statement_descriptor"`
+	SourceOrder         *SourceSourceOrder    `json:"source_order"`
 	Status              SourceStatus          `json:"status"`
 	Type                string                `json:"type"`
 	TypeData            map[string]interface{}

--- a/source.go
+++ b/source.go
@@ -264,11 +264,11 @@ type SourceSourceOrderItems struct {
 
 // SourceSourceOrder describes a source order for a source.
 type SourceSourceOrder struct {
-	Amount   int64                  `json:"amount"`
-	Currency Currency               `json:"currency"`
-	Email    string                 `json:"email"`
-	Items    SourceSourceOrderItems `json:"items"`
-	Shipping ShippingDetails        `json:"shipping"`
+	Amount   int64                   `json:"amount"`
+	Currency Currency                `json:"currency"`
+	Email    string                  `json:"email"`
+	Items    *SourceSourceOrderItems `json:"items"`
+	Shipping *ShippingDetails        `json:"shipping"`
 }
 
 // Source is the resource representing a Source.

--- a/source.go
+++ b/source.go
@@ -52,6 +52,7 @@ type SourceSourceOrderItemType string
 
 // The list of possible values for source order item types.
 const (
+	SourceSourceOrderItemTypeDiscount SourceSourceOrderItemType = "discount"
 	SourceSourceOrderItemTypeSKU      SourceSourceOrderItemType = "sku"
 	SourceSourceOrderItemTypeShipping SourceSourceOrderItemType = "shipping"
 	SourceSourceOrderItemTypeTax      SourceSourceOrderItemType = "tax"
@@ -133,27 +134,6 @@ type RedirectParams struct {
 	ReturnURL *string `form:"return_url"`
 }
 
-// SourceOrderShippingAddressParams is the set of parameters allowed for the
-// shipping address for source order shipping details.
-type SourceOrderShippingAddressParams struct {
-	City       *string `form:"city"`
-	Country    *string `form:"country"`
-	Line1      *string `form:"line1"`
-	Line2      *string `form:"line2"`
-	PostalCode *string `form:"postal_code"`
-	State      *string `form:"state"`
-}
-
-// SourceOrderShippingParams is the set of parameters allowed for the shipping
-// details on source order items.
-type SourceOrderShippingParams struct {
-	Address        *SourceOrderShippingAddressParams `form:"address"`
-	Carrier        *string                           `form:"carrier"`
-	Name           *string                           `form:"name"`
-	Phone          *string                           `form:"carrier"`
-	TrackingNumber *string                           `form:"carrier"`
-}
-
 // SourceOrderItemsParams is the set of parameters allowed for the items on a
 // source order for a source.
 type SourceOrderItemsParams struct {
@@ -168,8 +148,8 @@ type SourceOrderItemsParams struct {
 // SourceOrderParams is the set of parameters allowed for the source order of a
 // source.
 type SourceOrderParams struct {
-	Items    []*SourceOrderItemsParams  `form:"items"`
-	Shipping *SourceOrderShippingParams `form:"shipping"`
+	Items    []*SourceOrderItemsParams `form:"items"`
+	Shipping *ShippingDetailsParams    `form:"shipping"`
 }
 
 // SourceObjectParams is the set of parameters allowed on source creation or update.
@@ -273,17 +253,6 @@ type SourceMandate struct {
 	URL                string                          `json:"url"`
 }
 
-// SourceSourceOrderShippingAddress describes the Address for source orders on
-// sources.
-type SourceSourceOrderShippingAddress struct {
-	City       string `json:"city"`
-	Country    string `json:"country"`
-	Line1      string `json:"line1"`
-	Line2      string `json:"line2"`
-	PostalCode string `json:"postal_code"`
-	State      string `json:"state"`
-}
-
 // SourceSourceOrderItems describes the items on source orders for sources.
 type SourceSourceOrderItems struct {
 	Amount      int64                     `json:"amount"`
@@ -293,23 +262,13 @@ type SourceSourceOrderItems struct {
 	Type        SourceSourceOrderItemType `json:"type"`
 }
 
-// SourceSourceOrderShipping describes the shipping options for source orders on
-// sources.
-type SourceSourceOrderShipping struct {
-	Address        SourceSourceOrderShippingAddress `json:"address"`
-	Carrier        string                           `json:"carrier"`
-	Name           string                           `json:"name"`
-	Phone          string                           `json:"phone"`
-	TrackingNumber string                           `json:"tracking_number"`
-}
-
 // SourceSourceOrder describes a source order for a source.
 type SourceSourceOrder struct {
-	Amount   int64                     `json:"amount"`
-	Currency Currency                  `json:"currency"`
-	Email    string                    `json:"email"`
-	Items    SourceSourceOrderItems    `json:"items"`
-	Shipping SourceSourceOrderShipping `json:"shipping"`
+	Amount   int64                  `json:"amount"`
+	Currency Currency               `json:"currency"`
+	Email    string                 `json:"email"`
+	Items    SourceSourceOrderItems `json:"items"`
+	Shipping ShippingDetails        `json:"shipping"`
 }
 
 // Source is the resource representing a Source.


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Putting up for naming review, this was kinda a gnarly one for naming.

I saw another reference of `...ItemsParams` so I used `SourceOrderItemsParams` not sure if that's better as `SourceOrderItemParams` (single item param, technically.)

Also, for the deserialized json object having SourceSourceOrder... everywhere seems a little odd :)