### PR TITLE
Add support for multiple coupons on Billing APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.93.0
+    - STRIPE_MOCK_VERSION=0.94.0
 
 go:
   - "1.10.x"

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -44,6 +44,14 @@ func TestAccountNew(t *testing.T) {
 			SupportPhone: stripe.String("4151234567"),
 		},
 		BusinessType: stripe.String(string(stripe.AccountBusinessTypeCompany)),
+		Capabilities: &stripe.AccountCapabilitiesParams{
+			CardPayments: &stripe.AccountCapabilitiesCardPaymentsParams{
+				Requested: stripe.Bool(true),
+			},
+			Transfers: &stripe.AccountCapabilitiesTransfersParams{
+				Requested: stripe.Bool(true),
+			},
+		},
 		Company: &stripe.AccountCompanyParams{
 			DirectorsProvided: stripe.Bool(true),
 			Name:              stripe.String("company_name"),
@@ -58,9 +66,6 @@ func TestAccountNew(t *testing.T) {
 		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Token: stripe.String("tok_123"),
 		},
-		RequestedCapabilities: stripe.StringSlice([]string{
-			"card_payments",
-		}),
 		Settings: &stripe.AccountSettingsParams{
 			Branding: &stripe.AccountSettingsBrandingParams{
 				Icon: stripe.String("file_123"),

--- a/accountlink/client_test.go
+++ b/accountlink/client_test.go
@@ -14,7 +14,7 @@ func TestAccountLinkNew(t *testing.T) {
 		Collect:    stripe.String(string(stripe.AccountLinkCollectCurrentlyDue)),
 		RefreshURL: stripe.String("https://stripe.com/refresh"),
 		ReturnURL:  stripe.String("https://stripe.com/return"),
-		Type:       stripe.String(string(stripe.AccountLinkTypeCustomAccountVerification)),
+		Type:       stripe.String(string(stripe.AccountLinkTypeAccountOnboarding)),
 	}
 	link, err := New(params)
 	assert.Nil(t, err)

--- a/coupon.go
+++ b/coupon.go
@@ -50,6 +50,7 @@ type Coupon struct {
 	MaxRedemptions   int64             `json:"max_redemptions"`
 	Metadata         map[string]string `json:"metadata"`
 	Name             string            `json:"name"`
+	Object           string            `json:"object"`
 	PercentOff       float64           `json:"percent_off"`
 	RedeemBy         int64             `json:"redeem_by"`
 	TimesRedeemed    int64             `json:"times_redeemed"`

--- a/creditnote.go
+++ b/creditnote.go
@@ -118,6 +118,12 @@ type CreditNoteVoidParams struct {
 	Params `form:"*"`
 }
 
+// CreditNoteDiscountAmount represents the aggregate amounts calculated per discount for all line items.
+type CreditNoteDiscountAmount struct {
+	Amount   int64     `json:"amount"`
+	Discount *Discount `json:"discount"`
+}
+
 // CreditNoteTaxAmount represent the tax amount applied to a credit note.
 type CreditNoteTaxAmount struct {
 	Amount    int64    `json:"amount"`
@@ -135,6 +141,7 @@ type CreditNote struct {
 	Customer                   *Customer                   `json:"customer"`
 	CustomerBalanceTransaction *CustomerBalanceTransaction `json:"customer_balance_transaction"`
 	DiscountAmount             int64                       `json:"discount_amount"`
+	DiscountAmounts            []*CreditNoteDiscountAmount `json:"discount_amounts"`
 	Invoice                    *Invoice                    `json:"invoice"`
 	ID                         string                      `json:"id"`
 	Lines                      *CreditNoteLineItemList     `json:"lines"`
@@ -155,22 +162,29 @@ type CreditNote struct {
 	VoidedAt                   int64                       `json:"voided_at"`
 }
 
+// CreditNoteLineItemDiscountAmount represents the amount of discount calculated per discount for this line item.
+type CreditNoteLineItemDiscountAmount struct {
+	Amount   int64     `json:"amount"`
+	Discount *Discount `json:"discount"`
+}
+
 // CreditNoteLineItem is the resource representing a Stripe credit note line item.
 // For more details see https://stripe.com/docs/api/credit_notes/line_item
 type CreditNoteLineItem struct {
-	Amount            int64                  `json:"amount"`
-	Description       string                 `json:"description"`
-	DiscountAmount    int64                  `json:"discount_amount"`
-	ID                string                 `json:"id"`
-	InvoiceLineItem   string                 `json:"invoice_line_item"`
-	Livemode          bool                   `json:"livemode"`
-	Object            string                 `json:"object"`
-	Quantity          int64                  `json:"quantity"`
-	TaxAmounts        []*CreditNoteTaxAmount `json:"tax_amounts"`
-	TaxRates          []*TaxRate             `json:"tax_rates"`
-	Type              CreditNoteLineItemType `json:"type"`
-	UnitAmount        int64                  `json:"unit_amount"`
-	UnitAmountDecimal float64                `json:"unit_amount_decimal,string"`
+	Amount            int64                               `json:"amount"`
+	Description       string                              `json:"description"`
+	DiscountAmount    int64                               `json:"discount_amount"`
+	DiscountAmounts   []*CreditNoteLineItemDiscountAmount `json:"discount_amounts"`
+	ID                string                              `json:"id"`
+	InvoiceLineItem   string                              `json:"invoice_line_item"`
+	Livemode          bool                                `json:"livemode"`
+	Object            string                              `json:"object"`
+	Quantity          int64                               `json:"quantity"`
+	TaxAmounts        []*CreditNoteTaxAmount              `json:"tax_amounts"`
+	TaxRates          []*TaxRate                          `json:"tax_rates"`
+	Type              CreditNoteLineItemType              `json:"type"`
+	UnitAmount        int64                               `json:"unit_amount"`
+	UnitAmountDecimal float64                             `json:"unit_amount_decimal,string"`
 }
 
 // CreditNoteList is a list of credit notes as retrieved from a list endpoint.

--- a/discount.go
+++ b/discount.go
@@ -1,5 +1,7 @@
 package stripe
 
+import "encoding/json"
+
 // DiscountParams is the set of parameters that can be used when deleting a discount.
 type DiscountParams struct {
 	Params `form:"*"`
@@ -13,6 +15,29 @@ type Discount struct {
 	Customer     string  `json:"customer"`
 	Deleted      bool    `json:"deleted"`
 	End          int64   `json:"end"`
+	ID           string  `json:"id"`
+	Invoice      string  `json:"invoice"`
+	InvoiceItem  string  `json:"invoice_item"`
+	Object       string  `json:"object"`
 	Start        int64   `json:"start"`
 	Subscription string  `json:"subscription"`
+}
+
+// UnmarshalJSON handles deserialization of a Discount.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (s *Discount) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		s.ID = id
+		return nil
+	}
+
+	type discount Discount
+	var v discount
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*s = Discount(v)
+	return nil
 }

--- a/invoice.go
+++ b/invoice.go
@@ -64,6 +64,7 @@ type InvoiceUpcomingInvoiceItemParams struct {
 	Currency          *string                                 `form:"currency"`
 	Description       *string                                 `form:"description"`
 	Discountable      *bool                                   `form:"discountable"`
+	Discounts         []*InvoiceItemDiscountParams            `form:"discounts"`
 	InvoiceItem       *string                                 `form:"invoiceitem"`
 	Period            *InvoiceUpcomingInvoiceItemPeriodParams `form:"period"`
 	Price             *string                                 `form:"price"`
@@ -79,6 +80,12 @@ type InvoiceUpcomingInvoiceItemParams struct {
 type InvoiceCustomFieldParams struct {
 	Name  *string `form:"name"`
 	Value *string `form:"value"`
+}
+
+// InvoiceDiscountParams represents the parameters associated with the discounts to apply to an invoice.
+type InvoiceDiscountParams struct {
+	Coupon   *string `form:"coupon"`
+	Discount *string `form:"discount"`
 }
 
 // InvoiceTransferDataParams is the set of parameters allowed for the transfer_data hash.
@@ -101,6 +108,7 @@ type InvoiceParams struct {
 	DefaultSource        *string                     `form:"default_source"`
 	DefaultTaxRates      []*string                   `form:"default_tax_rates"`
 	Description          *string                     `form:"description"`
+	Discounts            []*InvoiceDiscountParams    `form:"discounts"`
 	DueDate              *int64                      `form:"due_date"`
 	Footer               *string                     `form:"footer"`
 	Paid                 *bool                       `form:"paid"`
@@ -242,6 +250,7 @@ type Invoice struct {
 	Deleted                      bool                     `json:"deleted"`
 	Description                  string                   `json:"description"`
 	Discount                     *Discount                `json:"discount"`
+	Discounts                    []*Discount              `json:"discounts"`
 	DueDate                      int64                    `json:"due_date"`
 	EndingBalance                int64                    `json:"ending_balance"`
 	Footer                       string                   `json:"footer"`
@@ -253,6 +262,7 @@ type Invoice struct {
 	Metadata                     map[string]string        `json:"metadata"`
 	NextPaymentAttempt           int64                    `json:"next_payment_attempt"`
 	Number                       string                   `json:"number"`
+	Object                       string                   `json:"object"`
 	Paid                         bool                     `json:"paid"`
 	PaymentIntent                *PaymentIntent           `json:"payment_intent"`
 	PeriodEnd                    int64                    `json:"period_end"`
@@ -270,6 +280,7 @@ type Invoice struct {
 	Tax                          int64                    `json:"tax"`
 	ThreasholdReason             *InvoiceThresholdReason  `json:"threshold_reason"`
 	Total                        int64                    `json:"total"`
+	TotalDiscountAmounts         []*InvoiceDiscountAmount `json:"total_discount_amounts"`
 	TotalTaxAmounts              []*InvoiceTaxAmount      `json:"total_tax_amounts"`
 	TransferData                 *InvoiceTransferData     `json:"transfer_data"`
 	WebhooksDeliveredAt          int64                    `json:"webhooks_delivered_at"`
@@ -288,6 +299,12 @@ type InvoiceCustomField struct {
 type InvoiceCustomerTaxID struct {
 	Type  TaxIDType `json:"type"`
 	Value string    `json:"value"`
+}
+
+// InvoiceDiscountAmount represents the aggregate amounts calculated per discount for all line items.
+type InvoiceDiscountAmount struct {
+	Amount   int64     `json:"amount"`
+	Discount *Discount `json:"discount"`
 }
 
 // InvoiceTaxAmount is a structure representing one of the tax amounts on an invoice.
@@ -317,28 +334,37 @@ type InvoiceList struct {
 	Data []*Invoice `json:"data"`
 }
 
+// InvoiceLineDiscountAmount represents the amount of discount calculated per discount for this line item.
+type InvoiceLineDiscountAmount struct {
+	Amount   int64     `json:"amount"`
+	Discount *Discount `json:"discount"`
+}
+
 // InvoiceLine is the resource representing a Stripe invoice line item.
 // For more details see https://stripe.com/docs/api#invoice_line_item_object.
 type InvoiceLine struct {
-	Amount           int64               `json:"amount"`
-	Currency         Currency            `json:"currency"`
-	Description      string              `json:"description"`
-	Discountable     bool                `json:"discountable"`
-	ID               string              `json:"id"`
-	InvoiceItem      string              `json:"invoice_item"`
-	Livemode         bool                `json:"livemode"`
-	Metadata         map[string]string   `json:"metadata"`
-	Period           *Period             `json:"period"`
-	Plan             *Plan               `json:"plan"`
-	Price            *Price              `json:"price"`
-	Proration        bool                `json:"proration"`
-	Quantity         int64               `json:"quantity"`
-	Subscription     string              `json:"subscription"`
-	SubscriptionItem string              `json:"subscription_item"`
-	TaxAmounts       []*InvoiceTaxAmount `json:"tax_amounts"`
-	TaxRates         []*TaxRate          `json:"tax_rates"`
-	Type             InvoiceLineType     `json:"type"`
-	UnifiedProration bool                `json:"unified_proration"`
+	Amount           int64                        `json:"amount"`
+	Currency         Currency                     `json:"currency"`
+	Description      string                       `json:"description"`
+	Discountable     bool                         `json:"discountable"`
+	Discounts        []*Discount                  `json:"discounts"`
+	DiscountAmounts  []*InvoiceLineDiscountAmount `json:"discount_amounts"`
+	ID               string                       `json:"id"`
+	InvoiceItem      string                       `json:"invoice_item"`
+	Livemode         bool                         `json:"livemode"`
+	Metadata         map[string]string            `json:"metadata"`
+	Object           string                       `json:"object"`
+	Period           *Period                      `json:"period"`
+	Plan             *Plan                        `json:"plan"`
+	Price            *Price                       `json:"price"`
+	Proration        bool                         `json:"proration"`
+	Quantity         int64                        `json:"quantity"`
+	Subscription     string                       `json:"subscription"`
+	SubscriptionItem string                       `json:"subscription_item"`
+	TaxAmounts       []*InvoiceTaxAmount          `json:"tax_amounts"`
+	TaxRates         []*TaxRate                   `json:"tax_rates"`
+	Type             InvoiceLineType              `json:"type"`
+	UnifiedProration bool                         `json:"unified_proration"`
 }
 
 // InvoiceTransferData represents the information for the transfer_data associated with an invoice.

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -26,6 +26,138 @@ func TestInvoiceParams_AppendTo(t *testing.T) {
 	}
 }
 
+func TestInvoice_Unmarshal(t *testing.T) {
+	invoiceDataUnexpanded := map[string]interface{}{
+		"id":     "in_123",
+		"object": "invoice",
+		"discounts": []string{
+			"dis_123",
+			"dis_abc",
+		},
+		"total_discount_amounts": []map[string]interface{}{
+			{
+				"amount":   123,
+				"discount": "dis_123",
+			},
+			{
+				"amount":   345,
+				"discount": "dis_abc",
+			},
+		},
+	}
+
+	bytes, err := json.Marshal(&invoiceDataUnexpanded)
+	assert.NoError(t, err)
+
+	var invoiceUnexpanded Invoice
+	err = json.Unmarshal(bytes, &invoiceUnexpanded)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "in_123", invoiceUnexpanded.ID)
+	assert.Equal(t, "invoice", invoiceUnexpanded.Object)
+
+	assert.Equal(t, 2, len(invoiceUnexpanded.Discounts))
+	assert.Equal(t, "dis_123", invoiceUnexpanded.Discounts[0].ID)
+	assert.Equal(t, "dis_abc", invoiceUnexpanded.Discounts[1].ID)
+
+	assert.Equal(t, 2, len(invoiceUnexpanded.TotalDiscountAmounts))
+	assert.Equal(t, int64(123), invoiceUnexpanded.TotalDiscountAmounts[0].Amount)
+	assert.Equal(t, "dis_123", invoiceUnexpanded.TotalDiscountAmounts[0].Discount.ID)
+	assert.Equal(t, int64(345), invoiceUnexpanded.TotalDiscountAmounts[1].Amount)
+	assert.Equal(t, "dis_abc", invoiceUnexpanded.TotalDiscountAmounts[1].Discount.ID)
+
+	invoiceDataExpanded := map[string]interface{}{
+		"id":     "in_123",
+		"object": "invoice",
+		"discounts": []map[string]interface{}{
+			{
+				"id":     "dis_123",
+				"object": "discount",
+				"coupon": map[string]interface{}{
+					"id":          "co_123",
+					"object":      "coupon",
+					"currency":    "usd",
+					"percent_off": 25.5,
+				},
+			},
+			{
+				"id":     "dis_abc",
+				"object": "discount",
+				"coupon": map[string]interface{}{
+					"id":          "co_abc",
+					"object":      "coupon",
+					"currency":    "eur",
+					"percent_off": 35.5,
+				},
+			},
+		},
+		"total_discount_amounts": []map[string]interface{}{
+			{
+				"amount": 123,
+				"discount": map[string]interface{}{
+					"id":     "dis_123",
+					"object": "discount",
+					"coupon": map[string]interface{}{
+						"id":          "co_123",
+						"object":      "coupon",
+						"currency":    "usd",
+						"percent_off": 25.5,
+					},
+				},
+			},
+			{
+				"amount": 345,
+				"discount": map[string]interface{}{
+					"id":     "dis_abc",
+					"object": "discount",
+					"coupon": map[string]interface{}{
+						"id":          "co_abc",
+						"object":      "coupon",
+						"currency":    "eur",
+						"percent_off": 35.5,
+					},
+				},
+			},
+		},
+	}
+
+	bytes2, err2 := json.Marshal(&invoiceDataExpanded)
+	assert.NoError(t, err2)
+
+	var invoiceExpanded Invoice
+	err = json.Unmarshal(bytes2, &invoiceExpanded)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "in_123", invoiceExpanded.ID)
+	assert.Equal(t, "invoice", invoiceExpanded.Object)
+
+	assert.Equal(t, 2, len(invoiceExpanded.Discounts))
+	assert.Equal(t, "dis_123", invoiceExpanded.Discounts[0].ID)
+	assert.Equal(t, "discount", invoiceExpanded.Discounts[0].Object)
+	assert.Equal(t, "co_123", invoiceExpanded.Discounts[0].Coupon.ID)
+	assert.Equal(t, "coupon", invoiceExpanded.Discounts[0].Coupon.Object)
+	assert.Equal(t, float64(25.5), invoiceExpanded.Discounts[0].Coupon.PercentOff)
+	assert.Equal(t, "dis_abc", invoiceExpanded.Discounts[1].ID)
+	assert.Equal(t, "discount", invoiceExpanded.Discounts[1].Object)
+	assert.Equal(t, "co_abc", invoiceExpanded.Discounts[1].Coupon.ID)
+	assert.Equal(t, "coupon", invoiceExpanded.Discounts[1].Coupon.Object)
+	assert.Equal(t, float64(35.5), invoiceExpanded.Discounts[1].Coupon.PercentOff)
+
+	assert.Equal(t, 2, len(invoiceExpanded.TotalDiscountAmounts))
+	assert.Equal(t, int64(123), invoiceExpanded.TotalDiscountAmounts[0].Amount)
+	assert.Equal(t, "dis_123", invoiceExpanded.TotalDiscountAmounts[0].Discount.ID)
+	assert.Equal(t, "discount", invoiceExpanded.TotalDiscountAmounts[0].Discount.Object)
+	assert.Equal(t, "co_123", invoiceExpanded.TotalDiscountAmounts[0].Discount.Coupon.ID)
+	assert.Equal(t, "coupon", invoiceExpanded.TotalDiscountAmounts[0].Discount.Coupon.Object)
+	assert.Equal(t, float64(25.5), invoiceExpanded.TotalDiscountAmounts[0].Discount.Coupon.PercentOff)
+	assert.Equal(t, int64(345), invoiceExpanded.TotalDiscountAmounts[1].Amount)
+	assert.Equal(t, "dis_abc", invoiceExpanded.TotalDiscountAmounts[1].Discount.ID)
+	assert.Equal(t, "discount", invoiceExpanded.TotalDiscountAmounts[1].Discount.Object)
+	assert.Equal(t, "co_abc", invoiceExpanded.TotalDiscountAmounts[1].Discount.Coupon.ID)
+	assert.Equal(t, "coupon", invoiceExpanded.TotalDiscountAmounts[1].Discount.Coupon.Object)
+	assert.Equal(t, float64(35.5), invoiceExpanded.TotalDiscountAmounts[1].Discount.Coupon.PercentOff)
+}
+
 func TestInvoice_UnmarshalJSON(t *testing.T) {
 	// Unmarshals from a JSON string
 	{

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -2,6 +2,12 @@ package stripe
 
 import "encoding/json"
 
+// InvoiceItemDiscountParams represents the parameters associated with the discounts to apply to an invoice item.
+type InvoiceItemDiscountParams struct {
+	Coupon   *string `form:"coupon"`
+	Discount *string `form:"discount"`
+}
+
 // InvoiceItemPeriodParams represents the period associated with that invoice item.
 type InvoiceItemPeriodParams struct {
 	End   *int64 `form:"end"`
@@ -20,20 +26,21 @@ type InvoiceItemPriceDataParams struct {
 // For more details see https://stripe.com/docs/api#create_invoiceitem and https://stripe.com/docs/api#update_invoiceitem.
 type InvoiceItemParams struct {
 	Params            `form:"*"`
-	Amount            *int64                      `form:"amount"`
-	Currency          *string                     `form:"currency"`
-	Customer          *string                     `form:"customer"`
-	Description       *string                     `form:"description"`
-	Discountable      *bool                       `form:"discountable"`
-	Invoice           *string                     `form:"invoice"`
-	Period            *InvoiceItemPeriodParams    `form:"period"`
-	Price             *string                     `form:"price"`
-	PriceData         *InvoiceItemPriceDataParams `form:"price_data"`
-	Quantity          *int64                      `form:"quantity"`
-	Subscription      *string                     `form:"subscription"`
-	TaxRates          []*string                   `form:"tax_rates"`
-	UnitAmount        *int64                      `form:"unit_amount"`
-	UnitAmountDecimal *float64                    `form:"unit_amount_decimal,high_precision"`
+	Amount            *int64                       `form:"amount"`
+	Currency          *string                      `form:"currency"`
+	Customer          *string                      `form:"customer"`
+	Description       *string                      `form:"description"`
+	Discountable      *bool                        `form:"discountable"`
+	Discounts         []*InvoiceItemDiscountParams `form:"discounts"`
+	Invoice           *string                      `form:"invoice"`
+	Period            *InvoiceItemPeriodParams     `form:"period"`
+	Price             *string                      `form:"price"`
+	PriceData         *InvoiceItemPriceDataParams  `form:"price_data"`
+	Quantity          *int64                       `form:"quantity"`
+	Subscription      *string                      `form:"subscription"`
+	TaxRates          []*string                    `form:"tax_rates"`
+	UnitAmount        *int64                       `form:"unit_amount"`
+	UnitAmountDecimal *float64                     `form:"unit_amount_decimal,high_precision"`
 }
 
 // InvoiceItemListParams is the set of parameters that can be used when listing invoice items.
@@ -58,6 +65,7 @@ type InvoiceItem struct {
 	Deleted           bool              `json:"deleted"`
 	Description       string            `json:"description"`
 	Discountable      bool              `json:"discountable"`
+	Discounts         []*Discount       `json:"discounts"`
 	ID                string            `json:"id"`
 	Invoice           *Invoice          `json:"invoice"`
 	Livemode          bool              `json:"livemode"`

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.93.0"
+	MockMinimumVersion = "0.94.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Add support for multiple coupons on Billing APIs
  * Add support for arrays of expandable API resources otherwise returning an array of strings by default
  * Add custom deserialization to `Discount` to support expansion of the object
  * Add support for `Id`, `Invoice` and `InvoiceItem` on `Discount`.
  * Add support for `Discounts` on `Invoice`, `InvoiceItem` and `InvoiceLineItem`
  * Add support for `DiscountAmounts` on `CreditNote`, `CreditNoteLineItem`, `InvoiceLineItem`
  * Add support for `TotalDiscountAmounts` on `Invoice`
  * Add `Object` to `Invoice`, `InvoiceLine`, `Discount` and `Coupon`

r? @richardm-stripe 
cc @stripe/api-libraries 

