### PR TITLE
Update to latest API version 2019-10-08

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.67.0
+    - STRIPE_MOCK_VERSION=0.68.0
 
 go:
   - "1.9.x"

--- a/account_test.go
+++ b/account_test.go
@@ -68,7 +68,7 @@ func TestAccount_Unmarshal(t *testing.T) {
 			},
 			"disabled_reason": "fields_needed",
 			"eventually_due": []interface{}{
-				"relationship.account_opener",
+				"relationship.representative",
 			},
 			"past_due": []interface{}{},
 		},

--- a/person.go
+++ b/person.go
@@ -54,11 +54,11 @@ type DOBParams struct {
 
 // RelationshipParams is used to set the relationship between an account and a person.
 type RelationshipParams struct {
-	AccountOpener    *bool    `form:"account_opener"`
 	Director         *bool    `form:"director"`
 	Executive        *bool    `form:"executive"`
 	Owner            *bool    `form:"owner"`
 	PercentOwnership *float64 `form:"percent_ownership"`
+	Representative   *bool    `form:"representative"`
 	Title            *string  `form:"title"`
 }
 
@@ -104,10 +104,10 @@ type PersonParams struct {
 
 // RelationshipListParams is used to filter persons by the relationship
 type RelationshipListParams struct {
-	AccountOpener *bool `form:"account_opener"`
-	Director      *bool `form:"director"`
-	Executive     *bool `form:"executive"`
-	Owner         *bool `form:"owner"`
+	Director       *bool `form:"director"`
+	Executive      *bool `form:"executive"`
+	Owner          *bool `form:"owner"`
+	Representative *bool `form:"representative"`
 }
 
 // PersonListParams is the set of parameters that can be used when listing persons.
@@ -127,11 +127,11 @@ type DOB struct {
 
 // Relationship represents how the Person relates to the business.
 type Relationship struct {
-	AccountOpener    bool    `json:"account_opener"`
 	Director         bool    `json:"director"`
 	Executive        bool    `json:"executive"`
 	Owner            bool    `json:"owner"`
 	PercentOwnership float64 `json:"percent_ownership"`
+	Representative   bool    `json:"representative"`
 	Title            string  `json:"title"`
 }
 

--- a/stripe.go
+++ b/stripe.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2019-09-09"
+	APIVersion string = "2019-10-08"
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.67.0"
+	MockMinimumVersion = "0.68.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
- Rename `AccountOpener` to `Representative` on `Account` and `Person`
- Update to latest API version `2019-10-08`

r? @ob-stripe 
cc @stripe/api-libraries 