### PR TITLE
Multiple API changes for Issuing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.83.0
+    - STRIPE_MOCK_VERSION=0.85.0
 
 go:
   - "1.9.x"

--- a/issuing/card/client_test.go
+++ b/issuing/card/client_test.go
@@ -34,19 +34,21 @@ func TestIssuingCardList(t *testing.T) {
 
 func TestIssuingCardNew(t *testing.T) {
 	params := &stripe.IssuingCardParams{
-		AuthorizationControls: &stripe.AuthorizationControlsParams{
-			SpendingLimits: []*stripe.IssuingAuthorizationControlsSpendingLimitsParams{
+		Cardholder: stripe.String("ich_123"),
+		Currency:   stripe.String(string(stripe.CurrencyUSD)),
+		SpendingControls: &stripe.IssuingCardSpendingControlsParams{
+			AllowedCategories: stripe.StringSlice([]string{
+				"fast_food_restaurants",
+				"miscellaneous_food_stores",
+			}),
+			SpendingLimits: []*stripe.IssuingCardSpendingControlsSpendingLimitParams{
 				{
-					Amount: stripe.Int64(1000),
-					Categories: stripe.StringSlice([]string{
-						"financial_institutions",
-					}),
-					Interval: stripe.String(string(stripe.IssuingSpendingLimitIntervalAllTime)),
+					Amount:   stripe.Int64(1000),
+					Interval: stripe.String(string(stripe.IssuingCardSpendingControlsSpendingLimitIntervalWeekly)),
 				},
 			},
 		},
-		Currency: stripe.String(string(stripe.CurrencyUSD)),
-		Type:     stripe.String(string(stripe.IssuingCardTypeVirtual)),
+		Type: stripe.String(string(stripe.IssuingCardTypeVirtual)),
 	}
 	card, err := New(params)
 	assert.Nil(t, err)

--- a/issuing/cardholder/client_test.go
+++ b/issuing/cardholder/client_test.go
@@ -53,11 +53,40 @@ func TestIssuingCardholderNew(t *testing.T) {
 			},
 		},
 		Name: stripe.String("cardholder name"),
+		SpendingControls: &stripe.IssuingCardholderSpendingControlsParams{
+			AllowedCategories: stripe.StringSlice([]string{
+				"fast_food_restaurants",
+				"miscellaneous_food_stores",
+			}),
+			SpendingLimits: []*stripe.IssuingCardholderSpendingControlsSpendingLimitParams{
+				{
+					Amount:   stripe.Int64(1000),
+					Interval: stripe.String(string(stripe.IssuingCardholderSpendingControlsSpendingLimitIntervalWeekly)),
+				},
+			},
+		},
 		Type: stripe.String(string(stripe.IssuingCardholderTypeIndividual)),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, cardholder)
 	assert.Equal(t, "issuing.cardholder", cardholder.Object)
+}
+
+// IssuingCardholderSpendingControlsSpendingLimitParams is the set of parameters that can be used to
+// represent a given spending limit for an issuing cardholder.
+type IssuingCardholderSpendingControlsSpendingLimitParams struct {
+	Amount     *int64    `form:"amount"`
+	Categories []*string `form:"categories"`
+	Interval   *string   `form:"interval"`
+}
+
+// IssuingCardholderSpendingControlsParams is the set of parameters that can be used to configure
+// the spending controls for an issuing cardholder
+type IssuingCardholderSpendingControlsParams struct {
+	AllowedCategories      []*string                                               `form:"allowed_categories"`
+	BlockedCategories      []*string                                               `form:"blocked_categories"`
+	SpendingLimits         []*IssuingCardholderSpendingControlsSpendingLimitParams `form:"spending_limits"`
+	SpendingLimitsCurrency *string                                                 `form:"spending_limits_currency"`
 }
 
 func TestIssuingCardholderUpdate(t *testing.T) {

--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -47,20 +47,26 @@ type IssuingAuthorizationRequestHistoryReason string
 const (
 	IssuingAuthorizationRequestHistoryReasonAccountComplianceDisabled      IssuingAuthorizationRequestHistoryReason = "account_compliance_disabled"
 	IssuingAuthorizationRequestHistoryReasonAccountInactive                IssuingAuthorizationRequestHistoryReason = "account_inactive"
-	IssuingAuthorizationRequestHistoryReasonAuthenticationFailed           IssuingAuthorizationRequestHistoryReason = "authentication_failed"
-	IssuingAuthorizationRequestHistoryReasonAuthorizationControls          IssuingAuthorizationRequestHistoryReason = "authorization_controls"
 	IssuingAuthorizationRequestHistoryReasonCardActive                     IssuingAuthorizationRequestHistoryReason = "card_active"
 	IssuingAuthorizationRequestHistoryReasonCardInactive                   IssuingAuthorizationRequestHistoryReason = "card_inactive"
 	IssuingAuthorizationRequestHistoryReasonCardholderInactive             IssuingAuthorizationRequestHistoryReason = "cardholder_inactive"
 	IssuingAuthorizationRequestHistoryReasonCardholderVerificationRequired IssuingAuthorizationRequestHistoryReason = "cardholder_verification_required"
-	IssuingAuthorizationRequestHistoryReasonIncorrectCVC                   IssuingAuthorizationRequestHistoryReason = "incorrect_cvc"
-	IssuingAuthorizationRequestHistoryReasonIncorrectExpiry                IssuingAuthorizationRequestHistoryReason = "incorrect_expiry"
 	IssuingAuthorizationRequestHistoryReasonInsufficientFunds              IssuingAuthorizationRequestHistoryReason = "insufficient_funds"
 	IssuingAuthorizationRequestHistoryReasonNotAllowed                     IssuingAuthorizationRequestHistoryReason = "not_allowed"
+	IssuingAuthorizationRequestHistoryReasonSpendingControls               IssuingAuthorizationRequestHistoryReason = "spending_controls"
 	IssuingAuthorizationRequestHistoryReasonSuspectedFraud                 IssuingAuthorizationRequestHistoryReason = "suspected_fraud"
+	IssuingAuthorizationRequestHistoryReasonVerificationFailed             IssuingAuthorizationRequestHistoryReason = "verification_failed"
 	IssuingAuthorizationRequestHistoryReasonWebhookApproved                IssuingAuthorizationRequestHistoryReason = "webhook_approved"
 	IssuingAuthorizationRequestHistoryReasonWebhookDeclined                IssuingAuthorizationRequestHistoryReason = "webhook_declined"
 	IssuingAuthorizationRequestHistoryReasonWebhookTimeout                 IssuingAuthorizationRequestHistoryReason = "webhook_timeout"
+
+	// The following value is deprecated. Use IssuingAuthorizationRequestHistoryReasonSpendingControls instead.
+	IssuingAuthorizationRequestHistoryReasonAuthorizationControls IssuingAuthorizationRequestHistoryReason = "authorization_controls"
+
+	// The following values are deprecated. Use IssuingAuthorizationRequestHistoryReasonVerificationFailed instead
+	IssuingAuthorizationRequestHistoryReasonAuthenticationFailed IssuingAuthorizationRequestHistoryReason = "authentication_failed"
+	IssuingAuthorizationRequestHistoryReasonIncorrectCVC         IssuingAuthorizationRequestHistoryReason = "incorrect_cvc"
+	IssuingAuthorizationRequestHistoryReasonIncorrectExpiry      IssuingAuthorizationRequestHistoryReason = "incorrect_expiry"
 )
 
 // IssuingAuthorizationStatus is the possible values for status for an issuing authorization.
@@ -148,6 +154,7 @@ type IssuingAuthorizationListParams struct {
 }
 
 // IssuingAuthorizationAuthorizationControls is the resource representing authorization controls on an issuing authorization.
+// This is deprecated and will be removed in the next major version
 type IssuingAuthorizationAuthorizationControls struct {
 	AllowedCategories []string `json:"allowed_categories"`
 	BlockedCategories []string `json:"blocked_categories"`
@@ -167,6 +174,7 @@ type IssuingAuthorizationPendingRequest struct {
 
 // IssuingAuthorizationRequestHistoryViolatedAuthorizationControl is the resource representing an
 // authorizaton control that caused the authorization to fail.
+// This is deprecated and will be removed in the next major version
 type IssuingAuthorizationRequestHistoryViolatedAuthorizationControl struct {
 	Entity IssuingAuthorizationRequestHistoryViolatedAuthorizationControlEntity `json:"entity"`
 	Name   IssuingAuthorizationRequestHistoryViolatedAuthorizationControlName   `json:"name"`
@@ -174,21 +182,21 @@ type IssuingAuthorizationRequestHistoryViolatedAuthorizationControl struct {
 
 // IssuingAuthorizationRequestHistory is the resource representing a request history on an issuing authorization.
 type IssuingAuthorizationRequestHistory struct {
-	Amount                        int64                                                             `json:"amount"`
-	Approved                      bool                                                              `json:"approved"`
-	Created                       int64                                                             `json:"created"`
-	Currency                      Currency                                                          `json:"currency"`
-	MerchantAmount                int64                                                             `json:"merchant_amount"`
-	MerchantCurrency              Currency                                                          `json:"merchant_currency"`
-	Reason                        IssuingAuthorizationRequestHistoryReason                          `json:"reason"`
-	ViolatedAuthorizationControls []*IssuingAuthorizationRequestHistoryViolatedAuthorizationControl `json:"violated_authorization_controls"`
+	Amount           int64                                    `json:"amount"`
+	Approved         bool                                     `json:"approved"`
+	Created          int64                                    `json:"created"`
+	Currency         Currency                                 `json:"currency"`
+	MerchantAmount   int64                                    `json:"merchant_amount"`
+	MerchantCurrency Currency                                 `json:"merchant_currency"`
+	Reason           IssuingAuthorizationRequestHistoryReason `json:"reason"`
 
 	// The following properties are deprecated
 	// TODO: remove in the next major version
-	AuthorizedAmount   int64    `json:"authorized_amount"`
-	AuthorizedCurrency Currency `json:"authorized_currency"`
-	HeldAmount         int64    `json:"held_amount"`
-	HeldCurrency       Currency `json:"held_currency"`
+	AuthorizedAmount              int64                                                             `json:"authorized_amount"`
+	AuthorizedCurrency            Currency                                                          `json:"authorized_currency"`
+	HeldAmount                    int64                                                             `json:"held_amount"`
+	HeldCurrency                  Currency                                                          `json:"held_currency"`
+	ViolatedAuthorizationControls []*IssuingAuthorizationRequestHistoryViolatedAuthorizationControl `json:"violated_authorization_controls"`
 }
 
 // IssuingAuthorizationVerificationDataThreeDSecure is the resource representing 3DS results.

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -41,15 +41,19 @@ type IssuingCardShippingService string
 
 // List of values that IssuingCardShippingService can take.
 const (
-	IssuingCardShippingServiceExpress   IssuingCardShippingService = "express"
+	IssuingCardShippingServiceExpress  IssuingCardShippingService = "express"
+	IssuingCardShippingServicePriority IssuingCardShippingService = "priority"
+	IssuingCardShippingServiceStandard IssuingCardShippingService = "standard"
+
+	// The following value is deprecated, use IssuingCardShippingServicePriority instead
 	IssuingCardShippingServiceOvernight IssuingCardShippingService = "overnight"
-	IssuingCardShippingServiceStandard  IssuingCardShippingService = "standard"
 )
 
 // IssuingCardShippingSpeed is the shipment speed for a card.
+// This is deprecated, use IssuingCardShippingService instead
 type IssuingCardShippingSpeed string
 
-// List of values that IssuingCardShippingSpeed can take.
+// List of values that IssuingCardShippingSpeed can take
 const (
 	IssuingCardShippingSpeedExpress   IssuingCardShippingSpeed = "express"
 	IssuingCardShippingSpeedOvernight IssuingCardShippingSpeed = "overnight"
@@ -64,6 +68,20 @@ type IssuingCardShippingType string
 const (
 	IssuingCardShippingTypeBulk       IssuingCardShippingType = "bulk"
 	IssuingCardShippingTypeIndividual IssuingCardShippingType = "individual"
+)
+
+// IssuingCardSpendingControlsSpendingLimitInterval is the list of possible values for the interval
+// for a spending limit on an issuing card.
+type IssuingCardSpendingControlsSpendingLimitInterval string
+
+// List of values that IssuingCardShippingStatus can take.
+const (
+	IssuingCardSpendingControlsSpendingLimitIntervalAllTime          IssuingCardSpendingControlsSpendingLimitInterval = "all_time"
+	IssuingCardSpendingControlsSpendingLimitIntervalDaily            IssuingCardSpendingControlsSpendingLimitInterval = "daily"
+	IssuingCardSpendingControlsSpendingLimitIntervalMonthly          IssuingCardSpendingControlsSpendingLimitInterval = "monthly"
+	IssuingCardSpendingControlsSpendingLimitIntervalPerAuthorization IssuingCardSpendingControlsSpendingLimitInterval = "per_authorization"
+	IssuingCardSpendingControlsSpendingLimitIntervalWeekly           IssuingCardSpendingControlsSpendingLimitInterval = "weekly"
+	IssuingCardSpendingControlsSpendingLimitIntervalYearly           IssuingCardSpendingControlsSpendingLimitInterval = "yearly"
 )
 
 // IssuingCardStatus is the list of possible values for status on an issuing card.
@@ -88,6 +106,7 @@ const (
 
 // IssuingSpendingLimitInterval is the list of possible values for the interval of a given
 // spending limit on an issuing card or cardholder.
+// This is deprecated, use IssuingCardSpendingControlsSpendingLimitInterval instead
 type IssuingSpendingLimitInterval string
 
 // List of values that IssuingCardShippingStatus can take.
@@ -102,6 +121,7 @@ const (
 
 // IssuingAuthorizationControlsSpendingLimitsParams is the set of parameters that can be used for
 // the spending limits associated with a given issuing card or cardholder.
+// This is deprecated and will be removed in the next major version.
 type IssuingAuthorizationControlsSpendingLimitsParams struct {
 	Amount     *int64    `form:"amount"`
 	Categories []*string `form:"categories"`
@@ -109,7 +129,7 @@ type IssuingAuthorizationControlsSpendingLimitsParams struct {
 }
 
 // AuthorizationControlsParams is the set of parameters that can be used for the shipping parameter.
-// TODO: Rename and "un-share" between Card and Cardholder in the next major version.
+// This is deprecated and will be removed in the next major version.
 type AuthorizationControlsParams struct {
 	AllowedCategories []*string                                           `form:"allowed_categories"`
 	BlockedCategories []*string                                           `form:"blocked_categories"`
@@ -119,7 +139,7 @@ type AuthorizationControlsParams struct {
 	// The following parameter only applies to Cardholder
 	SpendingLimitsCurrency *string `form:"spending_limits_currency"`
 
-	// The following parameter is considered deprecated
+	// The following parameter is deprecated
 	MaxAmount *int64 `form:"max_amount"`
 }
 
@@ -130,24 +150,47 @@ type IssuingCardShippingParams struct {
 	Service *string        `form:"service"`
 	Type    *string        `form:"type"`
 
-	// This parameter is considered deprecated. Use Service instead.
+	// This parameter is deprecated. Use Service instead.
 	// TODO remove in the next major version
 	Speed *string `form:"speed"`
 }
 
+// IssuingCardSpendingControlsSpendingLimitParams is the set of parameters that can be used to
+// represent a given spending limit for an issuing card.
+type IssuingCardSpendingControlsSpendingLimitParams struct {
+	Amount     *int64    `form:"amount"`
+	Categories []*string `form:"categories"`
+	Interval   *string   `form:"interval"`
+}
+
+// IssuingCardSpendingControlsParams is the set of parameters that can be used to configure
+// the spending controls for an issuing card
+type IssuingCardSpendingControlsParams struct {
+	AllowedCategories      []*string                                         `form:"allowed_categories"`
+	BlockedCategories      []*string                                         `form:"blocked_categories"`
+	MaxApprovals           *int64                                            `form:"max_approvals"`
+	SpendingLimits         []*IssuingCardSpendingControlsSpendingLimitParams `form:"spending_limits"`
+	SpendingLimitsCurrency *string                                           `form:"spending_limits_currency"`
+}
+
 // IssuingCardParams is the set of parameters that can be used when creating or updating an issuing card.
 type IssuingCardParams struct {
-	Params                `form:"*"`
+	Params            `form:"*"`
+	Billing           *IssuingBillingParams              `form:"billing"`
+	Cardholder        *string                            `form:"cardholder"`
+	Currency          *string                            `form:"currency"`
+	ReplacementFor    *string                            `form:"replacement_for"`
+	ReplacementReason *string                            `form:"replacement_reason"`
+	SpendingControls  *IssuingCardSpendingControlsParams `form:"spending_controls"`
+	Status            *string                            `form:"status"`
+	Shipping          *IssuingCardShippingParams         `form:"shipping"`
+	Type              *string                            `form:"type"`
+
+	// The following parameter is deprecated, use SpendingControls instead.
 	AuthorizationControls *AuthorizationControlsParams `form:"authorization_controls"`
-	Billing               *IssuingBillingParams        `form:"billing"`
-	Cardholder            *string                      `form:"cardholder"`
-	Currency              *string                      `form:"currency"`
-	Name                  *string                      `form:"name"`
-	ReplacementFor        *string                      `form:"replacement_for"`
-	ReplacementReason     *string                      `form:"replacement_reason"`
-	Status                *string                      `form:"status"`
-	Shipping              *IssuingCardShippingParams   `form:"shipping"`
-	Type                  *string                      `form:"type"`
+
+	// The following parameter is deprecated
+	Name *string `form:"name"`
 }
 
 // IssuingCardListParams is the set of parameters that can be used when listing issuing cards.
@@ -158,11 +201,13 @@ type IssuingCardListParams struct {
 	CreatedRange *RangeQueryParams `form:"created"`
 	ExpMonth     *int64            `form:"exp_month"`
 	ExpYear      *int64            `form:"exp_year"`
-	Name         *string           `form:"name"`
 	Last4        *string           `form:"last4"`
-	Source       *string           `form:"source"`
 	Status       *string           `form:"status"`
 	Type         *string           `form:"type"`
+
+	// The following parameters are deprecated
+	Name   *string `form:"name"`
+	Source *string `form:"source"`
 }
 
 // IssuingCardDetails is the resource representing issuing card details.
@@ -192,7 +237,7 @@ type IssuingCardAuthorizationControls struct {
 	SpendingLimits         []*IssuingAuthorizationControlsSpendingLimits `json:"spending_limits"`
 	SpendingLimitsCurrency Currency                                      `json:"spending_limits_currency"`
 
-	// The properties below are considered deprecated and can only be used for an issuing card.
+	// The properties below are deprecated and can only be used for an issuing card.
 	// TODO remove in the next major version
 	Currency  Currency `json:"currency"`
 	MaxAmount int64    `json:"max_amount"`
@@ -216,33 +261,56 @@ type IssuingCardShipping struct {
 	TrackingURL    string                     `json:"tracking_url"`
 	Type           IssuingCardShippingType    `json:"type"`
 
-	// The property is considered deprecated. Use AddressPostalCodeCheck instead.
+	// The property is deprecated. Use AddressPostalCodeCheck instead.
 	// TODO remove in the next major version
 	Speed IssuingCardShippingSpeed `json:"speed"`
 }
 
+// IssuingCardSpendingControlsSpendingLimit is the resource representing a spending limit
+// for an issuing card.
+type IssuingCardSpendingControlsSpendingLimit struct {
+	Amount     int64                                            `json:"amount"`
+	Categories []string                                         `json:"categories"`
+	Interval   IssuingCardSpendingControlsSpendingLimitInterval `json:"interval"`
+}
+
+// IssuingCardSpendingControls is the resource representing spending controls
+// for an issuing card.
+type IssuingCardSpendingControls struct {
+	AllowedCategories      []string                                    `json:"allowed_categories"`
+	BlockedCategories      []string                                    `json:"blocked_categories"`
+	MaxApprovals           int64                                       `json:"max_approvals"`
+	SpendingLimits         []*IssuingCardSpendingControlsSpendingLimit `json:"spending_limits"`
+	SpendingLimitsCurrency Currency                                    `json:"spending_limits_currency"`
+}
+
 // IssuingCard is the resource representing a Stripe issuing card.
 type IssuingCard struct {
+	Billing           *IssuingBilling              `json:"billing"`
+	Brand             string                       `json:"brand"`
+	Cardholder        *IssuingCardholder           `json:"cardholder"`
+	Created           int64                        `json:"created"`
+	ExpMonth          int64                        `json:"exp_month"`
+	ExpYear           int64                        `json:"exp_year"`
+	Last4             string                       `json:"last4"`
+	ID                string                       `json:"id"`
+	Livemode          bool                         `json:"livemode"`
+	Metadata          map[string]string            `json:"metadata"`
+	Object            string                       `json:"object"`
+	PIN               *IssuingCardPIN              `json:"pin"`
+	ReplacedBy        *IssuingCard                 `json:"replaced_by"`
+	ReplacementFor    *IssuingCard                 `json:"replacement_for"`
+	ReplacementReason IssuingCardReplacementReason `json:"replacement_reason"`
+	Shipping          *IssuingCardShipping         `json:"shipping"`
+	SpendingControls  *IssuingCardSpendingControls `json:"spending_controls"`
+	Status            IssuingCardStatus            `json:"status"`
+	Type              IssuingCardType              `json:"type"`
+
+	// The following property is deprecated, use SpendingControls instead.
 	AuthorizationControls *IssuingCardAuthorizationControls `json:"authorization_controls"`
-	Billing               *IssuingBilling                   `json:"billing"`
-	Brand                 string                            `json:"brand"`
-	Cardholder            *IssuingCardholder                `json:"cardholder"`
-	Created               int64                             `json:"created"`
-	ExpMonth              int64                             `json:"exp_month"`
-	ExpYear               int64                             `json:"exp_year"`
-	Last4                 string                            `json:"last4"`
-	ID                    string                            `json:"id"`
-	Livemode              bool                              `json:"livemode"`
-	Metadata              map[string]string                 `json:"metadata"`
-	Name                  string                            `json:"name"`
-	Object                string                            `json:"object"`
-	PIN                   *IssuingCardPIN                   `json:"pin"`
-	ReplacedBy            *IssuingCard                      `json:"replaced_by"`
-	ReplacementFor        *IssuingCard                      `json:"replacement_for"`
-	ReplacementReason     IssuingCardReplacementReason      `json:"replacement_reason"`
-	Shipping              *IssuingCardShipping              `json:"shipping"`
-	Status                IssuingCardStatus                 `json:"status"`
-	Type                  IssuingCardType                   `json:"type"`
+
+	// The following property is deprecated, use Cardholder.Name instead.
+	Name string `json:"name"`
 }
 
 // IssuingCardList is a list of issuing cards as retrieved from a list endpoint.

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -13,6 +13,20 @@ const (
 	IssuingCardholderRequirementsDisabledReasonUnderReview    IssuingCardholderRequirementsDisabledReason = "under_review"
 )
 
+// IssuingCardholderSpendingControlsSpendingLimitInterval is the list of possible values for the interval
+// for a spending limit on an issuing cardholder.
+type IssuingCardholderSpendingControlsSpendingLimitInterval string
+
+// List of values that IssuingCardShippingStatus can take.
+const (
+	IssuingCardholderSpendingControlsSpendingLimitIntervalAllTime          IssuingCardholderSpendingControlsSpendingLimitInterval = "all_time"
+	IssuingCardholderSpendingControlsSpendingLimitIntervalDaily            IssuingCardholderSpendingControlsSpendingLimitInterval = "daily"
+	IssuingCardholderSpendingControlsSpendingLimitIntervalMonthly          IssuingCardholderSpendingControlsSpendingLimitInterval = "monthly"
+	IssuingCardholderSpendingControlsSpendingLimitIntervalPerAuthorization IssuingCardholderSpendingControlsSpendingLimitInterval = "per_authorization"
+	IssuingCardholderSpendingControlsSpendingLimitIntervalWeekly           IssuingCardholderSpendingControlsSpendingLimitInterval = "weekly"
+	IssuingCardholderSpendingControlsSpendingLimitIntervalYearly           IssuingCardholderSpendingControlsSpendingLimitInterval = "yearly"
+)
+
 // IssuingCardholderStatus is the possible values for status on an issuing cardholder.
 type IssuingCardholderStatus string
 
@@ -20,7 +34,9 @@ type IssuingCardholderStatus string
 const (
 	IssuingCardholderStatusActive   IssuingCardholderStatus = "active"
 	IssuingCardholderStatusInactive IssuingCardholderStatus = "inactive"
-	IssuingCardholderStatusPending  IssuingCardholderStatus = "pending"
+
+	// This value is deprecated
+	IssuingCardholderStatusPending IssuingCardholderStatus = "pending"
 )
 
 // IssuingCardholderType is the type of an issuing cardholder.
@@ -28,14 +44,19 @@ type IssuingCardholderType string
 
 // List of values that IssuingCardholderType can take.
 const (
+	IssuingCardholderTypeCompany    IssuingCardholderType = "company"
+	IssuingCardholderTypeIndividual IssuingCardholderType = "individual"
+
+	// This value is deprecated. Use IssuingCardholderTypeCompany instead
 	IssuingCardholderTypeBusinessEntity IssuingCardholderType = "business_entity"
-	IssuingCardholderTypeIndividual     IssuingCardholderType = "individual"
 )
 
 // IssuingBillingParams is the set of parameters that can be used for billing with the Issuing APIs.
 type IssuingBillingParams struct {
 	Address *AddressParams `form:"address"`
-	Name    *string        `form:"name"`
+
+	// This parameter is deprecated
+	Name *string `form:"name"`
 }
 
 // IssuingCardholderCompanyParams represents additional information about a
@@ -74,22 +95,39 @@ type IssuingCardholderIndividualParams struct {
 	Verification *IssuingCardholderIndividualVerificationParams `form:"verification"`
 }
 
+// IssuingCardholderSpendingControlsSpendingLimitParams is the set of parameters that can be used to
+// represent a given spending limit for an issuing cardholder.
+type IssuingCardholderSpendingControlsSpendingLimitParams struct {
+	Amount     *int64    `form:"amount"`
+	Categories []*string `form:"categories"`
+	Interval   *string   `form:"interval"`
+}
+
+// IssuingCardholderSpendingControlsParams is the set of parameters that can be used to configure
+// the spending controls for an issuing cardholder
+type IssuingCardholderSpendingControlsParams struct {
+	AllowedCategories      []*string                                               `form:"allowed_categories"`
+	BlockedCategories      []*string                                               `form:"blocked_categories"`
+	SpendingLimits         []*IssuingCardholderSpendingControlsSpendingLimitParams `form:"spending_limits"`
+	SpendingLimitsCurrency *string                                                 `form:"spending_limits_currency"`
+}
+
 // IssuingCardholderParams is the set of parameters that can be used when creating or updating an issuing cardholder.
 type IssuingCardholderParams struct {
-	Params                `form:"*"`
-	AuthorizationControls *AuthorizationControlsParams       `form:"authorization_controls"`
-	Billing               *IssuingBillingParams              `form:"billing"`
-	Company               *IssuingCardholderCompanyParams    `form:"company"`
-	Email                 *string                            `form:"email"`
-	Individual            *IssuingCardholderIndividualParams `form:"individual"`
-	Name                  *string                            `form:"name"`
-	PhoneNumber           *string                            `form:"phone_number"`
-	Status                *string                            `form:"status"`
-	Type                  *string                            `form:"type"`
+	Params           `form:"*"`
+	Billing          *IssuingBillingParams                    `form:"billing"`
+	Company          *IssuingCardholderCompanyParams          `form:"company"`
+	Email            *string                                  `form:"email"`
+	Individual       *IssuingCardholderIndividualParams       `form:"individual"`
+	Name             *string                                  `form:"name"`
+	PhoneNumber      *string                                  `form:"phone_number"`
+	SpendingControls *IssuingCardholderSpendingControlsParams `form:"spending_controls"`
+	Status           *string                                  `form:"status"`
+	Type             *string                                  `form:"type"`
 
-	// This parameter is considered deprecated.
-	// TODO remove in the next major version
-	IsDefault *bool `form:"is_default"`
+	// The following parameters are deprecated
+	IsDefault             *bool                        `form:"is_default"`
+	AuthorizationControls *AuthorizationControlsParams `form:"authorization_controls"`
 }
 
 // IssuingCardholderListParams is the set of parameters that can be used when listing issuing cardholders.
@@ -110,7 +148,9 @@ type IssuingCardholderListParams struct {
 // IssuingBilling is the resource representing the billing hash with the Issuing APIs.
 type IssuingBilling struct {
 	Address *Address `json:"address"`
-	Name    string   `json:"name"`
+
+	// This property is deprecated
+	Name string `json:"name"`
 }
 
 // IssuingCardholderRequirements contains the verification requirements for the cardholder.
@@ -155,23 +195,43 @@ type IssuingCardholderCompany struct {
 	TaxIDProvided bool `json:"tax_id_provided"`
 }
 
+// IssuingCardholderSpendingControlsSpendingLimit is the resource representing a spending limit
+// for an issuing cardholder.
+type IssuingCardholderSpendingControlsSpendingLimit struct {
+	Amount     int64                                                  `json:"amount"`
+	Categories []string                                               `json:"categories"`
+	Interval   IssuingCardholderSpendingControlsSpendingLimitInterval `json:"interval"`
+}
+
+// IssuingCardholderSpendingControls is the resource representing spending controls
+// for an issuing cardholder.
+type IssuingCardholderSpendingControls struct {
+	AllowedCategories      []string                                          `json:"allowed_categories"`
+	BlockedCategories      []string                                          `json:"blocked_categories"`
+	SpendingLimits         []*IssuingCardholderSpendingControlsSpendingLimit `json:"spending_limits"`
+	SpendingLimitsCurrency Currency                                          `json:"spending_limits_currency"`
+}
+
 // IssuingCardholder is the resource representing a Stripe issuing cardholder.
 type IssuingCardholder struct {
+	Billing          *IssuingBilling                    `json:"billing"`
+	Company          *IssuingCardholderCompany          `json:"company"`
+	Created          int64                              `json:"created"`
+	Email            string                             `json:"email"`
+	ID               string                             `json:"id"`
+	Individual       *IssuingCardholderIndividual       `json:"individual"`
+	Livemode         bool                               `json:"livemode"`
+	Metadata         map[string]string                  `json:"metadata"`
+	Name             string                             `json:"name"`
+	Object           string                             `json:"object"`
+	PhoneNumber      string                             `json:"phone_number"`
+	Requirements     *IssuingCardholderRequirements     `json:"requirements"`
+	SpendingControls *IssuingCardholderSpendingControls `json:"spending_controls"`
+	Status           IssuingCardholderStatus            `json:"status"`
+	Type             IssuingCardholderType              `json:"type"`
+
+	// The following property is deprecated, use SpendingControls instead
 	AuthorizationControls *IssuingCardAuthorizationControls `json:"authorization_controls"`
-	Billing               *IssuingBilling                   `json:"billing"`
-	Company               *IssuingCardholderCompany         `json:"company"`
-	Created               int64                             `json:"created"`
-	Email                 string                            `json:"email"`
-	ID                    string                            `json:"id"`
-	Individual            *IssuingCardholderIndividual      `json:"individual"`
-	Livemode              bool                              `json:"livemode"`
-	Metadata              map[string]string                 `json:"metadata"`
-	Name                  string                            `json:"name"`
-	Object                string                            `json:"object"`
-	PhoneNumber           string                            `json:"phone_number"`
-	Requirements          *IssuingCardholderRequirements    `json:"requirements"`
-	Status                IssuingCardholderStatus           `json:"status"`
-	Type                  IssuingCardholderType             `json:"type"`
 }
 
 // IssuingCardholderList is a list of issuing cardholders as retrieved from a list endpoint.

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.83.0"
+	MockMinimumVersion = "0.85.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Multiple API changes for Issuing
* Add support for `SpendingControls` on `Card` and `Cardholder`
* Add new values for `Reason` on `Authorization`
* Add new value for `Type` on `Cardholder`
* Add new value for `Service` on `Card`
* Mark many classes and other fields as deprecated for the next major

r? @ob-stripe
cc @stripe/api-libraries 