### PR TITLE
Update webhook handler example to use `http.MaxBytesReader`

### DIFF
--- a/webhook/client_handler_test.go
+++ b/webhook/client_handler_test.go
@@ -11,6 +11,10 @@ import (
 
 func Example() {
 	http.HandleFunc("/webhook", func(w http.ResponseWriter, req *http.Request) {
+		// Protects against a malicious client streaming us an endless requst
+		// body
+		const MaxBodyBytes = int64(65536)
+		req.Body = http.MaxBytesReader(w, req.Body, MaxBodyBytes)
 
 		body, err := ioutil.ReadAll(req.Body)
 		if err != nil {


### PR DESCRIPTION
Updates the webhook handler example to use `http.MaxBytesReader` to
protect against a malicious client streaming an endless request body.

We're making a similar change in our server side documentation examples,
so I'm updating this spot as well for consistency.

r? @rattrayalex-stripe