### PR TITLE
Support `source_types` and `connect_reserved` from `/v1/balances` and add `fpx` source_type string constants

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -1,5 +1,17 @@
 package stripe
 
+// BalanceSourceType is the list of allowed values for the balance amount's source_type field keys.
+type BalanceSourceType string
+
+// List of values that BalanceSourceType can take.
+const (
+	BalanceSourceTypeAlipayAccount   BalanceSourceType = "alipay_account"
+	BalanceSourceTypeBankAccount     BalanceSourceType = "bank_account"
+	BalanceSourceTypeBitcoinReceiver BalanceSourceType = "bitcoin_receiver"
+	BalanceSourceTypeCard            BalanceSourceType = "card"
+	BalanceSourceTypeFPX             BalanceSourceType = "fpx"
+)
+
 // BalanceTransactionStatus is the list of allowed values for the balance transaction's status.
 type BalanceTransactionStatus string
 
@@ -12,13 +24,15 @@ type BalanceParams struct {
 // Balance is the resource representing your Stripe balance.
 // For more details see https://stripe.com/docs/api/#balance.
 type Balance struct {
-	Available []*Amount `json:"available"`
-	Livemode  bool      `json:"livemode"`
-	Pending   []*Amount `json:"pending"`
+	Available       []*Amount `json:"available"`
+	ConnectReserved []*Amount `json:"connect_reserved"`
+	Livemode        bool      `json:"livemode"`
+	Pending         []*Amount `json:"pending"`
 }
 
 // Amount is a structure wrapping an amount value and its currency.
 type Amount struct {
-	Value    int64    `json:"amount"`
-	Currency Currency `json:"currency"`
+	Currency    Currency                    `json:"currency"`
+	SourceTypes map[BalanceSourceType]int64 `json:"source_types"`
+	Value       int64                       `json:"amount"`
 }

--- a/balance_test.go
+++ b/balance_test.go
@@ -1,0 +1,70 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestBalance_Unmarshal(t *testing.T) {
+	balanceData := map[string]interface{}{
+		"available": []map[string]interface{}{
+			{
+				"amount":   111,
+				"currency": "usd",
+				"source_types": map[string]interface{}{
+					"bank_account": 100,
+					"card":         11,
+				},
+			},
+			{
+				"amount":   222,
+				"currency": "eur",
+				"source_types": map[string]interface{}{
+					"card": 222,
+				},
+			},
+		},
+		"object": "balance",
+		"pending": []map[string]interface{}{
+			{
+				"amount":   333,
+				"currency": "usd",
+				"source_types": map[string]interface{}{
+					"bank_account": 333,
+				},
+			},
+			{
+				"amount":   444,
+				"currency": "eur",
+				"source_types": map[string]interface{}{
+					"bank_account": 222,
+					"card":         222,
+				},
+			},
+		},
+	}
+
+	bytes, err := json.Marshal(&balanceData)
+	assert.NoError(t, err)
+
+	var balance Balance
+	err = json.Unmarshal(bytes, &balance)
+	assert.NoError(t, err)
+
+	assert.Equal(t, int64(111), balance.Available[0].Value)
+	assert.Equal(t, CurrencyUSD, balance.Available[0].Currency)
+	assert.Equal(t, int64(222), balance.Available[1].Value)
+	assert.Equal(t, CurrencyEUR, balance.Available[1].Currency)
+	assert.Equal(t, int64(222), balance.Available[1].Value)
+
+	assert.Equal(t, int64(333), balance.Pending[0].Value)
+	assert.Equal(t, CurrencyUSD, balance.Pending[0].Currency)
+	assert.Equal(t, int64(444), balance.Pending[1].Value)
+	assert.Equal(t, CurrencyEUR, balance.Pending[1].Currency)
+
+	// Confirm source-type deserialization works
+	assert.Equal(t, int64(100), balance.Available[0].SourceTypes[BalanceSourceTypeBankAccount])
+	assert.Equal(t, int64(11), balance.Available[0].SourceTypes[BalanceSourceTypeCard])
+}

--- a/payout.go
+++ b/payout.go
@@ -37,6 +37,7 @@ const (
 	PayoutSourceTypeBankAccount     PayoutSourceType = "bank_account"
 	PayoutSourceTypeBitcoinReceiver PayoutSourceType = "bitcoin_receiver"
 	PayoutSourceTypeCard            PayoutSourceType = "card"
+	PayoutSourceTypeFPX             PayoutSourceType = "fpx"
 )
 
 // PayoutStatus is the list of allowed values for the payout's status.

--- a/transfer.go
+++ b/transfer.go
@@ -11,6 +11,7 @@ const (
 	TransferSourceTypeBankAccount     TransferSourceType = "bank_account"
 	TransferSourceTypeBitcoinReceiver TransferSourceType = "bitcoin_receiver"
 	TransferSourceTypeCard            TransferSourceType = "card"
+	TransferSourceTypeFPX             TransferSourceType = "fpx"
 )
 
 // TransferDestination describes the destination of a Transfer.


### PR DESCRIPTION
Hi folks,

Closing https://github.com/stripe/stripe-go/pull/1025 in favor of this one per Remi's latest comment.

Have incorporated Remi's new test file (💯) as well as the `connect_reserved` addition, consolidated here into a single PR off this branch rather than a fork.

---

Summary of changes once more for posterity:

- Support the `source_types` hash on the pending/available top-level balance object:
https://stripe.com/docs/api/balance/balance_object#balance_object-available-source_types
- Support the `connect_reserved` top-level object on the `/v1/balances` endpoint:
https://stripe.com/docs/api/balance/balance_object#balance_object-connect_reserved
- Support the new `fpx` source type constant as a developer affordance in preparation for Stripe's broader FPX rollout (currently in private beta).

These changes are necessary to better support Stripe merchants in any markets that involve split balances for compliance/regulatory purposes. This also applies to payment methods like ACH debits in the US (where `source_type=bank_account`). 

The `connect_reserved` change also helps to broadly support connect platforms that require balance reserves for their businesses.

---

Thanks for all of the support,
Ethan