### PR TITLE
Add support for listing Checkout `Session` and passing tax rate information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.79.0
+    - STRIPE_MOCK_VERSION=0.80.0
 
 go:
   - "1.9.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.80.0
+    - STRIPE_MOCK_VERSION=0.82.0
 
 go:
   - "1.9.x"

--- a/checkout/session/client_test.go
+++ b/checkout/session/client_test.go
@@ -57,3 +57,12 @@ func TestCheckoutSessionNew(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, session)
 }
+
+func TestCheckoutSessionList(t *testing.T) {
+	i := List(&stripe.CheckoutSessionListParams{})
+
+	// Verify that we can get at least one session.
+	assert.True(t, i.Next())
+	assert.Nil(t, i.Err())
+	assert.NotNil(t, i.CheckoutSession())
+}

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -117,6 +117,15 @@ type CheckoutSessionParams struct {
 	SuccessURL               *string                                 `form:"success_url"`
 }
 
+// CheckoutSessionListParams is the set of parameters that can be
+// used when listing sessions.
+// For more details see: https://stripe.com/docs/api/checkout/sessions/list
+type CheckoutSessionListParams struct {
+	ListParams    `form:"*"`
+	Subscription  *string `form:"subscription"`
+	PaymentIntent *string `form:"payment_intent"`
+}
+
 // CheckoutSessionDisplayItemCustom represents an item of type custom in a checkout session
 type CheckoutSessionDisplayItemCustom struct {
 	Description string   `json:"description"`
@@ -156,6 +165,12 @@ type CheckoutSession struct {
 	Subscription       *Subscription                 `json:"subscription"`
 	SubmitType         CheckoutSessionSubmitType     `json:"submit_type"`
 	SuccessURL         string                        `json:"success_url"`
+}
+
+// CheckoutSessionList is a list of sessions as retrieved from a list endpoint.
+type CheckoutSessionList struct {
+	ListMeta
+	Data []*CheckoutSession `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a checkout session.

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -45,6 +45,7 @@ type CheckoutSessionLineItemParams struct {
 	Images      []*string `form:"images"`
 	Name        *string   `form:"name"`
 	Quantity    *int64    `form:"quantity"`
+	TaxRates    []*string `form:"tax_rates"`
 }
 
 // CheckoutSessionPaymentIntentDataTransferDataParams is the set of parameters allowed for the
@@ -81,8 +82,9 @@ type CheckoutSessionSetupIntentDataParams struct {
 // CheckoutSessionSubscriptionDataItemsParams is the set of parameters allowed for one item on a
 // checkout session associated with a subscription.
 type CheckoutSessionSubscriptionDataItemsParams struct {
-	Plan     *string `form:"plan"`
-	Quantity *int64  `form:"quantity"`
+	Plan     *string   `form:"plan"`
+	Quantity *int64    `form:"quantity"`
+	TaxRates []*string `form:"tax_rates"`
 }
 
 // CheckoutSessionSubscriptionDataParams is the set of parameters allowed for the subscription
@@ -90,6 +92,7 @@ type CheckoutSessionSubscriptionDataItemsParams struct {
 type CheckoutSessionSubscriptionDataParams struct {
 	Params                `form:"*"`
 	ApplicationFeePercent *float64                                      `form:"application_fee_percent"`
+	DefaultTaxRates       []*string                                     `form:"default_tax_rates"`
 	Items                 []*CheckoutSessionSubscriptionDataItemsParams `form:"items"`
 	TrialEnd              *int64                                        `form:"trial_end"`
 	TrialFromPlan         *bool                                         `form:"trial_from_plan"`
@@ -122,8 +125,8 @@ type CheckoutSessionParams struct {
 // For more details see: https://stripe.com/docs/api/checkout/sessions/list
 type CheckoutSessionListParams struct {
 	ListParams    `form:"*"`
-	Subscription  *string `form:"subscription"`
 	PaymentIntent *string `form:"payment_intent"`
+	Subscription  *string `form:"subscription"`
 }
 
 // CheckoutSessionDisplayItemCustom represents an item of type custom in a checkout session

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.80.0"
+	MockMinimumVersion = "0.82.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.79.0"
+	MockMinimumVersion = "0.80.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 