### PR TITLE
Add missing information for BACS Debit in `PaymentMethod`

### DIFF
--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -210,6 +210,9 @@ type PaymentMethodAUBECSDebit struct {
 
 // PaymentMethodBACSDebit represents the BACS Debit properties.
 type PaymentMethodBACSDebit struct {
+	Fingerprint string `json:"fingerprint"`
+	Last4       string `json:"last4"`
+	SortCode    string `json:"sort_code"`
 }
 
 // PaymentMethodBancontact represents the Bancontact properties.


### PR DESCRIPTION
r? @cjavilla-stripe 
cc @stripe/api-libraries @grahamhealy