### PR TITLE
Add support for Brazilian tax ids on `TaxID`

### DIFF
--- a/taxid.go
+++ b/taxid.go
@@ -8,6 +8,8 @@ type TaxIDType string
 // List of values that TaxIDType can take.
 const (
 	TaxIDTypeAUABN   TaxIDType = "au_abn"
+	TaxIDTypeBRCNPJ  TaxIDType = "br_cnpj"
+	TaxIDTypeBRCPF   TaxIDType = "br_cpf"
 	TaxIDTypeCABN    TaxIDType = "ca_bn"
 	TaxIDTypeCAQST   TaxIDType = "ca_qst"
 	TaxIDTypeCHVAT   TaxIDType = "ch_vat"


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 