### PR TITLE
Fix parameters supported in `Recurring` for `PriceData` across the API

### DIFF
--- a/subitem.go
+++ b/subitem.go
@@ -3,11 +3,8 @@ package stripe
 // SubscriptionItemPriceDataRecurringParams is a structure representing the parameters to create
 // an inline recurring price for a subscription item.
 type SubscriptionItemPriceDataRecurringParams struct {
-	AggregateUsage  *string `form:"aggregate_usage"`
-	Interval        *string `form:"interval"`
-	IntervalCount   *int64  `form:"interval_count"`
-	TrialPeriodDays *int64  `form:"trial_period_days"`
-	UsageType       *string `form:"usage_type"`
+	Interval      *string `form:"interval"`
+	IntervalCount *int64  `form:"interval_count"`
 }
 
 // SubscriptionItemPriceDataParams is a structure representing the parameters to create an inline


### PR DESCRIPTION
This fixes some parameters shipped recently in `price_data[recurring]` even though they are not supported. This applies across the API but the main class is shared.

While technically breaking, this has never worked so we should do a minor version.

This mirrors https://github.com/stripe/stripe-java/pull/1025

r? @ob-stripe 
cc @stripe/api-libraries 