### PR TITLE
Copy the JSON data of EphemeralKey

### DIFF
--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -46,7 +46,7 @@ func (e *EphemeralKey) UnmarshalJSON(data []byte) error {
 		*e = EphemeralKey(ee)
 	}
 
-	e.RawJSON = data
+	e.RawJSON = append(e.RawJSON[:0], data...)
 
 	return nil
 }

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -46,6 +46,9 @@ func (e *EphemeralKey) UnmarshalJSON(data []byte) error {
 		*e = EphemeralKey(ee)
 	}
 
+	// Go does guarantee the longevity of `data`, so copy when assigning `RawJSON`
+	// See https://golang.org/pkg/encoding/json/#Unmarshaler
+	// and https://github.com/stripe/stripe-go/pull/1142
 	e.RawJSON = append(e.RawJSON[:0], data...)
 
 	return nil


### PR DESCRIPTION
The godoc of json.Unmarshaler says:

> https://golang.org/pkg/encoding/json/#Unmarshaler
> UnmarshalJSON must copy the JSON data if it wishes to retain the data after returning.

This code comes from the implementation of RawMessage.UnmarshalJSON.

https://github.com/golang/go/blob/074f2d800f2c7b741a080081cfcc5295b375b23d/src/encoding/json/stream.go#L275