### PR TITLE
Add support for Sofort on `PaymentMethod` and `PaymentIntent`

### DIFF
--- a/paymentintent.go
+++ b/paymentintent.go
@@ -174,6 +174,7 @@ type PaymentIntentPaymentMethodDataParams struct {
 	FPX            *PaymentMethodFPXParams         `form:"fpx"`
 	Ideal          *PaymentMethodIdealParams       `form:"ideal"`
 	SepaDebit      *PaymentMethodSepaDebitParams   `form:"sepa_debit"`
+	Sofort         *PaymentMethodSofortParams      `form:"sofort"`
 	Type           *string                         `form:"type"`
 }
 

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -25,6 +25,7 @@ const (
 	PaymentMethodTypeInteracPresent PaymentMethodType = "interac_present"
 	PaymentMethodTypeP24            PaymentMethodType = "p24"
 	PaymentMethodTypeSepaDebit      PaymentMethodType = "sepa_debit"
+	PaymentMethodTypeSofort         PaymentMethodType = "sofort"
 )
 
 // PaymentMethodCardBrand is the list of allowed values for the brand property on a
@@ -150,6 +151,12 @@ type PaymentMethodSepaDebitParams struct {
 	Iban *string `form:"iban"`
 }
 
+// PaymentMethodSofortParams is the set of parameters allowed for the `sofort` hash when
+// creating a PaymentMethod of type sofort.
+type PaymentMethodSofortParams struct {
+	Country *string `form:"country"`
+}
+
 // PaymentMethodParams is the set of parameters that can be used when creating or updating a
 // PaymentMethod.
 type PaymentMethodParams struct {
@@ -166,6 +173,7 @@ type PaymentMethodParams struct {
 	InteracPresent *PaymentMethodInteracPresentParams `form:"interac_present"`
 	P24            *PaymentMethodP24Params            `form:"p24"`
 	SepaDebit      *PaymentMethodSepaDebitParams      `form:"sepa_debit"`
+	Sofort         *PaymentMethodSofortParams         `form:"sofort"`
 	Type           *string                            `form:"type"`
 
 	// The following parameters are used when cloning a PaymentMethod to the connected account
@@ -307,6 +315,11 @@ type PaymentMethodSepaDebit struct {
 	Last4       string `json:"last4"`
 }
 
+// PaymentMethodSofort represents the Sofort-specific properties.
+type PaymentMethodSofort struct {
+	Country string `json:"country"`
+}
+
 // PaymentMethod is the resource representing a PaymentMethod.
 type PaymentMethod struct {
 	APIResource
@@ -329,6 +342,7 @@ type PaymentMethod struct {
 	Object         string                       `json:"object"`
 	P24            *PaymentMethodP24            `json:"p24"`
 	SepaDebit      *PaymentMethodSepaDebit      `json:"sepa_debit"`
+	Sofort         *PaymentMethodSofort         `json:"sofort"`
 	Type           PaymentMethodType            `json:"type"`
 }
 


### PR DESCRIPTION
Adding on behalf a user that needs this. It's my first time writing Go.

I grepped for 'ideal' in the files paymentintent.go and paymentmethod.go and followed the same pattern for Sofort. 

I don't need PaymentMethods but I figured it makes sense to add Sofort for Payment Intents / Payment Methods only once!
