### PR TITLE
Add support for `CreditNote` preview

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.74.0
+    - STRIPE_MOCK_VERSION=0.76.0
 
 go:
   - "1.9.x"

--- a/creditnote.go
+++ b/creditnote.go
@@ -34,15 +34,18 @@ const (
 // CreditNoteParams is the set of parameters that can be used when creating or updating a credit note.
 // For more details see https://stripe.com/docs/api/credit_notes/create, https://stripe.com/docs/api/credit_notes/update.
 type CreditNoteParams struct {
-	Params           `form:"*"`
-	Amount           *int64  `form:"amount"`
-	CreditAmount     *int64  `form:"credit_amount"`
-	Invoice          *string `form:"invoice"`
-	Memo             *string `form:"memo"`
-	OutOfBankdAmount *int64  `form:"out_of_band_amount"`
-	Reason           *string `form:"reason"`
-	Refund           *string `form:"refund"`
-	RefundAmount     *int64  `form:"refund_amount"`
+	Params          `form:"*"`
+	Amount          *int64  `form:"amount"`
+	CreditAmount    *int64  `form:"credit_amount"`
+	Invoice         *string `form:"invoice"`
+	Memo            *string `form:"memo"`
+	OutOfBandAmount *int64  `form:"out_of_band_amount"`
+	Reason          *string `form:"reason"`
+	Refund          *string `form:"refund"`
+	RefundAmount    *int64  `form:"refund_amount"`
+
+	// TODO: Remove in the next major version as the name is incorrect.
+	OutOfBankdAmount *int64 `form:"out_of_band_amount"`
 }
 
 // CreditNoteListParams is the set of parameters that can be used when listing credit notes.
@@ -51,6 +54,20 @@ type CreditNoteListParams struct {
 	ListParams `form:"*"`
 	Customer   *string `form:"customer"`
 	Invoice    *string `form:"invoice"`
+}
+
+// CreditNotePreviewParams is the set of parameters that can be used when previewing a credit note.
+// For more details see https://stripe.com/docs/api/credit_notes/preview.
+type CreditNotePreviewParams struct {
+	Params          `form:"*"`
+	Amount          *int64  `form:"amount"`
+	CreditAmount    *int64  `form:"credit_amount"`
+	Invoice         *string `form:"invoice"`
+	Memo            *string `form:"memo"`
+	OutOfBandAmount *int64  `form:"out_of_band_amount"`
+	Reason          *string `form:"reason"`
+	Refund          *string `form:"refund"`
+	RefundAmount    *int64  `form:"refund_amount"`
 }
 
 // CreditNoteVoidParams is the set of parameters that can be used when voiding invoices.

--- a/creditnote/client.go
+++ b/creditnote/client.go
@@ -72,6 +72,18 @@ func (c Client) List(listParams *stripe.CreditNoteListParams) *Iter {
 	})}
 }
 
+// Preview previews a credit note.
+func Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
+	return getC().Preview(params)
+}
+
+// Preview previews a credit note.
+func (c Client) Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
+	cn := &stripe.CreditNote{}
+	err := c.B.Call(http.MethodGet, "/v1/credit_notes/preview", c.Key, params, cn)
+	return cn, err
+}
+
 // VoidCreditNote voids a credit note.
 func VoidCreditNote(id string, params *stripe.CreditNoteVoidParams) (*stripe.CreditNote, error) {
 	return getC().VoidCreditNote(id, params)

--- a/creditnote/client_test.go
+++ b/creditnote/client_test.go
@@ -50,6 +50,16 @@ func TestCreditNoteUpdate(t *testing.T) {
 	assert.NotNil(t, cn)
 }
 
+func TestCreditNotePreview(t *testing.T) {
+	params := &stripe.CreditNotePreviewParams{
+		Amount:  stripe.Int64(100),
+		Invoice: stripe.String("in_123"),
+	}
+	cn, err := Preview(params)
+	assert.Nil(t, err)
+	assert.NotNil(t, cn)
+}
+
 func TestCreditNoteVoidCreditNote(t *testing.T) {
 	params := &stripe.CreditNoteVoidParams{}
 	cn, err := VoidCreditNote("cn_123", params)

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.74.0"
+	MockMinimumVersion = "0.76.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Add the new preview endpoint on `CreditNote`. Also rename `OutOfBandAmount` which had a typo.

r? @ob-stripe 
cc @stripe/api-libraries 