### PR TITLE
Fix parameter on PaymentMethod creation that does not exist

### DIFF
--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -66,9 +66,12 @@ type PaymentMethodParams struct {
 	Params         `form:"*"`
 	BillingDetails *BillingDetailsParams    `form:"billing_details"`
 	Card           *PaymentMethodCardParams `form:"card"`
-	Customer       *string                  `form:"customer"`
 	PaymentMethod  *string                  `form:"payment_method"`
 	Type           *string                  `form:"type"`
+
+	// The following parameter is not supported by the API and should not have been added
+	// TODO: remove in the next major version
+	Customer *string `form:"customer"`
 }
 
 // PaymentMethodAttachParams is the set of parameters that can be used when attaching a


### PR DESCRIPTION
Fix issue reported in https://github.com/stripe/stripe-go/issues/920

r? @ob-stripe 
cc @stripe/api-libraries 