### PR TITLE
Add support for `DeclineCode` on `Error` top-level

### DIFF
--- a/error.go
+++ b/error.go
@@ -170,9 +170,10 @@ const (
 // Error is the response returned when a call is unsuccessful.
 // For more details see  https://stripe.com/docs/api#errors.
 type Error struct {
-	ChargeID string    `json:"charge,omitempty"`
-	Code     ErrorCode `json:"code,omitempty"`
-	DocURL   string    `json:"doc_url,omitempty"`
+	ChargeID    string      `json:"charge,omitempty"`
+	Code        ErrorCode   `json:"code,omitempty"`
+	DeclineCode DeclineCode `json:"decline_code,omitempty"`
+	DocURL      string      `json:"doc_url,omitempty"`
 
 	// Err contains an internal error with an additional level of granularity
 	// that can be used in some cases to get more detailed information about


### PR DESCRIPTION
The `Error` object has most properties top-level but we didn't have `DeclineCode`. Instead, it was inside `Err` if it was a `CardError`.

While it works, I think it might be easier to just make it top-level which is what this PR is introducing.

Fixes https://github.com/stripe/stripe-go/issues/948

r? @brandur-stripe 
cc @stripe/api-libraries 