### PR TITLE
Make API response accessible on returned API structs

### DIFF
--- a/account.go
+++ b/account.go
@@ -504,6 +504,7 @@ func (a *Account) UnmarshalJSON(data []byte) error {
 
 // AccountList is a list of accounts as returned from a list endpoint.
 type AccountList struct {
+	APIResource
 	ListMeta
 	Data []*Account `json:"data"`
 }
@@ -511,6 +512,7 @@ type AccountList struct {
 // ExternalAccountList is a list of external accounts that may be either bank
 // accounts or cards.
 type ExternalAccountList struct {
+	APIResource
 	ListMeta
 
 	// Values contains any external accounts (bank accounts and/or cards)

--- a/account.go
+++ b/account.go
@@ -459,6 +459,7 @@ type AccountTOSAcceptance struct {
 // Account is the resource representing your Stripe account.
 // For more details see https://stripe.com/docs/api/#account.
 type Account struct {
+	APIResource
 	BusinessProfile  *AccountBusinessProfile `json:"business_profile"`
 	BusinessType     AccountBusinessType     `json:"business_type"`
 	Capabilities     *AccountCapabilities    `json:"capabilities"`

--- a/accountlink.go
+++ b/accountlink.go
@@ -31,6 +31,7 @@ type AccountLinkParams struct {
 // AccountLink is the resource representing an account link.
 // For more details see https://stripe.com/docs/api/#account_links.
 type AccountLink struct {
+	APIResource
 	Created   int64  `json:"created"`
 	ExpiresAt int64  `json:"expires_at"`
 	Object    string `json:"object"`

--- a/applepaydomain.go
+++ b/applepaydomain.go
@@ -23,6 +23,7 @@ type ApplePayDomainListParams struct {
 
 // ApplePayDomainList is a list of ApplePayDomains as returned from a list endpoint.
 type ApplePayDomainList struct {
+	APIResource
 	ListMeta
 	Data []*ApplePayDomain `json:"data"`
 }

--- a/applepaydomain.go
+++ b/applepaydomain.go
@@ -8,6 +8,7 @@ type ApplePayDomainParams struct {
 
 // ApplePayDomain is the resource representing a Stripe ApplePayDomain object
 type ApplePayDomain struct {
+	APIResource
 	Created    int64  `json:"created"`
 	Deleted    bool   `json:"deleted"`
 	DomainName string `json:"domain_name"`

--- a/balance.go
+++ b/balance.go
@@ -24,6 +24,7 @@ type BalanceParams struct {
 // Balance is the resource representing your Stripe balance.
 // For more details see https://stripe.com/docs/api/#balance.
 type Balance struct {
+	APIResource
 	Available       []*Amount `json:"available"`
 	ConnectReserved []*Amount `json:"connect_reserved"`
 	Livemode        bool      `json:"livemode"`

--- a/balancetransaction.go
+++ b/balancetransaction.go
@@ -126,6 +126,7 @@ type BalanceTransactionListParams struct {
 // BalanceTransaction is the resource representing the balance transaction.
 // For more details see https://stripe.com/docs/api/#balance.
 type BalanceTransaction struct {
+	APIResource
 	Amount            int64                               `json:"amount"`
 	AvailableOn       int64                               `json:"available_on"`
 	Created           int64                               `json:"created"`

--- a/balancetransaction.go
+++ b/balancetransaction.go
@@ -146,6 +146,7 @@ type BalanceTransaction struct {
 
 // BalanceTransactionList is a list of transactions as returned from a list endpoint.
 type BalanceTransactionList struct {
+	APIResource
 	ListMeta
 	Data []*BalanceTransaction `json:"data"`
 }

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -161,6 +161,7 @@ type BankAccount struct {
 
 // BankAccountList is a list object for bank accounts.
 type BankAccountList struct {
+	APIResource
 	ListMeta
 	Data []*BankAccount `json:"data"`
 }

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -141,6 +141,7 @@ func (p *BankAccountListParams) AppendTo(body *form.Values, keyParts []string) {
 
 // BankAccount represents a Stripe bank account.
 type BankAccount struct {
+	APIResource
 	Account            *Account                     `json:"account"`
 	AccountHolderName  string                       `json:"account_holder_name"`
 	AccountHolderType  BankAccountAccountHolderType `json:"account_holder_type"`

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -16,6 +16,7 @@ type BitcoinReceiverListParams struct {
 // BitcoinReceiver is the resource representing a Stripe bitcoin receiver.
 // For more details see https://stripe.com/docs/api/#bitcoin_receivers
 type BitcoinReceiver struct {
+	APIResource
 	Active                bool                    `json:"active"`
 	Amount                int64                   `json:"amount"`
 	AmountReceived        int64                   `json:"amount_received"`

--- a/bitcoinreceiver.go
+++ b/bitcoinreceiver.go
@@ -40,6 +40,7 @@ type BitcoinReceiver struct {
 
 // BitcoinReceiverList is a list of bitcoin receivers as retrieved from a list endpoint.
 type BitcoinReceiverList struct {
+	APIResource
 	ListMeta
 	Data []*BitcoinReceiver `json:"data"`
 }

--- a/bitcointransaction.go
+++ b/bitcointransaction.go
@@ -13,6 +13,7 @@ type BitcoinTransactionListParams struct {
 // It is a child object of BitcoinReceivers
 // For more details see https://stripe.com/docs/api/#retrieve_bitcoin_receiver
 type BitcoinTransactionList struct {
+	APIResource
 	ListMeta
 	Data []*BitcoinTransaction `json:"data"`
 }

--- a/capability.go
+++ b/capability.go
@@ -67,6 +67,7 @@ type Capability struct {
 
 // CapabilityList is a list of capabilities as retrieved from a list endpoint.
 type CapabilityList struct {
+	APIResource
 	ListMeta
 	Data []*Capability `json:"data"`
 }

--- a/capability.go
+++ b/capability.go
@@ -55,6 +55,7 @@ type CapabilityRequirements struct {
 // Capability is the resource representing a Stripe capability.
 // For more details see https://stripe.com/docs/api/capabilities
 type Capability struct {
+	APIResource
 	Account      *Account                `json:"account"`
 	ID           string                  `json:"id"`
 	Object       string                  `json:"object"`

--- a/card.go
+++ b/card.go
@@ -197,6 +197,8 @@ func (p *CardListParams) AppendTo(body *form.Values, keyParts []string) {
 // Card is the resource representing a Stripe credit/debit card.
 // For more details see https://stripe.com/docs/api#cards.
 type Card struct {
+	APIResource
+
 	AddressCity            string                      `json:"address_city"`
 	AddressCountry         string                      `json:"address_country"`
 	AddressLine1           string                      `json:"address_line1"`

--- a/card.go
+++ b/card.go
@@ -251,6 +251,7 @@ type Card struct {
 
 // CardList is a list object for cards.
 type CardList struct {
+	APIResource
 	ListMeta
 	Data []*Card `json:"data"`
 }

--- a/charge.go
+++ b/charge.go
@@ -458,6 +458,7 @@ type ChargeTransferData struct {
 // Charge is the resource representing a Stripe charge.
 // For more details see https://stripe.com/docs/api#charges.
 type Charge struct {
+	APIResource
 	Amount                    int64                       `json:"amount"`
 	AmountRefunded            int64                       `json:"amount_refunded"`
 	Application               *Application                `json:"application"`

--- a/charge.go
+++ b/charge.go
@@ -527,6 +527,7 @@ func (c *Charge) UnmarshalJSON(data []byte) error {
 
 // ChargeList is a list of charges as retrieved from a list endpoint.
 type ChargeList struct {
+	APIResource
 	ListMeta
 	Data []*Charge `json:"data"`
 }

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -188,6 +188,7 @@ type CheckoutSession struct {
 
 // CheckoutSessionList is a list of sessions as retrieved from a list endpoint.
 type CheckoutSessionList struct {
+	APIResource
 	ListMeta
 	Data []*CheckoutSession `json:"data"`
 }

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -163,6 +163,7 @@ type CheckoutSessionShippingAddressCollection struct {
 // CheckoutSession is the resource representing a Stripe checkout session.
 // For more details see https://stripe.com/docs/api/checkout/sessions/object
 type CheckoutSession struct {
+	APIResource
 	CancelURL                 string                                    `json:"cancel_url"`
 	ClientReferenceID         string                                    `json:"client_reference_id"`
 	Customer                  *Customer                                 `json:"customer"`

--- a/countryspec.go
+++ b/countryspec.go
@@ -13,6 +13,7 @@ type VerificationFieldsList struct {
 // CountrySpec is the resource representing the rules required for a Stripe account.
 // For more details see https://stripe.com/docs/api/#country_specs.
 type CountrySpec struct {
+	APIResource
 	DefaultCurrency                Currency                                        `json:"default_currency"`
 	ID                             string                                          `json:"id"`
 	SupportedBankAccountCurrencies map[Currency][]Country                          `json:"supported_bank_account_currencies"`

--- a/countryspec.go
+++ b/countryspec.go
@@ -30,6 +30,7 @@ type CountrySpecParams struct {
 
 // CountrySpecList is a list of country specs as retrieved from a list endpoint.
 type CountrySpecList struct {
+	APIResource
 	ListMeta
 	Data []*CountrySpec `json:"data"`
 }

--- a/coupon.go
+++ b/coupon.go
@@ -58,6 +58,7 @@ type Coupon struct {
 
 // CouponList is a list of coupons as retrieved from a list endpoint.
 type CouponList struct {
+	APIResource
 	ListMeta
 	Data []*Coupon `json:"data"`
 }

--- a/coupon.go
+++ b/coupon.go
@@ -38,6 +38,7 @@ type CouponListParams struct {
 // Coupon is the resource representing a Stripe coupon.
 // For more details see https://stripe.com/docs/api#coupons.
 type Coupon struct {
+	APIResource
 	AmountOff        int64             `json:"amount_off"`
 	Created          int64             `json:"created"`
 	Currency         Currency          `json:"currency"`

--- a/creditnote.go
+++ b/creditnote.go
@@ -175,12 +175,14 @@ type CreditNoteLineItem struct {
 
 // CreditNoteList is a list of credit notes as retrieved from a list endpoint.
 type CreditNoteList struct {
+	APIResource
 	ListMeta
 	Data []*CreditNote `json:"data"`
 }
 
 // CreditNoteLineItemList is a list of credit note line items as retrieved from a list endpoint.
 type CreditNoteLineItemList struct {
+	APIResource
 	ListMeta
 	Data []*CreditNoteLineItem `json:"data"`
 }

--- a/creditnote.go
+++ b/creditnote.go
@@ -128,6 +128,7 @@ type CreditNoteTaxAmount struct {
 // CreditNote is the resource representing a Stripe credit note.
 // For more details see https://stripe.com/docs/api/credit_notes/object.
 type CreditNote struct {
+	APIResource
 	Amount                     int64                       `json:"amount"`
 	Created                    int64                       `json:"created"`
 	Currency                   Currency                    `json:"currency"`

--- a/customer.go
+++ b/customer.go
@@ -92,6 +92,7 @@ type CustomerListParams struct {
 // Customer is the resource representing a Stripe customer.
 // For more details see https://stripe.com/docs/api#customers.
 type Customer struct {
+	APIResource
 	Address             Address                  `json:"address"`
 	Balance             int64                    `json:"balance"`
 	Created             int64                    `json:"created"`

--- a/customer.go
+++ b/customer.go
@@ -135,6 +135,7 @@ type CustomerInvoiceSettings struct {
 
 // CustomerList is a list of customers as retrieved from a list endpoint.
 type CustomerList struct {
+	APIResource
 	ListMeta
 	Data []*Customer `json:"data"`
 }

--- a/customerbalancetransaction.go
+++ b/customerbalancetransaction.go
@@ -58,6 +58,7 @@ type CustomerBalanceTransaction struct {
 // CustomerBalanceTransactionList is a list of customer balance transactions as retrieved from a
 // list endpoint.
 type CustomerBalanceTransactionList struct {
+	APIResource
 	ListMeta
 	Data []*CustomerBalanceTransaction `json:"data"`
 }

--- a/customerbalancetransaction.go
+++ b/customerbalancetransaction.go
@@ -39,6 +39,7 @@ type CustomerBalanceTransactionListParams struct {
 // CustomerBalanceTransaction is the resource representing a customer balance transaction.
 // For more details see https://stripe.com/docs/api/customers/customer_balance_transaction_object
 type CustomerBalanceTransaction struct {
+	APIResource
 	Amount        int64                          `json:"amount"`
 	Created       int64                          `json:"created"`
 	CreditNote    *CreditNote                    `json:"credit_note"`

--- a/discount.go
+++ b/discount.go
@@ -8,6 +8,7 @@ type DiscountParams struct {
 // Discount is the resource representing a Stripe discount.
 // For more details see https://stripe.com/docs/api#discounts.
 type Discount struct {
+	APIResource
 	Coupon       *Coupon `json:"coupon"`
 	Customer     string  `json:"customer"`
 	Deleted      bool    `json:"deleted"`

--- a/dispute.go
+++ b/dispute.go
@@ -87,6 +87,7 @@ type DisputeListParams struct {
 // Dispute is the resource representing a Stripe dispute.
 // For more details see https://stripe.com/docs/api#disputes.
 type Dispute struct {
+	APIResource
 	Amount              int64                 `json:"amount"`
 	BalanceTransactions []*BalanceTransaction `json:"balance_transactions"`
 	Charge              *Charge               `json:"charge"`

--- a/dispute.go
+++ b/dispute.go
@@ -106,6 +106,7 @@ type Dispute struct {
 
 // DisputeList is a list of disputes as retrieved from a list endpoint.
 type DisputeList struct {
+	APIResource
 	ListMeta
 	Data []*Dispute `json:"data"`
 }

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -14,6 +14,8 @@ type EphemeralKeyParams struct {
 // EphemeralKey is the resource representing a Stripe ephemeral key. This is used by Mobile SDKs
 // to for example manage a Customer's payment methods.
 type EphemeralKey struct {
+	APIResource
+
 	AssociatedObjects []struct {
 		ID   string `json:"id"`
 		Type string `json:"type"`

--- a/error.go
+++ b/error.go
@@ -171,6 +171,8 @@ const (
 // Error is the response returned when a call is unsuccessful.
 // For more details see  https://stripe.com/docs/api#errors.
 type Error struct {
+	APIResource
+
 	ChargeID    string      `json:"charge,omitempty"`
 	Code        ErrorCode   `json:"code,omitempty"`
 	DeclineCode DeclineCode `json:"decline_code,omitempty"`

--- a/event.go
+++ b/event.go
@@ -50,6 +50,7 @@ type EventParams struct {
 
 // EventList is a list of events as retrieved from a list endpoint.
 type EventList struct {
+	APIResource
 	ListMeta
 	Data []*Event `json:"data"`
 }

--- a/event.go
+++ b/event.go
@@ -9,6 +9,7 @@ import (
 // Event is the resource representing a Stripe event.
 // For more details see https://stripe.com/docs/api#events.
 type Event struct {
+	APIResource
 	Account         string        `json:"account"`
 	Created         int64         `json:"created"`
 	Data            *EventData    `json:"data"`

--- a/exchangerate.go
+++ b/exchangerate.go
@@ -3,6 +3,7 @@ package stripe
 // ExchangeRate is the resource representing the currency exchange rates at
 // a given time.
 type ExchangeRate struct {
+	APIResource
 	ID    string               `json:"id"`
 	Rates map[Currency]float64 `json:"rates"`
 }

--- a/exchangerate.go
+++ b/exchangerate.go
@@ -16,6 +16,7 @@ type ExchangeRateParams struct {
 
 // ExchangeRateList is a list of exchange rates as retrieved from a list endpoint.
 type ExchangeRateList struct {
+	APIResource
 	ListMeta
 	Data []*ExchangeRate `json:"data"`
 }

--- a/fee.go
+++ b/fee.go
@@ -38,6 +38,7 @@ type ApplicationFee struct {
 
 //ApplicationFeeList is a list of application fees as retrieved from a list endpoint.
 type ApplicationFeeList struct {
+	APIResource
 	ListMeta
 	Data []*ApplicationFee `json:"data"`
 }

--- a/fee.go
+++ b/fee.go
@@ -20,6 +20,7 @@ type ApplicationFeeListParams struct {
 // ApplicationFee is the resource representing a Stripe application fee.
 // For more details see https://stripe.com/docs/api#application_fees.
 type ApplicationFee struct {
+	APIResource
 	Account                *Account            `json:"account"`
 	Amount                 int64               `json:"amount"`
 	AmountRefunded         int64               `json:"amount_refunded"`

--- a/feerefund.go
+++ b/feerefund.go
@@ -34,6 +34,7 @@ type FeeRefund struct {
 
 // FeeRefundList is a list object for application fee refunds.
 type FeeRefundList struct {
+	APIResource
 	ListMeta
 	Data []*FeeRefund `json:"data"`
 }

--- a/feerefund.go
+++ b/feerefund.go
@@ -22,6 +22,7 @@ type FeeRefundListParams struct {
 // FeeRefund is the resource representing a Stripe application fee refund.
 // For more details see https://stripe.com/docs/api#fee_refunds.
 type FeeRefund struct {
+	APIResource
 	Amount             int64               `json:"amount"`
 	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
 	Created            int64               `json:"created"`

--- a/file.go
+++ b/file.go
@@ -65,6 +65,7 @@ type FileListParams struct {
 // File is the resource representing a Stripe file.
 // For more details see https://stripe.com/docs/api#file_object.
 type File struct {
+	APIResource
 	Created  int64         `json:"created"`
 	ID       string        `json:"id"`
 	Filename string        `json:"filename"`

--- a/file.go
+++ b/file.go
@@ -78,6 +78,7 @@ type File struct {
 
 // FileList is a list of files as retrieved from a list endpoint.
 type FileList struct {
+	APIResource
 	ListMeta
 	Data []*File `json:"data"`
 }

--- a/filelink.go
+++ b/filelink.go
@@ -23,6 +23,7 @@ type FileLinkListParams struct {
 // FileLink is the resource representing a Stripe file link.
 // For more details see https://stripe.com/docs/api#file_links.
 type FileLink struct {
+	APIResource
 	Created   int64             `json:"created"`
 	Expired   bool              `json:"expired"`
 	ExpiresAt int64             `json:"expires_at"`

--- a/filelink.go
+++ b/filelink.go
@@ -56,6 +56,7 @@ func (c *FileLink) UnmarshalJSON(data []byte) error {
 
 // FileLinkList is a list of file links as retrieved from a list endpoint.
 type FileLinkList struct {
+	APIResource
 	ListMeta
 	Data []*FileLink `json:"data"`
 }

--- a/invoice.go
+++ b/invoice.go
@@ -209,6 +209,7 @@ type InvoiceVoidParams struct {
 // Invoice is the resource representing a Stripe invoice.
 // For more details see https://stripe.com/docs/api#invoice_object.
 type Invoice struct {
+	APIResource
 	AccountCountry               string                   `json:"account_country"`
 	AccountName                  string                   `json:"account_name"`
 	AmountDue                    int64                    `json:"amount_due"`

--- a/invoice.go
+++ b/invoice.go
@@ -308,6 +308,7 @@ type InvoiceThresholdReasonItemReason struct {
 
 // InvoiceList is a list of invoices as retrieved from a list endpoint.
 type InvoiceList struct {
+	APIResource
 	ListMeta
 	Data []*Invoice `json:"data"`
 }
@@ -348,6 +349,7 @@ type Period struct {
 
 // InvoiceLineList is a list object for invoice line items.
 type InvoiceLineList struct {
+	APIResource
 	ListMeta
 	Data []*InvoiceLine `json:"data"`
 }

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -40,6 +40,7 @@ type InvoiceItemListParams struct {
 // InvoiceItem is the resource represneting a Stripe invoice item.
 // For more details see https://stripe.com/docs/api#invoiceitems.
 type InvoiceItem struct {
+	APIResource
 	Amount            int64             `json:"amount"`
 	Currency          Currency          `json:"currency"`
 	Customer          *Customer         `json:"customer"`

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -64,6 +64,7 @@ type InvoiceItem struct {
 
 // InvoiceItemList is a list of invoice items as retrieved from a list endpoint.
 type InvoiceItemList struct {
+	APIResource
 	ListMeta
 	Data []*InvoiceItem `json:"data"`
 }

--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -275,6 +275,7 @@ type IssuingMerchantData struct {
 
 // IssuingAuthorizationList is a list of issuing authorizations as retrieved from a list endpoint.
 type IssuingAuthorizationList struct {
+	APIResource
 	ListMeta
 	Data []*IssuingAuthorization `json:"data"`
 }

--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -223,6 +223,7 @@ type IssuingAuthorizationVerificationData struct {
 
 // IssuingAuthorization is the resource representing a Stripe issuing authorization.
 type IssuingAuthorization struct {
+	APIResource
 	Amount              int64                                   `json:"amount"`
 	Approved            bool                                    `json:"approved"`
 	AuthorizationMethod IssuingAuthorizationAuthorizationMethod `json:"authorization_method"`

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -317,6 +317,7 @@ type IssuingCard struct {
 
 // IssuingCardList is a list of issuing cards as retrieved from a list endpoint.
 type IssuingCardList struct {
+	APIResource
 	ListMeta
 	Data []*IssuingCard `json:"data"`
 }

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -212,6 +212,7 @@ type IssuingCardListParams struct {
 
 // IssuingCardDetails is the resource representing issuing card details.
 type IssuingCardDetails struct {
+	APIResource
 	Card     *IssuingCard `json:"card"`
 	CVC      string       `json:"cvc"`
 	ExpMonth *string      `form:"exp_month"`
@@ -286,6 +287,7 @@ type IssuingCardSpendingControls struct {
 
 // IssuingCard is the resource representing a Stripe issuing card.
 type IssuingCard struct {
+	APIResource
 	Billing           *IssuingBilling              `json:"billing"`
 	Brand             string                       `json:"brand"`
 	Cardholder        *IssuingCardholder           `json:"cardholder"`

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -214,6 +214,8 @@ type IssuingCardholderSpendingControls struct {
 
 // IssuingCardholder is the resource representing a Stripe issuing cardholder.
 type IssuingCardholder struct {
+	APIResource
+
 	Billing          *IssuingBilling                    `json:"billing"`
 	Company          *IssuingCardholderCompany          `json:"company"`
 	Created          int64                              `json:"created"`

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -238,6 +238,7 @@ type IssuingCardholder struct {
 
 // IssuingCardholderList is a list of issuing cardholders as retrieved from a list endpoint.
 type IssuingCardholderList struct {
+	APIResource
 	ListMeta
 	Data []*IssuingCardholder `json:"data"`
 }

--- a/issuing_dispute.go
+++ b/issuing_dispute.go
@@ -84,6 +84,7 @@ type IssuingDisputeEvidence struct {
 
 // IssuingDispute is the resource representing an issuing dispute.
 type IssuingDispute struct {
+	APIResource
 	Amount      int64                   `json:"amount"`
 	Created     int64                   `json:"created"`
 	Currency    Currency                `json:"currency"`

--- a/issuing_dispute.go
+++ b/issuing_dispute.go
@@ -100,6 +100,7 @@ type IssuingDispute struct {
 
 // IssuingDisputeList is a list of issuing disputes as retrieved from a list endpoint.
 type IssuingDisputeList struct {
+	APIResource
 	ListMeta
 	Data []*IssuingDispute `json:"data"`
 }

--- a/issuing_transaction.go
+++ b/issuing_transaction.go
@@ -51,6 +51,7 @@ type IssuingTransaction struct {
 
 // IssuingTransactionList is a list of issuing transactions as retrieved from a list endpoint.
 type IssuingTransactionList struct {
+	APIResource
 	ListMeta
 	Data []*IssuingTransaction `json:"data"`
 }

--- a/issuing_transaction.go
+++ b/issuing_transaction.go
@@ -30,6 +30,7 @@ type IssuingTransactionListParams struct {
 
 // IssuingTransaction is the resource representing a Stripe issuing transaction.
 type IssuingTransaction struct {
+	APIResource
 	Amount             int64                  `json:"amount"`
 	Authorization      *IssuingAuthorization  `json:"authorization"`
 	BalanceTransaction *BalanceTransaction    `json:"balance_transaction"`

--- a/loginlink.go
+++ b/loginlink.go
@@ -11,6 +11,7 @@ type LoginLinkParams struct {
 // LoginLink is the resource representing a login link for Express accounts.
 // For more details see https://stripe.com/docs/api#login_link_object
 type LoginLink struct {
+	APIResource
 	Created int64  `json:"created"`
 	URL     string `json:"url"`
 }

--- a/mandate.go
+++ b/mandate.go
@@ -94,6 +94,7 @@ type MandateSingleUse struct {
 
 // Mandate is the resource representing a Mandate.
 type Mandate struct {
+	APIResource
 	CustomerAcceptance   *MandateCustomerAcceptance   `json:"customer_acceptance"`
 	ID                   string                       `json:"id"`
 	Livemode             bool                         `json:"livemode"`

--- a/oauth.go
+++ b/oauth.go
@@ -111,6 +111,8 @@ type OAuthTokenParams struct {
 // OAuthToken is the value of the OAuthToken from OAuth flow.
 // https://stripe.com/docs/connect/oauth-reference#post-token
 type OAuthToken struct {
+	APIResource
+
 	Livemode     bool           `json:"livemode"`
 	Scope        OAuthScopeType `json:"scope"`
 	StripeUserID string         `json:"stripe_user_id"`
@@ -125,5 +127,6 @@ type OAuthToken struct {
 // Deauthorize is the value of the return from deauthorizing.
 // https://stripe.com/docs/connect/oauth-reference#post-deauthorize
 type Deauthorize struct {
+	APIResource
 	StripeUserID string `json:"stripe_user_id"`
 }

--- a/order.go
+++ b/order.go
@@ -123,6 +123,7 @@ type DeliveryEstimate struct {
 // Order is the resource representing a Stripe charge.
 // For more details see https://stripe.com/docs/api#orders.
 type Order struct {
+	APIResource
 	Amount                 int64             `json:"amount"`
 	AmountReturned         int64             `json:"amount_returned"`
 	Application            string            `json:"application"`

--- a/order.go
+++ b/order.go
@@ -149,6 +149,7 @@ type Order struct {
 
 // OrderList is a list of orders as retrieved from a list endpoint.
 type OrderList struct {
+	APIResource
 	ListMeta
 	Data []*Order `json:"data"`
 }

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -25,6 +25,7 @@ type OrderReturn struct {
 
 // OrderReturnList is a list of order returns as retrieved from a list endpoint.
 type OrderReturnList struct {
+	APIResource
 	ListMeta
 	Data []*OrderReturn `json:"data"`
 }

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -12,6 +12,7 @@ type OrderReturnParams struct {
 // OrderReturn is the resource representing an order return.
 // For more details see https://stripe.com/docs/api#order_returns.
 type OrderReturn struct {
+	APIResource
 	Amount   int64        `json:"amount"`
 	Created  int64        `json:"created"`
 	Currency Currency     `json:"currency"`

--- a/params.go
+++ b/params.go
@@ -70,7 +70,6 @@ func (f Filters) AppendTo(body *form.Values, keyParts []string) {
 // of List iterators. The Count property is only populated if the
 // total_count include option is passed in (see tests for example).
 type ListMeta struct {
-	APIResource
 	HasMore    bool   `json:"has_more"`
 	TotalCount uint32 `json:"total_count"`
 	URL        string `json:"url"`

--- a/params.go
+++ b/params.go
@@ -70,6 +70,7 @@ func (f Filters) AppendTo(body *form.Values, keyParts []string) {
 // of List iterators. The Count property is only populated if the
 // total_count include option is passed in (see tests for example).
 type ListMeta struct {
+	APIResource
 	HasMore    bool   `json:"has_more"`
 	TotalCount uint32 `json:"total_count"`
 	URL        string `json:"url"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -332,6 +332,7 @@ type PaymentIntent struct {
 
 // PaymentIntentList is a list of payment intents as retrieved from a list endpoint.
 type PaymentIntentList struct {
+	APIResource
 	ListMeta
 	Data []*PaymentIntent `json:"data"`
 }

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -292,6 +292,7 @@ type PaymentIntentTransferData struct {
 // PaymentIntent is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payment_intents.
 type PaymentIntent struct {
+	APIResource
 	Amount                    int64                              `json:"amount"`
 	AmountCapturable          int64                              `json:"amount_capturable"`
 	AmountReceived            int64                              `json:"amount_received"`

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -234,6 +234,7 @@ type PaymentMethodSepaDebit struct {
 
 // PaymentMethod is the resource representing a PaymentMethod.
 type PaymentMethod struct {
+	APIResource
 	AUBECSDebit    *PaymentMethodAUBECSDebit `json:"au_becs_debit"`
 	BillingDetails *BillingDetails           `json:"billing_details"`
 	Card           *PaymentMethodCard        `json:"card"`

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -253,6 +253,7 @@ type PaymentMethod struct {
 
 // PaymentMethodList is a list of PaymentMethods as retrieved from a list endpoint.
 type PaymentMethodList struct {
+	APIResource
 	ListMeta
 	Data []*PaymentMethod `json:"data"`
 }

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -99,6 +99,7 @@ type PaymentSource struct {
 
 // SourceList is a list object for cards.
 type SourceList struct {
+	APIResource
 	ListMeta
 	Data []*PaymentSource `json:"data"`
 }

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -87,6 +87,7 @@ func SourceParamsFor(obj interface{}) (*SourceParams, error) {
 // The Type should indicate which object is fleshed out (eg. BitcoinReceiver or Card)
 // For more details see https://stripe.com/docs/api#retrieve_charge
 type PaymentSource struct {
+	APIResource
 	BankAccount     *BankAccount      `json:"-"`
 	BitcoinReceiver *BitcoinReceiver  `json:"-"`
 	Card            *Card             `json:"-"`

--- a/payout.go
+++ b/payout.go
@@ -108,6 +108,7 @@ type PayoutListParams struct {
 // Payout is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payouts.
 type Payout struct {
+	APIResource
 	Amount                    int64               `json:"amount"`
 	ArrivalDate               int64               `json:"arrival_date"`
 	Automatic                 bool                `json:"automatic"`

--- a/payout.go
+++ b/payout.go
@@ -134,6 +134,7 @@ type Payout struct {
 
 // PayoutList is a list of payouts as retrieved from a list endpoint.
 type PayoutList struct {
+	APIResource
 	ListMeta
 	Data []*Payout `json:"data"`
 }

--- a/person.go
+++ b/person.go
@@ -164,6 +164,7 @@ type PersonVerification struct {
 // Person is the resource representing a Stripe person.
 // For more details see https://stripe.com/docs/api#persons.
 type Person struct {
+	APIResource
 	Account          string              `json:"account"`
 	Address          *AccountAddress     `json:"address"`
 	AddressKana      *AccountAddress     `json:"address_kana"`

--- a/person.go
+++ b/person.go
@@ -193,6 +193,7 @@ type Person struct {
 
 // PersonList is a list of persons as retrieved from a list endpoint.
 type PersonList struct {
+	APIResource
 	ListMeta
 	Data []*Person `json:"data"`
 }

--- a/plan.go
+++ b/plan.go
@@ -68,6 +68,7 @@ const (
 // Plan is the resource representing a Stripe plan.
 // For more details see https://stripe.com/docs/api#plans.
 type Plan struct {
+	APIResource
 	Active          bool                `json:"active"`
 	AggregateUsage  string              `json:"aggregate_usage"`
 	Amount          int64               `json:"amount"`

--- a/plan.go
+++ b/plan.go
@@ -93,6 +93,7 @@ type Plan struct {
 
 // PlanList is a list of plans as returned from a list endpoint.
 type PlanList struct {
+	APIResource
 	ListMeta
 	Data []*Plan `json:"data"`
 }

--- a/product.go
+++ b/product.go
@@ -74,6 +74,7 @@ type Product struct {
 
 // ProductList is a list of products as retrieved from a list endpoint.
 type ProductList struct {
+	APIResource
 	ListMeta
 	Data []*Product `json:"data"`
 }

--- a/product.go
+++ b/product.go
@@ -51,6 +51,7 @@ type PackageDimensions struct {
 // Product is the resource representing a Stripe product.
 // For more details see https://stripe.com/docs/api#products.
 type Product struct {
+	APIResource
 	Active              bool               `json:"active"`
 	Attributes          []string           `json:"attributes"`
 	Caption             string             `json:"caption"`

--- a/radar_earlyfraudwarning.go
+++ b/radar_earlyfraudwarning.go
@@ -39,6 +39,7 @@ type RadarEarlyFraudWarningList struct {
 // RadarEarlyFraudWarning is the resource representing an early fraud warning. For
 // more details see https://stripe.com/docs/api/early_fraud_warnings/object.
 type RadarEarlyFraudWarning struct {
+	APIResource
 	Actionable bool                            `json:"actionable"`
 	Charge     *Charge                         `json:"charge"`
 	Created    int64                           `json:"created"`

--- a/radar_earlyfraudwarning.go
+++ b/radar_earlyfraudwarning.go
@@ -32,6 +32,7 @@ type RadarEarlyFraudWarningListParams struct {
 // RadarEarlyFraudWarningList is a list of early fraud warnings as retrieved from a
 // list endpoint.
 type RadarEarlyFraudWarningList struct {
+	APIResource
 	ListMeta
 	Values []*RadarEarlyFraudWarning `json:"data"`
 }

--- a/radar_valuelist.go
+++ b/radar_valuelist.go
@@ -51,6 +51,7 @@ type RadarValueList struct {
 
 // RadarValueListList is a list of value lists as retrieved from a list endpoint.
 type RadarValueListList struct {
+	APIResource
 	ListMeta
 	Data []*RadarValueList `json:"data"`
 }

--- a/radar_valuelist.go
+++ b/radar_valuelist.go
@@ -33,6 +33,7 @@ type RadarValueListListParams struct {
 
 // RadarValueList is the resource representing a value list.
 type RadarValueList struct {
+	APIResource
 	Alias     string                  `json:"alias"`
 	Created   int64                   `json:"created"`
 	CreatedBy string                  `json:"created_by"`

--- a/radar_valuelistitem.go
+++ b/radar_valuelistitem.go
@@ -18,6 +18,7 @@ type RadarValueListItemListParams struct {
 
 // RadarValueListItem is the resource representing a value list item.
 type RadarValueListItem struct {
+	APIResource
 	Created        int64  `json:"created"`
 	CreatedBy      string `json:"created_by"`
 	Deleted        bool   `json:"deleted"`

--- a/radar_valuelistitem.go
+++ b/radar_valuelistitem.go
@@ -32,6 +32,7 @@ type RadarValueListItem struct {
 
 // RadarValueListItemList is a list of value list items as retrieved from a list endpoint.
 type RadarValueListItemList struct {
+	APIResource
 	ListMeta
 	Data []*RadarValueListItem `json:"data"`
 }

--- a/recipient.go
+++ b/recipient.go
@@ -72,6 +72,7 @@ type Recipient struct {
 
 // RecipientList is a list of recipients as retrieved from a list endpoint.
 type RecipientList struct {
+	APIResource
 	ListMeta
 	Data []*Recipient `json:"data"`
 }

--- a/recipient.go
+++ b/recipient.go
@@ -54,6 +54,7 @@ type RecipientListParams struct {
 // Recipient is the resource representing a Stripe recipient.
 // For more details see https://stripe.com/docs/api#recipients.
 type Recipient struct {
+	APIResource
 	ActiveAccount *BankAccount      `json:"active_account"`
 	Cards         *CardList         `json:"cards"`
 	Created       int64             `json:"created"`

--- a/refund.go
+++ b/refund.go
@@ -59,6 +59,7 @@ type RefundListParams struct {
 // Refund is the resource representing a Stripe refund.
 // For more details see https://stripe.com/docs/api#refunds.
 type Refund struct {
+	APIResource
 	Amount                    int64               `json:"amount"`
 	BalanceTransaction        *BalanceTransaction `json:"balance_transaction"`
 	Charge                    *Charge             `json:"charge"`

--- a/refund.go
+++ b/refund.go
@@ -80,6 +80,7 @@ type Refund struct {
 
 // RefundList is a list object for refunds.
 type RefundList struct {
+	APIResource
 	ListMeta
 	Data []*Refund `json:"data"`
 }

--- a/reporting_reportrun.go
+++ b/reporting_reportrun.go
@@ -50,6 +50,7 @@ type ReportRunParameters struct {
 
 // ReportRun is the resource representing a report run.
 type ReportRun struct {
+	APIResource
 	Created     int64                `json:"created"`
 	Error       string               `json:"error"`
 	ID          string               `json:"id"`

--- a/reporting_reportrun.go
+++ b/reporting_reportrun.go
@@ -65,6 +65,7 @@ type ReportRun struct {
 
 // ReportRunList is a list of report runs as retrieved from a list endpoint.
 type ReportRunList struct {
+	APIResource
 	ListMeta
 	Data []*ReportRun `json:"data"`
 }

--- a/reporting_reporttype.go
+++ b/reporting_reporttype.go
@@ -12,6 +12,7 @@ type ReportTypeParams struct {
 
 // ReportType is the resource representing a report type.
 type ReportType struct {
+	APIResource
 	DefaultColumns     []string `json:"default_columns"`
 	Created            int64    `json:"created"`
 	DataAvailableEnd   int64    `json:"data_available_end"`

--- a/reporting_reporttype.go
+++ b/reporting_reporttype.go
@@ -26,6 +26,7 @@ type ReportType struct {
 
 // ReportTypeList is a list of report types as retrieved from a list endpoint.
 type ReportTypeList struct {
+	APIResource
 	ListMeta
 	Data []*ReportType `json:"data"`
 }

--- a/reversal.go
+++ b/reversal.go
@@ -19,6 +19,7 @@ type ReversalListParams struct {
 
 // Reversal represents a transfer reversal.
 type Reversal struct {
+	APIResource
 	Amount                   int64               `json:"amount"`
 	BalanceTransaction       *BalanceTransaction `json:"balance_transaction"`
 	Created                  int64               `json:"created"`

--- a/reversal.go
+++ b/reversal.go
@@ -34,6 +34,7 @@ type Reversal struct {
 
 // ReversalList is a list of object for reversals.
 type ReversalList struct {
+	APIResource
 	ListMeta
 	Data []*Reversal `json:"data"`
 }

--- a/review.go
+++ b/review.go
@@ -48,6 +48,7 @@ type Review struct {
 
 // ReviewList is a list of reviews as retrieved from a list endpoint.
 type ReviewList struct {
+	APIResource
 	ListMeta
 	Data []*Review `json:"data"`
 }

--- a/review.go
+++ b/review.go
@@ -35,6 +35,7 @@ type ReviewListParams struct {
 // Review is the resource representing a Radar review.
 // For more details see https://stripe.com/docs/api#reviews.
 type Review struct {
+	APIResource
 	Charge        *Charge          `json:"charge"`
 	Created       int64            `json:"created"`
 	ID            string           `json:"id"`

--- a/setupintent.go
+++ b/setupintent.go
@@ -195,6 +195,7 @@ type SetupIntent struct {
 
 // SetupIntentList is a list of setup intents as retrieved from a list endpoint.
 type SetupIntentList struct {
+	APIResource
 	ListMeta
 	Data []*SetupIntent `json:"data"`
 }

--- a/setupintent.go
+++ b/setupintent.go
@@ -170,6 +170,7 @@ type SetupIntentPaymentMethodOptions struct {
 // SetupIntent is the resource representing a Stripe payout.
 // For more details see https://stripe.com/docs/api#payment_intents.
 type SetupIntent struct {
+	APIResource
 	Application          *Application                     `json:"application"`
 	CancellationReason   SetupIntentCancellationReason    `json:"cancellation_reason"`
 	ClientSecret         string                           `json:"client_secret"`

--- a/sigma_scheduledqueryrun.go
+++ b/sigma_scheduledqueryrun.go
@@ -41,6 +41,7 @@ type SigmaScheduledQueryRun struct {
 
 // SigmaScheduledQueryRunList is a list of scheduled query runs as retrieved from a list endpoint.
 type SigmaScheduledQueryRunList struct {
+	APIResource
 	ListMeta
 	Data []*SigmaScheduledQueryRun `json:"data"`
 }

--- a/sigma_scheduledqueryrun.go
+++ b/sigma_scheduledqueryrun.go
@@ -25,6 +25,7 @@ type SigmaScheduledQueryRunListParams struct {
 
 // SigmaScheduledQueryRun is the resource representing a scheduled query run.
 type SigmaScheduledQueryRun struct {
+	APIResource
 	Created              int64                        `json:"created"`
 	DataLoadTime         int64                        `json:"data_load_time"`
 	Error                string                       `json:"error"`

--- a/sku.go
+++ b/sku.go
@@ -54,6 +54,7 @@ type Inventory struct {
 // SKU is the resource representing a SKU.
 // For more details see https://stripe.com/docs/api#skus.
 type SKU struct {
+	APIResource
 	Active            bool               `json:"active"`
 	Attributes        map[string]string  `json:"attributes"`
 	Created           int64              `json:"created"`

--- a/sku.go
+++ b/sku.go
@@ -73,6 +73,7 @@ type SKU struct {
 
 // SKUList is a list of SKUs as returned from a list endpoint.
 type SKUList struct {
+	APIResource
 	ListMeta
 	Data []*SKU `json:"data"`
 }

--- a/source.go
+++ b/source.go
@@ -292,6 +292,7 @@ type SourceSourceOrder struct {
 // Source is the resource representing a Source.
 // For more details see https://stripe.com/docs/api#sources.
 type Source struct {
+	APIResource
 	Amount              int64                 `json:"amount"`
 	ClientSecret        string                `json:"client_secret"`
 	CodeVerification    *CodeVerificationFlow `json:"code_verification,omitempty"`

--- a/sourcetransaction.go
+++ b/sourcetransaction.go
@@ -10,6 +10,7 @@ type SourceTransactionListParams struct {
 
 // SourceTransactionList is a list object for SourceTransactions.
 type SourceTransactionList struct {
+	APIResource
 	ListMeta
 	Data []*SourceTransaction `json:"data"`
 }

--- a/stripe.go
+++ b/stripe.go
@@ -78,7 +78,7 @@ var Key string
 // Stripe API.
 type APIResponse struct {
 	// Header contain a map of all HTTP header keys to values. Its behavior and
-	// caveats are identical to that of http.StripeResponse.Header.
+	// caveats are identical to that of http.Header.
 	Header http.Header
 
 	// IdempotencyKey contains the idempotency key used with this request.

--- a/stripe.go
+++ b/stripe.go
@@ -74,6 +74,59 @@ var Key string
 // Public types
 //
 
+// APIResponse encapsulates some common features of a response from the
+// Stripe API.
+type APIResponse struct {
+	// Header contain a map of all HTTP header keys to values. Its behavior and
+	// caveats are identical to that of http.StripeResponse.Header.
+	Header http.Header
+
+	// IdempotencyKey contains the idempotency key used with this request.
+	// Idempotency keys are a Stripe-specific concept that helps guarantee that
+	// requests that fail and need to be retried are not duplicated.
+	IdempotencyKey string
+
+	// RawJSON contains the response body as raw bytes.
+	RawJSON []byte
+
+	// RequestID contains a string that uniquely identifies the Stripe request.
+	// Used for debugging or support purposes.
+	RequestID string
+
+	// Status is a status code and message. e.g. "200 OK"
+	Status string
+
+	// StatusCode is a status code as integer. e.g. 200
+	StatusCode int
+}
+
+func newAPIResponse(res *http.Response, resBody []byte) *APIResponse {
+	return &APIResponse{
+		Header:         res.Header,
+		IdempotencyKey: res.Header.Get("Idempotency-Key"),
+		RawJSON:        resBody,
+		RequestID:      res.Header.Get("Request-Id"),
+		Status:         res.Status,
+		StatusCode:     res.StatusCode,
+	}
+}
+
+// APIResource is a type assigned to structs that may come from Stripe API
+// endpoints and contains facilities common to all of them.
+type APIResource struct {
+	LastResponse *APIResponse `json:"-"`
+}
+
+// GetLastResponse gets the HTTP response that returned the API resource.
+func (r *APIResource) GetLastResponse() *APIResponse {
+	return r.LastResponse
+}
+
+// SetLastResponse sets the HTTP response that returned the API resource.
+func (r *APIResource) SetLastResponse(response *APIResponse) {
+	r.LastResponse = response
+}
+
 // AppInfo contains information about the "app" which this integration belongs
 // to. This should be reserved for plugins that wish to identify themselves
 // with Stripe.
@@ -101,9 +154,9 @@ func (a *AppInfo) formatUserAgent() string {
 // Backend is an interface for making calls against a Stripe service.
 // This interface exists to enable mocking for during testing if needed.
 type Backend interface {
-	Call(method, path, key string, params ParamsContainer, v interface{}) error
-	CallRaw(method, path, key string, body *form.Values, params *Params, v interface{}) error
-	CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *Params, v interface{}) error
+	Call(method, path, key string, params ParamsContainer, v LastResponseGetter) error
+	CallRaw(method, path, key string, body *form.Values, params *Params, v LastResponseGetter) error
+	CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *Params, v LastResponseGetter) error
 	SetMaxNetworkRetries(maxNetworkRetries int)
 }
 
@@ -187,7 +240,7 @@ type BackendImplementation struct {
 }
 
 // Call is the Backend.Call implementation for invoking Stripe APIs.
-func (s *BackendImplementation) Call(method, path, key string, params ParamsContainer, v interface{}) error {
+func (s *BackendImplementation) Call(method, path, key string, params ParamsContainer, v LastResponseGetter) error {
 	var body *form.Values
 	var commonParams *Params
 
@@ -213,7 +266,7 @@ func (s *BackendImplementation) Call(method, path, key string, params ParamsCont
 }
 
 // CallMultipart is the Backend.CallMultipart implementation for invoking Stripe APIs.
-func (s *BackendImplementation) CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *Params, v interface{}) error {
+func (s *BackendImplementation) CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *Params, v LastResponseGetter) error {
 	contentType := "multipart/form-data; boundary=" + boundary
 
 	req, err := s.NewRequest(method, path, key, contentType, params)
@@ -229,7 +282,7 @@ func (s *BackendImplementation) CallMultipart(method, path, key, boundary string
 }
 
 // CallRaw is the implementation for invoking Stripe APIs internally without a backend.
-func (s *BackendImplementation) CallRaw(method, path, key string, form *form.Values, params *Params, v interface{}) error {
+func (s *BackendImplementation) CallRaw(method, path, key string, form *form.Values, params *Params, v LastResponseGetter) error {
 	var body string
 	if form != nil && !form.Empty() {
 		body = form.Encode()
@@ -312,7 +365,7 @@ func (s *BackendImplementation) NewRequest(method, path, key, contentType string
 // Do is used by Call to execute an API request and parse the response. It uses
 // the backend's HTTP client to execute the request and unmarshals the response
 // into v. It also handles unmarshaling errors returned by the API.
-func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v interface{}) error {
+func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v LastResponseGetter) error {
 	s.LeveledLogger.Infof("Requesting %v %v%v\n", req.Method, req.URL.Host, req.URL.Path)
 
 	if s.enableTelemetry {
@@ -458,6 +511,8 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v inte
 
 	s.LeveledLogger.Debugf("Response: %s\n", string(resBody))
 
+	v.SetLastResponse(newAPIResponse(res, resBody))
+
 	if v != nil {
 		return s.UnmarshalJSONVerbose(res.StatusCode, resBody, v)
 	}
@@ -512,6 +567,8 @@ func (s *BackendImplementation) ResponseToError(res *http.Response, resBody []by
 		typedError = &RateLimitError{stripeErr: raw.E.Error}
 	}
 	raw.E.Err = typedError
+
+	raw.E.SetLastResponse(newAPIResponse(res, resBody))
 
 	return raw.E.Error
 }
@@ -653,6 +710,13 @@ func (s *BackendImplementation) sleepTime(numRetries int) time.Duration {
 type Backends struct {
 	API, Connect, Uploads Backend
 	mu                    sync.RWMutex
+}
+
+// LastResponseGetter defines a type that contains an HTTP response from a Stripe
+// API endpoint.
+type LastResponseGetter interface {
+	GetLastResponse() *APIResponse
+	SetLastResponse(response *APIResponse)
 }
 
 // SupportedBackend is an enumeration of supported Stripe endpoints.

--- a/sub.go
+++ b/sub.go
@@ -273,6 +273,7 @@ type SubscriptionBillingThresholds struct {
 
 // SubscriptionList is a list object for subscriptions.
 type SubscriptionList struct {
+	APIResource
 	ListMeta
 	Data []*Subscription `json:"data"`
 }

--- a/sub.go
+++ b/sub.go
@@ -222,6 +222,7 @@ type SubscriptionTransferData struct {
 // Subscription is the resource representing a Stripe subscription.
 // For more details see https://stripe.com/docs/api#subscriptions.
 type Subscription struct {
+	APIResource
 	ApplicationFeePercent         float64                                `json:"application_fee_percent"`
 	BillingCycleAnchor            int64                                  `json:"billing_cycle_anchor"`
 	BillingThresholds             *SubscriptionBillingThresholds         `json:"billing_thresholds"`

--- a/subitem.go
+++ b/subitem.go
@@ -56,6 +56,7 @@ type SubscriptionItemBillingThresholds struct {
 
 // SubscriptionItemList is a list of invoice items as retrieved from a list endpoint.
 type SubscriptionItemList struct {
+	APIResource
 	ListMeta
 	Data []*SubscriptionItem `json:"data"`
 }

--- a/subitem.go
+++ b/subitem.go
@@ -36,6 +36,7 @@ type SubscriptionItemListParams struct {
 // SubscriptionItem is the resource representing a Stripe subscription item.
 // For more details see https://stripe.com/docs/api#subscription_items.
 type SubscriptionItem struct {
+	APIResource
 	BillingThresholds SubscriptionItemBillingThresholds `json:"billing_thresholds"`
 	Created           int64                             `json:"created"`
 	Deleted           bool                              `json:"deleted"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -186,6 +186,7 @@ type SubscriptionScheduleRenewalInterval struct {
 
 // SubscriptionSchedule is the resource representing a Stripe subscription schedule.
 type SubscriptionSchedule struct {
+	APIResource
 	CanceledAt           int64                                `json:"canceled_at"`
 	CompletedAt          int64                                `json:"completed_at"`
 	Created              int64                                `json:"created"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -207,6 +207,7 @@ type SubscriptionSchedule struct {
 
 // SubscriptionScheduleList is a list object for subscription schedules.
 type SubscriptionScheduleList struct {
+	APIResource
 	ListMeta
 	Data []*SubscriptionSchedule `json:"data"`
 }

--- a/taxid.go
+++ b/taxid.go
@@ -84,6 +84,7 @@ type TaxID struct {
 
 // TaxIDList is a list of tax ids as retrieved from a list endpoint.
 type TaxIDList struct {
+	APIResource
 	ListMeta
 	Data []*TaxID `json:"data"`
 }

--- a/taxid.go
+++ b/taxid.go
@@ -69,6 +69,7 @@ type TaxIDVerification struct {
 // TaxID is the resource representing a customer's tax id.
 // For more details see https://stripe.com/docs/api/customers/tax_id_object
 type TaxID struct {
+	APIResource
 	Country      string             `json:"country"`
 	Created      int64              `json:"created"`
 	Customer     *Customer          `json:"customer"`

--- a/taxrate.go
+++ b/taxrate.go
@@ -37,6 +37,7 @@ type TaxRateListParams struct {
 // TaxRate is the resource representing a Stripe tax rate.
 // For more details see https://stripe.com/docs/api/tax_rates/object.
 type TaxRate struct {
+	APIResource
 	Active       bool              `json:"active"`
 	Created      int64             `json:"created"`
 	Description  string            `json:"description"`

--- a/taxrate.go
+++ b/taxrate.go
@@ -53,6 +53,7 @@ type TaxRate struct {
 
 // TaxRateList is a list of tax rates as retrieved from a list endpoint.
 type TaxRateList struct {
+	APIResource
 	ListMeta
 	Data []*TaxRate `json:"data"`
 }

--- a/terminal_connectiontoken.go
+++ b/terminal_connectiontoken.go
@@ -8,6 +8,7 @@ type TerminalConnectionTokenParams struct {
 
 // TerminalConnectionToken is the resource representing a Stripe terminal connection token.
 type TerminalConnectionToken struct {
+	APIResource
 	Location string `json:"location"`
 	Object   string `json:"object"`
 	Secret   string `json:"secret"`

--- a/terminal_location.go
+++ b/terminal_location.go
@@ -14,6 +14,7 @@ type TerminalLocationListParams struct {
 
 // TerminalLocation is the resource representing a Stripe terminal location.
 type TerminalLocation struct {
+	APIResource
 	Address     *AccountAddressParams `json:"address"`
 	Deleted     bool                  `json:"deleted"`
 	DisplayName string                `json:"display_name"`

--- a/terminal_location.go
+++ b/terminal_location.go
@@ -26,6 +26,7 @@ type TerminalLocation struct {
 
 // TerminalLocationList is a list of terminal readers as retrieved from a list endpoint.
 type TerminalLocationList struct {
+	APIResource
 	ListMeta
 	Data []*TerminalLocation `json:"data"`
 }

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -23,6 +23,7 @@ type TerminalReaderListParams struct {
 
 // TerminalReader is the resource representing a Stripe terminal reader.
 type TerminalReader struct {
+	APIResource
 	Deleted         bool              `json:"deleted"`
 	DeviceSwVersion string            `json:"device_sw_version"`
 	DeviceType      string            `json:"device_type"`

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -40,6 +40,7 @@ type TerminalReader struct {
 
 // TerminalReaderList is a list of terminal readers as retrieved from a list endpoint.
 type TerminalReaderList struct {
+	APIResource
 	ListMeta
 	Data     []*TerminalReader `json:"data"`
 	Location *string           `json:"location"`

--- a/threedsecure.go
+++ b/threedsecure.go
@@ -16,6 +16,7 @@ type ThreeDSecureParams struct {
 // ThreeDSecure is the resource representing a Stripe 3DS object
 // For more details see https://stripe.com/docs/api#three_d_secure.
 type ThreeDSecure struct {
+	APIResource
 	Amount        int64              `json:"amount"`
 	Authenticated bool               `json:"authenticated"`
 	Card          *Card              `json:"card"`

--- a/token.go
+++ b/token.go
@@ -29,6 +29,8 @@ type TokenParams struct {
 // Token is the resource representing a Stripe token.
 // For more details see https://stripe.com/docs/api#tokens.
 type Token struct {
+	APIResource
+
 	BankAccount *BankAccount `json:"bank_account"`
 	Card        *Card        `json:"card"`
 	ClientIP    string       `json:"client_ip"`

--- a/topup.go
+++ b/topup.go
@@ -30,6 +30,7 @@ type TopupListParams struct {
 
 // TopupList is a list of top-ups as retrieved from a list endpoint.
 type TopupList struct {
+	APIResource
 	ListMeta
 	Data []*Topup `json:"data"`
 }

--- a/topup.go
+++ b/topup.go
@@ -37,6 +37,7 @@ type TopupList struct {
 // Topup is the resource representing a Stripe top-up.
 // For more details see https://stripe.com/docs/api#topups.
 type Topup struct {
+	APIResource
 	Amount                   int64               `json:"amount"`
 	ArrivalDate              int64               `json:"arrival_date"`
 	BalanceTransaction       *BalanceTransaction `json:"balance_transaction"`

--- a/transfer.go
+++ b/transfer.go
@@ -69,6 +69,7 @@ type Transfer struct {
 
 // TransferList is a list of transfers as retrieved from a list endpoint.
 type TransferList struct {
+	APIResource
 	ListMeta
 	Data []*Transfer `json:"data"`
 }

--- a/transfer.go
+++ b/transfer.go
@@ -48,6 +48,7 @@ type TransferListParams struct {
 // Transfer is the resource representing a Stripe transfer.
 // For more details see https://stripe.com/docs/api#transfers.
 type Transfer struct {
+	APIResource
 	Amount             int64                     `json:"amount"`
 	AmountReversed     int64                     `json:"amount_reversed"`
 	BalanceTransaction *BalanceTransaction       `json:"balance_transaction"`

--- a/usagerecord.go
+++ b/usagerecord.go
@@ -9,6 +9,7 @@ const (
 // UsageRecord represents a usage record.
 // See https://stripe.com/docs/api#usage_records
 type UsageRecord struct {
+	APIResource
 	ID               string `json:"id"`
 	Livemode         bool   `json:"livemode"`
 	Quantity         int64  `json:"quantity"`

--- a/usagerecordsummary.go
+++ b/usagerecordsummary.go
@@ -20,6 +20,7 @@ type UsageRecordSummaryListParams struct {
 
 // UsageRecordSummaryList is a list of usage record summaries as retrieved from a list endpoint.
 type UsageRecordSummaryList struct {
+	APIResource
 	ListMeta
 	Data []*UsageRecordSummary `json:"data"`
 }

--- a/webhookendpoint.go
+++ b/webhookendpoint.go
@@ -27,6 +27,7 @@ type WebhookEndpointListParams struct {
 // WebhookEndpoint is the resource representing a Stripe webhook endpoint.
 // For more details see https://stripe.com/docs/api#webhook_endpoints.
 type WebhookEndpoint struct {
+	APIResource
 	APIVersion    string   `json:"api_version"`
 	Application   string   `json:"application"`
 	Connect       bool     `json:"connect"`

--- a/webhookendpoint.go
+++ b/webhookendpoint.go
@@ -44,6 +44,7 @@ type WebhookEndpoint struct {
 
 // WebhookEndpointList is a list of webhook endpoints as retrieved from a list endpoint.
 type WebhookEndpointList struct {
+	APIResource
 	ListMeta
 	Data []*WebhookEndpoint `json:"data"`
 }


### PR DESCRIPTION
Makes an API response struct containing niceties like the raw response
body, status, and request ID accessible via API resource structs
returned from client functions. For example:

    customer, err := customer.New(params)
    fmt.Printf("request ID = %s\n", customer.LastResponse.RequestID)

This is a feature that already exists in other language API libraries
and which is requested occasionally here, usually for various situations
involving more complex usage or desire for better observability.

## Implementation

We introduce a few new types to make this work:

* `APIResponse`: Represents a response from the Stripe API and includes
  things like request ID, status, and headers. I elected to create my
  own object instead of reusing `http.Response` because it gives us a
  little more flexibility, and hides many of myriad of fields exposed by
  the `http` version, which will hopefully give us a little more API
  stability/forward compatibility.

* `APIResource`: A struct that contains `LastResponse` and is meant to
  represent any type that can we returned from a Stripe API endpoint. A
  coupon is an `APIResource` and so is a list object. This struct is
  embedded in response structs where appropriate across the whole API
  surface area (e.g. `Coupon`, `ListMeta`, etc.).

* `LastResponseGetter`: A very basic interface to an object that looks
  like an `APIResource`. This isn't strictly necessary, but gives us
  slightly more flexibility around the API and makes backward
  compatibility a little bit better for non-standard use cases (see the
  section on that below).

`stripe.Do` and other backend calls all start taking objects which are
`LastResponseGetter` instead of `interface{}`. This provides us with some
type safety around forgetting to include an embedded `APIResource` on
structs that should have it by making the compiler balk.

As `stripe.Do` finishes running a request, it generates an `APIResponse`
object and sets it onto the API resource type it's deserializing and
returning (e.g. a `Coupon`).

Errors also embed `APIResource` and similarly get access to the same set
of fields as response resources, although in their case some of the
fields provided in `APIResponse` are duplicates of what they had
already (see "Caveats" below).

## Backwards compatibility

This is a minor breaking change in that backend implementations methods
like `Do` now take `LastResponseGetter` instead of `interface{}`, which
is more strict.

The good news though is that:

* Very few users should be using any of these even if they're
  technically public. The resource-specific clients packages tend to do
  all the work.

* Users who are broken should have a very easy time updating code.
  Mostly this will just involve adding `APIResource` to structs that were
  being passed in.

## Naming

* `APIResponse`: Went with this instead of `StripeResponse` as we see in
  some other libraries because the linter will complain that it
  "stutters" when used outside of the package (meaning, uses the same
  word twice in a row), i.e. `stripe.StripeResponse`. `APIResponse`
  sorts nicely with `APIResource` though, so I think it's okay.

* `LastResponse`: Copied the "last" convention from other API libraries
  like stripe-python.

* `LastResponseGetter`: Given an "-er" name per Go convention around
  small interfaces that are basically one liners -- e.g. `Reader`,
  `Writer, `Formatter`, `CloseNotifier`, etc. I can see the argument
  that this maybe should just be `APIResourceInterface` or something
  like that in case we start adding new things, but I figure at that
  point we can either rename it, or create a parent interface that
  encapsulates it:

    ``` go
    type APIResourceInterface interface {
        LastResponseGetter
    }
    ```

## Caveats

* We only set the last response for top-level returned objects. For
  example, an `InvoiceItem` is an API resource, but if it's returned
  under an `Invoice`, only `Invoice` has a non-nil `LastResponse`. The
  same applies for all resources under list objects. I figure that doing
  it this way is more performant and makes a little bit more intuitive
  sense. Users should be able to work around it if they need to.

* There is some duplication between `LastResponse` and some other fields
  that already existed on `stripe.Error` because the latter was already
  exposing some of this information, e.g. `RequestID`. I figure this is
  okay: it's nice that `stripe.Error` is a `LastResponseGetter` for
  consistency with other API resources. The duplication is a little
  unfortunate, but not that big of a deal.

r? @ob-stripe @remi-stripe
cc @stripe/api-libraries

---

Note: Targets major version integration branch in #1055.