### PR TITLE
Make original list object accessible on iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ object attached to the iterator:
 ``` go
 it := coupon.List(...)
 for it.Next() {
+    // Last response *NOT* on the individual iterator object
+    it.Coupon().LastResponse // wrong
+
+    // But rather on the list object, also accessible through the iterator
     requestID := it.CouponList().LastResponse.RequestID
 }
 ```

--- a/README.md
+++ b/README.md
@@ -247,6 +247,31 @@ if err := i.Err(); err != nil {
 }
 ```
 
+### Accessing the Last Response
+
+Use `LastResponse` on any `APIResource` to look at the API response that
+generated the current object:
+
+``` go
+coupon, err := coupon.New(...)
+requestID := coupon.LastResponse.RequestID
+```
+
+Similarly, for `List` operations, the last response is available on the list
+object attached to the iterator:
+
+``` go
+it := coupon.List(...)
+for it.Next() {
+    requestID := it.CouponList().LastResponse.RequestID
+}
+```
+
+See the definition of [`APIResponse`][apiresponse] for available fields.
+
+Note that where API resources are nested in other API resources, only
+`LastResponse` on the top-level resource is set.
+
 ### Automatic Retries
 
 The library automatically retries requests on intermittent failures like on a
@@ -387,6 +412,7 @@ pull request][pulls].
 
 [api-docs]: https://stripe.com/docs/api/go
 [api-changelog]: https://stripe.com/docs/upgrades
+[apiresponse]: https://godoc.org/github.com/stripe/stripe-go#APIResponse
 [connect]: https://stripe.com/docs/connect/authentication
 [depgomodsupport]: https://github.com/golang/dep/pull/1963
 [godoc]: http://godoc.org/github.com/stripe/stripe-go

--- a/account/client.go
+++ b/account/client.go
@@ -99,7 +99,7 @@ func List(params *stripe.AccountListParams) *Iter {
 
 // List returns an iterator that iterates all accounts.
 func (c Client) List(listParams *stripe.AccountListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.AccountList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/accounts", c.Key, b, p, list)
 
@@ -108,7 +108,7 @@ func (c Client) List(listParams *stripe.AccountListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -120,6 +120,13 @@ type Iter struct {
 // Account returns the account which the iterator is currently pointing to.
 func (i *Iter) Account() *stripe.Account {
 	return i.Current().(*stripe.Account)
+}
+
+// AccountList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) AccountList() *stripe.AccountList {
+	return i.List().(*stripe.AccountList)
 }
 
 func getC() Client {

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -33,6 +33,7 @@ func TestAccountList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Account())
+	assert.NotNil(t, i.AccountList())
 }
 
 func TestAccountNew(t *testing.T) {

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -59,7 +59,7 @@ func List(params *stripe.ApplePayDomainListParams) *Iter {
 
 // List lists available Apple Pay domains.
 func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ApplePayDomainList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/apple_pay/domains", c.Key, b, p, list)
 
@@ -68,7 +68,7 @@ func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -80,6 +80,13 @@ type Iter struct {
 // ApplePayDomain returns the Apple Pay domain which the iterator is currently pointing to.
 func (i *Iter) ApplePayDomain() *stripe.ApplePayDomain {
 	return i.Current().(*stripe.ApplePayDomain)
+}
+
+// ApplePayDomainList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) ApplePayDomainList() *stripe.ApplePayDomainList {
+	return i.List().(*stripe.ApplePayDomainList)
 }
 
 func getC() Client {

--- a/applepaydomain/client_test.go
+++ b/applepaydomain/client_test.go
@@ -27,6 +27,7 @@ func TestApplePayDomainList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.ApplePayDomain())
+	assert.NotNil(t, i.ApplePayDomainList())
 }
 
 func TestApplePayDomainNew(t *testing.T) {

--- a/balancetransaction/client.go
+++ b/balancetransaction/client.go
@@ -34,7 +34,7 @@ func List(params *stripe.BalanceTransactionListParams) *Iter {
 
 // List returns a list of balance transactions.
 func (c Client) List(listParams *stripe.BalanceTransactionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.BalanceTransactionList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/balance_transactions", c.Key, b, p, list)
 
@@ -43,7 +43,7 @@ func (c Client) List(listParams *stripe.BalanceTransactionListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -55,6 +55,13 @@ type Iter struct {
 // BalanceTransaction returns the balance transaction which the iterator is currently pointing to.
 func (i *Iter) BalanceTransaction() *stripe.BalanceTransaction {
 	return i.Current().(*stripe.BalanceTransaction)
+}
+
+// BalanceTransactionList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) BalanceTransactionList() *stripe.BalanceTransactionList {
+	return i.List().(*stripe.BalanceTransactionList)
 }
 
 func getC() Client {

--- a/balancetransaction/client_test.go
+++ b/balancetransaction/client_test.go
@@ -21,4 +21,5 @@ func TestBalanceTransactionList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.BalanceTransaction())
+	assert.NotNil(t, i.BalanceTransactionList())
 }

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -151,11 +151,11 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 		outerErr = errors.New("Invalid bank account params: either Customer or Account need to be set")
 	}
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.BankAccountList{}
 
 		if outerErr != nil {
-			return nil, list.ListMeta, outerErr
+			return nil, list, outerErr
 		}
 
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -165,7 +165,7 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -177,6 +177,13 @@ type Iter struct {
 // BankAccount returns the bank account which the iterator is currently pointing to.
 func (i *Iter) BankAccount() *stripe.BankAccount {
 	return i.Current().(*stripe.BankAccount)
+}
+
+// BankAccountList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) BankAccountList() *stripe.BankAccountList {
+	return i.List().(*stripe.BankAccountList)
 }
 
 func getC() Client {

--- a/bankaccount/client_test.go
+++ b/bankaccount/client_test.go
@@ -43,6 +43,7 @@ func TestBankAccountList_ByCustomer(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.BankAccount())
+	assert.NotNil(t, i.BankAccountList())
 }
 
 func TestBankAccountNew_ByAccount(t *testing.T) {

--- a/bitcoinreceiver/client.go
+++ b/bitcoinreceiver/client.go
@@ -37,7 +37,7 @@ func List(params *stripe.BitcoinReceiverListParams) *Iter {
 
 // List returns a list of bitcoin receivers.
 func (c Client) List(listParams *stripe.BitcoinReceiverListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.BitcoinReceiverList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/bitcoin/receivers", c.Key, b, p, list)
 
@@ -46,7 +46,7 @@ func (c Client) List(listParams *stripe.BitcoinReceiverListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -58,6 +58,13 @@ type Iter struct {
 // BitcoinReceiver returns the bitcoin receiver which the iterator is currently pointing to.
 func (i *Iter) BitcoinReceiver() *stripe.BitcoinReceiver {
 	return i.Current().(*stripe.BitcoinReceiver)
+}
+
+// BitcoinReceiverList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) BitcoinReceiverList() *stripe.BitcoinReceiverList {
+	return i.List().(*stripe.BitcoinReceiverList)
 }
 
 func getC() Client {

--- a/bitcoinreceiver/client_test.go
+++ b/bitcoinreceiver/client_test.go
@@ -21,6 +21,7 @@ func TestBitcoinReceiverList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.BitcoinReceiver())
+	assert.NotNil(t, i.BitcoinReceiverList())
 }
 
 // New and Update endpoints for Bitcoin receivers no longer exist in the API or

--- a/bitcointransaction/client.go
+++ b/bitcointransaction/client.go
@@ -21,7 +21,7 @@ func List(params *stripe.BitcoinTransactionListParams) *Iter {
 
 // List returns a list of bitcoin transactions.
 func (c Client) List(listParams *stripe.BitcoinTransactionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		path := stripe.FormatURLPath("/v1/bitcoin/receivers/%s/transactions",
 			stripe.StringValue(listParams.Receiver))
 		list := &stripe.BitcoinTransactionList{}
@@ -32,7 +32,7 @@ func (c Client) List(listParams *stripe.BitcoinTransactionListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -44,6 +44,13 @@ type Iter struct {
 // BitcoinTransaction returns the bitcoin transaction which the iterator is currently pointing to.
 func (i *Iter) BitcoinTransaction() *stripe.BitcoinTransaction {
 	return i.Current().(*stripe.BitcoinTransaction)
+}
+
+// BitcoinTransactionList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) BitcoinTransactionList() *stripe.BitcoinTransactionList {
+	return i.List().(*stripe.BitcoinTransactionList)
 }
 
 func getC() Client {

--- a/bitcointransaction/client_test.go
+++ b/bitcointransaction/client_test.go
@@ -17,4 +17,5 @@ func TestBitcoinTransactionList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.BitcoinTransaction())
+	assert.NotNil(t, i.BitcoinTransactionList())
 }

--- a/capability/client.go
+++ b/capability/client.go
@@ -56,7 +56,7 @@ func List(params *stripe.CapabilityListParams) *Iter {
 func (c Client) List(listParams *stripe.CapabilityListParams) *Iter {
 	path := stripe.FormatURLPath("/v1/accounts/%s/capabilities", stripe.StringValue(listParams.Account))
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CapabilityList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -65,7 +65,7 @@ func (c Client) List(listParams *stripe.CapabilityListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -77,6 +77,13 @@ type Iter struct {
 // Capability returns the account capability which the iterator is currently pointing to.
 func (i *Iter) Capability() *stripe.Capability {
 	return i.Current().(*stripe.Capability)
+}
+
+// CapabilityList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) CapabilityList() *stripe.CapabilityList {
+	return i.List().(*stripe.CapabilityList)
 }
 
 func getC() Client {

--- a/capability/client_test.go
+++ b/capability/client_test.go
@@ -25,6 +25,7 @@ func TestCapabilityList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Capability())
+	assert.NotNil(t, i.CapabilityList())
 }
 
 func TestCapabilityUpdate(t *testing.T) {

--- a/card/client.go
+++ b/card/client.go
@@ -169,11 +169,11 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 		outerErr = errors.New("Invalid card params: either account, customer or recipient need to be set")
 	}
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CardList{}
 
 		if outerErr != nil {
-			return nil, list.ListMeta, outerErr
+			return nil, list, outerErr
 		}
 
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -183,7 +183,7 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -195,6 +195,13 @@ type Iter struct {
 // Card returns the card which the iterator is currently pointing to.
 func (i *Iter) Card() *stripe.Card {
 	return i.Current().(*stripe.Card)
+}
+
+// CardList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) CardList() *stripe.CardList {
+	return i.List().(*stripe.CardList)
 }
 
 func getC() Client {

--- a/card/client_test.go
+++ b/card/client_test.go
@@ -41,6 +41,7 @@ func TestCardList_ByCustomer(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Card())
+	assert.NotNil(t, i.CardList())
 }
 
 func TestCardList_RequiresParams(t *testing.T) {

--- a/charge/client.go
+++ b/charge/client.go
@@ -74,7 +74,7 @@ func List(params *stripe.ChargeListParams) *Iter {
 
 // List returns an iterator that iterates all charges.
 func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ChargeList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/charges", c.Key, b, p, list)
 
@@ -83,7 +83,7 @@ func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -95,6 +95,13 @@ type Iter struct {
 // Charge returns the charge which the iterator is currently pointing to.
 func (i *Iter) Charge() *stripe.Charge {
 	return i.Current().(*stripe.Charge)
+}
+
+// ChargeList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) ChargeList() *stripe.ChargeList {
+	return i.List().(*stripe.ChargeList)
 }
 
 func getC() Client {

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -29,6 +29,7 @@ func TestChargeList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Charge())
+	assert.NotNil(t, i.ChargeList())
 }
 
 func TestChargeNew(t *testing.T) {

--- a/checkout/session/client.go
+++ b/checkout/session/client.go
@@ -47,7 +47,7 @@ func List(params *stripe.CheckoutSessionListParams) *Iter {
 
 // List returns a list of sessions.
 func (c Client) List(listParams *stripe.CheckoutSessionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CheckoutSessionList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/checkout/sessions", c.Key, b, p, list)
 
@@ -56,7 +56,7 @@ func (c Client) List(listParams *stripe.CheckoutSessionListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -68,7 +68,7 @@ func ListLineItems(id string, params *stripe.CheckoutSessionListLineItemsParams)
 // ListLineItems returns a list of line items on a session.
 func (c Client) ListLineItems(id string, listParams *stripe.CheckoutSessionListLineItemsParams) *lineitem.Iter {
 	path := stripe.FormatURLPath("/v1/checkout/sessions/%s/line_items", id)
-	return &lineitem.Iter{Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &lineitem.Iter{Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.LineItemList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -77,7 +77,7 @@ func (c Client) ListLineItems(id string, listParams *stripe.CheckoutSessionListL
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -89,6 +89,13 @@ type Iter struct {
 // CheckoutSession returns the session which the iterator is currently pointing to.
 func (i *Iter) CheckoutSession() *stripe.CheckoutSession {
 	return i.Current().(*stripe.CheckoutSession)
+}
+
+// CheckoutSessionList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) CheckoutSessionList() *stripe.CheckoutSessionList {
+	return i.List().(*stripe.CheckoutSessionList)
 }
 
 func getC() Client {

--- a/checkout/session/client_test.go
+++ b/checkout/session/client_test.go
@@ -76,6 +76,7 @@ func TestCheckoutSessionList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.CheckoutSession())
+	assert.NotNil(t, i.CheckoutSessionList())
 }
 
 func TestCheckoutSessionListLineItems(t *testing.T) {
@@ -86,4 +87,5 @@ func TestCheckoutSessionListLineItems(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.LineItem())
+	assert.NotNil(t, i.LineItemList())
 }

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -34,7 +34,7 @@ func List(params *stripe.CountrySpecListParams) *Iter {
 
 // List lists available Country Specs.
 func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CountrySpecList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/country_specs", c.Key, b, p, list)
 
@@ -43,7 +43,7 @@ func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -55,6 +55,13 @@ type Iter struct {
 // CountrySpec returns the Country Spec which the iterator is currently pointing to.
 func (i *Iter) CountrySpec() *stripe.CountrySpec {
 	return i.Current().(*stripe.CountrySpec)
+}
+
+// CountrySpecList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) CountrySpecList() *stripe.CountrySpecList {
+	return i.List().(*stripe.CountrySpecList)
 }
 
 func getC() Client {

--- a/countryspec/client_test.go
+++ b/countryspec/client_test.go
@@ -21,4 +21,5 @@ func TestCountrySpecList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.CountrySpec())
+	assert.NotNil(t, i.CountrySpecList())
 }

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.CouponListParams) *Iter {
 
 // List returns a list of coupons.
 func (c Client) List(listParams *stripe.CouponListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CouponList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/coupons", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.CouponListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // Coupon returns the coupon which the iterator is currently pointing to.
 func (i *Iter) Coupon() *stripe.Coupon {
 	return i.Current().(*stripe.Coupon)
+}
+
+// CouponList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) CouponList() *stripe.CouponList {
+	return i.List().(*stripe.CouponList)
 }
 
 func getC() Client {

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -27,6 +27,7 @@ func TestCouponList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Coupon())
+	assert.NotNil(t, i.CouponList())
 }
 
 func TestCouponNew(t *testing.T) {

--- a/creditnote/client.go
+++ b/creditnote/client.go
@@ -168,7 +168,7 @@ func (i *LineItemIter) CreditNoteLineItem() *stripe.CreditNoteLineItem {
 // CreditNoteLineItemList returns the current list object which the iterator is
 // currently using. List objects will change as new API calls are made to
 // continue pagination.
-func (i *Iter) CreditNoteLineItemList() *stripe.CreditNoteLineItemList {
+func (i *LineItemIter) CreditNoteLineItemList() *stripe.CreditNoteLineItemList {
 	return i.List().(*stripe.CreditNoteLineItemList)
 }
 

--- a/creditnote/client.go
+++ b/creditnote/client.go
@@ -59,7 +59,7 @@ func List(params *stripe.CreditNoteListParams) *Iter {
 
 // List returns a list of credit notes.
 func (c Client) List(listParams *stripe.CreditNoteListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CreditNoteList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/credit_notes", c.Key, b, p, list)
 
@@ -68,7 +68,7 @@ func (c Client) List(listParams *stripe.CreditNoteListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -80,7 +80,7 @@ func ListLines(params *stripe.CreditNoteLineItemListParams) *LineItemIter {
 // ListLines returns a list of credit note line items on a credit note.
 func (c Client) ListLines(listParams *stripe.CreditNoteLineItemListParams) *LineItemIter {
 	path := stripe.FormatURLPath("/v1/credit_notes/%s/lines", stripe.StringValue(listParams.ID))
-	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CreditNoteLineItemList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -89,7 +89,7 @@ func (c Client) ListLines(listParams *stripe.CreditNoteLineItemListParams) *Line
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -100,7 +100,7 @@ func ListPreviewLines(params *stripe.CreditNoteLineItemListPreviewParams) *LineI
 
 // ListPreviewLines returns a list of lines on a previewed credit note.
 func (c Client) ListPreviewLines(listParams *stripe.CreditNoteLineItemListPreviewParams) *LineItemIter {
-	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CreditNoteLineItemList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/credit_notes/preview/lines", c.Key, b, p, list)
 
@@ -109,7 +109,7 @@ func (c Client) ListPreviewLines(listParams *stripe.CreditNoteLineItemListPrevie
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -148,6 +148,13 @@ func (i *Iter) CreditNote() *stripe.CreditNote {
 	return i.Current().(*stripe.CreditNote)
 }
 
+// CreditNoteList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) CreditNoteList() *stripe.CreditNoteList {
+	return i.List().(*stripe.CreditNoteList)
+}
+
 // LineItemIter is an iterator for credit note line items on a credit note.
 type LineItemIter struct {
 	*stripe.Iter
@@ -156,6 +163,13 @@ type LineItemIter struct {
 // CreditNoteLineItem returns the credit note line item which the iterator is currently pointing to.
 func (i *LineItemIter) CreditNoteLineItem() *stripe.CreditNoteLineItem {
 	return i.Current().(*stripe.CreditNoteLineItem)
+}
+
+// CreditNoteLineItemList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) CreditNoteLineItemList() *stripe.CreditNoteLineItemList {
+	return i.List().(*stripe.CreditNoteLineItemList)
 }
 
 func getC() Client {

--- a/creditnote/client_test.go
+++ b/creditnote/client_test.go
@@ -24,6 +24,7 @@ func TestCreditNoteList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.CreditNote())
+	assert.NotNil(t, i.CreditNoteList())
 }
 
 func TestCreditNoteListLines(t *testing.T) {
@@ -35,6 +36,7 @@ func TestCreditNoteListLines(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.CreditNoteLineItem())
+	assert.NotNil(t, i.CreditNoteLineItemList())
 }
 
 func TestCreditNoteListPreviewLines(t *testing.T) {

--- a/customer/client.go
+++ b/customer/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.CustomerListParams) *Iter {
 
 // List returns a list of customers.
 func (c Client) List(listParams *stripe.CustomerListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CustomerList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/customers", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.CustomerListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // Customer returns the customer which the iterator is currently pointing to.
 func (i *Iter) Customer() *stripe.Customer {
 	return i.Current().(*stripe.Customer)
+}
+
+// CustomerList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) CustomerList() *stripe.CustomerList {
+	return i.List().(*stripe.CustomerList)
 }
 
 func getC() Client {

--- a/customer/client_test.go
+++ b/customer/client_test.go
@@ -27,6 +27,7 @@ func TestCustomerList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Customer())
+	assert.NotNil(t, i.CustomerList())
 }
 
 func TestCustomerNew(t *testing.T) {

--- a/customerbalancetransaction/client.go
+++ b/customerbalancetransaction/client.go
@@ -58,7 +58,7 @@ func List(params *stripe.CustomerBalanceTransactionListParams) *Iter {
 func (c Client) List(listParams *stripe.CustomerBalanceTransactionListParams) *Iter {
 	path := stripe.FormatURLPath("/v1/customers/%s/balance_transactions", stripe.StringValue(listParams.Customer))
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CustomerBalanceTransactionList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -67,7 +67,7 @@ func (c Client) List(listParams *stripe.CustomerBalanceTransactionListParams) *I
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // currently pointing to.
 func (i *Iter) CustomerBalanceTransaction() *stripe.CustomerBalanceTransaction {
 	return i.Current().(*stripe.CustomerBalanceTransaction)
+}
+
+// CustomerBalanceTransactionList returns the current list object which the
+// iterator is currently using. List objects will change as new API calls are
+// made to continue pagination.
+func (i *Iter) CustomerBalanceTransactionList() *stripe.CustomerBalanceTransactionList {
+	return i.List().(*stripe.CustomerBalanceTransactionList)
 }
 
 func getC() Client {

--- a/customerbalancetransaction/client_test.go
+++ b/customerbalancetransaction/client_test.go
@@ -25,6 +25,7 @@ func TestCustomerBalanceTransactionList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.CustomerBalanceTransaction())
+	assert.NotNil(t, i.CustomerBalanceTransactionList())
 }
 
 func TestCustomerBalanceTransactionNew(t *testing.T) {

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -33,7 +33,7 @@ func List(params *stripe.DisputeListParams) *Iter {
 
 // List returns a list of disputes.
 func (c Client) List(listParams *stripe.DisputeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.DisputeList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/disputes", c.Key, b, p, list)
 
@@ -42,7 +42,7 @@ func (c Client) List(listParams *stripe.DisputeListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -80,6 +80,13 @@ type Iter struct {
 // Dispute returns the dispute which the iterator is currently pointing to.
 func (i *Iter) Dispute() *stripe.Dispute {
 	return i.Current().(*stripe.Dispute)
+}
+
+// DisputeList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) DisputeList() *stripe.DisputeList {
+	return i.List().(*stripe.DisputeList)
 }
 
 func getC() Client {

--- a/dispute/client_test.go
+++ b/dispute/client_test.go
@@ -27,6 +27,7 @@ func TestDisputeList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Dispute())
+	assert.NotNil(t, i.DisputeList())
 }
 
 func TestDisputeUpdate(t *testing.T) {

--- a/event/client.go
+++ b/event/client.go
@@ -34,7 +34,7 @@ func List(params *stripe.EventListParams) *Iter {
 
 // List returns a list of events.
 func (c Client) List(listParams *stripe.EventListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.EventList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/events", c.Key, b, p, list)
 
@@ -43,7 +43,7 @@ func (c Client) List(listParams *stripe.EventListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -55,6 +55,13 @@ type Iter struct {
 // Event returns the event which the iterator is currently pointing to.
 func (i *Iter) Event() *stripe.Event {
 	return i.Current().(*stripe.Event)
+}
+
+// EventList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) EventList() *stripe.EventList {
+	return i.List().(*stripe.EventList)
 }
 
 func getC() Client {

--- a/event/client_test.go
+++ b/event/client_test.go
@@ -21,4 +21,5 @@ func TestEventList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Event())
+	assert.NotNil(t, i.EventList())
 }

--- a/exchangerate/client.go
+++ b/exchangerate/client.go
@@ -35,7 +35,7 @@ func List(params *stripe.ExchangeRateListParams) *Iter {
 
 // List lists available exchange rates.
 func (c Client) List(listParams *stripe.ExchangeRateListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ExchangeRateList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/exchange_rates", c.Key, b, p, list)
 
@@ -44,7 +44,7 @@ func (c Client) List(listParams *stripe.ExchangeRateListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -56,6 +56,13 @@ type Iter struct {
 // ExchangeRate returns the exchange rate which the iterator is currently pointing to.
 func (i *Iter) ExchangeRate() *stripe.ExchangeRate {
 	return i.Current().(*stripe.ExchangeRate)
+}
+
+// ExchangeRateList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) ExchangeRateList() *stripe.ExchangeRateList {
+	return i.List().(*stripe.ExchangeRateList)
 }
 
 func getC() Client {

--- a/exchangerate/client_test.go
+++ b/exchangerate/client_test.go
@@ -21,4 +21,5 @@ func TestExchangeRateList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.ExchangeRate())
+	assert.NotNil(t, i.ExchangeRateList())
 }

--- a/fee/client.go
+++ b/fee/client.go
@@ -34,7 +34,7 @@ func List(params *stripe.ApplicationFeeListParams) *Iter {
 
 // List returns a list of application fees.
 func (c Client) List(listParams *stripe.ApplicationFeeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ApplicationFeeList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/application_fees", c.Key, b, p, list)
 
@@ -43,7 +43,7 @@ func (c Client) List(listParams *stripe.ApplicationFeeListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -55,6 +55,13 @@ type Iter struct {
 // ApplicationFee returns the application fee which the iterator is currently pointing to.
 func (i *Iter) ApplicationFee() *stripe.ApplicationFee {
 	return i.Current().(*stripe.ApplicationFee)
+}
+
+// ApplicationFeeList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) ApplicationFeeList() *stripe.ApplicationFeeList {
+	return i.List().(*stripe.ApplicationFeeList)
 }
 
 func getC() Client {

--- a/fee/client_test.go
+++ b/fee/client_test.go
@@ -21,4 +21,5 @@ func TestApplicationFeeList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.ApplicationFee())
+	assert.NotNil(t, i.ApplicationFeeList())
 }

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -89,7 +89,7 @@ func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
 	path := stripe.FormatURLPath("/v1/application_fees/%s/refunds",
 		stripe.StringValue(listParams.ApplicationFee))
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.FeeRefundList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -98,7 +98,7 @@ func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -110,6 +110,13 @@ type Iter struct {
 // FeeRefund returns the application fee refund which the iterator is currently pointing to.
 func (i *Iter) FeeRefund() *stripe.FeeRefund {
 	return i.Current().(*stripe.FeeRefund)
+}
+
+// FeeRefundList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) FeeRefundList() *stripe.FeeRefundList {
+	return i.List().(*stripe.FeeRefundList)
 }
 
 func getC() Client {

--- a/feerefund/client_test.go
+++ b/feerefund/client_test.go
@@ -25,6 +25,7 @@ func TestFeeRefundList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.FeeRefund())
+	assert.NotNil(t, i.FeeRefundList())
 }
 
 func TestFeeRefundNew(t *testing.T) {

--- a/file/client.go
+++ b/file/client.go
@@ -58,7 +58,7 @@ func List(params *stripe.FileListParams) *Iter {
 
 // List returns a list of files.
 func (c Client) List(listParams *stripe.FileListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.FileList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/files", c.Key, b, p, list)
 
@@ -67,7 +67,7 @@ func (c Client) List(listParams *stripe.FileListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -79,6 +79,13 @@ type Iter struct {
 // File returns the file which the iterator is currently pointing to.
 func (i *Iter) File() *stripe.File {
 	return i.Current().(*stripe.File)
+}
+
+// FileList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) FileList() *stripe.FileList {
+	return i.List().(*stripe.FileList)
 }
 
 func getC() Client {

--- a/file/client_test.go
+++ b/file/client_test.go
@@ -38,6 +38,7 @@ func TestFileList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.File())
+	assert.NotNil(t, i.FileList())
 }
 
 func TestFileNew(t *testing.T) {

--- a/filelink/client.go
+++ b/filelink/client.go
@@ -61,7 +61,7 @@ func List(params *stripe.FileLinkListParams) *Iter {
 
 // List returns an iterator that iterates all file links.
 func (c Client) List(listParams *stripe.FileLinkListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.FileLinkList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/file_links", c.Key, b, p, list)
 
@@ -70,7 +70,7 @@ func (c Client) List(listParams *stripe.FileLinkListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -82,6 +82,13 @@ type Iter struct {
 // FileLink returns the file link which the iterator is currently pointing to.
 func (i *Iter) FileLink() *stripe.FileLink {
 	return i.Current().(*stripe.FileLink)
+}
+
+// FileLinkList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) FileLinkList() *stripe.FileLinkList {
+	return i.List().(*stripe.FileLinkList)
 }
 
 func getC() Client {

--- a/filelink/client_test.go
+++ b/filelink/client_test.go
@@ -21,6 +21,7 @@ func TestFileLinkList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.FileLink())
+	assert.NotNil(t, i.FileLinkList())
 }
 
 func TestFileLinkNew(t *testing.T) {

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -213,7 +213,7 @@ func (i *LineIter) InvoiceLine() *stripe.InvoiceLine {
 // InvoiceLineList returns the current list object which the iterator is currently
 // using. List objects will change as new API calls are made to continue
 // pagination.
-func (i *Iter) InvoiceLineList() *stripe.InvoiceLineList {
+func (i *LineIter) InvoiceLineList() *stripe.InvoiceLineList {
 	return i.List().(*stripe.InvoiceLineList)
 }
 

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -97,7 +97,7 @@ func List(params *stripe.InvoiceListParams) *Iter {
 
 // List returns a list of invoices.
 func (c Client) List(listParams *stripe.InvoiceListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.InvoiceList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/invoices", c.Key, b, p, list)
 
@@ -106,7 +106,7 @@ func (c Client) List(listParams *stripe.InvoiceListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -118,7 +118,7 @@ func ListLines(params *stripe.InvoiceLineListParams) *LineIter {
 // ListLines returns a list of line items on an invoice.
 func (c Client) ListLines(listParams *stripe.InvoiceLineListParams) *LineIter {
 	path := stripe.FormatURLPath("/v1/invoices/%s/lines", stripe.StringValue(listParams.ID))
-	return &LineIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &LineIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.InvoiceLineList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -127,7 +127,7 @@ func (c Client) ListLines(listParams *stripe.InvoiceLineListParams) *LineIter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -193,6 +193,13 @@ func (i *Iter) Invoice() *stripe.Invoice {
 	return i.Current().(*stripe.Invoice)
 }
 
+// InvoiceList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) InvoiceList() *stripe.InvoiceList {
+	return i.List().(*stripe.InvoiceList)
+}
+
 // LineIter is an iterator for line items on an invoice.
 type LineIter struct {
 	*stripe.Iter
@@ -201,6 +208,13 @@ type LineIter struct {
 // InvoiceLine returns the line item which the iterator is currently pointing to.
 func (i *LineIter) InvoiceLine() *stripe.InvoiceLine {
 	return i.Current().(*stripe.InvoiceLine)
+}
+
+// InvoiceLineList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) InvoiceLineList() *stripe.InvoiceLineList {
+	return i.List().(*stripe.InvoiceLineList)
 }
 
 func getC() Client {

--- a/invoice/client_test.go
+++ b/invoice/client_test.go
@@ -21,6 +21,7 @@ func TestInvoiceList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Invoice())
+	assert.NotNil(t, i.InvoiceList())
 }
 
 func TestInvoiceListLines(t *testing.T) {
@@ -32,6 +33,7 @@ func TestInvoiceListLines(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.InvoiceLine())
+	assert.NotNil(t, i.InvoiceLineList())
 }
 
 func TestInvoiceNew(t *testing.T) {

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.InvoiceItemListParams) *Iter {
 
 // List returns a list of invoice items.
 func (c Client) List(listParams *stripe.InvoiceItemListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.InvoiceItemList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/invoiceitems", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.InvoiceItemListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // InvoiceItem returns the invoice item which the iterator is currently pointing to.
 func (i *Iter) InvoiceItem() *stripe.InvoiceItem {
 	return i.Current().(*stripe.InvoiceItem)
+}
+
+// InvoiceItemList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) InvoiceItemList() *stripe.InvoiceItemList {
+	return i.List().(*stripe.InvoiceItemList)
 }
 
 func getC() Client {

--- a/invoiceitem/client_test.go
+++ b/invoiceitem/client_test.go
@@ -27,6 +27,7 @@ func TestInvoiceItemList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.InvoiceItem())
+	assert.NotNil(t, i.InvoiceItemList())
 }
 
 func TestInvoiceItemNew(t *testing.T) {

--- a/issuing/authorization/client.go
+++ b/issuing/authorization/client.go
@@ -75,7 +75,7 @@ func List(params *stripe.IssuingAuthorizationListParams) *Iter {
 
 // List returns a list of issuing authorizations.
 func (c Client) List(listParams *stripe.IssuingAuthorizationListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.IssuingAuthorizationList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/authorizations", c.Key, b, p, list)
 
@@ -84,7 +84,7 @@ func (c Client) List(listParams *stripe.IssuingAuthorizationListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -96,6 +96,13 @@ type Iter struct {
 // IssuingAuthorization returns the issuing authorization which the iterator is currently pointing to.
 func (i *Iter) IssuingAuthorization() *stripe.IssuingAuthorization {
 	return i.Current().(*stripe.IssuingAuthorization)
+}
+
+// IssuingAuthorizationList returns the current list object which the iterator
+// is currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) IssuingAuthorizationList() *stripe.IssuingAuthorizationList {
+	return i.List().(*stripe.IssuingAuthorizationList)
 }
 
 func getC() Client {

--- a/issuing/authorization/client_test.go
+++ b/issuing/authorization/client_test.go
@@ -37,6 +37,7 @@ func TestIssuingAuthorizationList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.IssuingAuthorization())
 	assert.Equal(t, "issuing.authorization", i.IssuingAuthorization().Object)
+	assert.NotNil(t, i.IssuingAuthorizationList())
 }
 
 func TestIssuingAuthorizationUpdate(t *testing.T) {

--- a/issuing/card/client.go
+++ b/issuing/card/client.go
@@ -61,7 +61,7 @@ func List(params *stripe.IssuingCardListParams) *Iter {
 
 // List returns a list of issuing cards.
 func (c Client) List(listParams *stripe.IssuingCardListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.IssuingCardList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/cards", c.Key, b, p, list)
 
@@ -70,7 +70,7 @@ func (c Client) List(listParams *stripe.IssuingCardListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -82,6 +82,13 @@ type Iter struct {
 // IssuingCard returns the issuing card which the iterator is currently pointing to.
 func (i *Iter) IssuingCard() *stripe.IssuingCard {
 	return i.Current().(*stripe.IssuingCard)
+}
+
+// IssuingCardList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) IssuingCardList() *stripe.IssuingCardList {
+	return i.List().(*stripe.IssuingCardList)
 }
 
 func getC() Client {

--- a/issuing/card/client_test.go
+++ b/issuing/card/client_test.go
@@ -23,6 +23,7 @@ func TestIssuingCardList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.IssuingCard())
 	assert.Equal(t, "issuing.card", i.IssuingCard().Object)
+	assert.NotNil(t, i.IssuingCardList())
 }
 
 func TestIssuingCardNew(t *testing.T) {

--- a/issuing/cardholder/client.go
+++ b/issuing/cardholder/client.go
@@ -61,7 +61,7 @@ func List(params *stripe.IssuingCardholderListParams) *Iter {
 
 // List returns a list of issuing cardholders.
 func (c Client) List(listParams *stripe.IssuingCardholderListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.IssuingCardholderList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/cardholders", c.Key, b, p, list)
 
@@ -70,7 +70,7 @@ func (c Client) List(listParams *stripe.IssuingCardholderListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -82,6 +82,13 @@ type Iter struct {
 // IssuingCardholder returns the issuing cardholder which the iterator is currently pointing to.
 func (i *Iter) IssuingCardholder() *stripe.IssuingCardholder {
 	return i.Current().(*stripe.IssuingCardholder)
+}
+
+// IssuingCardholderList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) IssuingCardholderList() *stripe.IssuingCardholderList {
+	return i.List().(*stripe.IssuingCardholderList)
 }
 
 func getC() Client {

--- a/issuing/cardholder/client_test.go
+++ b/issuing/cardholder/client_test.go
@@ -23,6 +23,7 @@ func TestIssuingCardholderList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.IssuingCardholder())
 	assert.Equal(t, "issuing.cardholder", i.IssuingCardholder().Object)
+	assert.NotNil(t, i.IssuingCardholderList())
 }
 
 func TestIssuingCardholderNew(t *testing.T) {

--- a/issuing/dispute/client.go
+++ b/issuing/dispute/client.go
@@ -61,7 +61,7 @@ func List(params *stripe.IssuingDisputeListParams) *Iter {
 
 // List returns a list of issuing disputes.
 func (c Client) List(listParams *stripe.IssuingDisputeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.IssuingDisputeList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/disputes", c.Key, b, p, list)
 
@@ -70,7 +70,7 @@ func (c Client) List(listParams *stripe.IssuingDisputeListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -82,6 +82,13 @@ type Iter struct {
 // IssuingDispute returns the issuing dispute which the iterator is currently pointing to.
 func (i *Iter) IssuingDispute() *stripe.IssuingDispute {
 	return i.Current().(*stripe.IssuingDispute)
+}
+
+// IssuingDisputeList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) IssuingDisputeList() *stripe.IssuingDisputeList {
+	return i.List().(*stripe.IssuingDisputeList)
 }
 
 func getC() Client {

--- a/issuing/dispute/client_test.go
+++ b/issuing/dispute/client_test.go
@@ -23,6 +23,7 @@ func TestIssuingDisputeList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.IssuingDispute())
 	assert.Equal(t, "issuing.dispute", i.IssuingDispute().Object)
+	assert.NotNil(t, i.IssuingDisputeList())
 }
 
 func TestIssuingDisputeNew(t *testing.T) {

--- a/issuing/transaction/client.go
+++ b/issuing/transaction/client.go
@@ -49,7 +49,7 @@ func List(params *stripe.IssuingTransactionListParams) *Iter {
 
 // List returns a list of issuing transactions.
 func (c Client) List(listParams *stripe.IssuingTransactionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.IssuingTransactionList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/transactions", c.Key, b, p, list)
 
@@ -58,7 +58,7 @@ func (c Client) List(listParams *stripe.IssuingTransactionListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -70,6 +70,13 @@ type Iter struct {
 // IssuingTransaction returns the issuing transaction which the iterator is currently pointing to.
 func (i *Iter) IssuingTransaction() *stripe.IssuingTransaction {
 	return i.Current().(*stripe.IssuingTransaction)
+}
+
+// IssuingTransactionList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) IssuingTransactionList() *stripe.IssuingTransactionList {
+	return i.List().(*stripe.IssuingTransactionList)
 }
 
 func getC() Client {

--- a/issuing/transaction/client_test.go
+++ b/issuing/transaction/client_test.go
@@ -23,6 +23,7 @@ func TestIssuingTransactionList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.IssuingTransaction())
 	assert.Equal(t, "issuing.transaction", i.IssuingTransaction().Object)
+	assert.NotNil(t, i.IssuingTransactionList())
 }
 
 func TestIssuingTransactionUpdate(t *testing.T) {

--- a/iter.go
+++ b/iter.go
@@ -22,8 +22,9 @@ type Iter struct {
 	cur        interface{}
 	err        error
 	formValues *form.Values
+	list       ListContainer
 	listParams ListParams
-	meta       ListMeta
+	meta       *ListMeta
 	query      Query
 	values     []interface{}
 }
@@ -42,9 +43,15 @@ func (it *Iter) Err() error {
 	return it.err
 }
 
+// List returns the current list object which the iterator is currently using.
+// List objects will change as new API calls are made to continue pagination.
+func (it *Iter) List() ListContainer {
+	return it.list
+}
+
 // Meta returns the list metadata.
 func (it *Iter) Meta() *ListMeta {
-	return &it.meta
+	return it.meta
 }
 
 // Next advances the Iter to the next item in the list,
@@ -73,7 +80,8 @@ func (it *Iter) Next() bool {
 }
 
 func (it *Iter) getPage() {
-	it.values, it.meta, it.err = it.query(it.listParams.GetParams(), it.formValues)
+	it.values, it.list, it.err = it.query(it.listParams.GetParams(), it.formValues)
+	it.meta = it.list.GetListMeta()
 
 	if it.listParams.EndingBefore != nil {
 		// We are moving backward,
@@ -83,7 +91,7 @@ func (it *Iter) getPage() {
 }
 
 // Query is the function used to get a page listing.
-type Query func(*Params, *form.Values) ([]interface{}, ListMeta, error)
+type Query func(*Params, *form.Values) ([]interface{}, ListContainer, error)
 
 //
 // Public functions

--- a/lineitem/client.go
+++ b/lineitem/client.go
@@ -14,3 +14,8 @@ type Iter struct {
 func (i *Iter) LineItem() *stripe.LineItem {
 	return i.Current().(*stripe.LineItem)
 }
+
+// LineItemList returns the line item which the iterator is currently pointing to.
+func (i *Iter) LineItemList() *stripe.LineItemList {
+	return i.Current().(*stripe.LineItemList)
+}

--- a/lineitem/client.go
+++ b/lineitem/client.go
@@ -17,5 +17,5 @@ func (i *Iter) LineItem() *stripe.LineItem {
 
 // LineItemList returns the line item which the iterator is currently pointing to.
 func (i *Iter) LineItemList() *stripe.LineItemList {
-	return i.Current().(*stripe.LineItemList)
+	return i.List().(*stripe.LineItemList)
 }

--- a/order/client.go
+++ b/order/client.go
@@ -71,7 +71,7 @@ func List(params *stripe.OrderListParams) *Iter {
 
 // List returns a list of orders.
 func (c Client) List(listParams *stripe.OrderListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.OrderList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/orders", c.Key, b, p, list)
 
@@ -80,7 +80,7 @@ func (c Client) List(listParams *stripe.OrderListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -106,6 +106,14 @@ type Iter struct {
 func (i *Iter) Order() *stripe.Order {
 	return i.Current().(*stripe.Order)
 }
+
+// OrderList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) OrderList() *stripe.OrderList {
+	return i.List().(*stripe.OrderList)
+}
+
 func getC() Client {
 	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
 }

--- a/order/client_test.go
+++ b/order/client_test.go
@@ -25,6 +25,7 @@ func TestOrderList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Order())
+	assert.NotNil(t, i.OrderList())
 }
 
 func TestOrderNew(t *testing.T) {

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -33,7 +33,7 @@ func List(params *stripe.OrderReturnListParams) *Iter {
 
 // List returns a list of order returns.
 func (c Client) List(listParams *stripe.OrderReturnListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.OrderReturnList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/order_returns", c.Key, b, p, list)
 
@@ -42,7 +42,7 @@ func (c Client) List(listParams *stripe.OrderReturnListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -54,6 +54,13 @@ type Iter struct {
 // OrderReturn returns the order return which the iterator is currently pointing to.
 func (i *Iter) OrderReturn() *stripe.OrderReturn {
 	return i.Current().(*stripe.OrderReturn)
+}
+
+// OrderReturnList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) OrderReturnList() *stripe.OrderReturnList {
+	return i.List().(*stripe.OrderReturnList)
 }
 
 func getC() Client {

--- a/orderreturn/client_test.go
+++ b/orderreturn/client_test.go
@@ -23,4 +23,5 @@ func TestOrderReturnList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.OrderReturn())
+	assert.NotNil(t, i.OrderReturnList())
 }

--- a/params.go
+++ b/params.go
@@ -66,6 +66,13 @@ func (f Filters) AppendTo(body *form.Values, keyParts []string) {
 	}
 }
 
+// ListContainer is a general interface for which all list object structs
+// should comply. They achieve this by embedding a ListMeta struct and
+// inheriting its implementation of this interface.
+type ListContainer interface {
+	GetListMeta() *ListMeta
+}
+
 // ListMeta is the structure that contains the common properties
 // of List iterators. The Count property is only populated if the
 // total_count include option is passed in (see tests for example).
@@ -73,6 +80,13 @@ type ListMeta struct {
 	HasMore    bool   `json:"has_more"`
 	TotalCount uint32 `json:"total_count"`
 	URL        string `json:"url"`
+}
+
+// GetListMeta returns a ListMeta struct (itself). It exists because any
+// structs that embed ListMeta will inherit it, and thus implement the
+// ListContainer interface.
+func (l *ListMeta) GetListMeta() *ListMeta {
+	return l
 }
 
 // ListParams is the structure that contains the common properties

--- a/paymentintent/client.go
+++ b/paymentintent/client.go
@@ -100,7 +100,7 @@ func List(params *stripe.PaymentIntentListParams) *Iter {
 
 // List returns a list of payment intents.
 func (c Client) List(listParams *stripe.PaymentIntentListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.PaymentIntentList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/payment_intents", c.Key, b, p, list)
 
@@ -109,7 +109,7 @@ func (c Client) List(listParams *stripe.PaymentIntentListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -121,6 +121,13 @@ type Iter struct {
 // PaymentIntent returns the payment intent which the iterator is currently pointing to.
 func (i *Iter) PaymentIntent() *stripe.PaymentIntent {
 	return i.Current().(*stripe.PaymentIntent)
+}
+
+// PaymentIntentList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) PaymentIntentList() *stripe.PaymentIntentList {
+	return i.List().(*stripe.PaymentIntentList)
 }
 
 func getC() Client {

--- a/paymentintent/client_test.go
+++ b/paymentintent/client_test.go
@@ -46,6 +46,7 @@ func TestPaymentIntentList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.PaymentIntent())
+	assert.NotNil(t, i.PaymentIntentList())
 }
 
 func TestPaymentIntentNew(t *testing.T) {

--- a/paymentmethod/client.go
+++ b/paymentmethod/client.go
@@ -60,7 +60,7 @@ func List(params *stripe.PaymentMethodListParams) *Iter {
 
 // List returns a list of PaymentMethods.
 func (c Client) List(listParams *stripe.PaymentMethodListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.PaymentMethodList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/payment_methods", c.Key, b, p, list)
 
@@ -69,7 +69,7 @@ func (c Client) List(listParams *stripe.PaymentMethodListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -106,6 +106,13 @@ type Iter struct {
 // PaymentMethod returns the application fee which the iterator is currently pointing to.
 func (i *Iter) PaymentMethod() *stripe.PaymentMethod {
 	return i.Current().(*stripe.PaymentMethod)
+}
+
+// PaymentMethodList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) PaymentMethodList() *stripe.PaymentMethodList {
+	return i.List().(*stripe.PaymentMethodList)
 }
 
 func getC() Client {

--- a/paymentmethod/client_test.go
+++ b/paymentmethod/client_test.go
@@ -41,6 +41,7 @@ func TestPaymentMethodList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.PaymentMethod())
+	assert.NotNil(t, i.PaymentMethodList())
 }
 
 func TestPaymentMethodNew(t *testing.T) {

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -118,11 +118,11 @@ func (s Client) List(listParams *stripe.SourceListParams) *Iter {
 			stripe.StringValue(listParams.Customer))
 	}
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SourceList{}
 
 		if outerErr != nil {
-			return nil, list.ListMeta, outerErr
+			return nil, list, outerErr
 		}
 
 		err := s.B.CallRaw(http.MethodGet, path, s.Key, b, p, list)
@@ -132,7 +132,7 @@ func (s Client) List(listParams *stripe.SourceListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -170,6 +170,13 @@ type Iter struct {
 // PaymentSource returns the source which the iterator is currently pointing to.
 func (i *Iter) PaymentSource() *stripe.PaymentSource {
 	return i.Current().(*stripe.PaymentSource)
+}
+
+// SourceList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) SourceList() *stripe.SourceList {
+	return i.List().(*stripe.SourceList)
 }
 
 func getC() Client {

--- a/paymentsource/client_test.go
+++ b/paymentsource/client_test.go
@@ -25,6 +25,7 @@ func TestSourceList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.PaymentSource())
+	assert.NotNil(t, i.SourceList())
 }
 
 func TestSourceNew(t *testing.T) {

--- a/payout/client.go
+++ b/payout/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.PayoutListParams) *Iter {
 
 // List returns a list of payouts.
 func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.PayoutList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/payouts", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // Payout returns the payout which the iterator is currently pointing to.
 func (i *Iter) Payout() *stripe.Payout {
 	return i.Current().(*stripe.Payout)
+}
+
+// PayoutList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) PayoutList() *stripe.PayoutList {
+	return i.List().(*stripe.PayoutList)
 }
 
 func getC() Client {

--- a/payout/client_test.go
+++ b/payout/client_test.go
@@ -27,6 +27,7 @@ func TestPayoutList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Payout())
+	assert.NotNil(t, i.PayoutList())
 }
 
 func TestPayoutNew(t *testing.T) {

--- a/person/client.go
+++ b/person/client.go
@@ -83,7 +83,7 @@ func List(params *stripe.PersonListParams) *Iter {
 func (c Client) List(listParams *stripe.PersonListParams) *Iter {
 	path := stripe.FormatURLPath("/v1/accounts/%s/persons", stripe.StringValue(listParams.Account))
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.PersonList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -92,7 +92,7 @@ func (c Client) List(listParams *stripe.PersonListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -104,6 +104,13 @@ type Iter struct {
 // Person returns the account person which the iterator is currently pointing to.
 func (i *Iter) Person() *stripe.Person {
 	return i.Current().(*stripe.Person)
+}
+
+// PersonList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) PersonList() *stripe.PersonList {
+	return i.List().(*stripe.PersonList)
 }
 
 func getC() Client {

--- a/person/client_test.go
+++ b/person/client_test.go
@@ -36,6 +36,7 @@ func TestPersonList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Person())
+	assert.NotNil(t, i.PersonList())
 }
 
 func TestPersonNew(t *testing.T) {

--- a/plan/client.go
+++ b/plan/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.PlanListParams) *Iter {
 
 // List returns a list of plans.
 func (c Client) List(listParams *stripe.PlanListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.PlanList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/plans", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.PlanListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // Plan returns the plan which the iterator is currently pointing to.
 func (i *Iter) Plan() *stripe.Plan {
 	return i.Current().(*stripe.Plan)
+}
+
+// PlanList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) PlanList() *stripe.PlanList {
+	return i.List().(*stripe.PlanList)
 }
 
 func getC() Client {

--- a/plan/client_test.go
+++ b/plan/client_test.go
@@ -27,6 +27,7 @@ func TestPlanList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Plan())
+	assert.NotNil(t, i.PlanList())
 }
 
 func TestPlanNew(t *testing.T) {

--- a/price/client.go
+++ b/price/client.go
@@ -59,7 +59,7 @@ func List(params *stripe.PriceListParams) *Iter {
 
 // List returns a list of prices.
 func (c Client) List(listParams *stripe.PriceListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.PriceList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/prices", c.Key, b, p, list)
 
@@ -68,7 +68,7 @@ func (c Client) List(listParams *stripe.PriceListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -80,6 +80,13 @@ type Iter struct {
 // Price returns the price which the iterator is currently pointing to.
 func (i *Iter) Price() *stripe.Price {
 	return i.Current().(*stripe.Price)
+}
+
+// PriceList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) PriceList() *stripe.PriceList {
+	return i.List().(*stripe.PriceList)
 }
 
 func getC() Client {

--- a/price/client_test.go
+++ b/price/client_test.go
@@ -32,6 +32,7 @@ func TestPriceList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Price())
+	assert.NotNil(t, i.PriceList())
 }
 
 func TestPriceNew(t *testing.T) {

--- a/product/client.go
+++ b/product/client.go
@@ -58,7 +58,7 @@ func List(params *stripe.ProductListParams) *Iter {
 
 // List returns a list of products.
 func (c Client) List(listParams *stripe.ProductListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ProductList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/products", c.Key, b, p, list)
 
@@ -67,7 +67,7 @@ func (c Client) List(listParams *stripe.ProductListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // Product returns the product which the iterator is currently pointing to.
 func (i *Iter) Product() *stripe.Product {
 	return i.Current().(*stripe.Product)
+}
+
+// ProductList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) ProductList() *stripe.ProductList {
+	return i.List().(*stripe.ProductList)
 }
 
 func getC() Client {

--- a/product/client_test.go
+++ b/product/client_test.go
@@ -27,6 +27,7 @@ func TestProductList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Product())
+	assert.NotNil(t, i.ProductList())
 }
 
 func TestProductNew(t *testing.T) {

--- a/promotioncode/client.go
+++ b/promotioncode/client.go
@@ -59,7 +59,7 @@ func List(params *stripe.PromotionCodeListParams) *Iter {
 
 // List returns a list of promotion codes.
 func (c Client) List(listParams *stripe.PromotionCodeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.PromotionCodeList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/promotion_codes", c.Key, b, p, list)
 
@@ -68,7 +68,7 @@ func (c Client) List(listParams *stripe.PromotionCodeListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -80,6 +80,13 @@ type Iter struct {
 // PromotionCode returns the promotion code which the iterator is currently pointing to.
 func (i *Iter) PromotionCode() *stripe.PromotionCode {
 	return i.Current().(*stripe.PromotionCode)
+}
+
+// PromotionCodeList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) PromotionCodeList() *stripe.PromotionCodeList {
+	return i.List().(*stripe.PromotionCodeList)
 }
 
 func getC() Client {

--- a/promotioncode/client_test.go
+++ b/promotioncode/client_test.go
@@ -26,6 +26,7 @@ func TestPromotionCodeList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.PromotionCode())
+	assert.NotNil(t, i.PromotionCodeList())
 }
 
 func TestPromotionCodeNew(t *testing.T) {

--- a/radar/earlyfraudwarning/client.go
+++ b/radar/earlyfraudwarning/client.go
@@ -37,7 +37,7 @@ func List(params *stripe.RadarEarlyFraudWarningListParams) *Iter {
 
 // List returns a list of early fraud warnings.
 func (c Client) List(listParams *stripe.RadarEarlyFraudWarningListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.RadarEarlyFraudWarningList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/radar/early_fraud_warnings", c.Key, b, p, list)
 
@@ -46,7 +46,7 @@ func (c Client) List(listParams *stripe.RadarEarlyFraudWarningListParams) *Iter 
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -58,6 +58,13 @@ type Iter struct {
 // RadarEarlyFraudWarning returns the early fraud warning which the iterator is currently pointing to.
 func (i *Iter) RadarEarlyFraudWarning() *stripe.RadarEarlyFraudWarning {
 	return i.Current().(*stripe.RadarEarlyFraudWarning)
+}
+
+// RadarEarlyFraudWarningList returns the current list object which the
+// iterator is currently using. List objects will change as new API calls are
+// made to continue pagination.
+func (i *Iter) RadarEarlyFraudWarningList() *stripe.RadarEarlyFraudWarningList {
+	return i.List().(*stripe.RadarEarlyFraudWarningList)
 }
 
 func getC() Client {

--- a/radar/earlyfraudwarning/client_test.go
+++ b/radar/earlyfraudwarning/client_test.go
@@ -21,6 +21,7 @@ func TestRadarEarlyFraudWarningList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.RadarEarlyFraudWarning())
+	assert.NotNil(t, i.RadarEarlyFraudWarningList())
 }
 
 func TestRadarEarlyFraudWarningListByChargeID(t *testing.T) {
@@ -32,4 +33,5 @@ func TestRadarEarlyFraudWarningListByChargeID(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.RadarEarlyFraudWarning())
+	assert.NotNil(t, i.RadarEarlyFraudWarningList())
 }

--- a/radar/valuelist/client.go
+++ b/radar/valuelist/client.go
@@ -74,7 +74,7 @@ func List(params *stripe.RadarValueListListParams) *Iter {
 
 // List returns a list of vls.
 func (c Client) List(listParams *stripe.RadarValueListListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.RadarValueListList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/radar/value_lists", c.Key, b, p, list)
 
@@ -83,7 +83,7 @@ func (c Client) List(listParams *stripe.RadarValueListListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -95,6 +95,13 @@ type Iter struct {
 // RadarValueList returns the vl which the iterator is currently pointing to.
 func (i *Iter) RadarValueList() *stripe.RadarValueList {
 	return i.Current().(*stripe.RadarValueList)
+}
+
+// RadarValueListList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) RadarValueListList() *stripe.RadarValueListList {
+	return i.List().(*stripe.RadarValueListList)
 }
 
 func getC() Client {

--- a/radar/valuelist/client_test.go
+++ b/radar/valuelist/client_test.go
@@ -30,6 +30,7 @@ func TestRadarValueListList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.RadarValueList())
+	assert.NotNil(t, i.RadarValueListList())
 }
 
 func TestRadarValueListNew(t *testing.T) {

--- a/radar/valuelistitem/client.go
+++ b/radar/valuelistitem/client.go
@@ -61,7 +61,7 @@ func List(params *stripe.RadarValueListItemListParams) *Iter {
 
 // List returns a list of vlis.
 func (c Client) List(listParams *stripe.RadarValueListItemListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.RadarValueListItemList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/radar/value_list_items", c.Key, b, p, list)
 
@@ -70,7 +70,7 @@ func (c Client) List(listParams *stripe.RadarValueListItemListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -82,6 +82,13 @@ type Iter struct {
 // RadarValueListItem returns the vli which the iterator is currently pointing to.
 func (i *Iter) RadarValueListItem() *stripe.RadarValueListItem {
 	return i.Current().(*stripe.RadarValueListItem)
+}
+
+// RadarValueListItemList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) RadarValueListItemList() *stripe.RadarValueListItemList {
+	return i.List().(*stripe.RadarValueListItemList)
 }
 
 func getC() Client {

--- a/radar/valuelistitem/client_test.go
+++ b/radar/valuelistitem/client_test.go
@@ -29,6 +29,7 @@ func TestRadarValueListItemList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.RadarValueListItem())
+	assert.NotNil(t, i.RadarValueListItemList())
 }
 
 func TestRadarValueListItemNew(t *testing.T) {

--- a/recipient/client.go
+++ b/recipient/client.go
@@ -63,7 +63,7 @@ func List(params *stripe.RecipientListParams) *Iter {
 
 // List returns a list of recipients.
 func (c Client) List(listParams *stripe.RecipientListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.RecipientList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/recipients", c.Key, b, p, list)
 
@@ -72,7 +72,7 @@ func (c Client) List(listParams *stripe.RecipientListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -84,6 +84,13 @@ type Iter struct {
 // Recipient returns the recipient which the iterator is currently pointing to.
 func (i *Iter) Recipient() *stripe.Recipient {
 	return i.Current().(*stripe.Recipient)
+}
+
+// RecipientList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) RecipientList() *stripe.RecipientList {
+	return i.List().(*stripe.RecipientList)
 }
 
 func getC() Client {

--- a/recipient/client_test.go
+++ b/recipient/client_test.go
@@ -27,6 +27,7 @@ func TestRecipientList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Recipient())
+	assert.NotNil(t, i.RecipientList())
 }
 
 func TestRecipientUpdate(t *testing.T) {

--- a/refund/client.go
+++ b/refund/client.go
@@ -59,7 +59,7 @@ func List(params *stripe.RefundListParams) *Iter {
 
 // List returns a list of refunds.
 func (c Client) List(listParams *stripe.RefundListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.RefundList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/refunds", c.Key, b, p, list)
 
@@ -68,7 +68,7 @@ func (c Client) List(listParams *stripe.RefundListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -80,6 +80,13 @@ type Iter struct {
 // Refund returns the refund which the iterator is currently pointing to.
 func (i *Iter) Refund() *stripe.Refund {
 	return i.Current().(*stripe.Refund)
+}
+
+// RefundList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) RefundList() *stripe.RefundList {
+	return i.List().(*stripe.RefundList)
 }
 
 func getC() Client {

--- a/refund/client_test.go
+++ b/refund/client_test.go
@@ -21,6 +21,7 @@ func TestRefundList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Refund())
+	assert.NotNil(t, i.RefundList())
 }
 
 func TestRefundNew(t *testing.T) {

--- a/reporting/reportrun/client.go
+++ b/reporting/reportrun/client.go
@@ -48,7 +48,7 @@ func List(params *stripe.ReportRunListParams) *Iter {
 
 // List returns a list of report runs.
 func (c Client) List(listParams *stripe.ReportRunListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ReportRunList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_runs", c.Key, b, p, list)
 
@@ -57,7 +57,7 @@ func (c Client) List(listParams *stripe.ReportRunListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -69,6 +69,13 @@ type Iter struct {
 // ReportRun returns the report run which the iterator is currently pointing to.
 func (i *Iter) ReportRun() *stripe.ReportRun {
 	return i.Current().(*stripe.ReportRun)
+}
+
+// ReportRunList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) ReportRunList() *stripe.ReportRunList {
+	return i.List().(*stripe.ReportRunList)
 }
 
 func getC() Client {

--- a/reporting/reportrun/client_test.go
+++ b/reporting/reportrun/client_test.go
@@ -23,6 +23,7 @@ func TestReportRunList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.ReportRun())
 	assert.Equal(t, "reporting.report_run", i.ReportRun().Object)
+	assert.NotNil(t, i.ReportRunList())
 }
 
 func TestReportRunNew(t *testing.T) {

--- a/reporting/reporttype/client.go
+++ b/reporting/reporttype/client.go
@@ -36,7 +36,7 @@ func List(params *stripe.ReportTypeListParams) *Iter {
 
 // List returns a list of report types.
 func (c Client) List(listParams *stripe.ReportTypeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ReportTypeList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_types", c.Key, b, p, list)
 
@@ -45,7 +45,7 @@ func (c Client) List(listParams *stripe.ReportTypeListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -57,6 +57,13 @@ type Iter struct {
 // ReportType returns the report type which the iterator is currently pointing to.
 func (i *Iter) ReportType() *stripe.ReportType {
 	return i.Current().(*stripe.ReportType)
+}
+
+// ReportTypeList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) ReportTypeList() *stripe.ReportTypeList {
+	return i.List().(*stripe.ReportTypeList)
 }
 
 func getC() Client {

--- a/reporting/reporttype/client_test.go
+++ b/reporting/reporttype/client_test.go
@@ -23,4 +23,5 @@ func TestReportTestList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.ReportType())
 	assert.Equal(t, "reporting.report_type", i.ReportType().Object)
+	assert.NotNil(t, i.ReportTypeList())
 }

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -69,7 +69,7 @@ func List(params *stripe.ReversalListParams) *Iter {
 func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
 	path := stripe.FormatURLPath("/v1/transfers/%s/reversals", stripe.StringValue(listParams.Transfer))
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ReversalList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -78,7 +78,7 @@ func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -90,6 +90,13 @@ type Iter struct {
 // Reversal returns the transfer reversal which the iterator is currently pointing to.
 func (i *Iter) Reversal() *stripe.Reversal {
 	return i.Current().(*stripe.Reversal)
+}
+
+// ReversalList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) ReversalList() *stripe.ReversalList {
+	return i.List().(*stripe.ReversalList)
 }
 
 func getC() Client {

--- a/reversal/client_test.go
+++ b/reversal/client_test.go
@@ -25,6 +25,7 @@ func TestReversalList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Reversal())
+	assert.NotNil(t, i.ReversalList())
 }
 
 func TestReversalNew(t *testing.T) {

--- a/review/client.go
+++ b/review/client.go
@@ -47,7 +47,7 @@ func List(params *stripe.ReviewListParams) *Iter {
 
 // List returns a list of reviews.
 func (c Client) List(listParams *stripe.ReviewListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ReviewList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/reviews", c.Key, b, p, list)
 
@@ -56,7 +56,7 @@ func (c Client) List(listParams *stripe.ReviewListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -68,6 +68,13 @@ type Iter struct {
 // Review returns the review which the iterator is currently pointing to.
 func (i *Iter) Review() *stripe.Review {
 	return i.Current().(*stripe.Review)
+}
+
+// ReviewList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) ReviewList() *stripe.ReviewList {
+	return i.List().(*stripe.ReviewList)
 }
 
 func getC() Client {

--- a/review/client_test.go
+++ b/review/client_test.go
@@ -27,4 +27,5 @@ func TestReviewList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Review())
+	assert.NotNil(t, i.ReviewList())
 }

--- a/setupintent/client.go
+++ b/setupintent/client.go
@@ -87,7 +87,7 @@ func List(params *stripe.SetupIntentListParams) *Iter {
 
 // List returns a list of setup intents.
 func (c Client) List(listParams *stripe.SetupIntentListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SetupIntentList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/setup_intents", c.Key, b, p, list)
 
@@ -96,7 +96,7 @@ func (c Client) List(listParams *stripe.SetupIntentListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -108,6 +108,13 @@ type Iter struct {
 // SetupIntent returns the setup intent which the iterator is currently pointing to.
 func (i *Iter) SetupIntent() *stripe.SetupIntent {
 	return i.Current().(*stripe.SetupIntent)
+}
+
+// SetupIntentList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) SetupIntentList() *stripe.SetupIntentList {
+	return i.List().(*stripe.SetupIntentList)
 }
 
 func getC() Client {

--- a/setupintent/client_test.go
+++ b/setupintent/client_test.go
@@ -37,6 +37,7 @@ func TestSetupIntentList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.SetupIntent())
+	assert.NotNil(t, i.SetupIntentList())
 }
 
 func TestSetupIntentNew(t *testing.T) {

--- a/sigma/scheduledqueryrun/client.go
+++ b/sigma/scheduledqueryrun/client.go
@@ -36,7 +36,7 @@ func List(params *stripe.SigmaScheduledQueryRunListParams) *Iter {
 
 // List returns a list of scheduled query runs.
 func (c Client) List(listParams *stripe.SigmaScheduledQueryRunListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SigmaScheduledQueryRunList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/sigma/scheduled_query_runs", c.Key, b, p, list)
 
@@ -45,7 +45,7 @@ func (c Client) List(listParams *stripe.SigmaScheduledQueryRunListParams) *Iter 
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -57,6 +57,13 @@ type Iter struct {
 // SigmaScheduledQueryRun returns the scheduled query run which the iterator is currently pointing to.
 func (i *Iter) SigmaScheduledQueryRun() *stripe.SigmaScheduledQueryRun {
 	return i.Current().(*stripe.SigmaScheduledQueryRun)
+}
+
+// SigmaScheduledQueryRunList returns the current list object which the
+// iterator is currently using. List objects will change as new API calls are
+// made to continue pagination.
+func (i *Iter) SigmaScheduledQueryRunList() *stripe.SigmaScheduledQueryRunList {
+	return i.List().(*stripe.SigmaScheduledQueryRunList)
 }
 
 func getC() Client {

--- a/sigma/scheduledqueryrun/client_test.go
+++ b/sigma/scheduledqueryrun/client_test.go
@@ -23,4 +23,5 @@ func TestSigmaScheduledQueryRunList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.SigmaScheduledQueryRun())
 	assert.Equal(t, "scheduled_query_run", i.SigmaScheduledQueryRun().Object)
+	assert.NotNil(t, i.SigmaScheduledQueryRunList())
 }

--- a/sku/client.go
+++ b/sku/client.go
@@ -58,7 +58,7 @@ func List(params *stripe.SKUListParams) *Iter {
 
 // List returns a list of SKUs.
 func (c Client) List(listParams *stripe.SKUListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SKUList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/skus", c.Key, b, p, list)
 
@@ -67,7 +67,7 @@ func (c Client) List(listParams *stripe.SKUListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // SKU returns the SKU which the iterator is currently pointing to.
 func (i *Iter) SKU() *stripe.SKU {
 	return i.Current().(*stripe.SKU)
+}
+
+// SKUList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) SKUList() *stripe.SKUList {
+	return i.List().(*stripe.SKUList)
 }
 
 func getC() Client {

--- a/sku/client_test.go
+++ b/sku/client_test.go
@@ -27,6 +27,7 @@ func TestSKUList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.SKU())
+	assert.NotNil(t, i.SKUList())
 }
 
 func TestSKUNew(t *testing.T) {

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -32,11 +32,11 @@ func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 			stripe.StringValue(listParams.Source))
 	}
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SourceTransactionList{}
 
 		if outerErr != nil {
-			return nil, list.ListMeta, outerErr
+			return nil, list, outerErr
 		}
 
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -46,7 +46,7 @@ func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -58,6 +58,13 @@ type Iter struct {
 // SourceTransaction returns the source transaction which the iterator is currently pointing to.
 func (i *Iter) SourceTransaction() *stripe.SourceTransaction {
 	return i.Current().(*stripe.SourceTransaction)
+}
+
+// SourceTransactionList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) SourceTransactionList() *stripe.SourceTransactionList {
+	return i.List().(*stripe.SourceTransactionList)
 }
 
 func getC() Client {

--- a/sourcetransaction/client_test.go
+++ b/sourcetransaction/client_test.go
@@ -17,4 +17,5 @@ func TestSourceTransactionList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.SourceTransaction())
+	assert.NotNil(t, i.SourceTransactionList())
 }

--- a/sub/client.go
+++ b/sub/client.go
@@ -73,7 +73,7 @@ func List(params *stripe.SubscriptionListParams) *Iter {
 
 // List returns a list of subscriptions.
 func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SubscriptionList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/subscriptions", c.Key, b, p, list)
 
@@ -82,7 +82,7 @@ func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -94,6 +94,13 @@ type Iter struct {
 // Subscription returns the subscription which the iterator is currently pointing to.
 func (i *Iter) Subscription() *stripe.Subscription {
 	return i.Current().(*stripe.Subscription)
+}
+
+// SubscriptionList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) SubscriptionList() *stripe.SubscriptionList {
+	return i.List().(*stripe.SubscriptionList)
 }
 
 func getC() Client {

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -31,6 +31,7 @@ func TestSubscriptionList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Subscription())
+	assert.NotNil(t, i.SubscriptionList())
 }
 
 func TestSubscriptionNew(t *testing.T) {

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -73,7 +73,7 @@ func List(params *stripe.SubscriptionItemListParams) *Iter {
 
 // List returns a list of subscription items.
 func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SubscriptionItemList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/subscription_items", c.Key, b, p, list)
 
@@ -82,7 +82,7 @@ func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -94,6 +94,13 @@ type Iter struct {
 // SubscriptionItem returns the subscription item which the iterator is currently pointing to.
 func (i *Iter) SubscriptionItem() *stripe.SubscriptionItem {
 	return i.Current().(*stripe.SubscriptionItem)
+}
+
+// SubscriptionItemList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) SubscriptionItemList() *stripe.SubscriptionItemList {
+	return i.List().(*stripe.SubscriptionItemList)
 }
 
 func getC() Client {

--- a/subitem/client_test.go
+++ b/subitem/client_test.go
@@ -29,6 +29,7 @@ func TestSubscriptionItemList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.SubscriptionItem())
+	assert.NotNil(t, i.SubscriptionItemList())
 }
 
 func TestSubscriptionItemNew(t *testing.T) {

--- a/subschedule/client.go
+++ b/subschedule/client.go
@@ -47,7 +47,7 @@ func List(params *stripe.SubscriptionScheduleListParams) *Iter {
 
 // List returns a list of subscriptions.
 func (c Client) List(listParams *stripe.SubscriptionScheduleListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SubscriptionScheduleList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/subscription_schedules", c.Key, b, p, list)
 
@@ -56,7 +56,7 @@ func (c Client) List(listParams *stripe.SubscriptionScheduleListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -108,6 +108,13 @@ type Iter struct {
 // SubscriptionSchedule returns the subscription schedule which the iterator is currently pointing to.
 func (i *Iter) SubscriptionSchedule() *stripe.SubscriptionSchedule {
 	return i.Current().(*stripe.SubscriptionSchedule)
+}
+
+// SubscriptionScheduleList returns the current list object which the iterator
+// is currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) SubscriptionScheduleList() *stripe.SubscriptionScheduleList {
+	return i.List().(*stripe.SubscriptionScheduleList)
 }
 
 func getC() Client {

--- a/subschedule/client_test.go
+++ b/subschedule/client_test.go
@@ -36,6 +36,7 @@ func TestSubscriptionScheduleList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.SubscriptionSchedule())
+	assert.NotNil(t, i.SubscriptionScheduleList())
 }
 
 func TestSubscriptionScheduleNew(t *testing.T) {

--- a/taxid/client.go
+++ b/taxid/client.go
@@ -75,7 +75,7 @@ func List(params *stripe.TaxIDListParams) *Iter {
 func (c Client) List(listParams *stripe.TaxIDListParams) *Iter {
 	path := stripe.FormatURLPath("/v1/customers/%s/tax_ids", stripe.StringValue(listParams.Customer))
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.TaxIDList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -84,7 +84,7 @@ func (c Client) List(listParams *stripe.TaxIDListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -96,6 +96,13 @@ type Iter struct {
 // TaxID returns the tax id which the iterator is currently pointing to.
 func (i *Iter) TaxID() *stripe.TaxID {
 	return i.Current().(*stripe.TaxID)
+}
+
+// TaxIDList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) TaxIDList() *stripe.TaxIDList {
+	return i.List().(*stripe.TaxIDList)
 }
 
 func getC() Client {

--- a/taxid/client_test.go
+++ b/taxid/client_test.go
@@ -33,6 +33,7 @@ func TestTaxIDList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.TaxID())
+	assert.NotNil(t, i.TaxIDList())
 }
 
 func TestTaxIDNew(t *testing.T) {

--- a/taxrate/client.go
+++ b/taxrate/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.TaxRateListParams) *Iter {
 
 // List returns a list of trs.
 func (c Client) List(listParams *stripe.TaxRateListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.TaxRateList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/tax_rates", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.TaxRateListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // TaxRate returns the tr which the iterator is currently pointing to.
 func (i *Iter) TaxRate() *stripe.TaxRate {
 	return i.Current().(*stripe.TaxRate)
+}
+
+// TaxRateList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) TaxRateList() *stripe.TaxRateList {
+	return i.List().(*stripe.TaxRateList)
 }
 
 func getC() Client {

--- a/taxrate/client_test.go
+++ b/taxrate/client_test.go
@@ -21,6 +21,7 @@ func TestTaxRateList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.TaxRate())
+	assert.NotNil(t, i.TaxRateList())
 }
 
 func TestTaxRateNew(t *testing.T) {

--- a/terminal/location/client.go
+++ b/terminal/location/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.TerminalLocationListParams) *Iter {
 
 // List returns a list of terminal location.
 func (c Client) List(listParams *stripe.TerminalLocationListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.TerminalLocationList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/terminal/locations", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.TerminalLocationListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // TerminalLocation returns the terminal location which the iterator is currently pointing to.
 func (i *Iter) TerminalLocation() *stripe.TerminalLocation {
 	return i.Current().(*stripe.TerminalLocation)
+}
+
+// TerminalLocationList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) TerminalLocationList() *stripe.TerminalLocationList {
+	return i.List().(*stripe.TerminalLocationList)
 }
 
 func getC() Client {

--- a/terminal/location/client_test.go
+++ b/terminal/location/client_test.go
@@ -30,6 +30,7 @@ func TestTerminalLocationList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.TerminalLocation())
 	assert.Equal(t, "terminal.location", i.TerminalLocation().Object)
+	assert.NotNil(t, i.TerminalLocationList())
 }
 
 func TestTerminalLocationNew(t *testing.T) {

--- a/terminal/reader/client.go
+++ b/terminal/reader/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.TerminalReaderListParams) *Iter {
 
 // List returns a list of terminal readers.
 func (c Client) List(listParams *stripe.TerminalReaderListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.TerminalReaderList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/terminal/readers", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.TerminalReaderListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // TerminalReader returns the terminal reader which the iterator is currently pointing to.
 func (i *Iter) TerminalReader() *stripe.TerminalReader {
 	return i.Current().(*stripe.TerminalReader)
+}
+
+// TerminalReaderList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) TerminalReaderList() *stripe.TerminalReaderList {
+	return i.List().(*stripe.TerminalReaderList)
 }
 
 func getC() Client {

--- a/terminal/reader/client_test.go
+++ b/terminal/reader/client_test.go
@@ -30,6 +30,7 @@ func TestTerminalReaderList(t *testing.T) {
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.TerminalReader())
 	assert.Equal(t, "terminal.reader", i.TerminalReader().Object)
+	assert.NotNil(t, i.TerminalReaderList())
 }
 
 func TestTerminalReaderNew(t *testing.T) {

--- a/topup/client.go
+++ b/topup/client.go
@@ -71,7 +71,7 @@ func List(params *stripe.TopupListParams) *Iter {
 
 // List returns a list of topups.
 func (c Client) List(listParams *stripe.TopupListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.TopupList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/topups", c.Key, b, p, list)
 
@@ -80,7 +80,7 @@ func (c Client) List(listParams *stripe.TopupListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -92,6 +92,13 @@ type Iter struct {
 // Topup returns the topup item which the iterator is currently pointing to.
 func (i *Iter) Topup() *stripe.Topup {
 	return i.Current().(*stripe.Topup)
+}
+
+// TopupList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) TopupList() *stripe.TopupList {
+	return i.List().(*stripe.TopupList)
 }
 
 func getC() Client {

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -59,7 +59,7 @@ func List(params *stripe.TransferListParams) *Iter {
 
 // List returns a list of transfers.
 func (c Client) List(listParams *stripe.TransferListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.TransferList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/transfers", c.Key, b, p, list)
 
@@ -68,7 +68,7 @@ func (c Client) List(listParams *stripe.TransferListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -80,6 +80,13 @@ type Iter struct {
 // Transfer returns the transfer which the iterator is currently pointing to.
 func (i *Iter) Transfer() *stripe.Transfer {
 	return i.Current().(*stripe.Transfer)
+}
+
+// TransferList returns the current list object which the iterator is currently
+// using. List objects will change as new API calls are made to continue
+// pagination.
+func (i *Iter) TransferList() *stripe.TransferList {
+	return i.List().(*stripe.TransferList)
 }
 
 func getC() Client {

--- a/transfer/client_test.go
+++ b/transfer/client_test.go
@@ -21,6 +21,7 @@ func TestTransferList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.Transfer())
+	assert.NotNil(t, i.TransferList())
 }
 
 func TestTransferNew(t *testing.T) {

--- a/usagerecordsummary/client.go
+++ b/usagerecordsummary/client.go
@@ -21,7 +21,7 @@ func List(params *stripe.UsageRecordSummaryListParams) *Iter {
 
 // List returns an iterator that iterates all usage record summaries.
 func (c Client) List(listParams *stripe.UsageRecordSummaryListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		path := stripe.FormatURLPath("/v1/subscription_items/%s/usage_record_summaries", stripe.StringValue(listParams.SubscriptionItem))
 		list := &stripe.UsageRecordSummaryList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -31,7 +31,7 @@ func (c Client) List(listParams *stripe.UsageRecordSummaryListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -43,6 +43,13 @@ type Iter struct {
 // UsageRecordSummary returns the usage record summary which the iterator is currently pointing to.
 func (i *Iter) UsageRecordSummary() *stripe.UsageRecordSummary {
 	return i.Current().(*stripe.UsageRecordSummary)
+}
+
+// UsageRecordSummaryList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) UsageRecordSummaryList() *stripe.UsageRecordSummaryList {
+	return i.List().(*stripe.UsageRecordSummaryList)
 }
 
 func getC() Client {

--- a/usagerecordsummary/client_test.go
+++ b/usagerecordsummary/client_test.go
@@ -18,4 +18,5 @@ func TestUsageRecordSummaryList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.UsageRecordSummary())
+	assert.NotNil(t, i.UsageRecordSummaryList())
 }

--- a/webhookendpoint/client.go
+++ b/webhookendpoint/client.go
@@ -72,7 +72,7 @@ func List(params *stripe.WebhookEndpointListParams) *Iter {
 
 // List returns a list of webhook_endpoints.
 func (c Client) List(listParams *stripe.WebhookEndpointListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListMeta, error) {
+	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.WebhookEndpointList{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/webhook_endpoints", c.Key, b, p, list)
 
@@ -81,7 +81,7 @@ func (c Client) List(listParams *stripe.WebhookEndpointListParams) *Iter {
 			ret[i] = v
 		}
 
-		return ret, list.ListMeta, err
+		return ret, list, err
 	})}
 }
 
@@ -93,6 +93,13 @@ type Iter struct {
 // WebhookEndpoint returns the endpoint which the iterator is currently pointing to.
 func (i *Iter) WebhookEndpoint() *stripe.WebhookEndpoint {
 	return i.Current().(*stripe.WebhookEndpoint)
+}
+
+// WebhookEndpointList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) WebhookEndpointList() *stripe.WebhookEndpointList {
+	return i.List().(*stripe.WebhookEndpointList)
 }
 
 func getC() Client {

--- a/webhookendpoint/client_test.go
+++ b/webhookendpoint/client_test.go
@@ -27,6 +27,7 @@ func TestWebhookEndpointList(t *testing.T) {
 	assert.True(t, i.Next())
 	assert.Nil(t, i.Err())
 	assert.NotNil(t, i.WebhookEndpoint())
+	assert.NotNil(t, i.WebhookEndpointList())
 }
 
 func TestWebhookEndpointNew(t *testing.T) {


### PR DESCRIPTION
This patch makes some tweaks to `Iter` so that it doesn't just retain
list metadata, but a reference to the entirety of the list object.

This is mainly useful so that it'd be possible to access the last API
response, which could be used for things like this:

``` go
requestID := it.CustomerList().LastResponse.RequestID
```

Currently, it's not possible to access a list operation's last response
because we only set `LastResponse` on the top level API resource (which
is the list in this case), and `Iter` provides no access to that.

I also introduce a new `ListContainer` interface that all lists inherit
through their embedded `ListMeta` just to convey more typing information
so that we don't have to use an untyped `interface{}`. I think this is
fine though because it's very nicely symmetric with what we already have
for `ListParamsContainer` which has a nearly identical implementation.

The downside is that this changes the definition of `Query`:

``` go
// Old definition
type Query func(*Params, *form.Values) ([]interface{}, ListMeta, error)

// New definition
type Query func(*Params, *form.Values) ([]interface{}, ListContainer, error)
```

This is technically a breaking change because `Query` is exported from
the `stripe` package, but it's one of those changes that's very unlikely
to affect that vast majority of users because it's not a type that you'd
ever be using most of the time.

We also have to make a slight change to every existing `List` function
to adopt the new `Query` signature. I've shown what this would look like
in the changes in `customer/client.go`. Unfortunately, I can't find many
solutions to getting access to `LastResponse` that _don't_ involve
changing every `List` implementation to some degree. Similarly, we also
add a new function to every resource's `Iter` like `CustomerList` to get
back a typed version of the list object, similar to how each already has
a function to get a typed version of its API resource like `Customer()`.

Fixes #1141.

r? @remi-stripe Can you take a perfunctory initial review for this one?
Also see my last comment in #1141.