### PR TITLE
Remove all beta features from Issuing APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.86.0
+    - STRIPE_MOCK_VERSION=0.87.0
 
 go:
   - "1.9.x"

--- a/issuing/authorization/client.go
+++ b/issuing/authorization/client.go
@@ -17,12 +17,12 @@ type Client struct {
 }
 
 // Approve approves an issuing authorization.
-func Approve(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
+func Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
 	return getC().Approve(id, params)
 }
 
 // Approve updates an issuing authorization.
-func (c Client) Approve(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
+func (c Client) Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/approve", id)
 	authorization := &stripe.IssuingAuthorization{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
@@ -30,12 +30,12 @@ func (c Client) Approve(id string, params *stripe.IssuingAuthorizationParams) (*
 }
 
 // Decline decline an issuing authorization.
-func Decline(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
+func Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
 	return getC().Decline(id, params)
 }
 
 // Decline updates an issuing authorization.
-func (c Client) Decline(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
+func (c Client) Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/decline", id)
 	authorization := &stripe.IssuingAuthorization{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)

--- a/issuing/authorization/client_test.go
+++ b/issuing/authorization/client_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestIssuingAuthorizationApprove(t *testing.T) {
-	authorization, err := Approve("iauth_123", &stripe.IssuingAuthorizationParams{})
+	authorization, err := Approve("iauth_123", &stripe.IssuingAuthorizationApproveParams{})
 	assert.Nil(t, err)
 	assert.NotNil(t, authorization)
 	assert.Equal(t, "issuing.authorization", authorization.Object)
 }
 
 func TestIssuingAuthorizationDecline(t *testing.T) {
-	authorization, err := Decline("iauth_123", &stripe.IssuingAuthorizationParams{})
+	authorization, err := Decline("iauth_123", &stripe.IssuingAuthorizationDeclineParams{})
 	assert.Nil(t, err)
 	assert.NotNil(t, authorization)
 	assert.Equal(t, "issuing.authorization", authorization.Object)

--- a/issuing/card/client.go
+++ b/issuing/card/client.go
@@ -74,19 +74,6 @@ func (c Client) List(listParams *stripe.IssuingCardListParams) *Iter {
 	})}
 }
 
-// Details retrieves an issuing card details.
-func Details(id string, params *stripe.IssuingCardParams) (*stripe.IssuingCardDetails, error) {
-	return getC().Details(id, params)
-}
-
-// Details retrieves an issuing card details.
-func (c Client) Details(id string, params *stripe.IssuingCardParams) (*stripe.IssuingCardDetails, error) {
-	path := stripe.FormatURLPath("/v1/issuing/cards/%s/details", id)
-	cardDetails := &stripe.IssuingCardDetails{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, cardDetails)
-	return cardDetails, err
-}
-
 // Iter is an iterator for issuing cards.
 type Iter struct {
 	*stripe.Iter

--- a/issuing/card/client_test.go
+++ b/issuing/card/client_test.go
@@ -8,13 +8,6 @@ import (
 	_ "github.com/stripe/stripe-go/testing"
 )
 
-func TestIssuingCardDetails(t *testing.T) {
-	cardDetails, err := Details("ic_123", nil)
-	assert.Nil(t, err)
-	assert.NotNil(t, cardDetails)
-	assert.Equal(t, "issuing.card_details", cardDetails.Object)
-}
-
 func TestIssuingCardGet(t *testing.T) {
 	card, err := Get("ic_123", nil)
 	assert.Nil(t, err)

--- a/issuing/cardholder/client_test.go
+++ b/issuing/cardholder/client_test.go
@@ -27,7 +27,7 @@ func TestIssuingCardholderList(t *testing.T) {
 
 func TestIssuingCardholderNew(t *testing.T) {
 	cardholder, err := New(&stripe.IssuingCardholderParams{
-		Billing: &stripe.IssuingBillingParams{
+		Billing: &stripe.IssuingCardholderBillingParams{
 			Address: &stripe.AddressParams{
 				Country:    stripe.String("US"),
 				Line1:      stripe.String("line1"),
@@ -35,7 +35,6 @@ func TestIssuingCardholderNew(t *testing.T) {
 				PostalCode: stripe.String("90210"),
 				State:      stripe.String("CA"),
 			},
-			Name: stripe.String("billing name"),
 		},
 		Individual: &stripe.IssuingCardholderIndividualParams{
 			DOB: &stripe.IssuingCardholderIndividualDOBParams{

--- a/issuing/dispute/client_test.go
+++ b/issuing/dispute/client_test.go
@@ -26,9 +26,7 @@ func TestIssuingDisputeList(t *testing.T) {
 }
 
 func TestIssuingDisputeNew(t *testing.T) {
-	params := &stripe.IssuingDisputeParams{}
-	params.AddMetadata("key", "value")
-	dispute, err := New(params)
+	dispute, err := New(&stripe.IssuingDisputeParams{})
 	assert.Nil(t, err)
 	assert.NotNil(t, dispute)
 	assert.Equal(t, "issuing.dispute", dispute.Object)
@@ -36,7 +34,6 @@ func TestIssuingDisputeNew(t *testing.T) {
 
 func TestIssuingDisputeUpdate(t *testing.T) {
 	params := &stripe.IssuingDisputeParams{}
-	params.AddMetadata("key", "value")
 	dispute, err := Update("idp_123", params)
 	assert.Nil(t, err)
 	assert.NotNil(t, dispute)

--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -45,8 +45,7 @@ type IssuingAuthorizationRequestHistoryReason string
 
 // List of values that IssuingAuthorizationRequestHistoryReason can take.
 const (
-	IssuingAuthorizationRequestHistoryReasonAccountComplianceDisabled      IssuingAuthorizationRequestHistoryReason = "account_compliance_disabled"
-	IssuingAuthorizationRequestHistoryReasonAccountInactive                IssuingAuthorizationRequestHistoryReason = "account_inactive"
+	IssuingAuthorizationRequestHistoryReasonAccountDisabled                IssuingAuthorizationRequestHistoryReason = "account_disabled"
 	IssuingAuthorizationRequestHistoryReasonCardActive                     IssuingAuthorizationRequestHistoryReason = "card_active"
 	IssuingAuthorizationRequestHistoryReasonCardInactive                   IssuingAuthorizationRequestHistoryReason = "card_inactive"
 	IssuingAuthorizationRequestHistoryReasonCardholderInactive             IssuingAuthorizationRequestHistoryReason = "cardholder_inactive"
@@ -59,14 +58,6 @@ const (
 	IssuingAuthorizationRequestHistoryReasonWebhookApproved                IssuingAuthorizationRequestHistoryReason = "webhook_approved"
 	IssuingAuthorizationRequestHistoryReasonWebhookDeclined                IssuingAuthorizationRequestHistoryReason = "webhook_declined"
 	IssuingAuthorizationRequestHistoryReasonWebhookTimeout                 IssuingAuthorizationRequestHistoryReason = "webhook_timeout"
-
-	// The following value is deprecated. Use IssuingAuthorizationRequestHistoryReasonSpendingControls instead.
-	IssuingAuthorizationRequestHistoryReasonAuthorizationControls IssuingAuthorizationRequestHistoryReason = "authorization_controls"
-
-	// The following values are deprecated. Use IssuingAuthorizationRequestHistoryReasonVerificationFailed instead
-	IssuingAuthorizationRequestHistoryReasonAuthenticationFailed IssuingAuthorizationRequestHistoryReason = "authentication_failed"
-	IssuingAuthorizationRequestHistoryReasonIncorrectCVC         IssuingAuthorizationRequestHistoryReason = "incorrect_cvc"
-	IssuingAuthorizationRequestHistoryReasonIncorrectExpiry      IssuingAuthorizationRequestHistoryReason = "incorrect_expiry"
 )
 
 // IssuingAuthorizationStatus is the possible values for status for an issuing authorization.
@@ -77,18 +68,6 @@ const (
 	IssuingAuthorizationStatusClosed   IssuingAuthorizationStatus = "closed"
 	IssuingAuthorizationStatusPending  IssuingAuthorizationStatus = "pending"
 	IssuingAuthorizationStatusReversed IssuingAuthorizationStatus = "reversed"
-)
-
-// IssuingAuthorizationVerificationDataAuthentication is the list of possible values for the result
-// of an authentication on an issuing authorization.
-type IssuingAuthorizationVerificationDataAuthentication string
-
-// List of values that IssuingAuthorizationVerificationDataCheck can take.
-const (
-	IssuingAuthorizationVerificationDataAuthenticationExempt  IssuingAuthorizationVerificationDataAuthentication = "exempt"
-	IssuingAuthorizationVerificationDataAuthenticationFailure IssuingAuthorizationVerificationDataAuthentication = "failure"
-	IssuingAuthorizationVerificationDataAuthenticationNone    IssuingAuthorizationVerificationDataAuthentication = "none"
-	IssuingAuthorizationVerificationDataAuthenticationSuccess IssuingAuthorizationVerificationDataAuthentication = "success"
 )
 
 // IssuingAuthorizationVerificationDataCheck is the list of possible values for result of a check
@@ -102,16 +81,6 @@ const (
 	IssuingAuthorizationVerificationDataCheckNotProvided IssuingAuthorizationVerificationDataCheck = "not_provided"
 )
 
-// IssuingAuthorizationVerificationDataThreeDSecureResult is the list of possible values for result of 3DS.
-type IssuingAuthorizationVerificationDataThreeDSecureResult string
-
-// List of values that IssuingAuthorizationVerificationDataThreeDSecureResult can take.
-const (
-	IssuingAuthorizationVerificationDataThreeDSecureResultAttemptAcknowledged IssuingAuthorizationVerificationDataThreeDSecureResult = "attempt_acknowledged"
-	IssuingAuthorizationVerificationDataThreeDSecureResultAuthenticated       IssuingAuthorizationVerificationDataThreeDSecureResult = "authenticated"
-	IssuingAuthorizationVerificationDataThreeDSecureResultFailed              IssuingAuthorizationVerificationDataThreeDSecureResult = "failed"
-)
-
 // IssuingAuthorizationWalletType is the list of possible values for the authorization's wallet provider.
 type IssuingAuthorizationWalletType string
 
@@ -122,25 +91,20 @@ const (
 	IssuingAuthorizationWalletTypeSamsungPay IssuingAuthorizationWalletType = "samsung_pay"
 )
 
-// IssuingAuthorizationWalletProviderType is the list of possible values for the authorization's wallet provider.
-// TODO remove in the next major version
-type IssuingAuthorizationWalletProviderType string
-
-// List of values that IssuingAuthorizationWalletProviderType can take.
-const (
-	IssuingAuthorizationWalletProviderTypeApplePay   IssuingAuthorizationWalletProviderType = "apple_pay"
-	IssuingAuthorizationWalletProviderTypeGooglePay  IssuingAuthorizationWalletProviderType = "google_pay"
-	IssuingAuthorizationWalletProviderTypeSamsungPay IssuingAuthorizationWalletProviderType = "samsung_pay"
-)
-
 // IssuingAuthorizationParams is the set of parameters that can be used when updating an issuing authorization.
 type IssuingAuthorizationParams struct {
 	Params `form:"*"`
-	Amount *int64 `form:"amount"`
+}
 
-	// The following parameter is deprecated, use Amount instead.
-	// TODO: remove in a future major version
-	HeldAmount *int64 `form:"held_amount"`
+// IssuingAuthorizationApproveParams is the set of parameters that can be used when approving an issuing authorization.
+type IssuingAuthorizationApproveParams struct {
+	Params `form:"*"`
+	Amount *int64 `form:"amount"`
+}
+
+// IssuingAuthorizationDeclineParams is the set of parameters that can be used when declining an issuing authorization.
+type IssuingAuthorizationDeclineParams struct {
+	Params `form:"*"`
 }
 
 // IssuingAuthorizationListParams is the set of parameters that can be used when listing issuing authorizations.
@@ -153,14 +117,15 @@ type IssuingAuthorizationListParams struct {
 	Status       *string           `form:"status"`
 }
 
-// IssuingAuthorizationAuthorizationControls is the resource representing authorization controls on an issuing authorization.
-// This is deprecated and will be removed in the next major version
-type IssuingAuthorizationAuthorizationControls struct {
-	AllowedCategories []string `json:"allowed_categories"`
-	BlockedCategories []string `json:"blocked_categories"`
-	Currency          Currency `json:"currency"`
-	MaxAmount         int64    `json:"max_amount"`
-	MaxApprovals      int64    `json:"max_approvals"`
+// IssuingAuthorizationMerchantData is the resource representing merchant data on Issuing APIs.
+type IssuingAuthorizationMerchantData struct {
+	Category   string `json:"category"`
+	City       string `json:"city"`
+	Country    string `json:"country"`
+	Name       string `json:"name"`
+	NetworkID  string `json:"network_id"`
+	PostalCode string `json:"postal_code"`
+	State      string `json:"state"`
 }
 
 // IssuingAuthorizationPendingRequest is the resource representing details about the pending authorization request.
@@ -172,14 +137,6 @@ type IssuingAuthorizationPendingRequest struct {
 	MerchantCurrency     Currency `json:"merchant_currency"`
 }
 
-// IssuingAuthorizationRequestHistoryViolatedAuthorizationControl is the resource representing an
-// authorizaton control that caused the authorization to fail.
-// This is deprecated and will be removed in the next major version
-type IssuingAuthorizationRequestHistoryViolatedAuthorizationControl struct {
-	Entity IssuingAuthorizationRequestHistoryViolatedAuthorizationControlEntity `json:"entity"`
-	Name   IssuingAuthorizationRequestHistoryViolatedAuthorizationControlName   `json:"name"`
-}
-
 // IssuingAuthorizationRequestHistory is the resource representing a request history on an issuing authorization.
 type IssuingAuthorizationRequestHistory struct {
 	Amount           int64                                    `json:"amount"`
@@ -189,36 +146,14 @@ type IssuingAuthorizationRequestHistory struct {
 	MerchantAmount   int64                                    `json:"merchant_amount"`
 	MerchantCurrency Currency                                 `json:"merchant_currency"`
 	Reason           IssuingAuthorizationRequestHistoryReason `json:"reason"`
-
-	// The following properties are deprecated
-	// TODO: remove in the next major version
-	AuthorizedAmount              int64                                                             `json:"authorized_amount"`
-	AuthorizedCurrency            Currency                                                          `json:"authorized_currency"`
-	HeldAmount                    int64                                                             `json:"held_amount"`
-	HeldCurrency                  Currency                                                          `json:"held_currency"`
-	ViolatedAuthorizationControls []*IssuingAuthorizationRequestHistoryViolatedAuthorizationControl `json:"violated_authorization_controls"`
-}
-
-// IssuingAuthorizationVerificationDataThreeDSecure is the resource representing 3DS results.
-type IssuingAuthorizationVerificationDataThreeDSecure struct {
-	Result IssuingAuthorizationVerificationDataThreeDSecureResult `json:"result"`
 }
 
 // IssuingAuthorizationVerificationData is the resource representing verification data on an issuing authorization.
 type IssuingAuthorizationVerificationData struct {
-	AddressLine1Check      IssuingAuthorizationVerificationDataCheck         `json:"address_line1_check"`
-	AddressPostalCodeCheck IssuingAuthorizationVerificationDataCheck         `json:"address_postal_code_check"`
-	CVCCheck               IssuingAuthorizationVerificationDataCheck         `json:"cvc_check"`
-	ExpiryCheck            IssuingAuthorizationVerificationDataCheck         `json:"expiry_check"`
-	ThreeDSecure           *IssuingAuthorizationVerificationDataThreeDSecure `json:"three_d_secure"`
-
-	// The property is considered deprecated. Use AddressPostalCodeCheck instead.
-	// TODO remove in the next major version
-	AddressZipCheck IssuingAuthorizationVerificationDataCheck `json:"address_zip_check"`
-
-	// The property is considered deprecated. Use ThreeDSecure instead.
-	// TODO remove in the next major version
-	Authentication IssuingAuthorizationVerificationDataAuthentication `json:"authentication"`
+	AddressLine1Check      IssuingAuthorizationVerificationDataCheck `json:"address_line1_check"`
+	AddressPostalCodeCheck IssuingAuthorizationVerificationDataCheck `json:"address_postal_code_check"`
+	CVCCheck               IssuingAuthorizationVerificationDataCheck `json:"cvc_check"`
+	ExpiryCheck            IssuingAuthorizationVerificationDataCheck `json:"expiry_check"`
 }
 
 // IssuingAuthorization is the resource representing a Stripe issuing authorization.
@@ -236,7 +171,7 @@ type IssuingAuthorization struct {
 	Livemode            bool                                    `json:"livemode"`
 	MerchantAmount      int64                                   `json:"merchant_amount"`
 	MerchantCurrency    Currency                                `json:"merchant_currency"`
-	MerchantData        *IssuingMerchantData                    `json:"merchant_data"`
+	MerchantData        *IssuingAuthorizationMerchantData       `json:"merchant_data"`
 	Metadata            map[string]string                       `json:"metadata"`
 	Object              string                                  `json:"object"`
 	PendingRequest      *IssuingAuthorizationPendingRequest     `json:"pending_request"`
@@ -245,32 +180,6 @@ type IssuingAuthorization struct {
 	Transactions        []*IssuingTransaction                   `json:"transactions"`
 	VerificationData    *IssuingAuthorizationVerificationData   `json:"verification_data"`
 	Wallet              IssuingAuthorizationWalletType          `json:"wallet"`
-
-	// This property is deprecated and we recommend that you use Wallet instead.
-	// TODO: remove in the next major version
-	WalletProvider IssuingAuthorizationWalletProviderType `json:"wallet_provider"`
-
-	// The following properties are considered deprecated
-	// TODO: remove in the next major version
-	AuthorizedAmount         int64    `json:"authorized_amount"`
-	AuthorizedCurrency       Currency `json:"authorized_currency"`
-	HeldAmount               int64    `json:"held_amount"`
-	HeldCurrency             Currency `json:"held_currency"`
-	IsHeldAmountControllable bool     `json:"is_held_amount_controllable"`
-	PendingAuthorizedAmount  int64    `json:"pending_authorized_amount"`
-	PendingHeldAmount        int64    `json:"pending_held_amount"`
-}
-
-// IssuingMerchantData is the resource representing merchant data on Issuing APIs.
-type IssuingMerchantData struct {
-	Category   string `json:"category"`
-	City       string `json:"city"`
-	Country    string `json:"country"`
-	Name       string `json:"name"`
-	NetworkID  string `json:"network_id"`
-	PostalCode string `json:"postal_code"`
-	State      string `json:"state"`
-	URL        string `json:"url"`
 }
 
 // IssuingAuthorizationList is a list of issuing authorizations as retrieved from a list endpoint.

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -2,15 +2,6 @@ package stripe
 
 import "encoding/json"
 
-// IssuingCardPINStatus is the list of possible values for the status field of a Card PIN.
-type IssuingCardPINStatus string
-
-// List of values that IssuingCardPINStatus can take.
-const (
-	IssuingCardPINStatusActive  IssuingCardPINStatus = "active"
-	IssuingCardPINStatusBlocked IssuingCardPINStatus = "blocked"
-)
-
 // IssuingCardCancellationReason is the list of possible values for the cancellation reason
 // on an issuing card.
 type IssuingCardCancellationReason string
@@ -31,25 +22,16 @@ const (
 	IssuingCardReplacementReasonExpired IssuingCardReplacementReason = "expired"
 	IssuingCardReplacementReasonLost    IssuingCardReplacementReason = "lost"
 	IssuingCardReplacementReasonStolen  IssuingCardReplacementReason = "stolen"
-
-	// The following values are deprecated and will be removed in the next major version.
-	IssuingCardReplacementReasonDamage     IssuingCardReplacementReason = "damage"
-	IssuingCardReplacementReasonExpiration IssuingCardReplacementReason = "expiration"
-	IssuingCardReplacementReasonLoss       IssuingCardReplacementReason = "loss"
-	IssuingCardReplacementReasonTheft      IssuingCardReplacementReason = "theft"
 )
 
-// IssuingCardShippingStatus is the list of possible values for the shipping status
+// IssuingCardShippingCarrier is the list of possible values for the shipping carrier
 // on an issuing card.
-type IssuingCardShippingStatus string
+type IssuingCardShippingCarrier string
 
-// List of values that IssuingCardShippingStatus can take.
+// List of values that IssuingCardShippingCarrier can take.
 const (
-	IssuingCardShippingTypeDelivered IssuingCardShippingStatus = "delivered"
-	IssuingCardShippingTypeFailure   IssuingCardShippingStatus = "failure"
-	IssuingCardShippingTypePending   IssuingCardShippingStatus = "pending"
-	IssuingCardShippingTypeReturned  IssuingCardShippingStatus = "returned"
-	IssuingCardShippingTypeShipped   IssuingCardShippingStatus = "shipped"
+	IssuingCardShippingCarrierFEDEX IssuingCardShippingCarrier = "fedex"
+	IssuingCardShippingCarrierUSPS  IssuingCardShippingCarrier = "usps"
 )
 
 // IssuingCardShippingService is the shipment service for a card.
@@ -60,20 +42,20 @@ const (
 	IssuingCardShippingServiceExpress  IssuingCardShippingService = "express"
 	IssuingCardShippingServicePriority IssuingCardShippingService = "priority"
 	IssuingCardShippingServiceStandard IssuingCardShippingService = "standard"
-
-	// The following value is deprecated, use IssuingCardShippingServicePriority instead
-	IssuingCardShippingServiceOvernight IssuingCardShippingService = "overnight"
 )
 
-// IssuingCardShippingSpeed is the shipment speed for a card.
-// This is deprecated, use IssuingCardShippingService instead
-type IssuingCardShippingSpeed string
+// IssuingCardShippingStatus is the list of possible values for the shipping status
+// on an issuing card.
+type IssuingCardShippingStatus string
 
-// List of values that IssuingCardShippingSpeed can take
+// List of values that IssuingCardShippingStatus can take.
 const (
-	IssuingCardShippingSpeedExpress   IssuingCardShippingSpeed = "express"
-	IssuingCardShippingSpeedOvernight IssuingCardShippingSpeed = "overnight"
-	IssuingCardShippingSpeedStandard  IssuingCardShippingSpeed = "standard"
+	IssuingCardShippingStatusCanceled  IssuingCardShippingStatus = "canceled"
+	IssuingCardShippingStatusDelivered IssuingCardShippingStatus = "delivered"
+	IssuingCardShippingStatusFailure   IssuingCardShippingStatus = "failure"
+	IssuingCardShippingStatusPending   IssuingCardShippingStatus = "pending"
+	IssuingCardShippingStatusReturned  IssuingCardShippingStatus = "returned"
+	IssuingCardShippingStatusShipped   IssuingCardShippingStatus = "shipped"
 )
 
 // IssuingCardShippingType is the list of possible values for the shipping type
@@ -108,7 +90,6 @@ const (
 	IssuingCardStatusActive   IssuingCardStatus = "active"
 	IssuingCardStatusCanceled IssuingCardStatus = "canceled"
 	IssuingCardStatusInactive IssuingCardStatus = "inactive"
-	IssuingCardStatusPending  IssuingCardStatus = "pending"
 )
 
 // IssuingCardType is the type of an issuing card.
@@ -120,55 +101,12 @@ const (
 	IssuingCardTypeVirtual  IssuingCardType = "virtual"
 )
 
-// IssuingSpendingLimitInterval is the list of possible values for the interval of a given
-// spending limit on an issuing card or cardholder.
-// This is deprecated, use IssuingCardSpendingControlsSpendingLimitInterval instead
-type IssuingSpendingLimitInterval string
-
-// List of values that IssuingCardShippingStatus can take.
-const (
-	IssuingSpendingLimitIntervalAllTime          IssuingSpendingLimitInterval = "all_time"
-	IssuingSpendingLimitIntervalDaily            IssuingSpendingLimitInterval = "daily"
-	IssuingSpendingLimitIntervalMonthly          IssuingSpendingLimitInterval = "monthly"
-	IssuingSpendingLimitIntervalPerAuthorization IssuingSpendingLimitInterval = "per_authorization"
-	IssuingSpendingLimitIntervalWeekly           IssuingSpendingLimitInterval = "weekly"
-	IssuingSpendingLimitIntervalYearly           IssuingSpendingLimitInterval = "yearly"
-)
-
-// IssuingAuthorizationControlsSpendingLimitsParams is the set of parameters that can be used for
-// the spending limits associated with a given issuing card or cardholder.
-// This is deprecated and will be removed in the next major version.
-type IssuingAuthorizationControlsSpendingLimitsParams struct {
-	Amount     *int64    `form:"amount"`
-	Categories []*string `form:"categories"`
-	Interval   *string   `form:"interval"`
-}
-
-// AuthorizationControlsParams is the set of parameters that can be used for the shipping parameter.
-// This is deprecated and will be removed in the next major version.
-type AuthorizationControlsParams struct {
-	AllowedCategories []*string                                           `form:"allowed_categories"`
-	BlockedCategories []*string                                           `form:"blocked_categories"`
-	MaxApprovals      *int64                                              `form:"max_approvals"`
-	SpendingLimits    []*IssuingAuthorizationControlsSpendingLimitsParams `form:"spending_limits"`
-
-	// The following parameter only applies to Cardholder
-	SpendingLimitsCurrency *string `form:"spending_limits_currency"`
-
-	// The following parameter is deprecated
-	MaxAmount *int64 `form:"max_amount"`
-}
-
 // IssuingCardShippingParams is the set of parameters that can be used for the shipping parameter.
 type IssuingCardShippingParams struct {
 	Address *AddressParams `form:"address"`
 	Name    string         `form:"name"`
 	Service *string        `form:"service"`
 	Type    *string        `form:"type"`
-
-	// This parameter is deprecated. Use Service instead.
-	// TODO remove in the next major version
-	Speed *string `form:"speed"`
 }
 
 // IssuingCardSpendingControlsSpendingLimitParams is the set of parameters that can be used to
@@ -184,30 +122,24 @@ type IssuingCardSpendingControlsSpendingLimitParams struct {
 type IssuingCardSpendingControlsParams struct {
 	AllowedCategories      []*string                                         `form:"allowed_categories"`
 	BlockedCategories      []*string                                         `form:"blocked_categories"`
-	MaxApprovals           *int64                                            `form:"max_approvals"`
 	SpendingLimits         []*IssuingCardSpendingControlsSpendingLimitParams `form:"spending_limits"`
 	SpendingLimitsCurrency *string                                           `form:"spending_limits_currency"`
 }
 
 // IssuingCardParams is the set of parameters that can be used when creating or updating an issuing card.
 type IssuingCardParams struct {
-	Params             `form:"*"`
-	Billing            *IssuingBillingParams              `form:"billing"`
-	CancellationReason *string                            `form:"cancellation_reason"`
-	Cardholder         *string                            `form:"cardholder"`
-	Currency           *string                            `form:"currency"`
-	ReplacementFor     *string                            `form:"replacement_for"`
-	ReplacementReason  *string                            `form:"replacement_reason"`
-	SpendingControls   *IssuingCardSpendingControlsParams `form:"spending_controls"`
-	Status             *string                            `form:"status"`
-	Shipping           *IssuingCardShippingParams         `form:"shipping"`
-	Type               *string                            `form:"type"`
+	Params            `form:"*"`
+	Cardholder        *string                            `form:"cardholder"`
+	Currency          *string                            `form:"currency"`
+	ReplacementFor    *string                            `form:"replacement_for"`
+	ReplacementReason *string                            `form:"replacement_reason"`
+	SpendingControls  *IssuingCardSpendingControlsParams `form:"spending_controls"`
+	Shipping          *IssuingCardShippingParams         `form:"shipping"`
+	Status            *string                            `form:"status"`
+	Type              *string                            `form:"type"`
 
-	// The following parameter is deprecated, use SpendingControls instead.
-	AuthorizationControls *AuthorizationControlsParams `form:"authorization_controls"`
-
-	// The following parameter is deprecated
-	Name *string `form:"name"`
+	// The following parameter is only supported when updating a card
+	CancellationReason *string `form:"cancellation_reason"`
 }
 
 // IssuingCardListParams is the set of parameters that can be used when listing issuing cards.
@@ -221,67 +153,19 @@ type IssuingCardListParams struct {
 	Last4        *string           `form:"last4"`
 	Status       *string           `form:"status"`
 	Type         *string           `form:"type"`
-
-	// The following parameters are deprecated
-	Name   *string `form:"name"`
-	Source *string `form:"source"`
-}
-
-// IssuingCardDetails is the resource representing issuing card details.
-type IssuingCardDetails struct {
-	APIResource
-	Card     *IssuingCard `json:"card"`
-	CVC      string       `json:"cvc"`
-	ExpMonth *string      `form:"exp_month"`
-	ExpYear  *string      `form:"exp_year"`
-	Number   string       `json:"number"`
-	Object   string       `json:"object"`
-}
-
-// IssuingAuthorizationControlsSpendingLimits is the resource representing spending limits
-// associated with a card or cardholder.
-type IssuingAuthorizationControlsSpendingLimits struct {
-	Amount     int64                        `json:"amount"`
-	Categories []string                     `json:"categories"`
-	Interval   IssuingSpendingLimitInterval `json:"interval"`
-}
-
-// IssuingCardAuthorizationControls is the resource representing authorization controls on an issuing card.
-// TODO: Add the Cardholder version to "un-share" between Card and Cardholder in the next major version.
-type IssuingCardAuthorizationControls struct {
-	AllowedCategories      []string                                      `json:"allowed_categories"`
-	BlockedCategories      []string                                      `json:"blocked_categories"`
-	MaxApprovals           int64                                         `json:"max_approvals"`
-	SpendingLimits         []*IssuingAuthorizationControlsSpendingLimits `json:"spending_limits"`
-	SpendingLimitsCurrency Currency                                      `json:"spending_limits_currency"`
-
-	// The properties below are deprecated and can only be used for an issuing card.
-	// TODO remove in the next major version
-	Currency  Currency `json:"currency"`
-	MaxAmount int64    `json:"max_amount"`
-}
-
-// IssuingCardPIN contains data about the Card's PIN.
-type IssuingCardPIN struct {
-	Status IssuingCardPINStatus `json:"status"`
 }
 
 // IssuingCardShipping is the resource representing shipping on an issuing card.
 type IssuingCardShipping struct {
 	Address        *Address                   `json:"address"`
-	Carrier        string                     `json:"carrier"`
+	Carrier        IssuingCardShippingCarrier `json:"carrier"`
 	ETA            int64                      `json:"eta"`
 	Name           string                     `json:"name"`
-	Phone          string                     `json:"phone"`
 	Service        IssuingCardShippingService `json:"service"`
 	Status         IssuingCardShippingStatus  `json:"status"`
 	TrackingNumber string                     `json:"tracking_number"`
 	TrackingURL    string                     `json:"tracking_url"`
 	Type           IssuingCardShippingType    `json:"type"`
-
-	// The property is deprecated. Use AddressPostalCodeCheck instead.
-	// TODO remove in the next major version
-	Speed IssuingCardShippingSpeed `json:"speed"`
 }
 
 // IssuingCardSpendingControlsSpendingLimit is the resource representing a spending limit
@@ -297,7 +181,6 @@ type IssuingCardSpendingControlsSpendingLimit struct {
 type IssuingCardSpendingControls struct {
 	AllowedCategories      []string                                    `json:"allowed_categories"`
 	BlockedCategories      []string                                    `json:"blocked_categories"`
-	MaxApprovals           int64                                       `json:"max_approvals"`
 	SpendingLimits         []*IssuingCardSpendingControlsSpendingLimit `json:"spending_limits"`
 	SpendingLimitsCurrency Currency                                    `json:"spending_limits_currency"`
 }
@@ -305,19 +188,18 @@ type IssuingCardSpendingControls struct {
 // IssuingCard is the resource representing a Stripe issuing card.
 type IssuingCard struct {
 	APIResource
-	Billing            *IssuingBilling               `json:"billing"`
 	Brand              string                        `json:"brand"`
 	CancellationReason IssuingCardCancellationReason `json:"cancellation_reason"`
 	Cardholder         *IssuingCardholder            `json:"cardholder"`
 	Created            int64                         `json:"created"`
+	Currency           Currency                      `json:"currency"`
 	ExpMonth           int64                         `json:"exp_month"`
 	ExpYear            int64                         `json:"exp_year"`
-	Last4              string                        `json:"last4"`
 	ID                 string                        `json:"id"`
+	Last4              string                        `json:"last4"`
 	Livemode           bool                          `json:"livemode"`
 	Metadata           map[string]string             `json:"metadata"`
 	Object             string                        `json:"object"`
-	PIN                *IssuingCardPIN               `json:"pin"`
 	ReplacedBy         *IssuingCard                  `json:"replaced_by"`
 	ReplacementFor     *IssuingCard                  `json:"replacement_for"`
 	ReplacementReason  IssuingCardReplacementReason  `json:"replacement_reason"`
@@ -325,12 +207,6 @@ type IssuingCard struct {
 	SpendingControls   *IssuingCardSpendingControls  `json:"spending_controls"`
 	Status             IssuingCardStatus             `json:"status"`
 	Type               IssuingCardType               `json:"type"`
-
-	// The following property is deprecated, use SpendingControls instead.
-	AuthorizationControls *IssuingCardAuthorizationControls `json:"authorization_controls"`
-
-	// The following property is deprecated, use Cardholder.Name instead.
-	Name string `json:"name"`
 }
 
 // IssuingCardList is a list of issuing cards as retrieved from a list endpoint.

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -34,9 +34,6 @@ type IssuingCardholderStatus string
 const (
 	IssuingCardholderStatusActive   IssuingCardholderStatus = "active"
 	IssuingCardholderStatusInactive IssuingCardholderStatus = "inactive"
-
-	// This value is deprecated
-	IssuingCardholderStatusPending IssuingCardholderStatus = "pending"
 )
 
 // IssuingCardholderType is the type of an issuing cardholder.
@@ -46,23 +43,24 @@ type IssuingCardholderType string
 const (
 	IssuingCardholderTypeCompany    IssuingCardholderType = "company"
 	IssuingCardholderTypeIndividual IssuingCardholderType = "individual"
-
-	// This value is deprecated. Use IssuingCardholderTypeCompany instead
-	IssuingCardholderTypeBusinessEntity IssuingCardholderType = "business_entity"
 )
 
-// IssuingBillingParams is the set of parameters that can be used for billing with the Issuing APIs.
-type IssuingBillingParams struct {
+// IssuingCardholderBillingParams is the set of parameters that can be used for billing with the Issuing APIs.
+type IssuingCardholderBillingParams struct {
 	Address *AddressParams `form:"address"`
-
-	// This parameter is deprecated
-	Name *string `form:"name"`
 }
 
-// IssuingCardholderCompanyParams represents additional information about a
-// `business_entity` cardholder.
+// IssuingCardholderCompanyParams represents additional information about a company cardholder.
 type IssuingCardholderCompanyParams struct {
 	TaxID *string `form:"tax_id"`
+}
+
+// IssuingCardholderIndividualDOBParams represents the date of birth of the
+// cardholder individual.
+type IssuingCardholderIndividualDOBParams struct {
+	Day   *int64 `form:"day"`
+	Month *int64 `form:"month"`
+	Year  *int64 `form:"year"`
 }
 
 // IssuingCardholderIndividualVerificationDocumentParams represents an
@@ -76,14 +74,6 @@ type IssuingCardholderIndividualVerificationDocumentParams struct {
 // document for this cardholder.
 type IssuingCardholderIndividualVerificationParams struct {
 	Document *IssuingCardholderIndividualVerificationDocumentParams `form:"document"`
-}
-
-// IssuingCardholderIndividualDOBParams represents the date of birth of the
-// cardholder individual.
-type IssuingCardholderIndividualDOBParams struct {
-	Day   *int64 `form:"day"`
-	Month *int64 `form:"month"`
-	Year  *int64 `form:"year"`
 }
 
 // IssuingCardholderIndividualParams represents additional information about an
@@ -115,7 +105,7 @@ type IssuingCardholderSpendingControlsParams struct {
 // IssuingCardholderParams is the set of parameters that can be used when creating or updating an issuing cardholder.
 type IssuingCardholderParams struct {
 	Params           `form:"*"`
-	Billing          *IssuingBillingParams                    `form:"billing"`
+	Billing          *IssuingCardholderBillingParams          `form:"billing"`
 	Company          *IssuingCardholderCompanyParams          `form:"company"`
 	Email            *string                                  `form:"email"`
 	Individual       *IssuingCardholderIndividualParams       `form:"individual"`
@@ -124,10 +114,6 @@ type IssuingCardholderParams struct {
 	SpendingControls *IssuingCardholderSpendingControlsParams `form:"spending_controls"`
 	Status           *string                                  `form:"status"`
 	Type             *string                                  `form:"type"`
-
-	// The following parameters are deprecated
-	IsDefault             *bool                        `form:"is_default"`
-	AuthorizationControls *AuthorizationControlsParams `form:"authorization_controls"`
 }
 
 // IssuingCardholderListParams is the set of parameters that can be used when listing issuing cardholders.
@@ -139,24 +125,24 @@ type IssuingCardholderListParams struct {
 	PhoneNumber  *string           `form:"phone_number"`
 	Status       *string           `form:"status"`
 	Type         *string           `form:"type"`
-
-	// The property is considered deprecated.
-	// TODO remove in the next major version
-	IsDefault *bool `form:"is_default"`
 }
 
-// IssuingBilling is the resource representing the billing hash with the Issuing APIs.
-type IssuingBilling struct {
+// IssuingCardholderBilling is the resource representing the billing hash with the Issuing APIs.
+type IssuingCardholderBilling struct {
 	Address *Address `json:"address"`
-
-	// This property is deprecated
-	Name string `json:"name"`
 }
 
-// IssuingCardholderRequirements contains the verification requirements for the cardholder.
-type IssuingCardholderRequirements struct {
-	DisabledReason IssuingCardholderRequirementsDisabledReason `json:"disabled_reason"`
-	PastDue        []string                                    `json:"past_due"`
+// IssuingCardholderCompany represents additional information about a company cardholder.
+type IssuingCardholderCompany struct {
+	TaxIDProvided bool `json:"tax_id_provided"`
+}
+
+// IssuingCardholderIndividualDOB represents the date of birth of the issuing card hoder
+// individual.
+type IssuingCardholderIndividualDOB struct {
+	Day   int64 `json:"day"`
+	Month int64 `json:"month"`
+	Year  int64 `json:"year"`
 }
 
 // IssuingCardholderIndividualVerificationDocument represents an identifying
@@ -172,14 +158,6 @@ type IssuingCardholderIndividualVerification struct {
 	Document *IssuingCardholderIndividualVerificationDocument `json:"document"`
 }
 
-// IssuingCardholderIndividualDOB represents the date of birth of the issuing card hoder
-// individual.
-type IssuingCardholderIndividualDOB struct {
-	Day   int64 `json:"day"`
-	Month int64 `json:"month"`
-	Year  int64 `json:"year"`
-}
-
 // IssuingCardholderIndividual represents additional information about an
 // individual cardholder.
 type IssuingCardholderIndividual struct {
@@ -189,10 +167,10 @@ type IssuingCardholderIndividual struct {
 	Verification *IssuingCardholderIndividualVerification `json:"verification"`
 }
 
-// IssuingCardholderCompany represents additional information about a
-// business_entity cardholder.
-type IssuingCardholderCompany struct {
-	TaxIDProvided bool `json:"tax_id_provided"`
+// IssuingCardholderRequirements contains the verification requirements for the cardholder.
+type IssuingCardholderRequirements struct {
+	DisabledReason IssuingCardholderRequirementsDisabledReason `json:"disabled_reason"`
+	PastDue        []string                                    `json:"past_due"`
 }
 
 // IssuingCardholderSpendingControlsSpendingLimit is the resource representing a spending limit
@@ -215,8 +193,7 @@ type IssuingCardholderSpendingControls struct {
 // IssuingCardholder is the resource representing a Stripe issuing cardholder.
 type IssuingCardholder struct {
 	APIResource
-
-	Billing          *IssuingBilling                    `json:"billing"`
+	Billing          *IssuingCardholderBilling          `json:"billing"`
 	Company          *IssuingCardholderCompany          `json:"company"`
 	Created          int64                              `json:"created"`
 	Email            string                             `json:"email"`
@@ -231,9 +208,6 @@ type IssuingCardholder struct {
 	SpendingControls *IssuingCardholderSpendingControls `json:"spending_controls"`
 	Status           IssuingCardholderStatus            `json:"status"`
 	Type             IssuingCardholderType              `json:"type"`
-
-	// The following property is deprecated, use SpendingControls instead
-	AuthorizationControls *IssuingCardAuthorizationControls `json:"authorization_controls"`
 }
 
 // IssuingCardholderList is a list of issuing cardholders as retrieved from a list endpoint.

--- a/issuing_dispute.go
+++ b/issuing_dispute.go
@@ -2,100 +2,22 @@ package stripe
 
 import "encoding/json"
 
-// IssuingDisputeReason is the list of possible values for status on an issuing dispute.
-type IssuingDisputeReason string
-
-// List of values that IssuingDisputeReason can take.
-const (
-	IssuingDisputeReasonDuplicate          IssuingDisputeReason = "duplicate"
-	IssuingDisputeReasonFraudulent         IssuingDisputeReason = "fraudulent"
-	IssuingDisputeReasonOther              IssuingDisputeReason = "other"
-	IssuingDisputeReasonProductNotReceived IssuingDisputeReason = "product_not_received"
-)
-
-// IssuingDisputeStatus is the list of possible values for status on an issuing dispute.
-type IssuingDisputeStatus string
-
-// List of values that IssuingDisputeStatus can take.
-const (
-	IssuingDisputeStatusLost        IssuingDisputeStatus = "lost"
-	IssuingDisputeStatusUnderReview IssuingDisputeStatus = "under_review"
-	IssuingDisputeStatusUnsubmitted IssuingDisputeStatus = "unsubmitted"
-	IssuingDisputeStatusWon         IssuingDisputeStatus = "won"
-)
-
-// IssuingDisputeEvidenceFraudulentParams is the subset of parameters that can be sent as evidence for an issuing dispute
-// with the reason set as fraudulent.
-type IssuingDisputeEvidenceFraudulentParams struct {
-	DisputeExplanation *string `form:"dispute_explanation"`
-	UncategorizedFile  *string `form:"uncategorized_file"`
-}
-
-// IssuingDisputeEvidenceOtherParams is the subset of parameters that can be sent as evidence for an issuing dispute
-// with the reason set as other.
-type IssuingDisputeEvidenceOtherParams struct {
-	DisputeExplanation *string `form:"dispute_explanation"`
-	UncategorizedFile  *string `form:"uncategorized_file"`
-}
-
-// IssuingDisputeEvidenceParams is the set of parameters that can be sent as evidence for an issuing dispute.
-type IssuingDisputeEvidenceParams struct {
-	Fraudulent *IssuingDisputeEvidenceFraudulentParams `form:"fraudulent"`
-	Other      *IssuingDisputeEvidenceOtherParams      `form:"other"`
-}
-
 // IssuingDisputeParams is the set of parameters that can be used when creating or updating an issuing dispute.
 type IssuingDisputeParams struct {
-	Params              `form:"*"`
-	Amount              *int64                        `form:"amount"`
-	Evidence            *IssuingDisputeEvidenceParams `form:"evidence"`
-	Reason              *string                       `form:"reason"`
-	DisputedTransaction *string                       `form:"disputed_transaction"`
+	Params `form:"*"`
 }
 
 // IssuingDisputeListParams is the set of parameters that can be used when listing issuing dispute.
 type IssuingDisputeListParams struct {
-	ListParams          `form:"*"`
-	Created             *int64            `form:"created"`
-	CreatedRange        *RangeQueryParams `form:"created"`
-	DisputedTransaction *string           `form:"disputed_transaction"`
-	Transaction         *string           `form:"transaction"`
-}
-
-// IssuingDisputeEvidenceFraudulent is the resource representing the evidence hash on an issuing dispute
-// with the reason set as fraudulent.
-type IssuingDisputeEvidenceFraudulent struct {
-	DisputeExplanation string `json:"dispute_explanation"`
-	UncategorizedFile  *File  `json:"uncategorized_file"`
-}
-
-// IssuingDisputeEvidenceOther is the resource representing the evidence hash on an issuing dispute
-// with the reason set as other.
-type IssuingDisputeEvidenceOther struct {
-	DisputeExplanation string `json:"dispute_explanation"`
-	UncategorizedFile  *File  `json:"uncategorized_file"`
-}
-
-// IssuingDisputeEvidence is the resource representing evidence on an issuing dispute.
-type IssuingDisputeEvidence struct {
-	Fraudulent *IssuingDisputeEvidenceFraudulent `json:"fraudulent"`
-	Other      *IssuingDisputeEvidenceOther      `json:"other"`
+	ListParams `form:"*"`
 }
 
 // IssuingDispute is the resource representing an issuing dispute.
 type IssuingDispute struct {
 	APIResource
-	Amount      int64                   `json:"amount"`
-	Created     int64                   `json:"created"`
-	Currency    Currency                `json:"currency"`
-	Evidence    *IssuingDisputeEvidence `json:"evidence"`
-	ID          string                  `json:"id"`
-	Livemode    bool                    `json:"livemode"`
-	Metadata    map[string]string       `json:"metadata"`
-	Object      string                  `json:"object"`
-	Reason      IssuingDisputeReason    `json:"reason"`
-	Status      IssuingDisputeStatus    `json:"status"`
-	Transaction *IssuingTransaction     `json:"transaction"`
+	ID       string `json:"id"`
+	Livemode bool   `json:"livemode"`
+	Object   string `json:"object"`
 }
 
 // IssuingDisputeList is a list of issuing disputes as retrieved from a list endpoint.

--- a/issuing_transaction.go
+++ b/issuing_transaction.go
@@ -7,10 +7,8 @@ type IssuingTransactionType string
 
 // List of values that IssuingTransactionType can take.
 const (
-	IssuingTransactionTypeCapture        IssuingTransactionType = "capture"
-	IssuingTransactionTypeCashWithdrawal IssuingTransactionType = "cash_withdrawal"
-	IssuingTransactionTypeRefund         IssuingTransactionType = "refund"
-	IssuingTransactionTypeRefundReversal IssuingTransactionType = "refund_reversal"
+	IssuingTransactionTypeCapture IssuingTransactionType = "capture"
+	IssuingTransactionTypeRefund  IssuingTransactionType = "refund"
 )
 
 // IssuingTransactionParams is the set of parameters that can be used when creating or updating an issuing transaction.
@@ -25,28 +23,27 @@ type IssuingTransactionListParams struct {
 	Cardholder   *string           `form:"cardholder"`
 	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-	Dispute      *string           `form:"dispute"`
 }
 
 // IssuingTransaction is the resource representing a Stripe issuing transaction.
 type IssuingTransaction struct {
 	APIResource
-	Amount             int64                  `json:"amount"`
-	Authorization      *IssuingAuthorization  `json:"authorization"`
-	BalanceTransaction *BalanceTransaction    `json:"balance_transaction"`
-	Card               *IssuingCard           `json:"card"`
-	Cardholder         *IssuingCardholder     `json:"cardholder"`
-	Created            int64                  `json:"created"`
-	Currency           Currency               `json:"currency"`
-	Dispute            *IssuingDispute        `json:"dispute"`
-	ID                 string                 `json:"id"`
-	Livemode           bool                   `json:"livemode"`
-	MerchantData       *IssuingMerchantData   `json:"merchant_data"`
-	MerchantAmount     int64                  `json:"merchant_amount"`
-	MerchantCurrency   Currency               `json:"merchant_currency"`
-	Metadata           map[string]string      `json:"metadata"`
-	Object             string                 `json:"object"`
-	Type               IssuingTransactionType `json:"type"`
+	Amount             int64                             `json:"amount"`
+	Authorization      *IssuingAuthorization             `json:"authorization"`
+	BalanceTransaction *BalanceTransaction               `json:"balance_transaction"`
+	Card               *IssuingCard                      `json:"card"`
+	Cardholder         *IssuingCardholder                `json:"cardholder"`
+	Created            int64                             `json:"created"`
+	Currency           Currency                          `json:"currency"`
+	Dispute            *IssuingDispute                   `json:"dispute"`
+	ID                 string                            `json:"id"`
+	Livemode           bool                              `json:"livemode"`
+	MerchantData       *IssuingAuthorizationMerchantData `json:"merchant_data"`
+	MerchantAmount     int64                             `json:"merchant_amount"`
+	MerchantCurrency   Currency                          `json:"merchant_currency"`
+	Metadata           map[string]string                 `json:"metadata"`
+	Object             string                            `json:"object"`
+	Type               IssuingTransactionType            `json:"type"`
 }
 
 // IssuingTransactionList is a list of issuing transactions as retrieved from a list endpoint.

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.86.0"
+	MockMinimumVersion = "0.87.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
This PR removes all the deprecated features from the Issuing API and renames all relevant classes to ensure we have the right structure for codegen.

r? @richardm-stripe @ob-stripe 
cc @stripe/api-libraries 

---

Note: Targets major version integration branch in #1055.