### PR TITLE
Support for the `now` on `StartDate` on Subscription Schedule creation

### DIFF
--- a/subschedule.go
+++ b/subschedule.go
@@ -2,6 +2,8 @@ package stripe
 
 import (
 	"encoding/json"
+
+	"github.com/stripe/stripe-go/form"
 )
 
 // SubscriptionScheduleEndBehavior describe what happens to a schedule when it ends.
@@ -9,8 +11,11 @@ type SubscriptionScheduleEndBehavior string
 
 // List of values that SubscriptionScheduleEndBehavior can take.
 const (
-	SubscriptionScheduleEndBehaviorCancel SubscriptionScheduleEndBehavior = "cancel"
-	SubscriptionScheduleEndBehaviorRenew  SubscriptionScheduleEndBehavior = "release"
+	SubscriptionScheduleEndBehaviorCancel  SubscriptionScheduleEndBehavior = "cancel"
+	SubscriptionScheduleEndBehaviorRelease SubscriptionScheduleEndBehavior = "release"
+
+	// TODO: Remove in the next major version as the name is incorrect.
+	SubscriptionScheduleEndBehaviorRenew SubscriptionScheduleEndBehavior = "release"
 )
 
 // SubscriptionScheduleStatus is the list of allowed values for the schedule's status.
@@ -82,6 +87,15 @@ type SubscriptionScheduleParams struct {
 	Phases           []*SubscriptionSchedulePhaseParams         `form:"phases"`
 	Prorate          *bool                                      `form:"prorate"`
 	StartDate        *int64                                     `form:"start_date"`
+	StartDateNow     *bool                                      `form:"-"` // See custom AppendTo
+}
+
+// AppendTo implements custom encoding logic for SubscriptionScheduleParams so that the special
+// "now" value for start_date can be implemented (they're otherwise timestamps rather than strings).
+func (p *SubscriptionScheduleParams) AppendTo(body *form.Values, keyParts []string) {
+	if BoolValue(p.StartDateNow) {
+		body.Add(form.FormatKey(append(keyParts, "start_date")), "now")
+	}
 }
 
 // SubscriptionScheduleCancelParams is the set of parameters that can be used when canceling a

--- a/subschedule/client_test.go
+++ b/subschedule/client_test.go
@@ -40,7 +40,8 @@ func TestSubscriptionScheduleList(t *testing.T) {
 
 func TestSubscriptionScheduleNew(t *testing.T) {
 	params := &stripe.SubscriptionScheduleParams{
-		Customer: stripe.String("cus_123"),
+		Customer:     stripe.String("cus_123"),
+		StartDateNow: stripe.Bool(true),
 		Phases: []*stripe.SubscriptionSchedulePhaseParams{
 			{
 				Plans: []*stripe.SubscriptionSchedulePhaseItemParams{

--- a/subschedule_test.go
+++ b/subschedule_test.go
@@ -1,0 +1,40 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/form"
+)
+
+func TestSubscriptionScheduleParams_AppendTo(t *testing.T) {
+	{
+		params := &SubscriptionScheduleParams{StartDateNow: Bool(true)}
+		body := &form.Values{}
+		form.AppendTo(body, params)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"now"}, body.Get("start_date"))
+	}
+}
+
+func TestSubscriptionSchedule_UnmarshalJSON(t *testing.T) {
+	// Unmarshals from a JSON string
+	{
+		var v SubscriptionSchedule
+		err := json.Unmarshal([]byte(`"sub_sched_123"`), &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "sub_sched_123", v.ID)
+	}
+
+	// Unmarshals from a JSON object
+	{
+		v := SubscriptionSchedule{ID: "sub_sched_123"}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		err = json.Unmarshal(data, &v)
+		assert.NoError(t, err)
+		assert.Equal(t, "sub_sched_123", v.ID)
+	}
+}


### PR DESCRIPTION
Added support for `start_date: "now"` on Subscription Schedule creation similarly to how we do it for trials for example.

r? @brandur-stripe 
cc @stripe/api-libraries 