### PR TITLE
Multiple breaking API changes

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -193,10 +193,8 @@ type ChargePaymentMethodDetailsAchDebit struct {
 
 // ChargePaymentMethodDetailsAcssDebit represents details about the ACSS Debit PaymentMethod.
 type ChargePaymentMethodDetailsAcssDebit struct {
-	Country       string `json:"country"`
-	Fingerprint   string `json:"fingerprint"`
-	Last4         string `json:"last4"`
-	RoutingNumber string `json:"routing_number"`
+	Fingerprint string `json:"fingerprint"`
+	Last4       string `json:"last4"`
 }
 
 // ChargePaymentMethodDetailsAlipay represents details about the Alipay PaymentMethod.
@@ -487,7 +485,7 @@ type Charge struct {
 	OnBehalfOf                    *Account                    `json:"on_behalf_of"`
 	Outcome                       *ChargeOutcome              `json:"outcome"`
 	Paid                          bool                        `json:"paid"`
-	PaymentIntent                 string                      `json:"payment_intent"`
+	PaymentIntent                 *PaymentIntent              `json:"payment_intent"`
 	PaymentMethod                 string                      `json:"payment_method"`
 	PaymentMethodDetails          *ChargePaymentMethodDetails `json:"payment_method_details"`
 	ReceiptEmail                  string                      `json:"receipt_email"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -178,12 +178,6 @@ type SubscriptionSchedulePhase struct {
 	TaxPercent float64 `json:"tax_percent"`
 }
 
-// SubscriptionScheduleRenewalInterval represents the interval and duration of a schedule.
-type SubscriptionScheduleRenewalInterval struct {
-	Interval PlanInterval `form:"interval"`
-	Length   int64        `form:"length"`
-}
-
 // SubscriptionSchedule is the resource representing a Stripe subscription schedule.
 type SubscriptionSchedule struct {
 	APIResource
@@ -200,7 +194,6 @@ type SubscriptionSchedule struct {
 	Object               string                               `json:"object"`
 	Phases               []*SubscriptionSchedulePhase         `json:"phases"`
 	ReleasedSubscription *Subscription                        `json:"released_subscription"`
-	RenewalInterval      *SubscriptionScheduleRenewalInterval `json:"renewal_interval"`
 	Status               SubscriptionScheduleStatus           `json:"status"`
 	Subscription         *Subscription                        `json:"subscription"`
 }

--- a/taxrate.go
+++ b/taxrate.go
@@ -14,24 +14,14 @@ type TaxRateParams struct {
 	Percentage   *float64 `form:"percentage"`
 }
 
-// TaxRatePercentageRangeQueryParams are used to filter tax rates by specific percentage values.
-type TaxRatePercentageRangeQueryParams struct {
-	GreaterThan        float64 `form:"gt"`
-	GreaterThanOrEqual float64 `form:"gte"`
-	LesserThan         float64 `form:"lt"`
-	LesserThanOrEqual  float64 `form:"lte"`
-}
-
 // TaxRateListParams is the set of parameters that can be used when listing tax rates.
 // For more detail see https://stripe.com/docs/api/tax_rates/list.
 type TaxRateListParams struct {
-	ListParams      `form:"*"`
-	Active          *bool                              `form:"active"`
-	Created         *int64                             `form:"created"`
-	CreatedRange    *RangeQueryParams                  `form:"created"`
-	Inclusive       *bool                              `form:"inclusive"`
-	Percentage      *float64                           `form:"percentage"`
-	PercentageRange *TaxRatePercentageRangeQueryParams `form:"percentage"`
+	ListParams   `form:"*"`
+	Active       *bool             `form:"active"`
+	Created      *int64            `form:"created"`
+	CreatedRange *RangeQueryParams `form:"created"`
+	Inclusive    *bool             `form:"inclusive"`
 }
 
 // TaxRate is the resource representing a Stripe tax rate.


### PR DESCRIPTION
Multiple breaking API changes:
* `PaymentIntent` is now expandable on `Charge`
* `Percentage` was removed as a filter when listing `TaxRate`
* Removed `RenewalInterval` on `SubscriptionSchedule`
* Removed `Country` and `RoutingNumber` from `ChargePaymentMethodDetailsAcssDebit`

r? @richardm-stripe 
cc @stripe/api-libraries 