### PR TITLE
Add support for `DeclineCode` on `CardError` top-level

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -550,6 +550,7 @@ func (s *BackendImplementation) ResponseToError(res *http.Response, resBody []by
 	case ErrorTypeCard:
 		cardErr := &CardError{stripeErr: raw.E.Error}
 		if raw.E.DeclineCode != nil {
+			cardErr.stripeErr.DeclineCode = *raw.E.DeclineCode
 			cardErr.DeclineCode = *raw.E.DeclineCode
 		}
 		typedError = cardErr

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -900,6 +900,7 @@ func TestResponseToError(t *testing.T) {
 	assert.Equal(t, res.Header.Get("Request-Id"), stripeErr.RequestID)
 	assert.Equal(t, res.StatusCode, stripeErr.HTTPStatusCode)
 	assert.Equal(t, expectedErr.Type, stripeErr.Type)
+	assert.Equal(t, expectedDeclineCode, stripeErr.DeclineCode)
 
 	// Not exhaustive, but verify LastResponse is basically working as
 	// expected.


### PR DESCRIPTION
hi there,

If Error.DeclineCode is added, it should be initialized when CardError occurs.
Otherwise, remove it.

fix #1114