### PR TITLE
Add DefaultSettings to Subscription Schedules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.69.0
+    - STRIPE_MOCK_VERSION=0.71.0
 
 go:
   - "1.9.x"

--- a/stripe.go
+++ b/stripe.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2019-10-17"
+	APIVersion string = "2019-11-05"
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"

--- a/subschedule.go
+++ b/subschedule.go
@@ -31,6 +31,16 @@ type SubscriptionScheduleInvoiceSettingsParams struct {
 	DaysUntilDue *int64 `form:"days_until_due"`
 }
 
+// SubscriptionScheduleDefaultSettingsParams is the set of parameters
+// representing the subscription schedule’s default settings.
+type SubscriptionScheduleDefaultSettingsParams struct {
+	Params               `form:"*"`
+	BillingThresholds    *SubscriptionBillingThresholdsParams       `form:"billing_thresholds"`
+	CollectionMethod     *string                                    `form:"collection_method"`
+	DefaultPaymentMethod *string                                    `form:"default_payment_method"`
+	InvoiceSettings      *SubscriptionScheduleInvoiceSettingsParams `form:"invoice_settings"`
+}
+
 // SubscriptionSchedulePhaseItemParams is a structure representing the parameters allowed to control
 // a specic plan on a phase on a subscription schedule.
 type SubscriptionSchedulePhaseItemParams struct {
@@ -69,6 +79,7 @@ type SubscriptionScheduleParams struct {
 	CollectionMethod     *string                                    `form:"collection_method"`
 	Customer             *string                                    `form:"customer"`
 	DefaultPaymentMethod *string                                    `form:"default_payment_method"`
+	DefaultSettings      *SubscriptionScheduleDefaultSettingsParams `form:"default_settings"`
 	DefaultSource        *string                                    `form:"default_source"`
 	EndBehavior          *string                                    `form:"end_behavior"`
 	FromSubscription     *string                                    `form:"from_subscription"`
@@ -115,10 +126,26 @@ type SubscriptionScheduleCurrentPhase struct {
 	StartDate int64 `json:"start_date"`
 }
 
+// SubscriptionScheduleBillingThresholds is a structure representing the
+// parameters allowed to control billing thresholds for a subscription item.
+type SubscriptionScheduleBillingThresholds struct {
+	AmountGTE               int64 `json:"amount_gte"`
+	ResetBillingCycleAnchor bool  `json:"reset_billing_cycle_anchor"`
+}
+
 // SubscriptionScheduleInvoiceSettings is a structure representing the settings applied to invoices
 // associated with a subscription schedule.
 type SubscriptionScheduleInvoiceSettings struct {
 	DaysUntilDue int64 `json:"days_until_due"`
+}
+
+// SubscriptionScheduleDefaultSettings is a structure representing the
+// subscription schedule’s default settings.
+type SubscriptionScheduleDefaultSettings struct {
+	BillingThresholds    *SubscriptionScheduleBillingThresholds `json:"billing_thresholds"`
+	CollectionMethod     SubscriptionCollectionMethod           `json:"collection_method"`
+	DefaultPaymentMethod *PaymentMethod                         `json:"default_payment_method"`
+	InvoiceSettings      *SubscriptionScheduleInvoiceSettings   `json:"invoice_settings"`
 }
 
 // SubscriptionSchedulePhaseItem represents plan details for a given phase
@@ -163,6 +190,7 @@ type SubscriptionSchedule struct {
 	CurrentPhase         *SubscriptionScheduleCurrentPhase    `json:"current_phase"`
 	Customer             *Customer                            `json:"customer"`
 	DefaultPaymentMethod *PaymentMethod                       `json:"default_payment_method"`
+	DefaultSettings      *SubscriptionScheduleDefaultSettings `json:"default_settings"`
 	DefaultSource        *PaymentSource                       `json:"default_source"`
 	EndBehavior          SubscriptionScheduleEndBehavior      `json:"end_behavior"`
 	ID                   string                               `json:"id"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -74,15 +74,15 @@ type SubscriptionSchedulePhaseParams struct {
 // SubscriptionScheduleParams is the set of parameters that can be used when creating or updating a
 // subscription schedule.
 type SubscriptionScheduleParams struct {
-	Params               `form:"*"`
-	Customer             *string                                    `form:"customer"`
-	DefaultSettings      *SubscriptionScheduleDefaultSettingsParams `form:"default_settings"`
-	DefaultSource        *string                                    `form:"default_source"`
-	EndBehavior          *string                                    `form:"end_behavior"`
-	FromSubscription     *string                                    `form:"from_subscription"`
-	Phases               []*SubscriptionSchedulePhaseParams         `form:"phases"`
-	Prorate              *bool                                      `form:"prorate"`
-	StartDate            *int64                                     `form:"start_date"`
+	Params           `form:"*"`
+	Customer         *string                                    `form:"customer"`
+	DefaultSettings  *SubscriptionScheduleDefaultSettingsParams `form:"default_settings"`
+	DefaultSource    *string                                    `form:"default_source"`
+	EndBehavior      *string                                    `form:"end_behavior"`
+	FromSubscription *string                                    `form:"from_subscription"`
+	Phases           []*SubscriptionSchedulePhaseParams         `form:"phases"`
+	Prorate          *bool                                      `form:"prorate"`
+	StartDate        *int64                                     `form:"start_date"`
 }
 
 // SubscriptionScheduleCancelParams is the set of parameters that can be used when canceling a
@@ -184,7 +184,6 @@ type SubscriptionSchedule struct {
 	CurrentPhase         *SubscriptionScheduleCurrentPhase    `json:"current_phase"`
 	Customer             *Customer                            `json:"customer"`
 	DefaultSettings      *SubscriptionScheduleDefaultSettings `json:"default_settings"`
-	DefaultSource        *PaymentSource                       `json:"default_source"`
 	EndBehavior          SubscriptionScheduleEndBehavior      `json:"end_behavior"`
 	ID                   string                               `json:"id"`
 	Livemode             bool                                 `json:"livemode"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -77,7 +77,6 @@ type SubscriptionScheduleParams struct {
 	Params           `form:"*"`
 	Customer         *string                                    `form:"customer"`
 	DefaultSettings  *SubscriptionScheduleDefaultSettingsParams `form:"default_settings"`
-	DefaultSource    *string                                    `form:"default_source"`
 	EndBehavior      *string                                    `form:"end_behavior"`
 	FromSubscription *string                                    `form:"from_subscription"`
 	Phases           []*SubscriptionSchedulePhaseParams         `form:"phases"`
@@ -122,13 +121,6 @@ type SubscriptionScheduleCurrentPhase struct {
 	StartDate int64 `json:"start_date"`
 }
 
-// SubscriptionScheduleBillingThresholds is a structure representing the
-// parameters allowed to control billing thresholds for a subscription item.
-type SubscriptionScheduleBillingThresholds struct {
-	AmountGTE               int64 `json:"amount_gte"`
-	ResetBillingCycleAnchor bool  `json:"reset_billing_cycle_anchor"`
-}
-
 // SubscriptionScheduleInvoiceSettings is a structure representing the settings applied to invoices
 // associated with a subscription schedule.
 type SubscriptionScheduleInvoiceSettings struct {
@@ -138,10 +130,10 @@ type SubscriptionScheduleInvoiceSettings struct {
 // SubscriptionScheduleDefaultSettings is a structure representing the
 // subscription schedule’s default settings.
 type SubscriptionScheduleDefaultSettings struct {
-	BillingThresholds    *SubscriptionScheduleBillingThresholds `json:"billing_thresholds"`
-	CollectionMethod     SubscriptionCollectionMethod           `json:"collection_method"`
-	DefaultPaymentMethod *PaymentMethod                         `json:"default_payment_method"`
-	InvoiceSettings      *SubscriptionScheduleInvoiceSettings   `json:"invoice_settings"`
+	BillingThresholds    *SubscriptionBillingThresholds       `json:"billing_thresholds"`
+	CollectionMethod     SubscriptionCollectionMethod         `json:"collection_method"`
+	DefaultPaymentMethod *PaymentMethod                       `json:"default_payment_method"`
+	InvoiceSettings      *SubscriptionScheduleInvoiceSettings `json:"invoice_settings"`
 }
 
 // SubscriptionSchedulePhaseItem represents plan details for a given phase

--- a/subschedule.go
+++ b/subschedule.go
@@ -75,15 +75,11 @@ type SubscriptionSchedulePhaseParams struct {
 // subscription schedule.
 type SubscriptionScheduleParams struct {
 	Params               `form:"*"`
-	BillingThresholds    *SubscriptionBillingThresholdsParams       `form:"billing_thresholds"`
-	CollectionMethod     *string                                    `form:"collection_method"`
 	Customer             *string                                    `form:"customer"`
-	DefaultPaymentMethod *string                                    `form:"default_payment_method"`
 	DefaultSettings      *SubscriptionScheduleDefaultSettingsParams `form:"default_settings"`
 	DefaultSource        *string                                    `form:"default_source"`
 	EndBehavior          *string                                    `form:"end_behavior"`
 	FromSubscription     *string                                    `form:"from_subscription"`
-	InvoiceSettings      *SubscriptionScheduleInvoiceSettingsParams `form:"invoice_settings"`
 	Phases               []*SubscriptionSchedulePhaseParams         `form:"phases"`
 	Prorate              *bool                                      `form:"prorate"`
 	StartDate            *int64                                     `form:"start_date"`
@@ -182,19 +178,15 @@ type SubscriptionScheduleRenewalInterval struct {
 
 // SubscriptionSchedule is the resource representing a Stripe subscription schedule.
 type SubscriptionSchedule struct {
-	BillingThresholds    *SubscriptionBillingThresholds       `json:"billing_thresholds"`
 	CanceledAt           int64                                `json:"canceled_at"`
-	CollectionMethod     SubscriptionCollectionMethod         `json:"collection_method"`
 	CompletedAt          int64                                `json:"completed_at"`
 	Created              int64                                `json:"created"`
 	CurrentPhase         *SubscriptionScheduleCurrentPhase    `json:"current_phase"`
 	Customer             *Customer                            `json:"customer"`
-	DefaultPaymentMethod *PaymentMethod                       `json:"default_payment_method"`
 	DefaultSettings      *SubscriptionScheduleDefaultSettings `json:"default_settings"`
 	DefaultSource        *PaymentSource                       `json:"default_source"`
 	EndBehavior          SubscriptionScheduleEndBehavior      `json:"end_behavior"`
 	ID                   string                               `json:"id"`
-	InvoiceSettings      *SubscriptionScheduleInvoiceSettings `json:"invoice_settings"`
 	Livemode             bool                                 `json:"livemode"`
 	Metadata             map[string]string                    `json:"metadata"`
 	Object               string                               `json:"object"`

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.69.0"
+	MockMinimumVersion = "0.71.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Updates API version to: `2019-11-05`
Updates stripe-mock minimum version to `0.71.0`
Adds: `DefaultSettings` with `BillingThresholds`, `CollectionMethod`, `DefaultPaymentMethod`, `InvoiceSettings` to `SubscriptionSchedule`
Removes:  `BillingThresholds`, `CollectionMethod`, `DefaultPaymentMethod`, `DefaultSource`, `InvoiceSettings` from `SubscriptionSchedule`