### PR TITLE
Clean up logging for next major

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ retries are safe.
 
 ### Configuring Logging
 
-Configure logging using the global `DefaultLeveledLogger` variable:
+By default, the library logs error messages only (which are sent to `stderr`).
+Configure default logging using the global `DefaultLeveledLogger` variable:
 
 ```go
 stripe.DefaultLeveledLogger = &stripe.LeveledLogger{

--- a/log_test.go
+++ b/log_test.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"bytes"
-	"log"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -13,14 +12,7 @@ import (
 //
 
 func TestDefaultLeveledLogger(t *testing.T) {
-	// We don't set DefaultLeveledLogger by default for backwards compatibility
-	// reasons. If we did, then it would override Logger, which many people
-	// have been setting over the years.
-	assert.Nil(t, DefaultLeveledLogger)
-
-	// Logger continues to be set by default so that we have a non-nil object
-	// to log against.
-	_, ok := Logger.(*log.Logger)
+	_, ok := DefaultLeveledLogger.(*LeveledLogger)
 	assert.True(t, ok)
 }
 
@@ -111,82 +103,6 @@ func TestLeveledLoggerErrorf(t *testing.T) {
 		logger.Errorf("test")
 		assert.Equal(t, "", stdout.String())
 		assert.Equal(t, "[ERROR] test\n", stderr.String())
-	}
-}
-
-//
-// leveledLoggerPrintferShim
-//
-
-func TestLeveledLoggerPrintferShimDebugf(t *testing.T) {
-	var stdout bytes.Buffer
-	logger := &leveledLoggerPrintferShim{logger: log.New(&stdout, "", 0)}
-
-	{
-		clearBuffers(&stdout)
-		logger.level = printferLevelDebug
-
-		logger.Debugf("test")
-		assert.Equal(t, "test\n", stdout.String())
-	}
-
-	// Expect no logging
-	for _, level := range []printferLevel{printferLevelInfo, printferLevelError} {
-		clearBuffers(&stdout)
-		logger.level = level
-
-		logger.Debugf("test")
-		assert.Equal(t, "", stdout.String())
-	}
-}
-
-func TestLeveledLoggerPrintferShimInfof(t *testing.T) {
-	var stdout bytes.Buffer
-	logger := &leveledLoggerPrintferShim{logger: log.New(&stdout, "", 0)}
-
-	for _, level := range []printferLevel{printferLevelDebug, printferLevelInfo} {
-		clearBuffers(&stdout)
-		logger.level = level
-
-		logger.Infof("test")
-		assert.Equal(t, "test\n", stdout.String())
-	}
-
-	// Expect no logging
-	for _, level := range []printferLevel{printferLevelError} {
-		clearBuffers(&stdout)
-		logger.level = level
-
-		logger.Infof("test")
-		assert.Equal(t, "", stdout.String())
-	}
-}
-
-// Note: behaves identically to Errorf because historically there was no
-// warning level.
-func TestLeveledLoggerPrintferShimWarnf(t *testing.T) {
-	var stdout bytes.Buffer
-	logger := &leveledLoggerPrintferShim{logger: log.New(&stdout, "", 0)}
-
-	for _, level := range []printferLevel{printferLevelDebug, printferLevelInfo, printferLevelError} {
-		clearBuffers(&stdout)
-		logger.level = level
-
-		logger.Warnf("test")
-		assert.Equal(t, "test\n", stdout.String())
-	}
-}
-
-func TestLeveledLoggerPrintferShimErrorf(t *testing.T) {
-	var stdout bytes.Buffer
-	logger := &leveledLoggerPrintferShim{logger: log.New(&stdout, "", 0)}
-
-	for _, level := range []printferLevel{printferLevelDebug, printferLevelInfo, printferLevelError} {
-		clearBuffers(&stdout)
-		logger.level = level
-
-		logger.Errorf("test")
-		assert.Equal(t, "test\n", stdout.String())
 	}
 }
 

--- a/stripe.go
+++ b/stripe.go
@@ -176,27 +176,13 @@ type BackendConfig struct {
 	// also provides out-of-the-box compatibility with a Logrus Logger, but may
 	// require a thin shim for use with other logging libraries that use less
 	// standard conventions like Zap.
+	//
+	// Defaults to DefaultLeveledLogger.
+	//
+	// To set a logger that logs nothing, set this to a stripe.LeveledLogger
+	// with a Level of LevelNull (simply setting this field to nil will not
+	// work).
 	LeveledLogger LeveledLoggerInterface
-
-	// LogLevel is the logging level of the library and defined by:
-	//
-	// 0: no logging
-	// 1: errors only
-	// 2: errors + informational (default)
-	// 3: errors + informational + debug
-	//
-	// Defaults to 0 (no logging), so please make sure to set this if you want
-	// to see logging output in your custom configuration.
-	//
-	// Deprecated: Logging should be configured with LeveledLogger instead.
-	LogLevel int
-
-	// Logger is where this backend will write its logs.
-	//
-	// If left unset, it'll be set to Logger.
-	//
-	// Deprecated: Logging should be configured with LeveledLogger instead.
-	Logger Printfer
 
 	// MaxNetworkRetries sets maximum number of times that the library will
 	// retry requests that appear to have failed due to an intermittent
@@ -813,9 +799,7 @@ func GetBackend(backendType SupportedBackend) Backend {
 		backendType,
 		&BackendConfig{
 			HTTPClient:        httpClient,
-			LeveledLogger:     DefaultLeveledLogger,
-			LogLevel:          LogLevel,
-			Logger:            Logger,
+			LeveledLogger:     nil, // Set by GetBackendWithConfiguation when nil
 			MaxNetworkRetries: 0,
 			URL:               "", // Set by GetBackendWithConfiguation when empty
 		},
@@ -835,14 +819,7 @@ func GetBackendWithConfig(backendType SupportedBackend, config *BackendConfig) B
 	}
 
 	if config.LeveledLogger == nil {
-		if config.Logger == nil {
-			config.Logger = Logger
-		}
-
-		config.LeveledLogger = &leveledLoggerPrintferShim{
-			level:  printferLevel(config.LogLevel),
-			logger: config.Logger,
-		}
+		config.LeveledLogger = DefaultLeveledLogger
 	}
 
 	switch backendType {

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -90,9 +90,9 @@ func init() {
 	stripeMockBackend := stripe.GetBackendWithConfig(
 		stripe.APIBackend,
 		&stripe.BackendConfig{
-			URL:        "https://localhost:" + port,
-			HTTPClient: httpClient,
-			Logger:     stripe.Logger,
+			URL:           "https://localhost:" + port,
+			HTTPClient:    httpClient,
+			LeveledLogger: stripe.DefaultLeveledLogger,
 		},
 	)
 	stripe.SetBackend(stripe.APIBackend, stripeMockBackend)


### PR DESCRIPTION
## Background

For a very long time, stripe-go logged by way of the `Printfer`
interface:

``` go
type Printfer interface {
       Printf(format string, v ...interface{})
}
```

`Printfer` had a few problems: it didn't allow any kind of granularity
around logging levels, didn't allow us to behave well by sending errors
to `stderr` and other output to `stdout`, and wasn't interoperable with
any popular Go loggers (it was interoperable with the one in the
stdlib's `log`, but serious programs tend to move away from that).

A while back, I introduced the new `LeveledLogger` interface, which
corrected the deficiencies with `Printfer`.

We made quite a bit of effort to stay compatible with the existing
configuration options around logging like the `Logger` and `LogLevel`
globals, while also adding new ones for the leveled logger like
`DefaultLeveledLogger`.

The downside of that is it made reasoning about the different
combinations complicated. For example, you had to know that if both
`Logger` and `DefaultLeveledLogger` were set, then the former would take
precedence, which isn't necessarily obvious.

 ## Changes in this patch

Since we're on the verge of a major, I've taken the liberty of cleaning
up all the old logging infrastructure. This involves removing its types,
interfaces, helpers, global configuration options, and local
configuration options. We're left with a much simpler setup with just
`stripe.DefaultLeveledLogger` and `BackendConfig.LeveledLogger`.

Users who were already using the leveled logger (as recommended in the
README for sometime) won't have to change anything, nor will users who
had no logging configured. Users on the old infrastructure will have to
make some config tweaks, but ones that are quite easy.

And since we're changing logging things anyway: I've made a small tweak
such that if left unset by the user, the default logger now logs errors
only (instead of errors + informational). This is a more reasonable
default on Unix systems where programs are generally not expected to be
noisy over stdout. If a user wants to get informational messages back,
it's a very easy configuration tweak to `DefaultLeveledLogger`. I think
this change is okay for the reason above, but also because I don't think
a lot of thought was ever put into the original default -- we've just
been cargo culting through releases for a long time now.

r? @ob-stripe @remi-stripe
cc @stripe/api-libraries

---

Note: Targets the branch in #1055 for V71 integration.