### PR TITLE
Fix typo in property name for PaymentMethodOptions

### DIFF
--- a/paymentintent.go
+++ b/paymentintent.go
@@ -112,16 +112,19 @@ type PaymentIntentConfirmParams struct {
 	Params `form:"*"`
 	// This parameter expects a boolean but used to take an enum so we're adding support for both
 	// until the next major version (TODO).
-	OffSession          interface{}                              `form:"off_session"`
-	PaymentMethod       *string                                  `form:"payment_method"`
+	OffSession           interface{}                              `form:"off_session"`
+	PaymentMethod        *string                                  `form:"payment_method"`
+	PaymentMethodOptions *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
+	PaymentMethodTypes   []*string                                `form:"payment_method_types"`
+	ReceiptEmail         *string                                  `form:"receipt_email"`
+	ReturnURL            *string                                  `form:"return_url"`
+	SavePaymentMethod    *bool                                    `form:"save_payment_method"`
+	SetupFutureUsage     *string                                  `form:"setup_future_usage"`
+	Shipping             *ShippingDetailsParams                   `form:"shipping"`
+	Source               *string                                  `form:"source"`
+
+	// TODO: remove the following parameter in the next major version
 	PayentMethodOptions *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
-	PaymentMethodTypes  []*string                                `form:"payment_method_types"`
-	ReceiptEmail        *string                                  `form:"receipt_email"`
-	ReturnURL           *string                                  `form:"return_url"`
-	SavePaymentMethod   *bool                                    `form:"save_payment_method"`
-	SetupFutureUsage    *string                                  `form:"setup_future_usage"`
-	Shipping            *ShippingDetailsParams                   `form:"shipping"`
-	Source              *string                                  `form:"source"`
 }
 
 // PaymentIntentPaymentMethodOptionsCardParams represents the card-specific options applied to a
@@ -155,7 +158,7 @@ type PaymentIntentParams struct {
 	Description          *string                                  `form:"description"`
 	OnBehalfOf           *string                                  `form:"on_behalf_of"`
 	PaymentMethod        *string                                  `form:"payment_method"`
-	PayentMethodOptions  *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
+	PaymentMethodOptions *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
 	PaymentMethodTypes   []*string                                `form:"payment_method_types"`
 	ReceiptEmail         *string                                  `form:"receipt_email"`
 	ReturnURL            *string                                  `form:"return_url"`
@@ -170,6 +173,9 @@ type PaymentIntentParams struct {
 	// This parameter only works if you confirm on creation. It also expects a boolean but used to
 	// take an enum so we're adding support for both until the next major version (TODO).
 	OffSession interface{} `form:"off_session"`
+
+	// TODO: remove the following parameter in the next major version
+	PayentMethodOptions *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
 }
 
 // PaymentIntentListParams is the set of parameters that can be used when listing payment intents.

--- a/setupintent.go
+++ b/setupintent.go
@@ -66,10 +66,13 @@ type SetupIntentCancelParams struct {
 
 // SetupIntentConfirmParams is the set of parameters that can be used when confirming a setup intent.
 type SetupIntentConfirmParams struct {
-	Params              `form:"*"`
-	PaymentMethod       *string                                `form:"payment_method"`
+	Params               `form:"*"`
+	PaymentMethod        *string                                `form:"payment_method"`
+	PaymentMethodOptions *SetupIntentPaymentMethodOptionsParams `form:"payment_method_options"`
+	ReturnURL            *string                                `form:"return_url"`
+
+	// TODO: remove the following parameter in the next major version
 	PayentMethodOptions *SetupIntentPaymentMethodOptionsParams `form:"payment_method_options"`
-	ReturnURL           *string                                `form:"return_url"`
 }
 
 // SetupIntentPaymentMethodOptionsCardParams represents the card-specific options applied to a
@@ -86,16 +89,19 @@ type SetupIntentPaymentMethodOptionsParams struct {
 
 // SetupIntentParams is the set of parameters that can be used when handling a setup intent.
 type SetupIntentParams struct {
-	Params              `form:"*"`
-	Confirm             *bool                                  `form:"confirm"`
-	Customer            *string                                `form:"customer"`
-	Description         *string                                `form:"description"`
-	OnBehalfOf          *string                                `form:"on_behalf_of"`
-	PaymentMethod       *string                                `form:"payment_method"`
+	Params               `form:"*"`
+	Confirm              *bool                                  `form:"confirm"`
+	Customer             *string                                `form:"customer"`
+	Description          *string                                `form:"description"`
+	OnBehalfOf           *string                                `form:"on_behalf_of"`
+	PaymentMethod        *string                                `form:"payment_method"`
+	PaymentMethodOptions *SetupIntentPaymentMethodOptionsParams `form:"payment_method_options"`
+	PaymentMethodTypes   []*string                              `form:"payment_method_types"`
+	ReturnURL            *string                                `form:"return_url"`
+	Usage                *string                                `form:"usage"`
+
+	// TODO: remove the following parameter in the next major version
 	PayentMethodOptions *SetupIntentPaymentMethodOptionsParams `form:"payment_method_options"`
-	PaymentMethodTypes  []*string                              `form:"payment_method_types"`
-	ReturnURL           *string                                `form:"return_url"`
-	Usage               *string                                `form:"usage"`
 }
 
 // SetupIntentListParams is the set of parameters that can be used when listing setup intents.


### PR DESCRIPTION
Fix the issue that @yep found in https://github.com/stripe/stripe-go/pull/908 but across both resources and in a non-breaking way.

r? @brandur-stripe 
cc @stripe/api-libraries 