### PR TITLE
Fix top-level `DeclineCode` deserialization in errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -296,13 +296,5 @@ func (e *RateLimitError) Error() string {
 // rawError deserializes the outer JSON object returned in an error response
 // from the API.
 type rawError struct {
-	E *rawErrorInternal `json:"error,omitempty"`
-}
-
-// rawErrorInternal embeds Error to deserialize all the standard error fields,
-// but also adds other fields that may or may not be present depending on error
-// type to help with deserialization. (e.g. DeclineCode).
-type rawErrorInternal struct {
-	*Error
-	DeclineCode *DeclineCode `json:"decline_code,omitempty"`
+	Error *Error `json:"error,omitempty"`
 }

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -900,6 +900,7 @@ func TestResponseToError(t *testing.T) {
 	assert.Equal(t, res.Header.Get("Request-Id"), stripeErr.RequestID)
 	assert.Equal(t, res.StatusCode, stripeErr.HTTPStatusCode)
 	assert.Equal(t, expectedErr.Type, stripeErr.Type)
+	assert.Equal(t, expectedDeclineCode, stripeErr.DeclineCode)
 
 	// Not exhaustive, but verify LastResponse is basically working as
 	// expected.
@@ -914,6 +915,9 @@ func TestResponseToError(t *testing.T) {
 
 	cardErr, ok := stripeErr.Err.(*CardError)
 	assert.True(t, ok)
+
+	// For backwards compatibility, `DeclineCode` is also set on the
+	// `CardError` structure.
 	assert.Equal(t, expectedDeclineCode, cardErr.DeclineCode)
 }
 


### PR DESCRIPTION
Issue #1114 reveals a bug with `DeclineCode` on the top-level error
object.

In #949, we added `DeclineCode` on the top-level error object in
addition to where it was before on the specific `CardError` type as a
minor quality of life improvement.

It seemed like a very simple change, so we didn't put in a test, but
what we forgot about at the time was that we were already doing some
weird stuff in order to extract `DeclineCode` for `CardError`.
Specifically, we'd added this special wrapper type that extended
`Error`:

``` go
// rawErrorInternal embeds Error to deserialize all the standard error fields,
// but also adds other fields that may or may not be present depending on error
// type to help with deserialization. (e.g. DeclineCode).
type rawErrorInternal struct {
	*Error
	DeclineCode *DeclineCode `json:"decline_code,omitempty"`
}
```

It added `DeclineCode` in addition to the `DeclineCode` on the embedded
`Error`. The trouble was that Go will only deserialize any given field
_once_, so `rawErrorInternal.DeclineCode` was being populated, and
`rawErrorInternal.Error.DeclineCode` was not.

I fix the problem by essentially eliminating `rawErrorInternal` and
flattening our error type structure somewhat. This results in slightly
nicer code, and also fixes deserialization of `Error.DeclineCode`.
We continue to also support `CardError.DeclineCode` for backwards
compatibility.

Fixes #1114.

r? @remi-stripe
cc @stripe/api-libraries