### PR TITLE
Add various changes to the API

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -76,24 +76,25 @@ type ChargeTransferDataParams struct {
 
 // ChargeParams is the set of parameters that can be used when creating or updating a charge.
 type ChargeParams struct {
-	Params               `form:"*"`
-	Amount               *int64                    `form:"amount"`
-	ApplicationFeeAmount *int64                    `form:"application_fee_amount"`
-	Capture              *bool                     `form:"capture"`
-	Currency             *string                   `form:"currency"`
-	Customer             *string                   `form:"customer"`
-	Description          *string                   `form:"description"`
-	Destination          *DestinationParams        `form:"destination"`
-	ExchangeRate         *float64                  `form:"exchange_rate"`
-	FraudDetails         *FraudDetailsParams       `form:"fraud_details"`
-	Level3               *ChargeLevel3Params       `form:"level3"`
-	OnBehalfOf           *string                   `form:"on_behalf_of"`
-	ReceiptEmail         *string                   `form:"receipt_email"`
-	Shipping             *ShippingDetailsParams    `form:"shipping"`
-	Source               *SourceParams             `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	StatementDescriptor  *string                   `form:"statement_descriptor"`
-	TransferData         *ChargeTransferDataParams `form:"transfer_data"`
-	TransferGroup        *string                   `form:"transfer_group"`
+	Params                    `form:"*"`
+	Amount                    *int64                    `form:"amount"`
+	ApplicationFeeAmount      *int64                    `form:"application_fee_amount"`
+	Capture                   *bool                     `form:"capture"`
+	Currency                  *string                   `form:"currency"`
+	Customer                  *string                   `form:"customer"`
+	Description               *string                   `form:"description"`
+	Destination               *DestinationParams        `form:"destination"`
+	ExchangeRate              *float64                  `form:"exchange_rate"`
+	FraudDetails              *FraudDetailsParams       `form:"fraud_details"`
+	Level3                    *ChargeLevel3Params       `form:"level3"`
+	OnBehalfOf                *string                   `form:"on_behalf_of"`
+	ReceiptEmail              *string                   `form:"receipt_email"`
+	Shipping                  *ShippingDetailsParams    `form:"shipping"`
+	Source                    *SourceParams             `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	StatementDescriptor       *string                   `form:"statement_descriptor"`
+	StatementDescriptorSuffix *string                   `form:"statement_descriptor_suffix"`
+	TransferData              *ChargeTransferDataParams `form:"transfer_data"`
+	TransferGroup             *string                   `form:"transfer_group"`
 
 	// This property is considered deprecated. Prefer using ApplicationFeeAmount
 	ApplicationFee *int64 `form:"application_fee"`
@@ -139,14 +140,15 @@ type ChargeListParams struct {
 
 // CaptureParams is the set of parameters that can be used when capturing a charge.
 type CaptureParams struct {
-	Params               `form:"*"`
-	Amount               *int64                    `form:"amount"`
-	ApplicationFeeAmount *int64                    `form:"application_fee_amount"`
-	ExchangeRate         *float64                  `form:"exchange_rate"`
-	ReceiptEmail         *string                   `form:"receipt_email"`
-	StatementDescriptor  *string                   `form:"statement_descriptor"`
-	TransferGroup        *string                   `form:"transfer_group"`
-	TransferData         *ChargeTransferDataParams `form:"transfer_data"`
+	Params                    `form:"*"`
+	Amount                    *int64                    `form:"amount"`
+	ApplicationFeeAmount      *int64                    `form:"application_fee_amount"`
+	ExchangeRate              *float64                  `form:"exchange_rate"`
+	ReceiptEmail              *string                   `form:"receipt_email"`
+	StatementDescriptor       *string                   `form:"statement_descriptor"`
+	StatementDescriptorSuffix *string                   `form:"statement_descriptor_suffix"`
+	TransferGroup             *string                   `form:"transfer_group"`
+	TransferData              *ChargeTransferDataParams `form:"transfer_data"`
 
 	// This property is considered deprecated. Prefer using ApplicationFeeAmount
 	ApplicationFee *int64 `form:"application_fee"`
@@ -298,6 +300,7 @@ type ChargePaymentMethodDetailsCard struct {
 	Fingerprint  string                                      `json:"fingerprint"`
 	Funding      CardFunding                                 `json:"funding"`
 	Last4        string                                      `json:"last4"`
+	MOTO         bool                                        `json:"moto"`
 	ThreeDSecure *ChargePaymentMethodDetailsCardThreeDSecure `json:"three_d_secure"`
 	Wallet       *ChargePaymentMethodDetailsCardWallet       `json:"wallet"`
 
@@ -433,49 +436,50 @@ type ChargeTransferData struct {
 // Charge is the resource representing a Stripe charge.
 // For more details see https://stripe.com/docs/api#charges.
 type Charge struct {
-	Amount               int64                       `json:"amount"`
-	AmountRefunded       int64                       `json:"amount_refunded"`
-	Application          *Application                `json:"application"`
-	ApplicationFee       *ApplicationFee             `json:"application_fee"`
-	ApplicationFeeAmount int64                       `json:"application_fee_amount"`
-	AuthorizationCode    string                      `json:"authorization_code"`
-	BalanceTransaction   *BalanceTransaction         `json:"balance_transaction"`
-	BillingDetails       *BillingDetails             `json:"billing_details"`
-	Captured             bool                        `json:"captured"`
-	Created              int64                       `json:"created"`
-	Currency             Currency                    `json:"currency"`
-	Customer             *Customer                   `json:"customer"`
-	Description          string                      `json:"description"`
-	Destination          *Account                    `json:"destination"`
-	Dispute              *Dispute                    `json:"dispute"`
-	FailureCode          string                      `json:"failure_code"`
-	FailureMessage       string                      `json:"failure_message"`
-	FraudDetails         *FraudDetails               `json:"fraud_details"`
-	ID                   string                      `json:"id"`
-	Invoice              *Invoice                    `json:"invoice"`
-	Level3               ChargeLevel3                `json:"level3"`
-	Livemode             bool                        `json:"livemode"`
-	Metadata             map[string]string           `json:"metadata"`
-	OnBehalfOf           *Account                    `json:"on_behalf_of"`
-	Outcome              *ChargeOutcome              `json:"outcome"`
-	Paid                 bool                        `json:"paid"`
-	PaymentIntent        string                      `json:"payment_intent"`
-	PaymentMethod        string                      `json:"payment_method"`
-	PaymentMethodDetails *ChargePaymentMethodDetails `json:"payment_method_details"`
-	ReceiptEmail         string                      `json:"receipt_email"`
-	ReceiptNumber        string                      `json:"receipt_number"`
-	ReceiptURL           string                      `json:"receipt_url"`
-	Refunded             bool                        `json:"refunded"`
-	Refunds              *RefundList                 `json:"refunds"`
-	Review               *Review                     `json:"review"`
-	Shipping             *ShippingDetails            `json:"shipping"`
-	Source               *PaymentSource              `json:"source"`
-	SourceTransfer       *Transfer                   `json:"source_transfer"`
-	StatementDescriptor  string                      `json:"statement_descriptor"`
-	Status               string                      `json:"status"`
-	Transfer             *Transfer                   `json:"transfer"`
-	TransferData         *ChargeTransferData         `json:"transfer_data"`
-	TransferGroup        string                      `json:"transfer_group"`
+	Amount                    int64                       `json:"amount"`
+	AmountRefunded            int64                       `json:"amount_refunded"`
+	Application               *Application                `json:"application"`
+	ApplicationFee            *ApplicationFee             `json:"application_fee"`
+	ApplicationFeeAmount      int64                       `json:"application_fee_amount"`
+	AuthorizationCode         string                      `json:"authorization_code"`
+	BalanceTransaction        *BalanceTransaction         `json:"balance_transaction"`
+	BillingDetails            *BillingDetails             `json:"billing_details"`
+	Captured                  bool                        `json:"captured"`
+	Created                   int64                       `json:"created"`
+	Currency                  Currency                    `json:"currency"`
+	Customer                  *Customer                   `json:"customer"`
+	Description               string                      `json:"description"`
+	Destination               *Account                    `json:"destination"`
+	Dispute                   *Dispute                    `json:"dispute"`
+	FailureCode               string                      `json:"failure_code"`
+	FailureMessage            string                      `json:"failure_message"`
+	FraudDetails              *FraudDetails               `json:"fraud_details"`
+	ID                        string                      `json:"id"`
+	Invoice                   *Invoice                    `json:"invoice"`
+	Level3                    ChargeLevel3                `json:"level3"`
+	Livemode                  bool                        `json:"livemode"`
+	Metadata                  map[string]string           `json:"metadata"`
+	OnBehalfOf                *Account                    `json:"on_behalf_of"`
+	Outcome                   *ChargeOutcome              `json:"outcome"`
+	Paid                      bool                        `json:"paid"`
+	PaymentIntent             string                      `json:"payment_intent"`
+	PaymentMethod             string                      `json:"payment_method"`
+	PaymentMethodDetails      *ChargePaymentMethodDetails `json:"payment_method_details"`
+	ReceiptEmail              string                      `json:"receipt_email"`
+	ReceiptNumber             string                      `json:"receipt_number"`
+	ReceiptURL                string                      `json:"receipt_url"`
+	Refunded                  bool                        `json:"refunded"`
+	Refunds                   *RefundList                 `json:"refunds"`
+	Review                    *Review                     `json:"review"`
+	Shipping                  *ShippingDetails            `json:"shipping"`
+	Source                    *PaymentSource              `json:"source"`
+	SourceTransfer            *Transfer                   `json:"source_transfer"`
+	StatementDescriptor       string                      `json:"statement_descriptor"`
+	StatementDescriptorSuffix string                      `json:"statement_descriptor_suffix"`
+	Status                    string                      `json:"status"`
+	Transfer                  *Transfer                   `json:"transfer"`
+	TransferData              *ChargeTransferData         `json:"transfer_data"`
+	TransferGroup             string                      `json:"transfer_group"`
 }
 
 // UnmarshalJSON handles deserialization of a charge.

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -68,10 +68,11 @@ type CheckoutSessionSubscriptionDataItemsParams struct {
 // CheckoutSessionSubscriptionDataParams is the set of parameters allowed for the subscription
 // creation on a checkout session.
 type CheckoutSessionSubscriptionDataParams struct {
-	Params          `form:"*"`
-	Items           []*CheckoutSessionSubscriptionDataItemsParams `form:"items"`
-	TrialEnd        *int64                                        `form:"trial_end"`
-	TrialPeriodDays *int64                                        `form:"trial_period_days"`
+	Params                `form:"*"`
+	ApplicationFeePercent *float64                                      `form:"application_fee_percent"`
+	Items                 []*CheckoutSessionSubscriptionDataItemsParams `form:"items"`
+	TrialEnd              *int64                                        `form:"trial_end"`
+	TrialPeriodDays       *int64                                        `form:"trial_period_days"`
 }
 
 // CheckoutSessionParams is the set of parameters that can be used when creating

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -100,11 +100,12 @@ type PaymentIntentCancelParams struct {
 
 // PaymentIntentCaptureParams is the set of parameters that can be used when capturing a payment intent.
 type PaymentIntentCaptureParams struct {
-	Params               `form:"*"`
-	AmountToCapture      *int64                           `form:"amount_to_capture"`
-	ApplicationFeeAmount *int64                           `form:"application_fee_amount"`
-	StatementDescriptor  *string                          `form:"statement_descriptor"`
-	TransferData         *PaymentIntentTransferDataParams `form:"transfer_data"`
+	Params                    `form:"*"`
+	AmountToCapture           *int64                           `form:"amount_to_capture"`
+	ApplicationFeeAmount      *int64                           `form:"application_fee_amount"`
+	StatementDescriptor       *string                          `form:"statement_descriptor"`
+	StatementDescriptorSuffix *string                          `form:"statement_descriptor_suffix"`
+	TransferData              *PaymentIntentTransferDataParams `form:"transfer_data"`
 }
 
 // PaymentIntentConfirmParams is the set of parameters that can be used when confirming a payment intent.
@@ -130,6 +131,7 @@ type PaymentIntentConfirmParams struct {
 // PaymentIntentPaymentMethodOptionsCardParams represents the card-specific options applied to a
 // PaymentIntent.
 type PaymentIntentPaymentMethodOptionsCardParams struct {
+	MOTO                *bool   `form:"moto"`
 	RequestThreeDSecure *string `form:"request_three_d_secure"`
 }
 
@@ -147,28 +149,29 @@ type PaymentIntentTransferDataParams struct {
 
 // PaymentIntentParams is the set of parameters that can be used when handling a payment intent.
 type PaymentIntentParams struct {
-	Params               `form:"*"`
-	Amount               *int64                                   `form:"amount"`
-	ApplicationFeeAmount *int64                                   `form:"application_fee_amount"`
-	CaptureMethod        *string                                  `form:"capture_method"`
-	Confirm              *bool                                    `form:"confirm"`
-	ConfirmationMethod   *string                                  `form:"confirmation_method"`
-	Currency             *string                                  `form:"currency"`
-	Customer             *string                                  `form:"customer"`
-	Description          *string                                  `form:"description"`
-	OnBehalfOf           *string                                  `form:"on_behalf_of"`
-	PaymentMethod        *string                                  `form:"payment_method"`
-	PaymentMethodOptions *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
-	PaymentMethodTypes   []*string                                `form:"payment_method_types"`
-	ReceiptEmail         *string                                  `form:"receipt_email"`
-	ReturnURL            *string                                  `form:"return_url"`
-	SavePaymentMethod    *bool                                    `form:"save_payment_method"`
-	SetupFutureUsage     *string                                  `form:"setup_future_usage"`
-	Shipping             *ShippingDetailsParams                   `form:"shipping"`
-	Source               *string                                  `form:"source"`
-	StatementDescriptor  *string                                  `form:"statement_descriptor"`
-	TransferData         *PaymentIntentTransferDataParams         `form:"transfer_data"`
-	TransferGroup        *string                                  `form:"transfer_group"`
+	Params                    `form:"*"`
+	Amount                    *int64                                   `form:"amount"`
+	ApplicationFeeAmount      *int64                                   `form:"application_fee_amount"`
+	CaptureMethod             *string                                  `form:"capture_method"`
+	Confirm                   *bool                                    `form:"confirm"`
+	ConfirmationMethod        *string                                  `form:"confirmation_method"`
+	Currency                  *string                                  `form:"currency"`
+	Customer                  *string                                  `form:"customer"`
+	Description               *string                                  `form:"description"`
+	OnBehalfOf                *string                                  `form:"on_behalf_of"`
+	PaymentMethod             *string                                  `form:"payment_method"`
+	PaymentMethodOptions      *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
+	PaymentMethodTypes        []*string                                `form:"payment_method_types"`
+	ReceiptEmail              *string                                  `form:"receipt_email"`
+	ReturnURL                 *string                                  `form:"return_url"`
+	SavePaymentMethod         *bool                                    `form:"save_payment_method"`
+	SetupFutureUsage          *string                                  `form:"setup_future_usage"`
+	Shipping                  *ShippingDetailsParams                   `form:"shipping"`
+	Source                    *string                                  `form:"source"`
+	StatementDescriptor       *string                                  `form:"statement_descriptor"`
+	StatementDescriptorSuffix *string                                  `form:"statement_descriptor_suffix"`
+	TransferData              *PaymentIntentTransferDataParams         `form:"transfer_data"`
+	TransferGroup             *string                                  `form:"transfer_group"`
 
 	// This parameter only works if you confirm on creation. It also expects a boolean but used to
 	// take an enum so we're adding support for both until the next major version (TODO).
@@ -223,39 +226,40 @@ type PaymentIntentTransferData struct {
 // PaymentIntent is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payment_intents.
 type PaymentIntent struct {
-	Amount              int64                           `json:"amount"`
-	AmountCapturable    int64                           `json:"amount_capturable"`
-	AmountReceived      int64                           `json:"amount_received"`
-	Application         *Application                    `json:"application"`
-	ApplicationFee      int64                           `json:"application_fee"`
-	CanceledAt          int64                           `json:"canceled_at"`
-	CancellationReason  PaymentIntentCancellationReason `json:"cancellation_reason"`
-	CaptureMethod       PaymentIntentCaptureMethod      `json:"capture_method"`
-	Charges             *ChargeList                     `json:"charges"`
-	ClientSecret        string                          `json:"client_secret"`
-	ConfirmationMethod  PaymentIntentConfirmationMethod `json:"confirmation_method"`
-	Created             int64                           `json:"created"`
-	Currency            string                          `json:"currency"`
-	Customer            *Customer                       `json:"customer"`
-	Description         string                          `json:"description"`
-	Invoice             *Invoice                        `json:"invoice"`
-	LastPaymentError    *PaymentIntentLastPaymentError  `json:"last_payment_error"`
-	Livemode            bool                            `json:"livemode"`
-	ID                  string                          `json:"id"`
-	Metadata            map[string]string               `json:"metadata"`
-	NextAction          *PaymentIntentNextAction        `json:"next_action"`
-	OnBehalfOf          *Account                        `json:"on_behalf_of"`
-	PaymentMethod       *PaymentMethod                  `json:"payment_method"`
-	PaymentMethodTypes  []string                        `json:"payment_method_types"`
-	ReceiptEmail        string                          `json:"receipt_email"`
-	Review              *Review                         `json:"review"`
-	SetupFutureUsage    PaymentIntentSetupFutureUsage   `json:"setup_future_usage"`
-	Shipping            ShippingDetails                 `json:"shipping"`
-	Source              *PaymentSource                  `json:"source"`
-	StatementDescriptor string                          `json:"statement_descriptor"`
-	Status              PaymentIntentStatus             `json:"status"`
-	TransferData        *PaymentIntentTransferData      `json:"transfer_data"`
-	TransferGroup       string                          `json:"transfer_group"`
+	Amount                    int64                           `json:"amount"`
+	AmountCapturable          int64                           `json:"amount_capturable"`
+	AmountReceived            int64                           `json:"amount_received"`
+	Application               *Application                    `json:"application"`
+	ApplicationFee            int64                           `json:"application_fee"`
+	CanceledAt                int64                           `json:"canceled_at"`
+	CancellationReason        PaymentIntentCancellationReason `json:"cancellation_reason"`
+	CaptureMethod             PaymentIntentCaptureMethod      `json:"capture_method"`
+	Charges                   *ChargeList                     `json:"charges"`
+	ClientSecret              string                          `json:"client_secret"`
+	ConfirmationMethod        PaymentIntentConfirmationMethod `json:"confirmation_method"`
+	Created                   int64                           `json:"created"`
+	Currency                  string                          `json:"currency"`
+	Customer                  *Customer                       `json:"customer"`
+	Description               string                          `json:"description"`
+	Invoice                   *Invoice                        `json:"invoice"`
+	LastPaymentError          *PaymentIntentLastPaymentError  `json:"last_payment_error"`
+	Livemode                  bool                            `json:"livemode"`
+	ID                        string                          `json:"id"`
+	Metadata                  map[string]string               `json:"metadata"`
+	NextAction                *PaymentIntentNextAction        `json:"next_action"`
+	OnBehalfOf                *Account                        `json:"on_behalf_of"`
+	PaymentMethod             *PaymentMethod                  `json:"payment_method"`
+	PaymentMethodTypes        []string                        `json:"payment_method_types"`
+	ReceiptEmail              string                          `json:"receipt_email"`
+	Review                    *Review                         `json:"review"`
+	SetupFutureUsage          PaymentIntentSetupFutureUsage   `json:"setup_future_usage"`
+	Shipping                  ShippingDetails                 `json:"shipping"`
+	Source                    *PaymentSource                  `json:"source"`
+	StatementDescriptor       string                          `json:"statement_descriptor"`
+	StatementDescriptorSuffix string                          `json:"statement_descriptor_suffix"`
+	Status                    PaymentIntentStatus             `json:"status"`
+	TransferData              *PaymentIntentTransferData      `json:"transfer_data"`
+	TransferGroup             string                          `json:"transfer_group"`
 }
 
 // PaymentIntentList is a list of payment intents as retrieved from a list endpoint.

--- a/setupintent.go
+++ b/setupintent.go
@@ -78,6 +78,7 @@ type SetupIntentConfirmParams struct {
 // SetupIntentPaymentMethodOptionsCardParams represents the card-specific options applied to a
 // SetupIntent.
 type SetupIntentPaymentMethodOptionsCardParams struct {
+	MOTO                *bool   `form:"moto"`
 	RequestThreeDSecure *string `form:"request_three_d_secure"`
 }
 


### PR DESCRIPTION
* support for `payment_method_details[card][moto]` on `Charge`
* support `statement_descriptor_suffix` on `Charge` and `PaymentIntent`
* support `subscription_data[application_fee_percent]` on Checkout `Session`

r? @ob-stripe 
cc @stripe/api-libraries 