### PR TITLE
Multiple changes for Issuing APIs

### DIFF
--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -106,7 +106,18 @@ const (
 	IssuingAuthorizationVerificationDataThreeDSecureResultFailed              IssuingAuthorizationVerificationDataThreeDSecureResult = "failed"
 )
 
+// IssuingAuthorizationWalletType is the list of possible values for the authorization's wallet provider.
+type IssuingAuthorizationWalletType string
+
+// List of values that IssuingAuthorizationWalletType can take.
+const (
+	IssuingAuthorizationWalletTypeApplePay   IssuingAuthorizationWalletType = "apple_pay"
+	IssuingAuthorizationWalletTypeGooglePay  IssuingAuthorizationWalletType = "google_pay"
+	IssuingAuthorizationWalletTypeSamsungPay IssuingAuthorizationWalletType = "samsung_pay"
+)
+
 // IssuingAuthorizationWalletProviderType is the list of possible values for the authorization's wallet provider.
+// TODO remove in the next major version
 type IssuingAuthorizationWalletProviderType string
 
 // List of values that IssuingAuthorizationWalletProviderType can take.
@@ -167,13 +178,17 @@ type IssuingAuthorizationVerificationDataThreeDSecure struct {
 
 // IssuingAuthorizationVerificationData is the resource representing verification data on an issuing authorization.
 type IssuingAuthorizationVerificationData struct {
-	AddressLine1Check IssuingAuthorizationVerificationDataCheck         `json:"address_line1_check"`
-	AddressZipCheck   IssuingAuthorizationVerificationDataCheck         `json:"address_zip_check"`
-	CVCCheck          IssuingAuthorizationVerificationDataCheck         `json:"cvc_check"`
-	ExpiryCheck       IssuingAuthorizationVerificationDataCheck         `json:"expiry_check"`
-	ThreeDSecure      *IssuingAuthorizationVerificationDataThreeDSecure `json:"three_d_secure"`
+	AddressLine1Check      IssuingAuthorizationVerificationDataCheck         `json:"address_line1_check"`
+	AddressPostalCodeCheck IssuingAuthorizationVerificationDataCheck         `json:"address_postal_code_check"`
+	CVCCheck               IssuingAuthorizationVerificationDataCheck         `json:"cvc_check"`
+	ExpiryCheck            IssuingAuthorizationVerificationDataCheck         `json:"expiry_check"`
+	ThreeDSecure           *IssuingAuthorizationVerificationDataThreeDSecure `json:"three_d_secure"`
 
-	// This property is considered deprecated. Use ThreeDSecure instead.
+	// The property is considered deprecated. Use AddressPostalCodeCheck instead.
+	// TODO remove in the next major version
+	AddressZipCheck IssuingAuthorizationVerificationDataCheck `json:"address_zip_check"`
+
+	// The property is considered deprecated. Use ThreeDSecure instead.
 	// TODO remove in the next major version
 	Authentication IssuingAuthorizationVerificationDataAuthentication `json:"authentication"`
 }
@@ -202,7 +217,11 @@ type IssuingAuthorization struct {
 	Status                   IssuingAuthorizationStatus              `json:"status"`
 	Transactions             []*IssuingTransaction                   `json:"transactions"`
 	VerificationData         *IssuingAuthorizationVerificationData   `json:"verification_data"`
-	WalletProvider           IssuingAuthorizationWalletProviderType  `json:"wallet_provider"`
+	Wallet                   IssuingAuthorizationWalletType          `json:"wallet"`
+
+	// This property is deprecated and we recommend that you use Wallet instead.
+	// TODO: remove in the next major version
+	WalletProvider IssuingAuthorizationWalletProviderType `json:"wallet_provider"`
 }
 
 // IssuingMerchantData is the resource representing merchant data on Issuing APIs.

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -36,6 +36,16 @@ const (
 	IssuingCardShippingTypeShipped   IssuingCardShippingStatus = "shipped"
 )
 
+// IssuingCardShippingService is the shipment service for a card.
+type IssuingCardShippingService string
+
+// List of values that IssuingCardShippingService can take.
+const (
+	IssuingCardShippingServiceExpress   IssuingCardShippingService = "express"
+	IssuingCardShippingServiceOvernight IssuingCardShippingService = "overnight"
+	IssuingCardShippingServiceStandard  IssuingCardShippingService = "standard"
+)
+
 // IssuingCardShippingSpeed is the shipment speed for a card.
 type IssuingCardShippingSpeed string
 
@@ -117,8 +127,12 @@ type AuthorizationControlsParams struct {
 type IssuingCardShippingParams struct {
 	Address *AddressParams `form:"address"`
 	Name    string         `form:"name"`
-	Speed   *string        `form:"speed"`
+	Service *string        `form:"service"`
 	Type    *string        `form:"type"`
+
+	// This parameter is considered deprecated. Use Service instead.
+	// TODO remove in the next major version
+	Speed *string `form:"speed"`
 }
 
 // IssuingCardParams is the set of parameters that can be used when creating or updating an issuing card.
@@ -191,16 +205,20 @@ type IssuingCardPIN struct {
 
 // IssuingCardShipping is the resource representing shipping on an issuing card.
 type IssuingCardShipping struct {
-	Address        *Address                  `json:"address"`
-	Carrier        string                    `json:"carrier"`
-	ETA            int64                     `json:"eta"`
-	Name           string                    `json:"name"`
-	Phone          string                    `json:"phone"`
-	Status         IssuingCardShippingStatus `json:"status"`
-	Speed          IssuingCardShippingSpeed  `json:"speed"`
-	TrackingNumber string                    `json:"tracking_number"`
-	TrackingURL    string                    `json:"tracking_url"`
-	Type           IssuingCardShippingType   `json:"type"`
+	Address        *Address                   `json:"address"`
+	Carrier        string                     `json:"carrier"`
+	ETA            int64                      `json:"eta"`
+	Name           string                     `json:"name"`
+	Phone          string                     `json:"phone"`
+	Service        IssuingCardShippingService `json:"service"`
+	Status         IssuingCardShippingStatus  `json:"status"`
+	TrackingNumber string                     `json:"tracking_number"`
+	TrackingURL    string                     `json:"tracking_url"`
+	Type           IssuingCardShippingType    `json:"type"`
+
+	// The property is considered deprecated. Use AddressPostalCodeCheck instead.
+	// TODO remove in the next major version
+	Speed IssuingCardShippingSpeed `json:"speed"`
 }
 
 // IssuingCard is the resource representing a Stripe issuing card.

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -82,11 +82,14 @@ type IssuingCardholderParams struct {
 	Company               *IssuingCardholderCompanyParams    `form:"company"`
 	Email                 *string                            `form:"email"`
 	Individual            *IssuingCardholderIndividualParams `form:"individual"`
-	IsDefault             *bool                              `form:"is_default"`
 	Name                  *string                            `form:"name"`
 	PhoneNumber           *string                            `form:"phone_number"`
 	Status                *string                            `form:"status"`
 	Type                  *string                            `form:"type"`
+
+	// This parameter is considered deprecated.
+	// TODO remove in the next major version
+	IsDefault *bool `form:"is_default"`
 }
 
 // IssuingCardholderListParams is the set of parameters that can be used when listing issuing cardholders.
@@ -95,10 +98,13 @@ type IssuingCardholderListParams struct {
 	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 	Email        *string           `form:"email"`
-	IsDefault    *bool             `form:"is_default"`
 	PhoneNumber  *string           `form:"phone_number"`
 	Status       *string           `form:"status"`
 	Type         *string           `form:"type"`
+
+	// The property is considered deprecated.
+	// TODO remove in the next major version
+	IsDefault *bool `form:"is_default"`
 }
 
 // IssuingBilling is the resource representing the billing hash with the Issuing APIs.


### PR DESCRIPTION
Multiple changes for Issuing APIs
  * Rename `Speed` to `Service` on Issuing `Card`
  * Rename `WalletProvider` to `Wallet` and `AddressZipCheck` to `AddressPostalCodeCheck` on Issuing `Authorization`
  * Mark `IsDefault` as deprecated on Issuing `Cardholder`

r? @ob-stripe 
cc @stripe/api-libraries 