### PR TITLE
Move to latest API version `2020-03-02` and other API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.82.0
+    - STRIPE_MOCK_VERSION=0.83.0
 
 go:
   - "1.9.x"

--- a/customer.go
+++ b/customer.go
@@ -17,24 +17,25 @@ const (
 // CustomerParams is the set of parameters that can be used when creating or updating a customer.
 // For more details see https://stripe.com/docs/api#create_customer and https://stripe.com/docs/api#update_customer.
 type CustomerParams struct {
-	Params           `form:"*"`
-	Address          *AddressParams                 `form:"address"`
-	Balance          *int64                         `form:"balance"`
-	Coupon           *string                        `form:"coupon"`
-	DefaultSource    *string                        `form:"default_source"`
-	Description      *string                        `form:"description"`
-	Email            *string                        `form:"email"`
-	InvoicePrefix    *string                        `form:"invoice_prefix"`
-	InvoiceSettings  *CustomerInvoiceSettingsParams `form:"invoice_settings"`
-	Name             *string                        `form:"name"`
-	PaymentMethod    *string                        `form:"payment_method"`
-	Phone            *string                        `form:"phone"`
-	PreferredLocales []*string                      `form:"preferred_locales"`
-	Shipping         *CustomerShippingDetailsParams `form:"shipping"`
-	Source           *SourceParams                  `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
-	TaxExempt        *string                        `form:"tax_exempt"`
-	TaxIDData        []*CustomerTaxIDDataParams     `form:"tax_id_data"`
-	Token            *string                        `form:"-"` // This doesn't seem to be used?
+	Params              `form:"*"`
+	Address             *AddressParams                 `form:"address"`
+	Balance             *int64                         `form:"balance"`
+	Coupon              *string                        `form:"coupon"`
+	DefaultSource       *string                        `form:"default_source"`
+	Description         *string                        `form:"description"`
+	Email               *string                        `form:"email"`
+	InvoicePrefix       *string                        `form:"invoice_prefix"`
+	InvoiceSettings     *CustomerInvoiceSettingsParams `form:"invoice_settings"`
+	Name                *string                        `form:"name"`
+	NextInvoiceSequence *int64                         `form:"next_invoice_sequence"`
+	PaymentMethod       *string                        `form:"payment_method"`
+	Phone               *string                        `form:"phone"`
+	PreferredLocales    []*string                      `form:"preferred_locales"`
+	Shipping            *CustomerShippingDetailsParams `form:"shipping"`
+	Source              *SourceParams                  `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	TaxExempt           *string                        `form:"tax_exempt"`
+	TaxIDData           []*CustomerTaxIDDataParams     `form:"tax_id_data"`
+	Token               *string                        `form:"-"` // This doesn't seem to be used?
 
 	// The parameters below are considered deprecated. Consider creating a Subscription separately instead.
 	Plan       *string  `form:"plan"`
@@ -91,29 +92,30 @@ type CustomerListParams struct {
 // Customer is the resource representing a Stripe customer.
 // For more details see https://stripe.com/docs/api#customers.
 type Customer struct {
-	Address          Address                  `json:"address"`
-	Balance          int64                    `json:"balance"`
-	Created          int64                    `json:"created"`
-	Currency         Currency                 `json:"currency"`
-	DefaultSource    *PaymentSource           `json:"default_source"`
-	Deleted          bool                     `json:"deleted"`
-	Delinquent       bool                     `json:"delinquent"`
-	Description      string                   `json:"description"`
-	Discount         *Discount                `json:"discount"`
-	Email            string                   `json:"email"`
-	ID               string                   `json:"id"`
-	InvoicePrefix    string                   `json:"invoice_prefix"`
-	InvoiceSettings  *CustomerInvoiceSettings `json:"invoice_settings"`
-	Livemode         bool                     `json:"livemode"`
-	Metadata         map[string]string        `json:"metadata"`
-	Name             string                   `json:"name"`
-	Phone            string                   `json:"phone"`
-	PreferredLocales []string                 `json:"preferred_locales"`
-	Shipping         *CustomerShippingDetails `json:"shipping"`
-	Sources          *SourceList              `json:"sources"`
-	Subscriptions    *SubscriptionList        `json:"subscriptions"`
-	TaxExempt        CustomerTaxExempt        `json:"tax_exempt"`
-	TaxIDs           *TaxIDList               `json:"tax_ids"`
+	Address             Address                  `json:"address"`
+	Balance             int64                    `json:"balance"`
+	Created             int64                    `json:"created"`
+	Currency            Currency                 `json:"currency"`
+	DefaultSource       *PaymentSource           `json:"default_source"`
+	Deleted             bool                     `json:"deleted"`
+	Delinquent          bool                     `json:"delinquent"`
+	Description         string                   `json:"description"`
+	Discount            *Discount                `json:"discount"`
+	Email               string                   `json:"email"`
+	ID                  string                   `json:"id"`
+	InvoicePrefix       string                   `json:"invoice_prefix"`
+	InvoiceSettings     *CustomerInvoiceSettings `json:"invoice_settings"`
+	Livemode            bool                     `json:"livemode"`
+	Metadata            map[string]string        `json:"metadata"`
+	Name                string                   `json:"name"`
+	NextInvoiceSequence int64                    `json:"next_invoice_sequence"`
+	Phone               string                   `json:"phone"`
+	PreferredLocales    []string                 `json:"preferred_locales"`
+	Shipping            *CustomerShippingDetails `json:"shipping"`
+	Sources             *SourceList              `json:"sources"`
+	Subscriptions       *SubscriptionList        `json:"subscriptions"`
+	TaxExempt           CustomerTaxExempt        `json:"tax_exempt"`
+	TaxIDs              *TaxIDList               `json:"tax_ids"`
 }
 
 // CustomerInvoiceCustomField represents a custom field associated with the customer's invoices.

--- a/stripe.go
+++ b/stripe.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2019-12-03"
+	APIVersion string = "2020-03-02"
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.82.0"
+	MockMinimumVersion = "0.83.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Multiple API changes:
* Move to latest API version `2020-03-02`
* Add support for `NextInvoiceSequence` on `Customer`

r? @ob-stripe 
cc @stripe/api-libraries 