### PR TITLE
Attach LastResponse after unmarshaling

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -505,13 +505,10 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v Last
 
 	s.LeveledLogger.Debugf("Response: %s", string(resBody))
 
+	err = s.UnmarshalJSONVerbose(res.StatusCode, resBody, v)
 	v.SetLastResponse(newAPIResponse(res, resBody))
 
-	if v != nil {
-		return s.UnmarshalJSONVerbose(res.StatusCode, resBody, v)
-	}
-
-	return nil
+	return err
 }
 
 // ResponseToError converts a stripe response to an Error.


### PR DESCRIPTION
If a resource has a custom `UnmarshalJSON` file like `Charge` does, we lose the `LastResponse` property of the `APIResource` due to ordering.

Additionally—there's a guard here which doesn't make much sense which I've removed. If `v` is ever nil here, we'd panic before hitting the guard.

I found it kind of awkward to write a test for this behavior—the existing test in `stripe_test.go` doesn't expose it because it has no custom UnmarshalJSON defined; if you look at the definition for `Charge` you can see it completely overwrites the object (as do several others).

r? @brandur-stripe 
cc @stripe/api-libraries 