### PR TITLE
A few Billing changes

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -73,6 +73,7 @@ type InvoiceUpcomingInvoiceItemParams struct {
 	InvoiceItem  *string                                 `form:"invoiceitem"`
 	Period       *InvoiceUpcomingInvoiceItemPeriodParams `form:"period"`
 	Quantity     *int64                                  `form:"quantity"`
+	Schedule     *string                                 `form:"schedule"`
 	TaxRates     []*string                               `form:"tax_rates"`
 	UnitAmount   *int64                                  `form:"unit_amount"`
 }
@@ -114,7 +115,9 @@ type InvoiceParams struct {
 	Coupon                         *string                             `form:"coupon"`
 	InvoiceItems                   []*InvoiceUpcomingInvoiceItemParams `form:"invoice_items"`
 	SubscriptionBillingCycleAnchor *int64                              `form:"subscription_billing_cycle_anchor"`
+	SubscriptionCancelAt           *int64                              `form:"subscription_cancel_at"`
 	SubscriptionCancelAtPeriodEnd  *bool                               `form:"subscription_cancel_at_period_end"`
+	SubscriptionCancelNow          *bool                               `form:"subscription_cancel_now"`
 	SubscriptionDefaultTaxRates    []*string                           `form:"subscription_default_tax_rates"`
 	SubscriptionItems              []*SubscriptionItemsParams          `form:"subscription_items"`
 	SubscriptionPlan               *string                             `form:"subscription_plan"`

--- a/sub.go
+++ b/sub.go
@@ -195,6 +195,7 @@ type Subscription struct {
 	PendingSetupIntent    *SetupIntent                   `json:"pending_setup_intent"`
 	Plan                  *Plan                          `json:"plan"`
 	Quantity              int64                          `json:"quantity"`
+	Schedule              *SubscriptionSchedule          `json:"schedule"`
 	StartDate             int64                          `json:"start_date"`
 	Status                SubscriptionStatus             `json:"status"`
 	TransferData          *SubscriptionTransferData      `json:"transfer_data"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -44,15 +44,19 @@ type SubscriptionSchedulePhaseItemParams struct {
 // SubscriptionSchedulePhaseParams is a structure representing the parameters allowed to control
 // a phase on a subscription schedule.
 type SubscriptionSchedulePhaseParams struct {
-	ApplicationFeePercent *int64                                 `form:"application_fee_percent"`
-	Coupon                *string                                `form:"coupon"`
-	DefaultTaxRates       []*string                              `form:"default_tax_rates"`
-	EndDate               *int64                                 `form:"end_date"`
-	Iterations            *int64                                 `form:"iterations"`
-	Plans                 []*SubscriptionSchedulePhaseItemParams `form:"plans"`
-	StartDate             *int64                                 `form:"start_date"`
-	Trial                 *bool                                  `form:"trial"`
-	TrialEnd              *int64                                 `form:"trial_end"`
+	ApplicationFeePercent *int64                                     `form:"application_fee_percent"`
+	BillingThresholds     *SubscriptionBillingThresholdsParams       `form:"billing_thresholds"`
+	CollectionMethod      *string                                    `form:"collection_method"`
+	Coupon                *string                                    `form:"coupon"`
+	DefaultPaymentMethod  *string                                    `form:"default_payment_method"`
+	DefaultTaxRates       []*string                                  `form:"default_tax_rates"`
+	EndDate               *int64                                     `form:"end_date"`
+	InvoiceSettings       *SubscriptionScheduleInvoiceSettingsParams `form:"invoice_settings"`
+	Iterations            *int64                                     `form:"iterations"`
+	Plans                 []*SubscriptionSchedulePhaseItemParams     `form:"plans"`
+	StartDate             *int64                                     `form:"start_date"`
+	Trial                 *bool                                      `form:"trial"`
+	TrialEnd              *int64                                     `form:"trial_end"`
 
 	// This parameter is deprecated and we recommend that you use TaxRates instead.
 	TaxPercent *float64 `form:"tax_percent"`
@@ -139,13 +143,17 @@ type SubscriptionSchedulePhaseItem struct {
 
 // SubscriptionSchedulePhase is a structure a phase of a subscription schedule.
 type SubscriptionSchedulePhase struct {
-	ApplicationFeePercent float64                          `json:"application_fee_percent"`
-	Coupon                *Coupon                          `json:"coupon"`
-	DefaultTaxRates       []*TaxRate                       `json:"default_tax_rates"`
-	EndDate               int64                            `json:"end_date"`
-	Plans                 []*SubscriptionSchedulePhaseItem `json:"plans"`
-	StartDate             int64                            `json:"start_date"`
-	TrialEnd              int64                            `json:"trial_end"`
+	ApplicationFeePercent float64                              `json:"application_fee_percent"`
+	BillingThresholds     *SubscriptionBillingThresholds       `json:"billing_thresholds"`
+	CollectionMethod      SubscriptionCollectionMethod         `json:"collection_method"`
+	Coupon                *Coupon                              `json:"coupon"`
+	DefaultPaymentMethod  *PaymentMethod                       `json:"default_payment_method"`
+	DefaultTaxRates       []*TaxRate                           `json:"default_tax_rates"`
+	EndDate               int64                                `json:"end_date"`
+	InvoiceSettings       *SubscriptionScheduleInvoiceSettings `json:"invoice_settings"`
+	Plans                 []*SubscriptionSchedulePhaseItem     `json:"plans"`
+	StartDate             int64                                `json:"start_date"`
+	TrialEnd              int64                                `json:"trial_end"`
 
 	// This field is deprecated and we recommend that you use TaxRates instead.
 	TaxPercent float64 `json:"tax_percent"`


### PR DESCRIPTION
* Add `Schedule` to `Subscription`
* Add missing parameters for the Upcoming Invoice API
  * `Schedule`
  * `SubscriptionCancelAt`
  * `SubscriptionCancelNow`
* Add missing properties and parameters for a `SubscriptionSchedule` phase:
  * `BillingThresholds`
  * `CollectionMethod`
  * `DefaultPaymentMethod`
  * `InvoiceSettings`

r? @ob-stripe 
cc @stripe/api-libraries 

(Looks like we also need to fix the List Lines on upcoming invoices here in the future)