### PR TITLE
Add `Object` on `BankAccount`

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -155,6 +155,7 @@ type BankAccount struct {
 	ID                 string                       `json:"id"`
 	Last4              string                       `json:"last4"`
 	Metadata           map[string]string            `json:"metadata"`
+	Object             string                       `json:"object"`
 	RoutingNumber      string                       `json:"routing_number"`
 	Status             BankAccountStatus            `json:"status"`
 }


### PR DESCRIPTION
According to the [docs](https://stripe.com/docs/api/customer_bank_accounts/object), object is an attribute of the bank account object but the struct does not have such a field.