### PR TITLE
Various API changes

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -208,6 +208,7 @@ type ChargePaymentMethodDetailsAUBECSDebit struct {
 	BSBNumber   string `json:"bsb_number"`
 	Fingerprint string `json:"fingerprint"`
 	Last4       string `json:"last4"`
+	Mandate     string `json:"mandate"`
 }
 
 // ChargePaymentMethodDetailsBancontact represents details about the Bancontact PaymentMethod.

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -90,6 +90,7 @@ type CheckoutSessionSubscriptionDataParams struct {
 	ApplicationFeePercent *float64                                      `form:"application_fee_percent"`
 	Items                 []*CheckoutSessionSubscriptionDataItemsParams `form:"items"`
 	TrialEnd              *int64                                        `form:"trial_end"`
+	TrialFromPlan         *bool                                         `form:"trial_from_plan"`
 	TrialPeriodDays       *int64                                        `form:"trial_period_days"`
 }
 

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -2,6 +2,17 @@ package stripe
 
 import "encoding/json"
 
+// IssuingCardholderRequirementsDisabledReason is the possible values for the disabled reason on an
+// issuing cardholder.
+type IssuingCardholderRequirementsDisabledReason string
+
+// List of values that IssuingCardholderRequirementsDisabledReason can take.
+const (
+	IssuingCardholderRequirementsDisabledReasonListed         IssuingCardholderRequirementsDisabledReason = "listed"
+	IssuingCardholderRequirementsDisabledReasonRejectedListed IssuingCardholderRequirementsDisabledReason = "rejected.listed"
+	IssuingCardholderRequirementsDisabledReasonUnderReview    IssuingCardholderRequirementsDisabledReason = "under_review"
+)
+
 // IssuingCardholderStatus is the possible values for status on an issuing cardholder.
 type IssuingCardholderStatus string
 
@@ -58,6 +69,12 @@ type IssuingBilling struct {
 	Name    string   `json:"name"`
 }
 
+// IssuingCardholderRequirements contains the verification requirements for the cardholder.
+type IssuingCardholderRequirements struct {
+	DisabledReason IssuingCardholderRequirementsDisabledReason `json:"disabled_reason"`
+	PastDue        []string                                    `json:"past_due"`
+}
+
 // IssuingCardholder is the resource representing a Stripe issuing cardholder.
 type IssuingCardholder struct {
 	AuthorizationControls *IssuingCardAuthorizationControls `json:"authorization_controls"`
@@ -70,6 +87,7 @@ type IssuingCardholder struct {
 	Name                  string                            `json:"name"`
 	Object                string                            `json:"object"`
 	PhoneNumber           string                            `json:"phone_number"`
+	Requirements          *IssuingCardholderRequirements    `json:"requirements"`
 	Status                IssuingCardholderStatus           `json:"status"`
 	Type                  IssuingCardholderType             `json:"type"`
 }

--- a/sub.go
+++ b/sub.go
@@ -36,8 +36,9 @@ type SubscriptionPaymentBehavior string
 
 // List of values that SubscriptionPaymentBehavior can take.
 const (
-	SubscriptionPaymentBehaviorAllowIncomplete   SubscriptionPaymentBehavior = "allow_incomplete"
-	SubscriptionPaymentBehaviorErrorIfIncomplete SubscriptionPaymentBehavior = "error_if_incomplete"
+	SubscriptionPaymentBehaviorAllowIncomplete     SubscriptionPaymentBehavior = "allow_incomplete"
+	SubscriptionPaymentBehaviorErrorIfIncomplete   SubscriptionPaymentBehavior = "error_if_incomplete"
+	SubscriptionPaymentBehaviorPendingIfIncomplete SubscriptionPaymentBehavior = "pending_if_incomplete"
 )
 
 // SubscriptionTransferDataParams is the set of parameters allowed for the transfer_data hash.

--- a/subitem.go
+++ b/subitem.go
@@ -7,6 +7,7 @@ type SubscriptionItemParams struct {
 	ID                *string                                  `form:"-"` // Handled in URL
 	BillingThresholds *SubscriptionItemBillingThresholdsParams `form:"billing_thresholds"`
 	ClearUsage        *bool                                    `form:"clear_usage"`
+	PaymentBehavior   *string                                  `form:"payment_behavior"`
 	Plan              *string                                  `form:"plan"`
 	Prorate           *bool                                    `form:"prorate"`
 	ProrationDate     *int64                                   `form:"proration_date"`
@@ -15,8 +16,7 @@ type SubscriptionItemParams struct {
 	TaxRates          []*string                                `form:"tax_rates"`
 
 	// The following parameters are only supported on updates
-	OffSession      *bool   `form:"off_session"`
-	PaymentBehavior *string `form:"payment_behavior"`
+	OffSession *bool `form:"off_session"`
 }
 
 // SubscriptionItemBillingThresholdsParams is a structure representing the parameters allowed to

--- a/taxid.go
+++ b/taxid.go
@@ -5,13 +5,15 @@ import "encoding/json"
 // TaxIDType is the list of allowed values for the tax id's type..
 type TaxIDType string
 
-// List of values that TaxIDDuration can take.
+// List of values that TaxIDType can take.
 const (
 	TaxIDTypeAUABN   TaxIDType = "au_abn"
+	TaxIDTypeCHVAT   TaxIDType = "eu_vat"
 	TaxIDTypeEUVAT   TaxIDType = "eu_vat"
 	TaxIDTypeINGST   TaxIDType = "in_gst"
 	TaxIDTypeNOVAT   TaxIDType = "no_vat"
 	TaxIDTypeNZGST   TaxIDType = "nz_gst"
+	TaxIDTypeZAVAT   TaxIDType = "za_vat"
 	TaxIDTypeUnknown TaxIDType = "unknown"
 )
 


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

This PR adds multiple changes
- `Requirements` on Issuing `Cardholder`.
- `PaymentMethodDetails.AuBecsDebit.Mandate` on `Charge`.
- `PaymentBehavior` on `Subscription` creation can now take the value `pending_if_incomplete`.
- `PaymentBehavior` on `SubscriptionItem` creation is now supported.
- `SubscriptionData.TrialFromPlan` is now supported on Checkout `Session` creation.
- New values for `TaxIDType`.