### PR TITLE
Add the Account field to BankAccount

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -141,6 +141,7 @@ func (p *BankAccountListParams) AppendTo(body *form.Values, keyParts []string) {
 
 // BankAccount represents a Stripe bank account.
 type BankAccount struct {
+	Account            string                       `json:"account"`
 	AccountHolderName  string                       `json:"account_holder_name"`
 	AccountHolderType  BankAccountAccountHolderType `json:"account_holder_type"`
 	BankName           string                       `json:"bank_name"`

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -141,7 +141,7 @@ func (p *BankAccountListParams) AppendTo(body *form.Values, keyParts []string) {
 
 // BankAccount represents a Stripe bank account.
 type BankAccount struct {
-	Account            string                       `json:"account"`
+	Account            *Account                     `json:"account"`
 	AccountHolderName  string                       `json:"account_holder_name"`
 	AccountHolderType  BankAccountAccountHolderType `json:"account_holder_type"`
 	BankName           string                       `json:"bank_name"`


### PR DESCRIPTION
This change adds the already present (network-wise) Account field to the BankAccount struct, and allows the BankAccount to become self contained --no longer needing to tuple an Event struct alongside the BankAccount when handling webhooks.

Tested working for `sc.BankAccounts.New` and when responding to a `account.external_account.updated` event in a webhook.