### PR TITLE
Add disputed to charge and allow listing disputes by charge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.72.0
+    - STRIPE_MOCK_VERSION=0.73.0
 
 go:
   - "1.9.x"

--- a/charge.go
+++ b/charge.go
@@ -471,6 +471,7 @@ type Charge struct {
 	Description               string                      `json:"description"`
 	Destination               *Account                    `json:"destination"`
 	Dispute                   *Dispute                    `json:"dispute"`
+	Disputed                  bool                        `json:"disputed"`
 	FailureCode               string                      `json:"failure_code"`
 	FailureMessage            string                      `json:"failure_message"`
 	FraudDetails              *FraudDetails               `json:"fraud_details"`

--- a/dispute.go
+++ b/dispute.go
@@ -78,6 +78,7 @@ type DisputeEvidenceParams struct {
 // For more details see https://stripe.com/docs/api#list_disputes.
 type DisputeListParams struct {
 	ListParams   `form:"*"`
+	Charge       *string           `form:"charge"`
 	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
@@ -96,6 +97,7 @@ type Dispute struct {
 	IsChargeRefundable  bool                  `json:"is_charge_refundable"`
 	Livemode            bool                  `json:"livemode"`
 	Metadata            map[string]string     `json:"metadata"`
+	PaymentIntent       *PaymentIntent        `json:"payment_intent"`
 	Reason              DisputeReason         `json:"reason"`
 	Status              DisputeStatus         `json:"status"`
 }

--- a/refund.go
+++ b/refund.go
@@ -39,6 +39,7 @@ type RefundParams struct {
 	Params               `form:"*"`
 	Amount               *int64  `form:"amount"`
 	Charge               *string `form:"charge"`
+	PaymentIntent        *string `form:"payment_intent"`
 	Reason               *string `form:"reason"`
 	RefundApplicationFee *bool   `form:"refund_application_fee"`
 	ReverseTransfer      *bool   `form:"reverse_transfer"`
@@ -47,10 +48,11 @@ type RefundParams struct {
 // RefundListParams is the set of parameters that can be used when listing refunds.
 // For more details see https://stripe.com/docs/api#list_refunds.
 type RefundListParams struct {
-	ListParams   `form:"*"`
-	Charge       *string           `form:"charge"`
-	Created      *int64            `form:"created"`
-	CreatedRange *RangeQueryParams `form:"created"`
+	ListParams    `form:"*"`
+	Charge        *string           `form:"charge"`
+	Created       *int64            `form:"created"`
+	CreatedRange  *RangeQueryParams `form:"created"`
+	PaymentIntent *string           `form:"payment_intent"`
 }
 
 // Refund is the resource representing a Stripe refund.
@@ -66,6 +68,7 @@ type Refund struct {
 	ID                        string              `json:"id"`
 	Metadata                  map[string]string   `json:"metadata"`
 	Object                    string              `json:"object"`
+	PaymentIntent             *PaymentIntent      `json:"payment_intent"`
 	Reason                    RefundReason        `json:"reason"`
 	ReceiptNumber             string              `json:"receipt_number"`
 	SourceTransferReversal    *Reversal           `json:"source_transfer_reversal"`

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -25,8 +25,9 @@ func TestRefundList(t *testing.T) {
 
 func TestRefundNew(t *testing.T) {
 	refund, err := New(&stripe.RefundParams{
-		Charge: stripe.String("ch_123"),
-		Reason: stripe.String(string(stripe.RefundReasonDuplicate)),
+		Charge:        stripe.String("ch_123"),
+		PaymentIntent: stripe.String("pi_123"),
+		Reason:        stripe.String(string(stripe.RefundReasonDuplicate)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, refund)

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.72.0"
+	MockMinimumVersion = "0.73.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Multiple API changes
* Add `Disputed` to `Charge`
* Add `PaymentIntent` to `Refund` and `Dispute`
* Add `Charge` to `DisputeListParams`
* Add `PaymentIntent` to `RefundListParams` and `RefundParams`

r? @remi-stripe 
cc @stripe/api-libraries 