### PR TITLE
Move to API version 2019-08-14 and other changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.63.0
+    - STRIPE_MOCK_VERSION=0.64.0
 
 go:
   - "1.9.x"

--- a/account.go
+++ b/account.go
@@ -21,9 +21,9 @@ type AccountCapability string
 
 // List of values that AccountCapability can take.
 const (
-	AccountCapabilityCardPayments     AccountCapability = "card_payments"
-	AccountCapabilityLegacyPayments   AccountCapability = "legacy_payments"
-	AccountCapabilityPlatformPayments AccountCapability = "platform_payments"
+	AccountCapabilityCardPayments   AccountCapability = "card_payments"
+	AccountCapabilityLegacyPayments AccountCapability = "legacy_payments"
+	AccountCapabilityTransfers      AccountCapability = "transfers"
 )
 
 // AccountCapabilityStatus is the status a given capability can have
@@ -277,9 +277,9 @@ type AccountBusinessProfile struct {
 
 // AccountCapabilities is the resource representing the capabilities enabled on that account.
 type AccountCapabilities struct {
-	CardPayments     AccountCapabilityStatus `json:"card_payments"`
-	LegacyPayments   AccountCapabilityStatus `json:"legacy_payments"`
-	PlatformPayments AccountCapabilityStatus `json:"platform_payments"`
+	CardPayments   AccountCapabilityStatus `json:"card_payments"`
+	LegacyPayments AccountCapabilityStatus `json:"legacy_payments"`
+	Transfers      AccountCapabilityStatus `json:"transfers"`
 }
 
 // AccountCompany represents details about the company or business associated with the account.

--- a/account_test.go
+++ b/account_test.go
@@ -38,8 +38,8 @@ func TestAccount_Unmarshal(t *testing.T) {
 		},
 		"business_type": "company",
 		"capabilities": map[string]interface{}{
-			"card_payments":     "active",
-			"platform_payments": "inactive",
+			"card_payments": "active",
+			"transfers":     "inactive",
 		},
 		"external_accounts": map[string]interface{}{
 			"object":   "list",
@@ -117,7 +117,7 @@ func TestAccount_Unmarshal(t *testing.T) {
 
 	assert.Equal(t, AccountCapabilityStatusActive, account.Capabilities.CardPayments)
 	assert.Equal(t, AccountCapabilityStatus(""), account.Capabilities.LegacyPayments)
-	assert.Equal(t, AccountCapabilityStatusInactive, account.Capabilities.PlatformPayments)
+	assert.Equal(t, AccountCapabilityStatusInactive, account.Capabilities.Transfers)
 
 	assert.Equal(t, AccountBusinessTypeCompany, account.BusinessType)
 

--- a/error.go
+++ b/error.go
@@ -171,6 +171,7 @@ const (
 type Error struct {
 	ChargeID string    `json:"charge,omitempty"`
 	Code     ErrorCode `json:"code,omitempty"`
+	DocURL   string    `json:"doc_url,omitempty"`
 
 	// Err contains an internal error with an additional level of granularity
 	// that can be used in some cases to get more detailed information about
@@ -248,11 +249,7 @@ type CardError struct {
 	stripeErr *Error
 	// DeclineCode is a code indicating a card issuer's reason for declining a
 	// card (if they provided one).
-	//
-	// TODO: This field should be of type DeclineCode (as defined above), but
-	// we've let it as a string for now for backwards compatibility. Change its
-	// type on the library's next major version.
-	DeclineCode string `json:"decline_code,omitempty"`
+	DeclineCode DeclineCode `json:"decline_code,omitempty"`
 }
 
 // Error serializes the error object to JSON and returns it as a string.
@@ -293,5 +290,5 @@ type rawError struct {
 // type to help with deserialization. (e.g. DeclineCode).
 type rawErrorInternal struct {
 	*Error
-	DeclineCode *string `json:"decline_code,omitempty"`
+	DeclineCode *DeclineCode `json:"decline_code,omitempty"`
 }

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -110,10 +110,8 @@ type PaymentIntentCaptureParams struct {
 
 // PaymentIntentConfirmParams is the set of parameters that can be used when confirming a payment intent.
 type PaymentIntentConfirmParams struct {
-	Params `form:"*"`
-	// This parameter expects a boolean but used to take an enum so we're adding support for both
-	// until the next major version (TODO).
-	OffSession           interface{}                              `form:"off_session"`
+	Params               `form:"*"`
+	OffSession           *bool                                    `form:"off_session"`
 	PaymentMethod        *string                                  `form:"payment_method"`
 	PaymentMethodOptions *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
 	PaymentMethodTypes   []*string                                `form:"payment_method_types"`
@@ -123,9 +121,6 @@ type PaymentIntentConfirmParams struct {
 	SetupFutureUsage     *string                                  `form:"setup_future_usage"`
 	Shipping             *ShippingDetailsParams                   `form:"shipping"`
 	Source               *string                                  `form:"source"`
-
-	// TODO: remove the following parameter in the next major version
-	PayentMethodOptions *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
 }
 
 // PaymentIntentPaymentMethodOptionsCardParams represents the card-specific options applied to a
@@ -173,12 +168,8 @@ type PaymentIntentParams struct {
 	TransferData              *PaymentIntentTransferDataParams         `form:"transfer_data"`
 	TransferGroup             *string                                  `form:"transfer_group"`
 
-	// This parameter only works if you confirm on creation. It also expects a boolean but used to
-	// take an enum so we're adding support for both until the next major version (TODO).
-	OffSession interface{} `form:"off_session"`
-
-	// TODO: remove the following parameter in the next major version
-	PayentMethodOptions *PaymentIntentPaymentMethodOptionsParams `form:"payment_method_options"`
+	// This parameter only works if you confirm on creation.
+	OffSession *bool `form:"off_session"`
 }
 
 // PaymentIntentListParams is the set of parameters that can be used when listing payment intents.
@@ -188,20 +179,6 @@ type PaymentIntentListParams struct {
 	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 	Customer     *string           `form:"customer"`
-}
-
-// PaymentIntentLastPaymentError represents the last error happening on a payment intent.
-type PaymentIntentLastPaymentError struct {
-	Charge        string         `json:"charge"`
-	Code          string         `json:"code"`
-	DeclineCode   string         `json:"decline_code"`
-	DocURL        string         `json:"doc_url"`
-	Message       string         `json:"message"`
-	Param         string         `json:"param"`
-	PaymentIntent *PaymentIntent `json:"payment_intent"`
-	PaymentMethod *PaymentMethod `json:"payment_method"`
-	Source        *PaymentSource `json:"source"`
-	Type          ErrorType      `json:"type"`
 }
 
 // PaymentIntentNextActionRedirectToURL represents the resource for the next action of type
@@ -242,7 +219,7 @@ type PaymentIntent struct {
 	Customer                  *Customer                       `json:"customer"`
 	Description               string                          `json:"description"`
 	Invoice                   *Invoice                        `json:"invoice"`
-	LastPaymentError          *PaymentIntentLastPaymentError  `json:"last_payment_error"`
+	LastPaymentError          *Error                          `json:"last_payment_error"`
 	Livemode                  bool                            `json:"livemode"`
 	ID                        string                          `json:"id"`
 	Metadata                  map[string]string               `json:"metadata"`

--- a/paymentintent/client_test.go
+++ b/paymentintent/client_test.go
@@ -5,7 +5,6 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -32,15 +31,6 @@ func TestPaymentIntentConfirm(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, intent)
-}
-
-func TestPaymentIntentConfirmWithAlternative(t *testing.T) {
-	params := &stripe.PaymentIntentConfirmParams{
-		OffSession: stripe.String(string(stripe.PaymentIntentSetupFutureUsageOffSession)),
-	}
-	body := &form.Values{}
-	form.AppendTo(body, params)
-	assert.Equal(t, []string{"off_session"}, body.Get("off_session"))
 }
 
 func TestPaymentIntentGet(t *testing.T) {

--- a/paymentintent_test.go
+++ b/paymentintent_test.go
@@ -7,40 +7,6 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func TestPaymentIntentLastPaymentError_UnmarshalJSON(t *testing.T) {
-	errorData := map[string]interface{}{
-		"charge":       "ch_123",
-		"code":         "card_declined",
-		"decline_code": "generic_decline",
-		"doc_url":      "https://stripe.com/docs/error-codes/card-declined",
-		"message":      "Your card was declined.",
-		"source": map[string]interface{}{
-			"id":          "card_123",
-			"object":      "card",
-			"brand":       "Visa",
-			"country":     "US",
-			"customer":    "cus_123",
-			"exp_month":   9,
-			"exp_year":    2019,
-			"fingerprint": "fingerprint",
-			"last4":       "0341",
-		},
-		"type": "card_error",
-	}
-	bytes, err := json.Marshal(&errorData)
-	assert.NoError(t, err)
-
-	var lastPaymentError PaymentIntentLastPaymentError
-	err = json.Unmarshal(bytes, &lastPaymentError)
-	assert.NoError(t, err)
-
-	assert.Equal(t, ErrorTypeCard, lastPaymentError.Type)
-	assert.Equal(t, "ch_123", lastPaymentError.Charge)
-	assert.Equal(t, "https://stripe.com/docs/error-codes/card-declined", lastPaymentError.DocURL)
-	assert.Equal(t, PaymentSourceTypeCard, lastPaymentError.Source.Type)
-	assert.Equal(t, "card_123", lastPaymentError.Source.Card.ID)
-}
-
 func TestPaymentIntentNextAction_UnmarshalJSON(t *testing.T) {
 	actionData := map[string]interface{}{
 		"redirect_to_url": map[string]interface{}{

--- a/person.go
+++ b/person.go
@@ -126,6 +126,7 @@ type DOB struct {
 type Relationship struct {
 	AccountOpener    bool    `json:"account_opener"`
 	Director         bool    `json:"director"`
+	Executive        bool    `json:"executive"`
 	Owner            bool    `json:"owner"`
 	PercentOwnership float64 `json:"percent_ownership"`
 	Title            string  `json:"title"`

--- a/setupintent.go
+++ b/setupintent.go
@@ -70,9 +70,6 @@ type SetupIntentConfirmParams struct {
 	PaymentMethod        *string                                `form:"payment_method"`
 	PaymentMethodOptions *SetupIntentPaymentMethodOptionsParams `form:"payment_method_options"`
 	ReturnURL            *string                                `form:"return_url"`
-
-	// TODO: remove the following parameter in the next major version
-	PayentMethodOptions *SetupIntentPaymentMethodOptionsParams `form:"payment_method_options"`
 }
 
 // SetupIntentPaymentMethodOptionsCardParams represents the card-specific options applied to a
@@ -100,9 +97,6 @@ type SetupIntentParams struct {
 	PaymentMethodTypes   []*string                              `form:"payment_method_types"`
 	ReturnURL            *string                                `form:"return_url"`
 	Usage                *string                                `form:"usage"`
-
-	// TODO: remove the following parameter in the next major version
-	PayentMethodOptions *SetupIntentPaymentMethodOptionsParams `form:"payment_method_options"`
 }
 
 // SetupIntentListParams is the set of parameters that can be used when listing setup intents.

--- a/stripe.go
+++ b/stripe.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2019-05-16"
+	APIVersion string = "2019-08-14"
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -714,8 +714,8 @@ func TestResponseToError(t *testing.T) {
 	err = json.Unmarshal(bytes, &raw)
 	assert.NoError(t, err)
 
-	expectedDeclineCode := string(stripe.DeclineCodeInvalidCVC)
-	raw["decline_code"] = expectedDeclineCode
+	expectedDeclineCode := stripe.DeclineCodeInvalidCVC
+	raw["decline_code"] = string(expectedDeclineCode)
 	bytes, err = json.Marshal(raw)
 	assert.NoError(t, err)
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.63.0"
+	MockMinimumVersion = "0.64.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
* Pin to API version 2019-08-14
* Rename AccountCapabilityPlatformPayments to AccountCapabilityTransfers
* Add `Executive` in `PersonRelationship`
* Remove `PayentMethodOptions` as there was a typo which was fixed.
* Make `OffSession` only support booleans on `PaymentIntent`
* Remove `PaymentIntentLastPaymentError` and use `Error` instead
* Move `DeclineCode` on `Error` to the `DeclineCode` instead of `string`

r? @ob-stripe @brandur-stripe (tagging you both are there are multiple changes
cc @stripe/api-libraries 