### PR TITLE
Add a note on using `go get` to get the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ import (
 Run any of the normal `go` commands (`build`/`install`/`test`). The Go
 toolchain will resolve and fetch the stripe-go module automatically.
 
+Alternatively, you can also explicitly `go get` the package into a project:
+
+```
+go get -u github.com/stripe/stripe-go/v71
+```
+
 ## Documentation
 
 For a comprehensive list of examples, check out the [API


### PR DESCRIPTION
Adds a note to the `README.md` that mentions how it's also possible to fetch the project using `go get`.