### PR TITLE
Add support for `Network` on `Charge`

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -311,6 +311,7 @@ type ChargePaymentMethodDetailsCard struct {
 	Funding      CardFunding                                 `json:"funding"`
 	Installments *ChargePaymentMethodDetailsCardInstallments `json:"installments"`
 	Last4        string                                      `json:"last4"`
+	Network      PaymentMethodCardNetwork                    `json:"network"`
 	MOTO         bool                                        `json:"moto"`
 	ThreeDSecure *ChargePaymentMethodDetailsCardThreeDSecure `json:"three_d_secure"`
 	Wallet       *ChargePaymentMethodDetailsCardWallet       `json:"wallet"`
@@ -346,6 +347,7 @@ type ChargePaymentMethodDetailsCardPresent struct {
 	Funding       CardFunding                                   `json:"funding"`
 	GeneratedCard string                                        `json:"generated_card"`
 	Last4         string                                        `json:"last4"`
+	Network       PaymentMethodCardNetwork                      `json:"network"`
 	ReadMethod    string                                        `json:"read_method"`
 	Receipt       *ChargePaymentMethodDetailsCardPresentReceipt `json:"receipt"`
 }

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -39,6 +39,23 @@ const (
 	PaymentMethodCardBrandVisa       PaymentMethodCardBrand = "visa"
 )
 
+// PaymentMethodCardNetwork is the list of allowed values to represent the network
+// used for a card-like transaction.
+type PaymentMethodCardNetwork string
+
+// List of values that PaymentMethodCardNetwork can take.
+const (
+	PaymentMethodCardNetworkAmex       PaymentMethodCardNetwork = "amex"
+	PaymentMethodCardNetworkDiners     PaymentMethodCardNetwork = "diners"
+	PaymentMethodCardNetworkDiscover   PaymentMethodCardNetwork = "discover"
+	PaymentMethodCardNetworkInterac    PaymentMethodCardNetwork = "interac"
+	PaymentMethodCardNetworkJCB        PaymentMethodCardNetwork = "jcb"
+	PaymentMethodCardNetworkMastercard PaymentMethodCardNetwork = "mastercard"
+	PaymentMethodCardNetworkUnionpay   PaymentMethodCardNetwork = "unionpay"
+	PaymentMethodCardNetworkUnknown    PaymentMethodCardNetwork = "unknown"
+	PaymentMethodCardNetworkVisa       PaymentMethodCardNetwork = "visa"
+)
+
 // PaymentMethodCardWalletType is the list of allowed values for the type a wallet can take on
 // a Card PaymentMethod.
 type PaymentMethodCardWalletType string


### PR DESCRIPTION
Similar to the java one but not touching `SourceTransaction` as stripe-go doesn't support the hash specific for now and since this is low usage I want to avoid adding features that will go away in the future.

r? @richardm-stripe 
cc @stripe/api-libraries 