### PR TITLE
Retry requests on a 429 that's a lock timeout

### DIFF
--- a/error.go
+++ b/error.go
@@ -66,6 +66,7 @@ const (
 	ErrorCodeInvoiceNotEditable                     ErrorCode = "invoice_not_editable"
 	ErrorCodeInvoiceUpcomingNone                    ErrorCode = "invoice_upcoming_none"
 	ErrorCodeLivemodeMismatch                       ErrorCode = "livemode_mismatch"
+	ErrorCodeLockTimeout                            ErrorCode = "lock_timeout"
 	ErrorCodeMissing                                ErrorCode = "missing"
 	ErrorCodeNotAllowedOnStandardAccount            ErrorCode = "not_allowed_on_standard_account"
 	ErrorCodeOrderCreationFailed                    ErrorCode = "order_creation_failed"


### PR DESCRIPTION
Tweaks the retry logic so that 429s which have the special status code
`lock_timeout` are retried automatically. Retrying other 429s might
eventually be plausible as well, but we need to find a way to do that
which would not hide (and probably worsen) an integration's rate
problems.

This patch took a little more code than you might expect because I had
to restructure the retry loop so that we unmarshal an error body before
checking `shouldRetry` (previously, this was not necessary because retry
logic was based entirely on response status code and request verb).
Always decoding an error body has a tiny performance implication for
requests that fail and are retried, but it's small enough that it's not
really meaningful. The good news is that the code improves slightly as I
was able to eliminate a duplicate `ioutil.ReadAll` by bringing all
response body reading into one place.

Add new `ErrorCodeLockTimeout` and tests for `checkRetry`'s new
conditions.

r? @ob-stripe
cc @stripe/api-libraries