### PR TITLE
Put `stripe_test.go` into main `stripe` package

### DIFF
--- a/stripe_test.go
+++ b/stripe_test.go
@@ -1,4 +1,4 @@
-package stripe_test
+package stripe
 
 import (
 	"bytes"
@@ -17,12 +17,10 @@ import (
 	"time"
 
 	assert "github.com/stretchr/testify/require"
-	"github.com/stripe/stripe-go"
-	. "github.com/stripe/stripe-go/testing"
 )
 
 func TestBearerAuth(t *testing.T) {
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
+	c := GetBackend(APIBackend).(*BackendImplementation)
 	key := "apiKey"
 
 	req, err := c.NewRequest("", "", key, "", nil)
@@ -32,8 +30,8 @@ func TestBearerAuth(t *testing.T) {
 }
 
 func TestContext(t *testing.T) {
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
-	p := &stripe.Params{Context: context.Background()}
+	c := GetBackend(APIBackend).(*BackendImplementation)
+	p := &Params{Context: context.Background()}
 
 	req, err := c.NewRequest("", "", "", "", p)
 	assert.NoError(t, err)
@@ -91,14 +89,14 @@ func TestDo_Retry(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	backend := stripe.GetBackendWithConfig(
-		stripe.APIBackend,
-		&stripe.BackendConfig{
+	backend := GetBackendWithConfig(
+		APIBackend,
+		&BackendConfig{
 			LogLevel:          3,
 			MaxNetworkRetries: 5,
 			URL:               testServer.URL,
 		},
-	).(*stripe.BackendImplementation)
+	).(*BackendImplementation)
 
 	// Disable sleeping duration our tests.
 	backend.SetNetworkRetriesSleep(false)
@@ -137,15 +135,15 @@ func TestDo_RetryOnTimeout(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	backend := stripe.GetBackendWithConfig(
-		stripe.APIBackend,
-		&stripe.BackendConfig{
+	backend := GetBackendWithConfig(
+		APIBackend,
+		&BackendConfig{
 			LogLevel:          3,
 			MaxNetworkRetries: 1,
 			URL:               testServer.URL,
 			HTTPClient:        &http.Client{Timeout: timeout},
 		},
-	).(*stripe.BackendImplementation)
+	).(*BackendImplementation)
 
 	backend.SetNetworkRetriesSleep(false)
 
@@ -193,14 +191,14 @@ func TestDo_TelemetryDisabled(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	backend := stripe.GetBackendWithConfig(
-		stripe.APIBackend,
-		&stripe.BackendConfig{
+	backend := GetBackendWithConfig(
+		APIBackend,
+		&BackendConfig{
 			LogLevel:          3,
 			MaxNetworkRetries: 0,
 			URL:               testServer.URL,
 		},
-	).(*stripe.BackendImplementation)
+	).(*BackendImplementation)
 
 	// When telemetry is enabled, the metrics for a request are sent with the
 	// _next_ request via the `X-Stripe-Client-Telemetry header`. To test that
@@ -227,7 +225,7 @@ func TestDo_TelemetryDisabled(t *testing.T) {
 }
 
 // Test that telemetry metrics are sent on subsequent requests when
-// stripe.EnableTelemetry = true.
+// EnableTelemetry = true.
 func TestDo_TelemetryEnabled(t *testing.T) {
 	type testServerResponse struct {
 		Message string `json:"message"`
@@ -257,7 +255,7 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 		case 2:
 			assert.True(t, len(telemetryStr) > 0, "telemetryStr should not be empty")
 
-			// the telemetry should properly unmarshal into stripe.RequestTelemetry
+			// the telemetry should properly unmarshal into RequestTelemetry
 			var telemetry requestTelemetry
 			err := json.Unmarshal([]byte(telemetryStr), &telemetry)
 			assert.NoError(t, err)
@@ -281,15 +279,15 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	backend := stripe.GetBackendWithConfig(
-		stripe.APIBackend,
-		&stripe.BackendConfig{
+	backend := GetBackendWithConfig(
+		APIBackend,
+		&BackendConfig{
 			LogLevel:          3,
 			MaxNetworkRetries: 0,
 			URL:               testServer.URL,
 			EnableTelemetry:   true,
 		},
-	).(*stripe.BackendImplementation)
+	).(*BackendImplementation)
 
 	for i := 0; i < 2; i++ {
 		request, err := backend.NewRequest(
@@ -338,15 +336,15 @@ func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	backend := stripe.GetBackendWithConfig(
-		stripe.APIBackend,
-		&stripe.BackendConfig{
+	backend := GetBackendWithConfig(
+		APIBackend,
+		&BackendConfig{
 			LogLevel:          3,
 			MaxNetworkRetries: 0,
 			URL:               testServer.URL,
 			EnableTelemetry:   true,
 		},
-	).(*stripe.BackendImplementation)
+	).(*BackendImplementation)
 
 	times := 20 // 20 > telemetryBufferSize, so some metrics could be discarded
 	done := make(chan struct{})
@@ -381,38 +379,38 @@ func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 
 func TestFormatURLPath(t *testing.T) {
 	assert.Equal(t, "/v1/resources/1/subresources/2",
-		stripe.FormatURLPath("/v1/resources/%s/subresources/%s", "1", "2"))
+		FormatURLPath("/v1/resources/%s/subresources/%s", "1", "2"))
 
 	// Tests that each parameter is escaped for use in URLs
 	assert.Equal(t, "/v1/resources/%25",
-		stripe.FormatURLPath("/v1/resources/%s", "%"))
+		FormatURLPath("/v1/resources/%s", "%"))
 }
 
 func TestGetBackendWithConfig_Loggers(t *testing.T) {
-	leveledLogger := &stripe.LeveledLogger{}
+	leveledLogger := &LeveledLogger{}
 	logger := log.New(os.Stdout, "", 0)
 
 	// Prefers a LeveledLogger
 	{
-		backend := stripe.GetBackendWithConfig(
-			stripe.APIBackend,
-			&stripe.BackendConfig{
+		backend := GetBackendWithConfig(
+			APIBackend,
+			&BackendConfig{
 				LeveledLogger: leveledLogger,
 				Logger:        logger,
 			},
-		).(*stripe.BackendImplementation)
+		).(*BackendImplementation)
 
 		assert.Equal(t, leveledLogger, backend.LeveledLogger)
 	}
 
 	// Falls back to Logger
 	{
-		backend := stripe.GetBackendWithConfig(
-			stripe.APIBackend,
-			&stripe.BackendConfig{
+		backend := GetBackendWithConfig(
+			APIBackend,
+			&BackendConfig{
 				Logger: logger,
 			},
-		).(*stripe.BackendImplementation)
+		).(*BackendImplementation)
 
 		assert.NotNil(t, backend.LeveledLogger)
 	}
@@ -420,61 +418,61 @@ func TestGetBackendWithConfig_Loggers(t *testing.T) {
 
 func TestGetBackendWithConfig_TrimV1Suffix(t *testing.T) {
 	{
-		backend := stripe.GetBackendWithConfig(
-			stripe.APIBackend,
-			&stripe.BackendConfig{
-				URL: "https://api.stripe.com/v1",
+		backend := GetBackendWithConfig(
+			APIBackend,
+			&BackendConfig{
+				URL: "https://api.com/v1",
 			},
-		).(*stripe.BackendImplementation)
+		).(*BackendImplementation)
 
 		// The `/v1` suffix has been stripped.
-		assert.Equal(t, "https://api.stripe.com", backend.URL)
+		assert.Equal(t, "https://api.com", backend.URL)
 	}
 
 	// Also support trimming a `/v1/` with an extra trailing slash which is
 	// probably an often seen mistake.
 	{
-		backend := stripe.GetBackendWithConfig(
-			stripe.APIBackend,
-			&stripe.BackendConfig{
-				URL: "https://api.stripe.com/v1/",
+		backend := GetBackendWithConfig(
+			APIBackend,
+			&BackendConfig{
+				URL: "https://api.com/v1/",
 			},
-		).(*stripe.BackendImplementation)
+		).(*BackendImplementation)
 
-		assert.Equal(t, "https://api.stripe.com", backend.URL)
+		assert.Equal(t, "https://api.com", backend.URL)
 	}
 
 	// No-op otherwise.
 	{
-		backend := stripe.GetBackendWithConfig(
-			stripe.APIBackend,
-			&stripe.BackendConfig{
-				URL: "https://api.stripe.com",
+		backend := GetBackendWithConfig(
+			APIBackend,
+			&BackendConfig{
+				URL: "https://api.com",
 			},
-		).(*stripe.BackendImplementation)
+		).(*BackendImplementation)
 
-		assert.Equal(t, "https://api.stripe.com", backend.URL)
+		assert.Equal(t, "https://api.com", backend.URL)
 	}
 }
 
 func TestParseID(t *testing.T) {
 	// JSON string
 	{
-		id, ok := stripe.ParseID([]byte(`"ch_123"`))
+		id, ok := ParseID([]byte(`"ch_123"`))
 		assert.Equal(t, "ch_123", id)
 		assert.True(t, ok)
 	}
 
 	// JSON object
 	{
-		id, ok := stripe.ParseID([]byte(`{"id":"ch_123"}`))
+		id, ok := ParseID([]byte(`{"id":"ch_123"}`))
 		assert.Equal(t, "", id)
 		assert.False(t, ok)
 	}
 
 	// Other JSON scalar (this should never be used, but check the results anyway)
 	{
-		id, ok := stripe.ParseID([]byte(`123`))
+		id, ok := ParseID([]byte(`123`))
 		assert.Equal(t, "", id)
 		assert.False(t, ok)
 	}
@@ -487,7 +485,7 @@ func TestMultipleAPICalls(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
+			c := GetBackend(APIBackend).(*BackendImplementation)
 			key := "apiKey"
 
 			req, err := c.NewRequest("", "", key, "", nil)
@@ -500,8 +498,8 @@ func TestMultipleAPICalls(t *testing.T) {
 }
 
 func TestIdempotencyKey(t *testing.T) {
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
-	p := &stripe.Params{IdempotencyKey: stripe.String("idempotency-key")}
+	c := GetBackend(APIBackend).(*BackendImplementation)
+	p := &Params{IdempotencyKey: String("idempotency-key")}
 
 	req, err := c.NewRequest("", "", "", "", p)
 	assert.NoError(t, err)
@@ -511,20 +509,20 @@ func TestIdempotencyKey(t *testing.T) {
 
 func TestNewBackends(t *testing.T) {
 	httpClient := &http.Client{}
-	backends := stripe.NewBackends(httpClient)
-	assert.Equal(t, httpClient, backends.API.(*stripe.BackendImplementation).HTTPClient)
-	assert.Equal(t, httpClient, backends.Uploads.(*stripe.BackendImplementation).HTTPClient)
+	backends := NewBackends(httpClient)
+	assert.Equal(t, httpClient, backends.API.(*BackendImplementation).HTTPClient)
+	assert.Equal(t, httpClient, backends.Uploads.(*BackendImplementation).HTTPClient)
 }
 
 func TestStripeAccount(t *testing.T) {
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
-	p := &stripe.Params{}
-	p.SetStripeAccount(TestMerchantID)
+	c := GetBackend(APIBackend).(*BackendImplementation)
+	p := &Params{}
+	p.SetStripeAccount("acct_123")
 
 	req, err := c.NewRequest("", "", "", "", p)
 	assert.NoError(t, err)
 
-	assert.Equal(t, TestMerchantID, req.Header.Get("Stripe-Account"))
+	assert.Equal(t, "acct_123", req.Header.Get("Stripe-Account"))
 }
 
 func TestUnmarshalJSONVerbose(t *testing.T) {
@@ -532,7 +530,7 @@ func TestUnmarshalJSONVerbose(t *testing.T) {
 		Message string `json:"message"`
 	}
 
-	backend := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
+	backend := GetBackend(APIBackend).(*BackendImplementation)
 
 	// Valid JSON
 	{
@@ -573,7 +571,7 @@ func TestUnmarshalJSONVerbose(t *testing.T) {
 }
 
 func TestUserAgent(t *testing.T) {
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
+	c := GetBackend(APIBackend).(*BackendImplementation)
 
 	req, err := c.NewRequest("", "", "", "", nil)
 	assert.NoError(t, err)
@@ -587,16 +585,16 @@ func TestUserAgent(t *testing.T) {
 }
 
 func TestUserAgentWithAppInfo(t *testing.T) {
-	appInfo := &stripe.AppInfo{
+	appInfo := &AppInfo{
 		Name:      "MyAwesomePlugin",
 		PartnerID: "partner_1234",
 		URL:       "https://myawesomeplugin.info",
 		Version:   "1.2.34",
 	}
-	stripe.SetAppInfo(appInfo)
-	defer stripe.SetAppInfo(nil)
+	SetAppInfo(appInfo)
+	defer SetAppInfo(nil)
 
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
+	c := GetBackend(APIBackend).(*BackendImplementation)
 
 	req, err := c.NewRequest("", "", "", "", nil)
 	assert.NoError(t, err)
@@ -632,7 +630,7 @@ func TestUserAgentWithAppInfo(t *testing.T) {
 }
 
 func TestStripeClientUserAgent(t *testing.T) {
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
+	c := GetBackend(APIBackend).(*BackendImplementation)
 
 	req, err := c.NewRequest("", "", "", "", nil)
 	assert.NoError(t, err)
@@ -654,19 +652,19 @@ func TestStripeClientUserAgent(t *testing.T) {
 
 	// Anywhere these tests are running can reasonable be expected to have a
 	// `uname` to run, so do this basic check.
-	assert.NotEqual(t, stripe.UnknownPlatform, userAgent["lang_version"])
+	assert.NotEqual(t, UnknownPlatform, userAgent["lang_version"])
 }
 
 func TestStripeClientUserAgentWithAppInfo(t *testing.T) {
-	appInfo := &stripe.AppInfo{
+	appInfo := &AppInfo{
 		Name:    "MyAwesomePlugin",
 		URL:     "https://myawesomeplugin.info",
 		Version: "1.2.34",
 	}
-	stripe.SetAppInfo(appInfo)
-	defer stripe.SetAppInfo(nil)
+	SetAppInfo(appInfo)
+	defer SetAppInfo(nil)
 
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
+	c := GetBackend(APIBackend).(*BackendImplementation)
 
 	req, err := c.NewRequest("", "", "", "", nil)
 	assert.NoError(t, err)
@@ -685,7 +683,7 @@ func TestStripeClientUserAgentWithAppInfo(t *testing.T) {
 }
 
 func TestResponseToError(t *testing.T) {
-	c := stripe.GetBackend(stripe.APIBackend).(*stripe.BackendImplementation)
+	c := GetBackend(APIBackend).(*BackendImplementation)
 
 	// A test response that includes a status code and request ID.
 	res := &http.Response{
@@ -697,24 +695,24 @@ func TestResponseToError(t *testing.T) {
 
 	// An error that contains expected fields which we're going to serialize to
 	// JSON and inject into our conversion function.
-	expectedErr := &stripe.Error{
-		Code:  stripe.ErrorCodeMissing,
+	expectedErr := &Error{
+		Code:  ErrorCodeMissing,
 		Msg:   "That card was declined",
 		Param: "expiry_date",
-		Type:  stripe.ErrorTypeCard,
+		Type:  ErrorTypeCard,
 	}
 	bytes, err := json.Marshal(expectedErr)
 	assert.NoError(t, err)
 
 	// Unpack the error that we just serialized so that we can inject a
 	// type-specific field into it ("decline_code"). This will show up in a
-	// field on a special stripe.CardError type which is attached to the common
-	// stripe.Error.
+	// field on a special CardError type which is attached to the common
+	// Error.
 	var raw map[string]string
 	err = json.Unmarshal(bytes, &raw)
 	assert.NoError(t, err)
 
-	expectedDeclineCode := stripe.DeclineCodeInvalidCVC
+	expectedDeclineCode := DeclineCodeInvalidCVC
 	raw["decline_code"] = string(expectedDeclineCode)
 	bytes, err = json.Marshal(raw)
 	assert.NoError(t, err)
@@ -724,7 +722,7 @@ func TestResponseToError(t *testing.T) {
 
 	// An error containing Stripe-specific fields that we cast back from the
 	// generic Golang error.
-	stripeErr := err.(*stripe.Error)
+	stripeErr := err.(*Error)
 
 	assert.Equal(t, expectedErr.Code, stripeErr.Code)
 	assert.Equal(t, expectedErr.Msg, stripeErr.Msg)
@@ -736,57 +734,57 @@ func TestResponseToError(t *testing.T) {
 	// Just a bogus type coercion to demonstrate how this code might be
 	// written. Because we've assigned ErrorTypeCard as the error's type, Err
 	// should always come out as a CardError.
-	_, ok := stripeErr.Err.(*stripe.InvalidRequestError)
+	_, ok := stripeErr.Err.(*InvalidRequestError)
 	assert.False(t, ok)
 
-	cardErr, ok := stripeErr.Err.(*stripe.CardError)
+	cardErr, ok := stripeErr.Err.(*CardError)
 	assert.True(t, ok)
 	assert.Equal(t, expectedDeclineCode, cardErr.DeclineCode)
 }
 
 func TestStringSlice(t *testing.T) {
 	input := []string{"a", "b", "c"}
-	result := stripe.StringSlice(input)
+	result := StringSlice(input)
 
 	assert.Equal(t, "a", *result[0])
 	assert.Equal(t, "b", *result[1])
 	assert.Equal(t, "c", *result[2])
 
-	assert.Equal(t, 0, len(stripe.StringSlice(nil)))
+	assert.Equal(t, 0, len(StringSlice(nil)))
 }
 
 func TestInt64Slice(t *testing.T) {
 	input := []int64{8, 7, 6}
-	result := stripe.Int64Slice(input)
+	result := Int64Slice(input)
 
 	assert.Equal(t, int64(8), *result[0])
 	assert.Equal(t, int64(7), *result[1])
 	assert.Equal(t, int64(6), *result[2])
 
-	assert.Equal(t, 0, len(stripe.Int64Slice(nil)))
+	assert.Equal(t, 0, len(Int64Slice(nil)))
 }
 
 func TestFloat64Slice(t *testing.T) {
 	input := []float64{8, 7, 6}
-	result := stripe.Float64Slice(input)
+	result := Float64Slice(input)
 
 	assert.Equal(t, float64(8), *result[0])
 	assert.Equal(t, float64(7), *result[1])
 	assert.Equal(t, float64(6), *result[2])
 
-	assert.Equal(t, 0, len(stripe.Float64Slice(nil)))
+	assert.Equal(t, 0, len(Float64Slice(nil)))
 }
 
 func TestBoolSlice(t *testing.T) {
 	input := []bool{true, false, true, false}
-	result := stripe.BoolSlice(input)
+	result := BoolSlice(input)
 
 	assert.Equal(t, true, *result[0])
 	assert.Equal(t, false, *result[1])
 	assert.Equal(t, true, *result[2])
 	assert.Equal(t, false, *result[3])
 
-	assert.Equal(t, 0, len(stripe.BoolSlice(nil)))
+	assert.Equal(t, 0, len(BoolSlice(nil)))
 }
 
 //


### PR DESCRIPTION
Moves `stripe_test.go` out of the `stripe_test` package and into
`stripe`. This makes it consistent with all other `*_test.go` files in
the top-level package. The upside of the change is that it will allow
us to test certain unexported functions without having to export them.
The downside is that the hygiene isn't quite as good because we're no
longer just testing against the package's public interface which may
reduce flexibility in future changes.

Go standard library convention seems to use both methods. Just looking
through the `net/http` source code for example, you can find tests in
the `http` package _and_ in the `http_test` package depending on the
file.

I've been wanting to making this change for a while because it'd give us
a route to making internal-ish structures like `BackendImplementation`
unexported, but the direct impetus for today is that I was making some
changes to the `shouldRetry` function and noticed that it was difficult
to test them without having to go through the expensive song and dance
of spinning up a test HTTP server and making the test really
complicated. (I could also just export the function as `ShouldRetry`,
but I'd prefer not to do that if possible.)

r? @ob-stripe @remi-stripe Any thoughts/opinions on this change? I
personally like the idea of only testing public interfaces, but it can
be impractical in some cases.