### PR TITLE
Remi remove todos

### DIFF
--- a/balance/client.go
+++ b/balance/client.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go"
-	"github.com/stripe/stripe-go/form"
 )
 
 // Client is used to invoke /balance and transaction-related APIs.
@@ -24,43 +23,6 @@ func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 	balance := &stripe.Balance{}
 	err := c.B.Call(http.MethodGet, "/v1/balance", c.Key, params, balance)
 	return balance, err
-}
-
-// GetBalanceTransaction retrieves a balance transaction
-// Deprecated: Prefer using balancetransaction.Get instead.
-func GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
-	return getC().GetBalanceTransaction(id, params)
-}
-
-// GetBalanceTransaction retrieves a balance transaction
-// Deprecated: Prefer using balancetransaction.Get instead.
-func (c Client) GetBalanceTransaction(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
-	path := stripe.FormatURLPath("/v1/balance_transactions/%s", id)
-	balance := &stripe.BalanceTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, balance)
-	return balance, err
-}
-
-// List returns a list of balance transactions
-// Deprecated: Prefer using balancetransaction.List instead.
-func List(params *stripe.BalanceTransactionListParams) *Iter {
-	return getC().List(params)
-}
-
-// List returns a list of balance transactions.
-// Deprecated: Prefer using balancetransaction.List instead.
-func (c Client) List(listParams *stripe.BalanceTransactionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
-		list := &stripe.BalanceTransactionList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/balance_transactions", c.Key, b, p, list)
-
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
-
-		return ret, list.ListMeta, err
-	})}
 }
 
 // Iter is an iterator for balance transactions.

--- a/balance/client_test.go
+++ b/balance/client_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
-	stripe "github.com/stripe/stripe-go"
 	_ "github.com/stripe/stripe-go/testing"
 )
 
@@ -12,19 +11,4 @@ func TestBalanceGet(t *testing.T) {
 	balance, err := Get(nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, balance)
-}
-
-func TestBalanceTransactionList(t *testing.T) {
-	i := List(&stripe.BalanceTransactionListParams{})
-
-	// Verify that we can get at least one transaction
-	assert.True(t, i.Next())
-	assert.Nil(t, i.Err())
-	assert.NotNil(t, i.BalanceTransaction())
-}
-
-func TestBalanceBalanceTransactionGet(t *testing.T) {
-	transaction, err := GetBalanceTransaction("txn_123", nil)
-	assert.Nil(t, err)
-	assert.NotNil(t, transaction)
 }

--- a/charge.go
+++ b/charge.go
@@ -95,9 +95,6 @@ type ChargeParams struct {
 	StatementDescriptorSuffix *string                   `form:"statement_descriptor_suffix"`
 	TransferData              *ChargeTransferDataParams `form:"transfer_data"`
 	TransferGroup             *string                   `form:"transfer_group"`
-
-	// This property is considered deprecated. Prefer using ApplicationFeeAmount
-	ApplicationFee *int64 `form:"application_fee"`
 }
 
 // ShippingDetailsParams is the structure containing shipping information as parameters
@@ -149,9 +146,6 @@ type CaptureParams struct {
 	StatementDescriptorSuffix *string                   `form:"statement_descriptor_suffix"`
 	TransferGroup             *string                   `form:"transfer_group"`
 	TransferData              *ChargeTransferDataParams `form:"transfer_data"`
-
-	// This property is considered deprecated. Prefer using ApplicationFeeAmount
-	ApplicationFee *int64 `form:"application_fee"`
 }
 
 // ChargeLevel3LineItem represents a line item on level III data.

--- a/customer.go
+++ b/customer.go
@@ -7,29 +7,11 @@ import (
 // CustomerTaxExempt is the type of tax exemption associated with a customer.
 type CustomerTaxExempt string
 
-// List of values that CustomerTaxInfoType can take.
+// List of values that CustomerTaxExempt can take.
 const (
 	CustomerTaxExemptExempt  CustomerTaxExempt = "exempt"
 	CustomerTaxExemptNone    CustomerTaxExempt = "none"
 	CustomerTaxExemptReverse CustomerTaxExempt = "reverse"
-)
-
-// CustomerTaxInfoType is the type of tax info associated with a customer.
-type CustomerTaxInfoType string
-
-// List of values that CustomerTaxInfoType can take.
-const (
-	CustomerTaxInfoTypeVAT CustomerTaxInfoType = "vat"
-)
-
-// CustomerTaxInfoVerificationStatus is the type of tax info associated with a customer.
-type CustomerTaxInfoVerificationStatus string
-
-// List of values that CustomerTaxInfoType can take.
-const (
-	CustomerTaxInfoVerificationStatusPending    CustomerTaxInfoVerificationStatus = "pending"
-	CustomerTaxInfoVerificationStatusUnverified CustomerTaxInfoVerificationStatus = "unverified"
-	CustomerTaxInfoVerificationStatusVerified   CustomerTaxInfoVerificationStatus = "verified"
 )
 
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
@@ -53,12 +35,6 @@ type CustomerParams struct {
 	TaxExempt        *string                        `form:"tax_exempt"`
 	TaxIDData        []*CustomerTaxIDDataParams     `form:"tax_id_data"`
 	Token            *string                        `form:"-"` // This doesn't seem to be used?
-
-	// The following parameter is deprecated. Use Balance instead.
-	AccountBalance *int64 `form:"account_balance"`
-
-	// The following parameter is deprecated. Use TaxIDData instead.
-	TaxInfo *CustomerTaxInfoParams `form:"tax_info"`
 
 	// The parameters below are considered deprecated. Consider creating a Subscription separately instead.
 	Plan       *string  `form:"plan"`
@@ -93,12 +69,6 @@ type CustomerShippingDetailsParams struct {
 type CustomerTaxIDDataParams struct {
 	Type  *string `form:"type"`
 	Value *string `form:"value"`
-}
-
-// CustomerTaxInfoParams is the structure containing tax information for the customer.
-type CustomerTaxInfoParams struct {
-	TaxID *string `form:"tax_id"`
-	Type  *string `form:"type"`
 }
 
 // SetSource adds valid sources to a CustomerParams object,
@@ -144,13 +114,6 @@ type Customer struct {
 	Subscriptions    *SubscriptionList        `json:"subscriptions"`
 	TaxExempt        CustomerTaxExempt        `json:"tax_exempt"`
 	TaxIDs           *TaxIDList               `json:"tax_ids"`
-
-	// The following property is deprecated. Use Balance instead.
-	AccountBalance int64 `json:"account_balance"`
-
-	// The following properties are deprecated. Use TaxIds instead.
-	TaxInfo             *CustomerTaxInfo             `json:"tax_info"`
-	TaxInfoVerification *CustomerTaxInfoVerification `json:"tax_info_verification"`
 }
 
 // CustomerInvoiceCustomField represents a custom field associated with the customer's invoices.
@@ -178,18 +141,6 @@ type CustomerShippingDetails struct {
 	Address Address `json:"address"`
 	Name    string  `json:"name"`
 	Phone   string  `json:"phone"`
-}
-
-// CustomerTaxInfo is the structure containing tax information for the customer.
-type CustomerTaxInfo struct {
-	TaxID string              `json:"tax_id"`
-	Type  CustomerTaxInfoType `json:"type"`
-}
-
-// CustomerTaxInfoVerification is the structure containing tax verification for the customer.
-type CustomerTaxInfoVerification struct {
-	Status       CustomerTaxInfoVerificationStatus `json:"status"`
-	VerifiedName string                            `json:"verified_name"`
 }
 
 // UnmarshalJSON handles deserialization of a Customer.

--- a/invoice.go
+++ b/invoice.go
@@ -15,16 +15,6 @@ const (
 	InvoiceLineTypeSubscription InvoiceLineType = "subscription"
 )
 
-// InvoiceBilling is the type of collection method for this invoice.
-// This is considered deprecated. Use InvoiceCollectionMethod instead.
-type InvoiceBilling string
-
-// List of values that InvoiceBilling can take.
-const (
-	InvoiceBillingChargeAutomatically InvoiceBilling = "charge_automatically"
-	InvoiceBillingSendInvoice         InvoiceBilling = "send_invoice"
-)
-
 // InvoiceBillingReason is the reason why a given invoice was created
 type InvoiceBillingReason string
 
@@ -40,6 +30,7 @@ const (
 )
 
 // InvoiceBillingStatus is the reason why a given invoice was created
+// TODO: rename to InvoiceStatus
 type InvoiceBillingStatus string
 
 // List of values that InvoiceBillingStatus can take.
@@ -134,12 +125,6 @@ type InvoiceParams struct {
 	SubscriptionTrialEnd                    *int64                              `form:"subscription_trial_end"`
 	SubscriptionTrialFromPlan               *bool                               `form:"subscription_trial_from_plan"`
 
-	// This parameter is considered deprecated. Prefer using ApplicationFeeAmount
-	ApplicationFee *int64 `form:"application_fee"`
-
-	// This parameter is considered deprecated. Prefer using CollectionMethod
-	Billing *string `form:"billing"`
-
 	// This parameter is deprecated and we recommend that you use DefaultTaxRates instead.
 	TaxPercent *float64 `form:"tax_percent"`
 
@@ -171,9 +156,6 @@ type InvoiceListParams struct {
 	DueDate          *int64            `form:"due_date"`
 	DueDateRange     *RangeQueryParams `form:"due_date"`
 	Subscription     *string           `form:"subscription"`
-
-	// This parameter is considered deprecated. Prefer using CollectionMethod
-	Billing *string `form:"billing"`
 }
 
 // InvoiceLineListParams is the set of parameters that can be used when listing invoice line items.
@@ -285,9 +267,6 @@ type Invoice struct {
 	TotalTaxAmounts              []*InvoiceTaxAmount      `json:"total_tax_amounts"`
 	TransferData                 *InvoiceTransferData     `json:"transfer_data"`
 	WebhooksDeliveredAt          int64                    `json:"webhooks_delivered_at"`
-
-	// This property is considered deprecated. Prefer using CollectionMethod
-	Billing *InvoiceBilling `form:"billing"`
 
 	// This field is deprecated and we recommend that you use TaxRates instead.
 	TaxPercent float64 `json:"tax_percent"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -34,9 +34,6 @@ type PaymentIntentConfirmationMethod string
 const (
 	PaymentIntentConfirmationMethodAutomatic PaymentIntentConfirmationMethod = "automatic"
 	PaymentIntentConfirmationMethodManual    PaymentIntentConfirmationMethod = "manual"
-	// The following constants are considered deprecated
-	PaymentIntentConfirmationMethodPublishable PaymentIntentConfirmationMethod = "publishable"
-	PaymentIntentConfirmationMethodSecret      PaymentIntentConfirmationMethod = "secret"
 )
 
 // PaymentIntentNextActionType is the list of allowed values for the next action's type.
@@ -207,7 +204,7 @@ type PaymentIntent struct {
 	AmountCapturable          int64                           `json:"amount_capturable"`
 	AmountReceived            int64                           `json:"amount_received"`
 	Application               *Application                    `json:"application"`
-	ApplicationFee            int64                           `json:"application_fee"`
+	ApplicationFeeAmount      int64                           `json:"application_fee_amount"`
 	CanceledAt                int64                           `json:"canceled_at"`
 	CancellationReason        PaymentIntentCancellationReason `json:"cancellation_reason"`
 	CaptureMethod             PaymentIntentCaptureMethod      `json:"capture_method"`

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -68,10 +68,6 @@ type PaymentMethodParams struct {
 	Card           *PaymentMethodCardParams `form:"card"`
 	PaymentMethod  *string                  `form:"payment_method"`
 	Type           *string                  `form:"type"`
-
-	// The following parameter is not supported by the API and should not have been added
-	// TODO: remove in the next major version
-	Customer *string `form:"customer"`
 }
 
 // PaymentMethodAttachParams is the set of parameters that can be used when attaching a
@@ -85,9 +81,6 @@ type PaymentMethodAttachParams struct {
 // PaymentMethod.
 type PaymentMethodDetachParams struct {
 	Params `form:"*"`
-	// The following parameter is not supported by the API and should not have been added
-	// TODO: remove in the next major version
-	Customer *string `form:"customer"`
 }
 
 // PaymentMethodListParams is the set of parameters that can be used when listing PaymentMethods.

--- a/sub.go
+++ b/sub.go
@@ -21,16 +21,6 @@ const (
 	SubscriptionStatusUnpaid            SubscriptionStatus = "unpaid"
 )
 
-// SubscriptionBilling is the type of collection method for this subscription's invoices.
-// This is considered deprecated. Use SubscriptionCollectionMethod instead.
-type SubscriptionBilling string
-
-// List of values that SubscriptionBilling can take.
-const (
-	SubscriptionBillingChargeAutomatically SubscriptionBilling = "charge_automatically"
-	SubscriptionBillingSendInvoice         SubscriptionBilling = "send_invoice"
-)
-
 // SubscriptionCollectionMethod is the type of collection method for this subscription's invoices.
 type SubscriptionCollectionMethod string
 
@@ -88,9 +78,6 @@ type SubscriptionParams struct {
 	TrialEndNow                 *bool                                `form:"-"` // See custom AppendTo
 	TrialFromPlan               *bool                                `form:"trial_from_plan"`
 	TrialPeriodDays             *int64                               `form:"trial_period_days"`
-
-	// This parameter is deprecated and we recommend that you use CollectionMethod instead.
-	Billing *string `form:"billing"`
 
 	// This parameter is deprecated and we recommend that you use TaxRates instead.
 	TaxPercent *float64 `form:"tax_percent"`
@@ -155,9 +142,6 @@ type SubscriptionListParams struct {
 	Customer                string            `form:"customer"`
 	Plan                    string            `form:"plan"`
 	Status                  string            `form:"status"`
-
-	// This parameter is deprecated and we recommend that you use CollectionMethod instead.
-	Billing *string `form:"billing"`
 }
 
 // SubscriptionTransferData represents the information for the transfer_data associated with a subscription.
@@ -201,12 +185,6 @@ type Subscription struct {
 	TransferData          *SubscriptionTransferData      `json:"transfer_data"`
 	TrialEnd              int64                          `json:"trial_end"`
 	TrialStart            int64                          `json:"trial_start"`
-
-	// This field is deprecated and we recommend that you use CollectionMethod instead.
-	Billing SubscriptionBilling `json:"billing"`
-
-	// This field is deprecated and we recommend that you use StartDate instead.
-	Start int64 `json:"start"`
 
 	// This field is deprecated and we recommend that you use TaxRates instead.
 	TaxPercent float64 `json:"tax_percent"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -98,9 +98,6 @@ type SubscriptionScheduleParams struct {
 	RenewalBehavior      *string                                    `form:"renewal_behavior"`
 	RenewalInterval      *SubscriptionScheduleRenewalIntervalParams `form:"renewal_interval"`
 	StartDate            *int64                                     `form:"start_date"`
-
-	// This parameter is deprecated and we recommend that you use CollectionMethod instead.
-	Billing *string `form:"billing"`
 }
 
 // SubscriptionScheduleCancelParams is the set of parameters that can be used when canceling a
@@ -201,9 +198,6 @@ type SubscriptionSchedule struct {
 	RenewalInterval      *SubscriptionScheduleRenewalInterval `json:"renewal_interval"`
 	Status               SubscriptionScheduleStatus           `json:"status"`
 	Subscription         *Subscription                        `json:"subscription"`
-
-	// This field is deprecated and we recommend that you use CollectionMethod instead.
-	Billing SubscriptionBilling `json:"billing"`
 }
 
 // SubscriptionScheduleList is a list object for subscription schedules.

--- a/terminal_connectiontoken.go
+++ b/terminal_connectiontoken.go
@@ -4,9 +4,6 @@ package stripe
 type TerminalConnectionTokenParams struct {
 	Params   `form:"*"`
 	Location string `form:"location"`
-
-	// This feature has been deprecated and should not be used anymore.
-	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalConnectionToken is the resource representing a Stripe terminal connection token.

--- a/terminal_location.go
+++ b/terminal_location.go
@@ -5,9 +5,6 @@ type TerminalLocationParams struct {
 	Params      `form:"*"`
 	Address     *AccountAddressParams `form:"address"`
 	DisplayName *string               `form:"display_name"`
-
-	// This feature has been deprecated and should not be used anymore.
-	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalLocationListParams is the set of parameters that can be used when listing temrinal locations.

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -6,17 +6,11 @@ type TerminalReaderParams struct {
 	Label            *string `form:"label"`
 	Location         *string `form:"location"`
 	RegistrationCode *string `form:"registration_code"`
-
-	// This feature has been deprecated and should not be used anymore.
-	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalReaderGetParams is the set of parameters that can be used to get a terminal reader.
 type TerminalReaderGetParams struct {
 	Params `form:"*"`
-
-	// This feature has been deprecated and should not be used anymore.
-	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalReaderListParams is the set of parameters that can be used when listing temrinal readers.
@@ -24,9 +18,6 @@ type TerminalReaderListParams struct {
 	ListParams `form:"*"`
 	Location   *string `form:"location"`
 	Status     *string `form:"status"`
-
-	// This feature has been deprecated and should not be used anymore.
-	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalReader is the resource representing a Stripe terminal reader.


### PR DESCRIPTION
Remove TODOs and deprecated parts

* Removed `GetBalanceTransaction` and `List` from the `balance` package. Prefer using `Get` and `List` in the `balancetransaction` package.
* Removed `ApplicationFee` from the `charge` and `paymentintent` packages. Prefer using `ApplicationFeeAmount`.
* Removed `TaxInfo` and related fields from the `customer` packager. Prefer using the `customertaxid` package.
* Removed unsupported `Customer` parameter on `PaymentMethodParams` and `PaymentMethodDetachParams` in the `paymentmethod` package.
* Removed `Billing` properties in the `invoice`, `sub` and `subschedule` packages. Prefer using `CollectionMethod`.
* Removed the `InvoiceBilling` type from the `invoice` package. Prefer using `InvoiceCollectionMethod`.
* Removed the `SubscriptionBilling` type from the `sub` package. Prefer using `SubscriptionCollectionMethod`.
* Removed deprecated constants for `PaymentIntentConfirmationMethod` in `paymentintent` package.
* Removed `OperatorAccount` from Terminal APIs.

r? @ob-stripe 
cc @stripe/api-libraries 