### PR TITLE
Add `individual` and `company` to IssuingCardholder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.73.0
+    - STRIPE_MOCK_VERSION=0.74.0
 
 go:
   - "1.9.x"

--- a/issuing/cardholder/client_test.go
+++ b/issuing/cardholder/client_test.go
@@ -37,6 +37,21 @@ func TestIssuingCardholderNew(t *testing.T) {
 			},
 			Name: stripe.String("billing name"),
 		},
+		Individual: &stripe.IssuingCardholderIndividualParams{
+			DOB: &stripe.IssuingCardholderIndividualDOBParams{
+				Day:   stripe.Int64(1),
+				Month: stripe.Int64(1),
+				Year:  stripe.Int64(1980),
+			},
+			FirstName: stripe.String("Jenny"),
+			LastName:  stripe.String("Rosen"),
+			Verification: &stripe.IssuingCardholderIndividualVerificationParams{
+				Document: &stripe.IssuingCardholderIndividualVerificationDocumentParams{
+					Back:  stripe.String("file_back"),
+					Front: stripe.String("file_front"),
+				},
+			},
+		},
 		Name: stripe.String("cardholder name"),
 		Type: stripe.String(string(stripe.IssuingCardholderTypeIndividual)),
 	})

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -38,17 +38,55 @@ type IssuingBillingParams struct {
 	Name    *string        `form:"name"`
 }
 
+// IssuingCardholderCompanyParams represents additional information about a
+// `business_entity` cardholder.
+type IssuingCardholderCompanyParams struct {
+	TaxID *string `form:"tax_id"`
+}
+
+// IssuingCardholderIndividualVerificationDocumentParams represents an
+// identifying document, either a passport or local ID card.
+type IssuingCardholderIndividualVerificationDocumentParams struct {
+	Back  *string `form:"back"`
+	Front *string `form:"front"`
+}
+
+// IssuingCardholderIndividualVerificationParams represents government-issued ID
+// document for this cardholder.
+type IssuingCardholderIndividualVerificationParams struct {
+	Document *IssuingCardholderIndividualVerificationDocumentParams `form:"document"`
+}
+
+// IssuingCardholderIndividualDOBParams represents the date of birth of the
+// cardholder individual.
+type IssuingCardholderIndividualDOBParams struct {
+	Day   *int64 `form:"day"`
+	Month *int64 `form:"month"`
+	Year  *int64 `form:"year"`
+}
+
+// IssuingCardholderIndividualParams represents additional information about an
+// `individual` cardholder.
+type IssuingCardholderIndividualParams struct {
+	DOB          *IssuingCardholderIndividualDOBParams          `form:"dob"`
+	FirstName    *string                                        `form:"first_name"`
+	LastName     *string                                        `form:"last_name"`
+	Verification *IssuingCardholderIndividualVerificationParams `form:"verification"`
+}
+
 // IssuingCardholderParams is the set of parameters that can be used when creating or updating an issuing cardholder.
 type IssuingCardholderParams struct {
 	Params                `form:"*"`
-	AuthorizationControls *AuthorizationControlsParams `form:"authorization_controls"`
-	Billing               *IssuingBillingParams        `form:"billing"`
-	Email                 *string                      `form:"email"`
-	IsDefault             *bool                        `form:"is_default"`
-	Name                  *string                      `form:"name"`
-	PhoneNumber           *string                      `form:"phone_number"`
-	Status                *string                      `form:"status"`
-	Type                  *string                      `form:"type"`
+	AuthorizationControls *AuthorizationControlsParams       `form:"authorization_controls"`
+	Billing               *IssuingBillingParams              `form:"billing"`
+	Company               *IssuingCardholderCompanyParams    `form:"company"`
+	Email                 *string                            `form:"email"`
+	Individual            *IssuingCardholderIndividualParams `form:"individual"`
+	IsDefault             *bool                              `form:"is_default"`
+	Name                  *string                            `form:"name"`
+	PhoneNumber           *string                            `form:"phone_number"`
+	Status                *string                            `form:"status"`
+	Type                  *string                            `form:"type"`
 }
 
 // IssuingCardholderListParams is the set of parameters that can be used when listing issuing cardholders.
@@ -75,13 +113,51 @@ type IssuingCardholderRequirements struct {
 	PastDue        []string                                    `json:"past_due"`
 }
 
+// IssuingCardholderIndividualVerificationDocument represents an identifying
+// document, either a passport or local ID card.
+type IssuingCardholderIndividualVerificationDocument struct {
+	Back  *File `json:"back"`
+	Front *File `json:"front"`
+}
+
+// IssuingCardholderIndividualVerification represents the Government-issued ID
+// document for this cardholder
+type IssuingCardholderIndividualVerification struct {
+	Document *IssuingCardholderIndividualVerificationDocument `json:"document"`
+}
+
+// IssuingCardholderIndividualDOB represents the date of birth of the issuing card hoder
+// individual.
+type IssuingCardholderIndividualDOB struct {
+	Day   int64 `json:"day"`
+	Month int64 `json:"month"`
+	Year  int64 `json:"year"`
+}
+
+// IssuingCardholderIndividual represents additional information about an
+// individual cardholder.
+type IssuingCardholderIndividual struct {
+	DOB          *IssuingCardholderIndividualDOB          `json:"dob"`
+	FirstName    string                                   `json:"first_name"`
+	LastName     string                                   `json:"last_name"`
+	Verification *IssuingCardholderIndividualVerification `json:"verification"`
+}
+
+// IssuingCardholderCompany represents additional information about a
+// business_entity cardholder.
+type IssuingCardholderCompany struct {
+	TaxIDProvided bool `json:"tax_id_provided"`
+}
+
 // IssuingCardholder is the resource representing a Stripe issuing cardholder.
 type IssuingCardholder struct {
 	AuthorizationControls *IssuingCardAuthorizationControls `json:"authorization_controls"`
 	Billing               *IssuingBilling                   `json:"billing"`
+	Company               *IssuingCardholderCompany         `json:"company"`
 	Created               int64                             `json:"created"`
 	Email                 string                            `json:"email"`
 	ID                    string                            `json:"id"`
+	Individual            *IssuingCardholderIndividual      `json:"individual"`
 	Livemode              bool                              `json:"livemode"`
 	Metadata              map[string]string                 `json:"metadata"`
 	Name                  string                            `json:"name"`

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -94,10 +94,11 @@ type PaymentMethodSepaDebitParams struct {
 // PaymentMethod.
 type PaymentMethodParams struct {
 	Params         `form:"*"`
-	BillingDetails *BillingDetailsParams    `form:"billing_details"`
-	Card           *PaymentMethodCardParams `form:"card"`
-	FPX            *PaymentMethodFPXParams  `form:"fpx"`
-	Type           *string                  `form:"type"`
+	BillingDetails *BillingDetailsParams         `form:"billing_details"`
+	Card           *PaymentMethodCardParams      `form:"card"`
+	FPX            *PaymentMethodFPXParams       `form:"fpx"`
+	SepaDebit      *PaymentMethodSepaDebitParams `form:"sepa_debit"`
+	Type           *string                       `form:"type"`
 
 	// The following parameters are used when cloning a PaymentMethod to the connected account
 	Customer      *string `form:"customer"`

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.73.0"
+	MockMinimumVersion = "0.74.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Adds `Individual` and `Company` to `IssuingCardHolder`
Adds `PaymentMethodSepaDebitParams` for `PaymentMethodParams`
Bumps `stripe-mock` version to `0.74.0`

r? @remi-stripe 
cc @stripe/api-libraries 