### PR TITLE
Also log error in case of non-`stripe.Error`

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -415,6 +415,8 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 					s.LeveledLogger.Errorf("Request error from Stripe (status %v): %v",
 						res.StatusCode, stripeErr)
 				}
+			} else {
+				s.LeveledLogger.Errorf("Error decoding error from Stripe: %v", err)
 			}
 		}
 
@@ -483,7 +485,6 @@ func (s *BackendImplementation) ResponseToError(res *http.Response, resBody []by
 	// no error in resBody
 	if raw.E == nil {
 		err := errors.New(string(resBody))
-		s.LeveledLogger.Errorf("Unparsable error returned from Stripe: %v", err)
 		return err
 	}
 	raw.E.HTTPStatusCode = res.StatusCode


### PR DESCRIPTION
In a few cases it's possible for `ResponseToError` to return an error
that's not a `*stripe.Error`. This should never happen, but could occur
if say the Stripe API returned a mangled JSON blob, but somehow managed
to close the connection properly. It's an unlikely scenario, but even
so, it's better not to let it slip through the cracks.

I also moved one more logging statement out of `ResponseToError` so we
can log everything of this type in one place.

r? @ob-stripe (Sorry, one more tweak on the last patch.)
cc @stripe/api-libraries