### PR TITLE
Move to API version 2019-10-17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.68.0
+    - STRIPE_MOCK_VERSION=0.69.0
 
 go:
   - "1.9.x"

--- a/README.md
+++ b/README.md
@@ -67,11 +67,9 @@ Below are a few simple examples:
 
 ```go
 params := &stripe.CustomerParams{
-	AccountBalance:     stripe.Int64(-123),
 	Description:        stripe.String("Stripe Developer"),
 	Email:              stripe.String("gostripe@stripe.com"),
 }
-params.SetSource("tok_1234")
 
 customer, err := customer.New(params)
 ```

--- a/stripe.go
+++ b/stripe.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2019-10-08"
+	APIVersion string = "2019-10-17"
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"

--- a/subschedule.go
+++ b/subschedule.go
@@ -9,10 +9,8 @@ type SubscriptionScheduleEndBehavior string
 
 // List of values that SubscriptionScheduleEndBehavior can take.
 const (
-	SubscriptionScheduleEndBehaviorCancel  SubscriptionScheduleEndBehavior = "cancel"
-	SubscriptionScheduleEndBehaviorNone    SubscriptionScheduleEndBehavior = "none"
-	SubscriptionScheduleEndBehaviorRenew   SubscriptionScheduleEndBehavior = "release"
-	SubscriptionScheduleEndBehaviorRelease SubscriptionScheduleEndBehavior = "renew"
+	SubscriptionScheduleEndBehaviorCancel SubscriptionScheduleEndBehavior = "cancel"
+	SubscriptionScheduleEndBehaviorRenew  SubscriptionScheduleEndBehavior = "release"
 )
 
 // SubscriptionScheduleStatus is the list of allowed values for the schedule's status.
@@ -25,17 +23,6 @@ const (
 	SubscriptionScheduleStatusCompleted SubscriptionScheduleStatus = "completed"
 	SubscriptionScheduleStatusPastDue   SubscriptionScheduleStatus = "not_started"
 	SubscriptionScheduleStatusTrialing  SubscriptionScheduleStatus = "released"
-)
-
-// SubscriptionScheduleRenewalBehavior describe what happens to a schedule when it ends.
-type SubscriptionScheduleRenewalBehavior string
-
-// List of values that SubscriptionScheduleRenewalBehavior can take.
-const (
-	SubscriptionScheduleRenewalBehaviorCancel  SubscriptionScheduleRenewalBehavior = "cancel"
-	SubscriptionScheduleRenewalBehaviorNone    SubscriptionScheduleRenewalBehavior = "none"
-	SubscriptionScheduleRenewalBehaviorRenew   SubscriptionScheduleRenewalBehavior = "release"
-	SubscriptionScheduleRenewalBehaviorRelease SubscriptionScheduleRenewalBehavior = "renew"
 )
 
 // SubscriptionScheduleInvoiceSettingsParams is a structure representing the parameters allowed to
@@ -74,13 +61,6 @@ type SubscriptionSchedulePhaseParams struct {
 	TaxPercent *float64 `form:"tax_percent"`
 }
 
-// SubscriptionScheduleRenewalIntervalParams is a structure representing the renewal interval
-// for a given subscription schedule.
-type SubscriptionScheduleRenewalIntervalParams struct {
-	Interval *string `form:"interval"`
-	Length   *int64  `form:"length"`
-}
-
 // SubscriptionScheduleParams is the set of parameters that can be used when creating or updating a
 // subscription schedule.
 type SubscriptionScheduleParams struct {
@@ -95,8 +75,6 @@ type SubscriptionScheduleParams struct {
 	InvoiceSettings      *SubscriptionScheduleInvoiceSettingsParams `form:"invoice_settings"`
 	Phases               []*SubscriptionSchedulePhaseParams         `form:"phases"`
 	Prorate              *bool                                      `form:"prorate"`
-	RenewalBehavior      *string                                    `form:"renewal_behavior"`
-	RenewalInterval      *SubscriptionScheduleRenewalIntervalParams `form:"renewal_interval"`
 	StartDate            *int64                                     `form:"start_date"`
 }
 
@@ -194,7 +172,6 @@ type SubscriptionSchedule struct {
 	Object               string                               `json:"object"`
 	Phases               []*SubscriptionSchedulePhase         `json:"phases"`
 	ReleasedSubscription *Subscription                        `json:"released_subscription"`
-	RenewalBehavior      SubscriptionScheduleRenewalBehavior  `json:"renewal_behavior"`
 	RenewalInterval      *SubscriptionScheduleRenewalInterval `json:"renewal_interval"`
 	Status               SubscriptionScheduleStatus           `json:"status"`
 	Subscription         *Subscription                        `json:"subscription"`

--- a/subschedule/client_test.go
+++ b/subschedule/client_test.go
@@ -64,7 +64,7 @@ func TestSubscriptionScheduleNew(t *testing.T) {
 				},
 			},
 		},
-		RenewalBehavior: stripe.String(string(stripe.SubscriptionScheduleRenewalBehaviorNone)),
+		EndBehavior: stripe.String(string(stripe.SubscriptionScheduleEndBehaviorCancel)),
 	}
 	schedule, err := New(params)
 	assert.Nil(t, err)

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.68.0"
+	MockMinimumVersion = "0.69.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

* Pin to the latest API version `2019-10-17`
* Remove `RenewalBehavior` on `SubscriptionSchedule`
* Remove `RenewalBehavior` and `RenewalInterval` as parameters on `SubscriptionSchedule`