### PR TITLE
Mark `Customer` on `PaymentMethodDetachParams` as deprecated

### DIFF
--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -77,7 +77,9 @@ type PaymentMethodParams struct {
 // PaymentMethodAttachParams is the set of parameters that can be used when attaching a
 // PaymentMethod to a Customer.
 type PaymentMethodAttachParams struct {
-	Params   `form:"*"`
+	Params `form:"*"`
+	// The following parameter is not supported by the API and should not have been added
+	// TODO: remove in the next major version
 	Customer *string `form:"customer"`
 }
 


### PR DESCRIPTION
Related to https://github.com/stripe/stripe-go/issues/958

r? @ob-stripe 
cc @stripe/api-libraries 