### PR TITLE
Add `Metadata` support on Checkout `Session`

### DIFF
--- a/checkout_session.go
+++ b/checkout_session.go
@@ -145,6 +145,7 @@ type CheckoutSession struct {
 	ID                 string                        `json:"id"`
 	Livemode           bool                          `json:"livemode"`
 	Locale             string                        `json:"locale"`
+	Metadata           map[string]string             `json:"metadata"`
 	Mode               CheckoutSessionMode           `json:"mode"`
 	Object             string                        `json:"object"`
 	PaymentIntent      *PaymentIntent                `json:"payment_intent"`


### PR DESCRIPTION
Only add support on the resource as `metadata` is automatically supported on all params class via the nested `Params` (even on resources that don't support it).

r? @cjavilla-stripe 
cc @stripe/api-libraries 