### PR TITLE
Add support for cloning saved PaymentMethods

### DIFF
--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -83,8 +83,11 @@ type PaymentMethodParams struct {
 	BillingDetails *BillingDetailsParams    `form:"billing_details"`
 	Card           *PaymentMethodCardParams `form:"card"`
 	FPX            *PaymentMethodFPXParams  `form:"fpx"`
-	PaymentMethod  *string                  `form:"payment_method"`
 	Type           *string                  `form:"type"`
+
+	// The following parameters are used when cloning a PaymentMethod to the connected account
+	Customer      *string `form:"customer"`
+	PaymentMethod *string `form:"payment_method"`
 }
 
 // PaymentMethodAttachParams is the set of parameters that can be used when attaching a


### PR DESCRIPTION
I incorrectly removed this parameter in a recent PR. Adding it back and making it explicitly why it's here

r? @ob-stripe 
cc @stripe/api-libraries  @XplittR