### PR TITLE
Add `metadata` and `livemode` to Terminal Reader and Location

### DIFF
--- a/terminal_location.go
+++ b/terminal_location.go
@@ -18,6 +18,8 @@ type TerminalLocation struct {
 	Deleted     bool                  `json:"deleted"`
 	DisplayName string                `json:"display_name"`
 	ID          string                `json:"id"`
+	Livemode    bool                  `json:"livemode"`
+	Metadata    map[string]string     `json:"metadata"`
 	Object      string                `json:"object"`
 }
 

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -23,16 +23,18 @@ type TerminalReaderListParams struct {
 
 // TerminalReader is the resource representing a Stripe terminal reader.
 type TerminalReader struct {
-	Deleted         bool   `json:"deleted"`
-	DeviceSwVersion string `json:"device_sw_version"`
-	DeviceType      string `json:"device_type"`
-	ID              string `json:"id"`
-	IPAddress       string `json:"ip_address"`
-	Label           string `json:"label"`
-	Location        string `json:"location"`
-	Object          string `json:"object"`
-	SerialNumber    string `json:"serial_number"`
-	Status          string `json:"status"`
+	Deleted         bool              `json:"deleted"`
+	DeviceSwVersion string            `json:"device_sw_version"`
+	DeviceType      string            `json:"device_type"`
+	ID              string            `json:"id"`
+	IPAddress       string            `json:"ip_address"`
+	Label           string            `json:"label"`
+	Livemode        bool              `json:"livemode"`
+	Location        string            `json:"location"`
+	Metadata        map[string]string `json:"metadata"`
+	Object          string            `json:"object"`
+	SerialNumber    string            `json:"serial_number"`
+	Status          string            `json:"status"`
 }
 
 // TerminalReaderList is a list of terminal readers as retrieved from a list endpoint.


### PR DESCRIPTION
Adds support for `metadata` and `livemode` on `TerminalReader` and `TerminalLocation` 

r? @remi-stripe 
cc @stripe/api-libraries 