### PR TITLE
Re-enable H/2 on the default HTTP client for Go 1.15+

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -1091,6 +1091,11 @@ var httpClient = &http.Client{
 	// own HTTP client with it enabled. See `testing/testing.go`.
 	//
 	// (Written 2019/07/24.)
+	//
+	// UPDATE: With the release of Go 1.15, this bug has been fixed.
+	// As such, stripego115.go contains conditionally-compiled code that sets
+	// a different HTTP client as the default, since Go 1.15+ does not contain
+	// the aforementioned HTTP/2 bug.
 	Transport: &http.Transport{
 		TLSNextProto: make(map[string]func(string, *tls.Conn) http.RoundTripper),
 	},

--- a/stripego115.go
+++ b/stripego115.go
@@ -1,0 +1,28 @@
+// +build go1.15
+
+package stripe
+
+import "net/http"
+
+// This init block is only compiled on Go 1.15 and above
+// (per https://golang.org/cmd/go/#hdr-Build_constraints).
+//
+// Go 1.15 fixes a long-standing bug https://github.com/golang/go/issues/32441
+// that led to HTTP/2 being disabled by default in stripe-go
+// in https://github.com/stripe/stripe-go/pull/903.
+//
+// This init is guaranteed to execute after all package-level var
+// initializations have been completed, so the initialization of
+// the `httpClient` package-level var will have completed before we
+// run this init.
+//
+// Once stripe-go drops support for major Go versions below 1.15, this
+// conditional build and init block should be removed, in favor of making
+// this HTTP client the default.
+func init() {
+
+	// Sets a default HTTP client that can utilize H/2 if the upstream supports it.
+	SetHTTPClient(&http.Client{
+		Timeout: defaultHTTPTimeout,
+	})
+}


### PR DESCRIPTION
[Go 1.15](https://blog.golang.org/go1.15) fixes a [long-standing bug](https://github.com/golang/go/issues/32441) in the HTTP/2 client that led to HTTP/2 being disabled by default in stripe-go as part of https://github.com/stripe/stripe-go/pull/903.

This PR modifies the default HTTP/2 client for those users running Go 1.15 or above to remove the restriction against using HTTP/2.  It accomplishes this via the use of a `+build` tag (aka conditional compliation) of the new source file `stripego115.go`.

The bug is scheduled to be backported to [1.13.16](https://github.com/golang/go/issues/39278) and [1.14.8](https://github.com/golang/go/issues/39279), but even once those backports are complete, we can only conditionally compile against a _major_ release of Go, per https://golang.org/cmd/go/#hdr-Build_constraints:

> - a term for each Go major release, through the current version:
> “go1.1” from Go version 1.1 onward, “go1.12" from Go 1.12, and so on.


