### PR TITLE
Clean up logging in some noisier tests

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -23,6 +23,10 @@ func TestErrorResponse(t *testing.T) {
 	defer ts.Close()
 
 	backend := GetBackendWithConfig(APIBackend, &BackendConfig{
+		// Suppress error log output to make a verbose run of this test less
+		// alarming (because we're testing specifically for an error).
+		LeveledLogger: &LeveledLogger{Level: LevelNull},
+
 		URL: String(ts.URL),
 	})
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -22,6 +22,13 @@ var debugLeveledLogger = &LeveledLogger{
 	Level: LevelDebug,
 }
 
+// For tests that produce a lot of logging or alarming error logs on a
+// successful run (thereby making `go test . -test.v` quite noisy), use this
+// null leveled logger instead of the debug one above.
+var nullLeveledLogger = &LeveledLogger{
+	Level: LevelNull,
+}
+
 //
 // ---
 //
@@ -100,7 +107,7 @@ func TestDo_Retry(t *testing.T) {
 	backend := GetBackendWithConfig(
 		APIBackend,
 		&BackendConfig{
-			LeveledLogger:     debugLeveledLogger,
+			LeveledLogger:     nullLeveledLogger,
 			MaxNetworkRetries: Int64(5),
 			URL:               String(testServer.URL),
 		},
@@ -260,7 +267,7 @@ func TestDo_RetryOnTimeout(t *testing.T) {
 	backend := GetBackendWithConfig(
 		APIBackend,
 		&BackendConfig{
-			LeveledLogger:     debugLeveledLogger,
+			LeveledLogger:     nullLeveledLogger,
 			MaxNetworkRetries: Int64(1),
 			URL:               String(testServer.URL),
 			HTTPClient:        &http.Client{Timeout: timeout},
@@ -520,7 +527,7 @@ func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 		APIBackend,
 		&BackendConfig{
 			EnableTelemetry:   Bool(true),
-			LeveledLogger:     debugLeveledLogger,
+			LeveledLogger:     nullLeveledLogger,
 			MaxNetworkRetries: Int64(0),
 			URL:               String(testServer.URL),
 		},


### PR DESCRIPTION
There are a few tests in the top-level package (especially in
`stripe_test.go`) that produce either (1) a lot of logging, or (2) error
logging even on a successful run. This normally isn't a problem because
Go captures output by default when `go test .` is run, but it can be a
little alarming when a test case fails and a swath of unrelated logging
is produced.

Here we still keep most test logging on by default (so you will still
see output when a test case fails), but turn off logging specifically
for tests that produce either lots of output or error output that we
expect to happen. My selection methodology was basically to go through
with a `-test.v` and eyeball for anything in either of these categories.

r? @remi-stripe
cc @stripe/api-libraries