### PR TITLE
Remove lossy "MarshalJSON" implementations

### DIFF
--- a/balancetransaction.go
+++ b/balancetransaction.go
@@ -186,8 +186,3 @@ func (s *BalanceTransactionSource) UnmarshalJSON(data []byte) error {
 
 	return err
 }
-
-// MarshalJSON handles serialization of a BalanceTransactionSource.
-func (s *BalanceTransactionSource) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.ID)
-}

--- a/payout.go
+++ b/payout.go
@@ -182,11 +182,3 @@ func (d *PayoutDestination) UnmarshalJSON(data []byte) error {
 
 	return err
 }
-
-// MarshalJSON handles serialization of a PayoutDestination.
-// This custom marshaling is needed because we can only send a string
-// ID as a destination, even though it can be expanded to a full
-// object when retrieving
-func (d *PayoutDestination) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.ID)
-}

--- a/recipienttransfer.go
+++ b/recipienttransfer.go
@@ -153,11 +153,3 @@ func (d *RecipientTransferDestination) UnmarshalJSON(data []byte) error {
 
 	return err
 }
-
-// MarshalJSON handles serialization of a RecipientTransferDestination.
-// This custom marshaling is needed because we can only send a string
-// ID as a destination, even though it can be expanded to a full
-// object when retrieving
-func (d *RecipientTransferDestination) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.ID)
-}

--- a/transfer.go
+++ b/transfer.go
@@ -108,11 +108,3 @@ func (d *TransferDestination) UnmarshalJSON(data []byte) error {
 	*d = TransferDestination(v)
 	return json.Unmarshal(data, &d.Account)
 }
-
-// MarshalJSON handles serialization of a TransferDestination.
-// This custom marshaling is needed because we can only send a string
-// ID as a destination, even though it can be expanded to a full
-// object when retrieving
-func (d *TransferDestination) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.ID)
-}

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -39,14 +39,11 @@ func TestTransferDestination_UnmarshalJSON(t *testing.T) {
 
 	// Unmarshals from a JSON object
 	{
-		// We build the JSON object manually here because TransferDestination
-		// has a custom MarshalJSON implementation as well, and it'll turn into
-		// a string if we marshaled a struct instance. This ensures that we're
-		// working with a JSON objects.
-		data := []byte(`{"id":"acct_123"}`)
+		v := TransferDestination{ID: "acct_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
 
-		var v TransferDestination
-		err := json.Unmarshal(data, &v)
+		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
 		assert.Equal(t, "acct_123", v.ID)
 


### PR DESCRIPTION
See #946 for context, but we're removing some `MarshalJSON`
implementations that are "lossy" in that they throw out information that
might be useful to somebody.

Note that we don't actually marshal API resources as part of normal
operations in stripe-go, so the only users that this will affect are
those that are manually re-marshaling resources to JSON in their
integrations.

Fixes #946.

r? @remi-stripe
cc @stripe/api-libraries

---

Targets the V64 integration branch in # instead of `master`.