### PR TITLE
The title property is missing from the SigmaScheduledQueryRun object

### DIFF
--- a/sigma_scheduledqueryrun.go
+++ b/sigma_scheduledqueryrun.go
@@ -37,6 +37,7 @@ type SigmaScheduledQueryRun struct {
 	SQL                  string                       `json:"sql"`
 	Status               SigmaScheduledQueryRunStatus `json:"status"`
 	Query                string                       `json:"query"`
+	Title                string                       `json:"title"`
 }
 
 // SigmaScheduledQueryRunList is a list of scheduled query runs as retrieved from a list endpoint.


### PR DESCRIPTION
This morning while parsing a received webhook I noticed that the title field is not included within the the golang struct: https://stripe.com/docs/api/sigma/scheduled_queries/object#scheduled_query_run_object-title