### PR TITLE
Changes to Account and Person to represent identity verification state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.65.0
+    - STRIPE_MOCK_VERSION=0.66.0
 
 go:
   - "1.9.x"

--- a/account.go
+++ b/account.go
@@ -90,6 +90,24 @@ const (
 	AccountRejectReasonTermsOfService AccountRejectReason = "terms_of_service"
 )
 
+// AccountCompanyVerificationDocumentDetailsCode is a machine-readable code specifying the
+// verification state of a document associated with a company.
+type AccountCompanyVerificationDocumentDetailsCode string
+
+// List of values that AccountCompanyVerificationDocumentDetailsCode can take.
+const (
+	AccountCompanyVerificationDocumentDetailsCodeDocumentCorrupt        AccountCompanyVerificationDocumentDetailsCode = "document_corrupt"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentFailedCopy     AccountCompanyVerificationDocumentDetailsCode = "document_failed_copy"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentFailedOther    AccountCompanyVerificationDocumentDetailsCode = "document_failed_other"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentFailedTestMode AccountCompanyVerificationDocumentDetailsCode = "document_failed_test_mode"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentFraudulent     AccountCompanyVerificationDocumentDetailsCode = "document_fraudulent"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentInvalid        AccountCompanyVerificationDocumentDetailsCode = "document_invalid"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentManipulated    AccountCompanyVerificationDocumentDetailsCode = "document_manipulated"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentNotReadable    AccountCompanyVerificationDocumentDetailsCode = "document_not_readable"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentNotUploaded    AccountCompanyVerificationDocumentDetailsCode = "document_not_uploaded"
+	AccountCompanyVerificationDocumentDetailsCodeDocumentTooLarge       AccountCompanyVerificationDocumentDetailsCode = "document_too_large"
+)
+
 // AccountBusinessProfileParams are the parameters allowed for an account's business information
 type AccountBusinessProfileParams struct {
 	MCC                *string `form:"mcc"`
@@ -101,20 +119,33 @@ type AccountBusinessProfileParams struct {
 	URL                *string `form:"url"`
 }
 
+// AccountCompanyVerificationDocumentParams are the parameters allowed to pass for a document
+// verifying a company.
+type AccountCompanyVerificationDocumentParams struct {
+	Back  *string `form:"back"`
+	Front *string `form:"front"`
+}
+
+// AccountCompanyVerificationParams are the parameters allowed to verify a company.
+type AccountCompanyVerificationParams struct {
+	Document *AccountCompanyVerificationDocumentParams `form:"document"`
+}
+
 // AccountCompanyParams are the parameters describing the company associated with the account.
 type AccountCompanyParams struct {
-	Address           *AccountAddressParams `form:"address"`
-	AddressKana       *AccountAddressParams `form:"address_kana"`
-	AddressKanji      *AccountAddressParams `form:"address_kanji"`
-	DirectorsProvided *bool                 `form:"directors_provided"`
-	Name              *string               `form:"name"`
-	NameKana          *string               `form:"name_kana"`
-	NameKanji         *string               `form:"name_kanji"`
-	OwnersProvided    *bool                 `form:"owners_provided"`
-	Phone             *string               `form:"phone"`
-	TaxID             *string               `form:"tax_id"`
-	TaxIDRegistrar    *string               `form:"tax_id_registrar"`
-	VATID             *string               `form:"vat_id"`
+	Address           *AccountAddressParams             `form:"address"`
+	AddressKana       *AccountAddressParams             `form:"address_kana"`
+	AddressKanji      *AccountAddressParams             `form:"address_kanji"`
+	DirectorsProvided *bool                             `form:"directors_provided"`
+	Name              *string                           `form:"name"`
+	NameKana          *string                           `form:"name_kana"`
+	NameKanji         *string                           `form:"name_kanji"`
+	OwnersProvided    *bool                             `form:"owners_provided"`
+	Phone             *string                           `form:"phone"`
+	TaxID             *string                           `form:"tax_id"`
+	TaxIDRegistrar    *string                           `form:"tax_id_registrar"`
+	VATID             *string                           `form:"vat_id"`
+	Verification      *AccountCompanyVerificationParams `form:"verification"`
 }
 
 // AccountDeclineSettingsParams represents the parameters allowed for configuring
@@ -282,20 +313,34 @@ type AccountCapabilities struct {
 	Transfers      AccountCapabilityStatus `json:"transfers"`
 }
 
+// AccountCompanyVerificationDocument represents details about a company's verification state.
+type AccountCompanyVerificationDocument struct {
+	Back        *File                                         `json:"back"`
+	Details     string                                        `json:"details"`
+	DetailsCode AccountCompanyVerificationDocumentDetailsCode `json:"details_code"`
+	Front       *File                                         `json:"front"`
+}
+
+// AccountCompanyVerification represents details about a company's verification state.
+type AccountCompanyVerification struct {
+	Document *AccountCompanyVerificationDocument `json:"document"`
+}
+
 // AccountCompany represents details about the company or business associated with the account.
 type AccountCompany struct {
-	Address           *AccountAddress `json:"address"`
-	AddressKana       *AccountAddress `json:"address_kana"`
-	AddressKanji      *AccountAddress `json:"address_kanji"`
-	DirectorsProvided bool            `json:"directors_provided"`
-	Name              string          `json:"name"`
-	NameKana          string          `json:"name_kana"`
-	NameKanji         string          `json:"name_kanji"`
-	OwnersProvided    bool            `json:"owners_provided"`
-	Phone             string          `json:"phone"`
-	TaxIDProvided     bool            `json:"tax_id_provided"`
-	TaxIDRegistrar    string          `json:"tax_id_registrar"`
-	VATIDProvided     bool            `json:"vat_id_provided"`
+	Address           *AccountAddress             `json:"address"`
+	AddressKana       *AccountAddress             `json:"address_kana"`
+	AddressKanji      *AccountAddress             `json:"address_kanji"`
+	DirectorsProvided bool                        `json:"directors_provided"`
+	Name              string                      `json:"name"`
+	NameKana          string                      `json:"name_kana"`
+	NameKanji         string                      `json:"name_kanji"`
+	OwnersProvided    bool                        `json:"owners_provided"`
+	Phone             string                      `json:"phone"`
+	TaxIDProvided     bool                        `json:"tax_id_provided"`
+	TaxIDRegistrar    string                      `json:"tax_id_registrar"`
+	VATIDProvided     bool                        `json:"vat_id_provided"`
+	Verification      *AccountCompanyVerification `json:"verification"`
 }
 
 // AccountDeclineOn represents card charges decline behavior for that account.

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -47,6 +47,12 @@ func TestAccountNew(t *testing.T) {
 		Company: &stripe.AccountCompanyParams{
 			DirectorsProvided: stripe.Bool(true),
 			Name:              stripe.String("company_name"),
+			Verification: &stripe.AccountCompanyVerificationParams{
+				Document: &stripe.AccountCompanyVerificationDocumentParams{
+					Back:  stripe.String("file_123"),
+					Front: stripe.String("file_abc"),
+				},
+			},
 		},
 		Country: stripe.String("CA"),
 		ExternalAccount: &stripe.AccountExternalAccountParams{

--- a/person.go
+++ b/person.go
@@ -72,7 +72,8 @@ type PersonVerificationDocumentParams struct {
 // PersonVerificationParams is used to represent parameters associated with a person's verification
 // details.
 type PersonVerificationParams struct {
-	Document *PersonVerificationDocumentParams `form:"document"`
+	AdditionalDocument *PersonVerificationDocumentParams `form:"additional_document"`
+	Document           *PersonVerificationDocumentParams `form:"document"`
 }
 
 // PersonParams is the set of parameters that can be used when creating or updating a person.
@@ -152,10 +153,11 @@ type PersonVerificationDocument struct {
 
 // PersonVerification is the structure for a person's verification details.
 type PersonVerification struct {
-	Details     string                        `json:"details"`
-	DetailsCode PersonVerificationDetailsCode `json:"details_code"`
-	Document    *PersonVerificationDocument   `json:"document"`
-	Status      IdentityVerificationStatus    `json:"status"`
+	AdditionalDocument *PersonVerificationDocument   `json:"additional_document"`
+	Details            string                        `json:"details"`
+	DetailsCode        PersonVerificationDetailsCode `json:"details_code"`
+	Document           *PersonVerificationDocument   `json:"document"`
+	Status             IdentityVerificationStatus    `json:"status"`
 }
 
 // Person is the resource representing a Stripe person.

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.65.0"
+	MockMinimumVersion = "0.66.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
This adds new properties and parameters to reflect the verification state of an `Account` and a `Person`:
* `company[verification]` on `Account` to support passing a document to verify a business entity.
* `verification[additional_document]` on `Person` for cases where a second document might be required for identity verification.

r? @ob-stripe
cc @stripe/api-libraries
