### PR TITLE
Fix `ApplicationFeePercent` on `SubscriptionSchedule` to support floats

### DIFF
--- a/subschedule.go
+++ b/subschedule.go
@@ -97,23 +97,25 @@ type SubscriptionSchedulePhaseItemParams struct {
 // SubscriptionSchedulePhaseParams is a structure representing the parameters allowed to control
 // a phase on a subscription schedule.
 type SubscriptionSchedulePhaseParams struct {
-	AddInvoiceItems       []*SubscriptionSchedulePhaseAddInvoiceItemParams `form:"add_invoice_items"`
-	ApplicationFeePercent *int64                                           `form:"application_fee_percent"`
-	BillingCycleAnchor    *string                                          `form:"billing_cycle_anchor"`
-	BillingThresholds     *SubscriptionBillingThresholdsParams             `form:"billing_thresholds"`
-	CollectionMethod      *string                                          `form:"collection_method"`
-	Coupon                *string                                          `form:"coupon"`
-	DefaultPaymentMethod  *string                                          `form:"default_payment_method"`
-	DefaultTaxRates       []*string                                        `form:"default_tax_rates"`
-	EndDate               *int64                                           `form:"end_date"`
-	InvoiceSettings       *SubscriptionScheduleInvoiceSettingsParams       `form:"invoice_settings"`
-	Iterations            *int64                                           `form:"iterations"`
-	Plans                 []*SubscriptionSchedulePhaseItemParams           `form:"plans"`
-	ProrationBehavior     *string                                          `form:"proration_behavior"`
-	StartDate             *int64                                           `form:"start_date"`
-	TransferData          *SubscriptionTransferDataParams                  `form:"transfer_data"`
-	Trial                 *bool                                            `form:"trial"`
-	TrialEnd              *int64                                           `form:"trial_end"`
+	AddInvoiceItems []*SubscriptionSchedulePhaseAddInvoiceItemParams `form:"add_invoice_items"`
+	// This parameter expects a *float64 but was defined as *int64 so we're adding support for both
+	// TODO: Remove in the next major
+	ApplicationFeePercent interface{}                                `form:"application_fee_percent"`
+	BillingCycleAnchor    *string                                    `form:"billing_cycle_anchor"`
+	BillingThresholds     *SubscriptionBillingThresholdsParams       `form:"billing_thresholds"`
+	CollectionMethod      *string                                    `form:"collection_method"`
+	Coupon                *string                                    `form:"coupon"`
+	DefaultPaymentMethod  *string                                    `form:"default_payment_method"`
+	DefaultTaxRates       []*string                                  `form:"default_tax_rates"`
+	EndDate               *int64                                     `form:"end_date"`
+	InvoiceSettings       *SubscriptionScheduleInvoiceSettingsParams `form:"invoice_settings"`
+	Iterations            *int64                                     `form:"iterations"`
+	Plans                 []*SubscriptionSchedulePhaseItemParams     `form:"plans"`
+	ProrationBehavior     *string                                    `form:"proration_behavior"`
+	StartDate             *int64                                     `form:"start_date"`
+	TransferData          *SubscriptionTransferDataParams            `form:"transfer_data"`
+	Trial                 *bool                                      `form:"trial"`
+	TrialEnd              *int64                                     `form:"trial_end"`
 
 	// This parameter is deprecated and we recommend that you use TaxRates instead.
 	TaxPercent *float64 `form:"tax_percent"`

--- a/subschedule/client_test.go
+++ b/subschedule/client_test.go
@@ -71,6 +71,36 @@ func TestSubscriptionScheduleNew(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, schedule)
 }
+func TestSubscriptionScheduleNew_ApplicationFeePercent(t *testing.T) {
+	params := &stripe.SubscriptionScheduleParams{
+		Customer:     stripe.String("cus_123"),
+		StartDateNow: stripe.Bool(true),
+		Phases: []*stripe.SubscriptionSchedulePhaseParams{
+			{
+				ApplicationFeePercent: stripe.Float64(10.123),
+				Plans: []*stripe.SubscriptionSchedulePhaseItemParams{
+					{
+						Plan:     stripe.String("plan_123"),
+						Quantity: stripe.Int64(10),
+					},
+				},
+			},
+			{
+				ApplicationFeePercent: stripe.Int64(10),
+				Plans: []*stripe.SubscriptionSchedulePhaseItemParams{
+					{
+						Plan:     stripe.String("plan_789"),
+						Quantity: stripe.Int64(30),
+					},
+				},
+			},
+		},
+		EndBehavior: stripe.String(string(stripe.SubscriptionScheduleEndBehaviorCancel)),
+	}
+	schedule, err := New(params)
+	assert.Nil(t, err)
+	assert.NotNil(t, schedule)
+}
 
 func TestSubscriptionScheduleRelease(t *testing.T) {
 	params := &stripe.SubscriptionScheduleReleaseParams{


### PR DESCRIPTION
This parameter was always expecting a float but it's been `*int64` since we introduced this API in stripe-go. I went with `interface{}` since it is technically a breaking change, mirroring what we did for `off_session` on `PaymentIntent` in https://github.com/stripe/stripe-go/pull/887 We will move to the expected `*float64` in the next major instead. 

Can you confirm this is safe and okay despite also being a breaking change technically?

r? @brandur-stripe 
cc @stripe/api-libraries 