### PR TITLE
Fix code coverage toolchain in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
   # Install lint / code coverage / coveralls tooling
   - travis_retry go get -u golang.org/x/net/http2
   - travis_retry go get -u golang.org/x/tools/cmd/cover
-  - travis_retry go get -u github.com/modocache/gover
   - travis_retry go get -u github.com/mattn/goveralls
   - travis_retry go get -u golang.org/x/lint/golint
 
@@ -36,7 +35,6 @@ env:
     - STRIPE_MOCK_VERSION=0.87.0
 
 go:
-  - "1.9.x"
   - "1.10.x"
   - "1.11.x"
   - "1.12.x"
@@ -56,9 +54,7 @@ script:
   - make coverage
 
 after_script:
-  # Merge all coverage reports located in subdirectories and put them under: gover.coverprofile
-  - gover
   # Send code coverage report to coveralls.io
-  - goveralls -service=travis-ci -coverprofile=gover.coverprofile
+  - goveralls -service=travis-ci -coverprofile=combined.coverprofile
 
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,7 @@ vet:
 	go vet ./...
 
 coverage:
-	# go currently cannot create coverage profiles when testing multiple packages, so we test each package
-	# independently. This issue should be fixed in Go 1.10 (https://github.com/golang/go/issues/6909).
-	go list ./... | xargs -n1 -I {} -P 4 go run scripts/test_with_stripe_mock/main.go -covermode=count -coverprofile=../../../{}/profile.coverprofile {}
+	go run scripts/test_with_stripe_mock/main.go -covermode=count -coverprofile=combined.coverprofile ./...
 
 clean:
 	find . -name \*.coverprofile -delete


### PR DESCRIPTION
Unfortunately, the confluence between Go 1.13+ (which I recently added
to CI) and the change to use Go Modules is failing our coverage
pipeline. The addition of a major version in require paths seems to
confuse the scripts:

```
$ make coverage
go list ./... | xargs -n1 -I {} -P 4 go run scripts/test_with_stripe_mock/main.go -covermode=count -coverprofile=../../../{}/profile.coverprofile {}
open ../../../github.com/stripe/stripe-go/v70/accountlink/profile.coverprofile: no such file or directory
```

There's a comment on the `make coverage` task that implies that we
shouldn't need to do our `go list ./...` trick anymore because Go can
now create a full coverage report from just a single `go test ./...`
invocation. This seems to work for me locally, so I'm trying it here.

The only build this didn't work for was Go 1.9 (as implied by the
original `Makefile` comment). Instead of putting in some Travis
conditionals, I've elected just to remove that from the matrix given
it's very outdated and we're already testing against five other
versions anyway.

As far as I can tell from the Coveralls website, the change seems to be
working:

https://coveralls.io/github/stripe/stripe-go?branch=brandur-fix-coverage

r? @ob-stripe
cc @stripe/api-libraries