### PR TITLE
Pin to API version 2019-12-03 and remove deprecated fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.76.0
+    - STRIPE_MOCK_VERSION=0.78.0
 
 go:
   - "1.9.x"

--- a/creditnote.go
+++ b/creditnote.go
@@ -43,9 +43,6 @@ type CreditNoteParams struct {
 	Reason          *string `form:"reason"`
 	Refund          *string `form:"refund"`
 	RefundAmount    *int64  `form:"refund_amount"`
-
-	// TODO: Remove in the next major version as the name is incorrect.
-	OutOfBankdAmount *int64 `form:"out_of_band_amount"`
 }
 
 // CreditNoteListParams is the set of parameters that can be used when listing credit notes.

--- a/invoice.go
+++ b/invoice.go
@@ -29,17 +29,16 @@ const (
 	InvoiceBillingReasonUpcoming              InvoiceBillingReason = "upcoming"
 )
 
-// InvoiceBillingStatus is the reason why a given invoice was created
-// TODO: rename to InvoiceStatus
-type InvoiceBillingStatus string
+// InvoiceStatus is the reason why a given invoice was created
+type InvoiceStatus string
 
-// List of values that InvoiceBillingStatus can take.
+// List of values that InvoiceStatus can take.
 const (
-	InvoiceBillingStatusDraft         InvoiceBillingStatus = "draft"
-	InvoiceBillingStatusOpen          InvoiceBillingStatus = "open"
-	InvoiceBillingStatusPaid          InvoiceBillingStatus = "paid"
-	InvoiceBillingStatusUncollectible InvoiceBillingStatus = "uncollectible"
-	InvoiceBillingStatusVoid          InvoiceBillingStatus = "void"
+	InvoiceStatusDraft         InvoiceStatus = "draft"
+	InvoiceStatusOpen          InvoiceStatus = "open"
+	InvoiceStatusPaid          InvoiceStatus = "paid"
+	InvoiceStatusUncollectible InvoiceStatus = "uncollectible"
+	InvoiceStatusVoid          InvoiceStatus = "void"
 )
 
 // InvoiceCollectionMethod is the type of collection method for this invoice.
@@ -257,7 +256,7 @@ type Invoice struct {
 	ReceiptNumber                string                   `json:"receipt_number"`
 	StartingBalance              int64                    `json:"starting_balance"`
 	StatementDescriptor          string                   `json:"statement_descriptor"`
-	Status                       InvoiceBillingStatus     `json:"status"`
+	Status                       InvoiceStatus            `json:"status"`
 	StatusTransitions            InvoiceStatusTransitions `json:"status_transitions"`
 	Subscription                 string                   `json:"subscription"`
 	SubscriptionProrationDate    int64                    `json:"subscription_proration_date"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -77,9 +77,6 @@ type PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure string
 const (
 	PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureAny       PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure = "any"
 	PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureAutomatic PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
-
-	// The following constant is considered deprecated and will be removed in the next major version.
-	PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureChallengeOnly PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure = "challenge_only"
 )
 
 // PaymentIntentSetupFutureUsage is the list of allowed values for SetupFutureUsage.

--- a/setupintent.go
+++ b/setupintent.go
@@ -31,9 +31,6 @@ type SetupIntentPaymentMethodOptionsCardRequestThreeDSecure string
 const (
 	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureAny       SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "any"
 	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureAutomatic SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
-
-	// The following constant is considered deprecated and will be removed in the next major version.
-	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureChallengeOnly SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "challenge_only"
 )
 
 // SetupIntentStatus is the list of allowed values for the setup intent's status.

--- a/stripe.go
+++ b/stripe.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2019-11-05"
+	APIVersion string = "2019-12-03"
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"

--- a/subschedule.go
+++ b/subschedule.go
@@ -13,9 +13,6 @@ type SubscriptionScheduleEndBehavior string
 const (
 	SubscriptionScheduleEndBehaviorCancel  SubscriptionScheduleEndBehavior = "cancel"
 	SubscriptionScheduleEndBehaviorRelease SubscriptionScheduleEndBehavior = "release"
-
-	// TODO: Remove in the next major version as the name is incorrect.
-	SubscriptionScheduleEndBehaviorRenew SubscriptionScheduleEndBehavior = "release"
 )
 
 // SubscriptionScheduleStatus is the list of allowed values for the schedule's status.

--- a/terminal_location.go
+++ b/terminal_location.go
@@ -10,9 +10,6 @@ type TerminalLocationParams struct {
 // TerminalLocationListParams is the set of parameters that can be used when listing temrinal locations.
 type TerminalLocationListParams struct {
 	ListParams `form:"*"`
-
-	// This feature has been deprecated and should not be used anymore.
-	OperatorAccount *string `form:"operator_account"`
 }
 
 // TerminalLocation is the resource representing a Stripe terminal location.

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.76.0"
+	MockMinimumVersion = "0.78.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Multiple API changes as we release a new major version
* Pin to API version `2019-12-03`
* Rename `InvoiceBillingStatus` to `InvoiceStatus` for consistency
* Remove typo-ed field `OutOfBankdAmount` on `CreditNote`
* Remove deprecated `PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureChallengeOnly` and `SetupIntentPaymentMethodOptionsCardRequestThreeDSecureChallengeOnly` from `PaymentIntent` and `SetupIntent`.
* Remove `OperatorAccount` on `TerminalLocationListParams`

r? @tomer-stripe @richardm-stripe 
cc @stripe/api-libraries 