### PR TITLE
Default number of network retries to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,15 @@ if err := i.Err(); err != nil {
 }
 ```
 
-### Configuring Automatic Retries
+### Automatic Retries
 
-You can enable automatic retries on requests that fail due to a transient
-problem by configuring the maximum number of retries:
+The library automatically retries requests on intermittent failures like on a
+connection error, timeout, or on certain API responses like a status `409
+Conflict`. [Idempotency keys][idempotency-keys] are always added to requests to
+make any such subsequent retries safe.
+
+By default, it will perform up to two retries. That number can be configured
+with `MaxNetworkRetries`:
 
 ```go
 import (
@@ -249,7 +254,7 @@ import (
 )
 
 config := &stripe.BackendConfig{
-    MaxNetworkRetries: 2,
+    MaxNetworkRetries: stripe.Int64(0), // Zero retries
 }
 
 sc := &client.API{}
@@ -260,12 +265,6 @@ sc.Init("sk_key", &stripe.Backends{
 
 coupon, err := sc.Coupons.New(...)
 ```
-
-Various errors can trigger a retry, like a connection error or a timeout, and
-also certain API responses like HTTP status `409 Conflict`.
-
-[Idempotency keys][idempotency-keys] are added to requests to guarantee that
-retries are safe.
 
 ### Configuring Logging
 
@@ -331,7 +330,7 @@ You can disable this behavior if you prefer:
 
 ```go
 config := &stripe.BackendConfig{
-	EnableTelemetry: false,
+	EnableTelemetry: stripe.Bool(false),
 }
 ```
 

--- a/error_test.go
+++ b/error_test.go
@@ -23,7 +23,7 @@ func TestErrorResponse(t *testing.T) {
 	defer ts.Close()
 
 	backend := GetBackendWithConfig(APIBackend, &BackendConfig{
-		URL: ts.URL,
+		URL: String(ts.URL),
 	})
 
 	err := backend.Call(http.MethodGet, "/v1/account", "sk_test_badKey", nil, nil)

--- a/oauth/client_test.go
+++ b/oauth/client_test.go
@@ -121,7 +121,7 @@ func stubConnectBackend(httpClient *http.Client) {
 	mockBackend := stripe.GetBackendWithConfig(
 		stripe.ConnectBackend,
 		&stripe.BackendConfig{
-			URL:        "https://localhost:12113",
+			URL:        stripe.String("https://localhost:12113"),
 			HTTPClient: httpClient,
 		},
 	)

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -64,7 +64,7 @@ func TestOrderReturn_RequestParams(t *testing.T) {
 
 	// Configure the stripe client to use the ephemeral backend.
 	backend := stripe.GetBackendWithConfig(stripe.APIBackend, &stripe.BackendConfig{
-		URL: ts.URL,
+		URL: stripe.String(ts.URL),
 	})
 	orderClient := Client{B: backend, Key: stripe.Key}
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -101,8 +101,8 @@ func TestDo_Retry(t *testing.T) {
 		APIBackend,
 		&BackendConfig{
 			LeveledLogger:     debugLeveledLogger,
-			MaxNetworkRetries: 5,
-			URL:               testServer.URL,
+			MaxNetworkRetries: Int64(5),
+			URL:               String(testServer.URL),
 		},
 	).(*BackendImplementation)
 
@@ -130,12 +130,12 @@ func TestDo_Retry(t *testing.T) {
 }
 
 func TestShouldRetry(t *testing.T) {
-	MaxNetworkRetries := 3
+	MaxNetworkRetries := int64(3)
 
 	c := GetBackendWithConfig(
 		APIBackend,
 		&BackendConfig{
-			MaxNetworkRetries: MaxNetworkRetries,
+			MaxNetworkRetries: Int64(MaxNetworkRetries),
 		},
 	).(*BackendImplementation)
 
@@ -144,7 +144,7 @@ func TestShouldRetry(t *testing.T) {
 		nil,
 		&http.Request{},
 		&http.Response{},
-		MaxNetworkRetries,
+		int(MaxNetworkRetries),
 	))
 
 	// Doesn't retry most Stripe errors (they must also match a status code
@@ -261,8 +261,8 @@ func TestDo_RetryOnTimeout(t *testing.T) {
 		APIBackend,
 		&BackendConfig{
 			LeveledLogger:     debugLeveledLogger,
-			MaxNetworkRetries: 1,
-			URL:               testServer.URL,
+			MaxNetworkRetries: Int64(1),
+			URL:               String(testServer.URL),
 			HTTPClient:        &http.Client{Timeout: timeout},
 		},
 	).(*BackendImplementation)
@@ -314,8 +314,8 @@ func TestDo_LastResponsePopulated(t *testing.T) {
 		APIBackend,
 		&BackendConfig{
 			LeveledLogger:     debugLeveledLogger,
-			MaxNetworkRetries: 0,
-			URL:               testServer.URL,
+			MaxNetworkRetries: Int64(0),
+			URL:               String(testServer.URL),
 		},
 	).(*BackendImplementation)
 
@@ -373,8 +373,8 @@ func TestDo_TelemetryDisabled(t *testing.T) {
 		APIBackend,
 		&BackendConfig{
 			LeveledLogger:     debugLeveledLogger,
-			MaxNetworkRetries: 0,
-			URL:               testServer.URL,
+			MaxNetworkRetries: Int64(0),
+			URL:               String(testServer.URL),
 		},
 	).(*BackendImplementation)
 
@@ -461,10 +461,10 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 	backend := GetBackendWithConfig(
 		APIBackend,
 		&BackendConfig{
+			EnableTelemetry:   Bool(true),
 			LeveledLogger:     debugLeveledLogger,
-			MaxNetworkRetries: 0,
-			URL:               testServer.URL,
-			EnableTelemetry:   true,
+			MaxNetworkRetries: Int64(0),
+			URL:               String(testServer.URL),
 		},
 	).(*BackendImplementation)
 
@@ -519,10 +519,10 @@ func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 	backend := GetBackendWithConfig(
 		APIBackend,
 		&BackendConfig{
+			EnableTelemetry:   Bool(true),
 			LeveledLogger:     debugLeveledLogger,
-			MaxNetworkRetries: 0,
-			URL:               testServer.URL,
-			EnableTelemetry:   true,
+			MaxNetworkRetries: Int64(0),
+			URL:               String(testServer.URL),
 		},
 	).(*BackendImplementation)
 
@@ -584,7 +584,7 @@ func TestGetBackendWithConfig_TrimV1Suffix(t *testing.T) {
 		backend := GetBackendWithConfig(
 			APIBackend,
 			&BackendConfig{
-				URL: "https://api.com/v1",
+				URL: String("https://api.com/v1"),
 			},
 		).(*BackendImplementation)
 
@@ -598,7 +598,7 @@ func TestGetBackendWithConfig_TrimV1Suffix(t *testing.T) {
 		backend := GetBackendWithConfig(
 			APIBackend,
 			&BackendConfig{
-				URL: "https://api.com/v1/",
+				URL: String("https://api.com/v1/"),
 			},
 		).(*BackendImplementation)
 
@@ -610,7 +610,7 @@ func TestGetBackendWithConfig_TrimV1Suffix(t *testing.T) {
 		backend := GetBackendWithConfig(
 			APIBackend,
 			&BackendConfig{
-				URL: "https://api.com",
+				URL: String("https://api.com"),
 			},
 		).(*BackendImplementation)
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -90,7 +90,7 @@ func init() {
 	stripeMockBackend := stripe.GetBackendWithConfig(
 		stripe.APIBackend,
 		&stripe.BackendConfig{
-			URL:           "https://localhost:" + port,
+			URL:           stripe.String("https://localhost:" + port),
 			HTTPClient:    httpClient,
 			LeveledLogger: stripe.DefaultLeveledLogger,
 		},


### PR DESCRIPTION
Currently, it's possible to have the library retry intermittently failed
requests by configuring `MaxNetworkRetries` on a `BackendConfig`.
Because this is a pretty useful feature that many users will never
discover because it's off by default, we've been mulling around the idea
internally to change that default on the next major so that more people
get access to it. We're about to release V71, so now is an opportune
moment.

The slight complication is that `BackendConfig.MaxNetworkRetries` is
currently a simple `int`, which means that it's hard for us to recognize
an unset value versus an explicitly set 0 (the same problem we had with
fields on parameter structs for years). So by example, this code is
problematic:

``` go
if conf.MaxNetworkRetries == 0 {
    backend.MaxNetworkRetries = 2
}
```

The most obvious solution is that change `MaxNetworkRetries` to a
nilable pointer, and have it set using our `stripe.Int64` helper,
exactly as we do for parameter structs. So compared to today,
configuring it would change like this:

``` patch
 config := &stripe.BackendConfig{
-    MaxNetworkRetries: 2,
+    MaxNetworkRetries: stripe.Int64(2),
 }
```

It's not too bad, and follows convention found elsewhere in the library,
but will require a small code update for users.

The slight follow on complication is that to make `BackendConfig`
self-consistent, I also changed the other primitives on it to also be
pointers, so `EnableTelemetry` changes from `bool` to `*bool` and `URL`
changes from `string` to `*string`. I don't think this is a big deal
because ~99% of users will probably just be using the defaults by having
left them unset.

r? @ob-stripe @remi-stripe A little more complicated than I was
originally hoping, but not too bad. I still think we should do it.
Thoughts?
cc @stripe/api-libraries

---

Note: Targets the branch in #1055 for V71 integration.