### PR TITLE
Fix misleading install instructions for stripe-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ The official [Stripe][stripe] Go client library.
 
 ## Installation
 
-Install stripe-go with:
+Make sure your project is using Go Modules (it will have a `go.mod` file in its
+root if it already is):
 
-```sh
-go get -u github.com/stripe/stripe-go
+``` sh
+go mod init
 ```
 
-Then, import it using:
+Then, reference stripe-go in a Go program with `import`:
 
 ``` go
 import (
@@ -22,6 +23,9 @@ import (
     "github.com/stripe/stripe-go/v71/customer"
 )
 ```
+
+Run any of the normal `go` commands (`build`/`install`/`test`). The Go
+toolchain will resolve and fetch the stripe-go module automatically.
 
 ## Documentation
 


### PR DESCRIPTION
Previous to Go Modules, it was often necessary to manually fetch
dependencies with `go get` before using them.

With Go Modules, the much more standard way now is to make sure a
project is initialized with Go Modules (`go mod init`), then just start
including modules in your `import` paths. Go will resolve them
automatically.

This came up in #1098 because our instructions still recommend `go get`.
Here, we change them to recommend using `go mod init` + `import`
instead.

r? @remi-stripe