### PR TITLE
Add payment_intent filter for listing disputes

### DIFF
--- a/dispute.go
+++ b/dispute.go
@@ -77,10 +77,11 @@ type DisputeEvidenceParams struct {
 // DisputeListParams is the set of parameters that can be used when listing disputes.
 // For more details see https://stripe.com/docs/api#list_disputes.
 type DisputeListParams struct {
-	ListParams   `form:"*"`
-	Charge       *string           `form:"charge"`
-	Created      *int64            `form:"created"`
-	CreatedRange *RangeQueryParams `form:"created"`
+	ListParams    `form:"*"`
+	Charge        *string           `form:"charge"`
+	Created       *int64            `form:"created"`
+	CreatedRange  *RangeQueryParams `form:"created"`
+	PaymentIntent *string           `form:"payment_intent"`
 }
 
 // Dispute is the resource representing a Stripe dispute.


### PR DESCRIPTION
Adds support for filtering the list of disputes by a `PaymentIntent`.

I noticed that the Charge & PaymentIntent are mutually exclusive, but wasn't sure if we have a mechanism for that in the bindings. 

r? @remi-stripe 
cc @stripe/api-libraries 