### PR TITLE
Add support for `Metadata` for `PaymentIntentData` and `SubscriptionData` on Checkout `Session`

### DIFF
--- a/checkout/session/client_test.go
+++ b/checkout/session/client_test.go
@@ -32,6 +32,10 @@ func TestCheckoutSessionNew(t *testing.T) {
 		},
 		PaymentIntentData: &stripe.CheckoutSessionPaymentIntentDataParams{
 			Description: stripe.String("description"),
+			Metadata: map[string]string{
+				"attr1": "val1",
+				"attr2": "val2",
+			},
 			Shipping: &stripe.ShippingDetailsParams{
 				Address: &stripe.AddressParams{
 					Line1: stripe.String("line1"),
@@ -50,6 +54,10 @@ func TestCheckoutSessionNew(t *testing.T) {
 					Plan:     stripe.String("plan"),
 					Quantity: stripe.Int64(2),
 				},
+			},
+			Metadata: map[string]string{
+				"attr1": "val1",
+				"attr2": "val2",
 			},
 		},
 		SuccessURL: stripe.String("https://stripe.com/success"),

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -62,6 +62,7 @@ type CheckoutSessionPaymentIntentDataParams struct {
 	ApplicationFeeAmount      *int64                                              `form:"application_fee_amount"`
 	CaptureMethod             *string                                             `form:"capture_method"`
 	Description               *string                                             `form:"description"`
+	Metadata                  map[string]string                                   `form:"metadata"`
 	OnBehalfOf                *string                                             `form:"on_behalf_of"`
 	ReceiptEmail              *string                                             `form:"receipt_email"`
 	SetupFutureUsage          *string                                             `form:"setup_future_usage"`
@@ -101,6 +102,7 @@ type CheckoutSessionSubscriptionDataParams struct {
 	Coupon                *string                                       `form:"coupon"`
 	DefaultTaxRates       []*string                                     `form:"default_tax_rates"`
 	Items                 []*CheckoutSessionSubscriptionDataItemsParams `form:"items"`
+	Metadata              map[string]string                             `form:"metadata"`
 	TrialEnd              *int64                                        `form:"trial_end"`
 	TrialFromPlan         *bool                                         `form:"trial_from_plan"`
 	TrialPeriodDays       *int64                                        `form:"trial_period_days"`


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-go/issues/1092

r? @ob-stripe 
cc @stripe/api-libraries 