### PR TITLE
Multiple API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.95.0
+    - STRIPE_MOCK_VERSION=0.96.0
 
 go:
   - "1.10.x"

--- a/accountlink.go
+++ b/accountlink.go
@@ -7,10 +7,6 @@ type AccountLinkType string
 const (
 	AccountLinkTypeAccountOnboarding AccountLinkType = "account_onboarding"
 	AccountLinkTypeAccountUpdate     AccountLinkType = "account_update"
-
-	// TODO: The following constants are deprecated
-	AccountLinkTypeCustomAccountUpdate       AccountLinkType = "custom_account_update"
-	AccountLinkTypeCustomAccountVerification AccountLinkType = "custom_account_verification"
 )
 
 // AccountLinkCollect describes what information the platform wants to collect with the account link.
@@ -30,11 +26,6 @@ type AccountLinkParams struct {
 	RefreshURL *string `form:"refresh_url"`
 	ReturnURL  *string `form:"return_url"`
 	Type       *string `form:"type"`
-
-	// TODO remove in the next major version
-	// Those parameters are deprecated.
-	FailureURL *string `form:"failure_url"`
-	SuccessURL *string `form:"success_url"`
 }
 
 // AccountLink is the resource representing an account link.

--- a/charge.go
+++ b/charge.go
@@ -310,11 +310,9 @@ type ChargePaymentMethodDetailsCardInstallments struct {
 // ChargePaymentMethodDetailsCardThreeDSecure represents details about 3DS associated with the
 // charge's PaymentMethod.
 type ChargePaymentMethodDetailsCardThreeDSecure struct {
-	Authenticated      bool                                                         `json:"authenticated"`
 	AuthenticationFlow ChargePaymentMethodDetailsCardThreeDSecureAuthenticationFlow `json:"authentication_flow"`
 	Result             ChargePaymentMethodDetailsCardThreeDSecureResult             `json:"result"`
 	ResultReason       ChargePaymentMethodDetailsCardThreeDSecureResultReason       `json:"result_reason"`
-	Succeeded          bool                                                         `json:"succeeded"`
 	Version            string                                                       `json:"version"`
 }
 

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -16,16 +16,6 @@ const (
 	CheckoutSessionSubmitTypePay    CheckoutSessionSubmitType = "pay"
 )
 
-// CheckoutSessionDisplayItemType is the list of allowed values for the display item type.
-type CheckoutSessionDisplayItemType string
-
-// List of values that CheckoutSessionDisplayItemType can take.
-const (
-	CheckoutSessionDisplayItemTypeCustom CheckoutSessionDisplayItemType = "custom"
-	CheckoutSessionDisplayItemTypePlan   CheckoutSessionDisplayItemType = "plan"
-	CheckoutSessionDisplayItemTypeSKU    CheckoutSessionDisplayItemType = "sku"
-)
-
 // CheckoutSessionMode is the list of allowed values for the mode on a Session.
 type CheckoutSessionMode string
 
@@ -180,24 +170,6 @@ type CheckoutSessionListParams struct {
 	Subscription  *string `form:"subscription"`
 }
 
-// CheckoutSessionDisplayItemCustom represents an item of type custom in a checkout session
-type CheckoutSessionDisplayItemCustom struct {
-	Description string   `json:"description"`
-	Images      []string `json:"images"`
-	Name        string   `json:"name"`
-}
-
-// CheckoutSessionDisplayItem represents one of the items in a checkout session.
-type CheckoutSessionDisplayItem struct {
-	Amount   int64                             `json:"amount"`
-	Currency Currency                          `json:"currency"`
-	Custom   *CheckoutSessionDisplayItemCustom `json:"custom"`
-	Quantity int64                             `json:"quantity"`
-	Plan     *Plan                             `json:"plan"`
-	SKU      *SKU                              `json:"sku"`
-	Type     CheckoutSessionDisplayItemType    `json:"type"`
-}
-
 // CheckoutSessionShippingAddressCollection is the set of parameters allowed for the
 // shipping address collection.
 type CheckoutSessionShippingAddressCollection struct {
@@ -242,7 +214,6 @@ type CheckoutSession struct {
 	Customer                  *Customer                                 `json:"customer"`
 	CustomerEmail             string                                    `json:"customer_email"`
 	Deleted                   bool                                      `json:"deleted"`
-	DisplayItems              []*CheckoutSessionDisplayItem             `json:"display_items"`
 	ID                        string                                    `json:"id"`
 	LineItems                 *LineItemList                             `json:"line_items"`
 	Livemode                  bool                                      `json:"livemode"`

--- a/customer.go
+++ b/customer.go
@@ -37,12 +37,6 @@ type CustomerParams struct {
 	TaxExempt           *string                        `form:"tax_exempt"`
 	TaxIDData           []*CustomerTaxIDDataParams     `form:"tax_id_data"`
 	Token               *string                        `form:"-"` // This doesn't seem to be used?
-
-	// The parameters below are considered deprecated. Consider creating a Subscription separately instead.
-	Plan       *string  `form:"plan"`
-	Quantity   *int64   `form:"quantity"`
-	TaxPercent *float64 `form:"tax_percent"`
-	TrialEnd   *int64   `form:"trial_end"`
 }
 
 // CustomerInvoiceCustomFieldParams represents the parameters associated with one custom field on

--- a/invoice.go
+++ b/invoice.go
@@ -129,18 +129,11 @@ type InvoiceParams struct {
 	SubscriptionDefaultTaxRates             []*string                           `form:"subscription_default_tax_rates"`
 	SubscriptionItems                       []*SubscriptionItemsParams          `form:"subscription_items"`
 	SubscriptionPlan                        *string                             `form:"subscription_plan"`
-	SubscriptionProrate                     *bool                               `form:"subscription_prorate"`
 	SubscriptionProrationBehavior           *string                             `form:"subscription_proration_behavior"`
 	SubscriptionProrationDate               *int64                              `form:"subscription_proration_date"`
 	SubscriptionQuantity                    *int64                              `form:"subscription_quantity"`
 	SubscriptionTrialEnd                    *int64                              `form:"subscription_trial_end"`
 	SubscriptionTrialFromPlan               *bool                               `form:"subscription_trial_from_plan"`
-
-	// This parameter is deprecated and we recommend that you use DefaultTaxRates instead.
-	TaxPercent *float64 `form:"tax_percent"`
-
-	// This parameter is deprecated and we recommend that you use SubscriptionDefaultTaxRates instead.
-	SubscriptionTaxPercent *float64 `form:"subscription_tax_percent"`
 }
 
 // AppendTo implements custom encoding logic for InvoiceParams so that the special
@@ -284,9 +277,6 @@ type Invoice struct {
 	TotalTaxAmounts              []*InvoiceTaxAmount      `json:"total_tax_amounts"`
 	TransferData                 *InvoiceTransferData     `json:"transfer_data"`
 	WebhooksDeliveredAt          int64                    `json:"webhooks_delivered_at"`
-
-	// This field is deprecated and we recommend that you use TaxRates instead.
-	TaxPercent float64 `json:"tax_percent"`
 }
 
 // InvoiceCustomField is a structure representing a custom field on an invoice.

--- a/stripe.go
+++ b/stripe.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2020-03-02"
+	APIVersion string = "2020-08-27"
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"

--- a/sub.go
+++ b/sub.go
@@ -128,7 +128,6 @@ type SubscriptionParams struct {
 	PendingInvoiceItemInterval  *SubscriptionPendingInvoiceItemIntervalParams `form:"pending_invoice_item_interval"`
 	Plan                        *string                                       `form:"plan"`
 	PromotionCode               *string                                       `form:"promotion_code"`
-	Prorate                     *bool                                         `form:"prorate"`
 	ProrationBehavior           *string                                       `form:"proration_behavior"`
 	ProrationDate               *int64                                        `form:"proration_date"`
 	Quantity                    *int64                                        `form:"quantity"`
@@ -137,9 +136,6 @@ type SubscriptionParams struct {
 	TrialEndNow                 *bool                                         `form:"-"` // See custom AppendTo
 	TrialFromPlan               *bool                                         `form:"trial_from_plan"`
 	TrialPeriodDays             *int64                                        `form:"trial_period_days"`
-
-	// This parameter is deprecated and we recommend that you use TaxRates instead.
-	TaxPercent *float64 `form:"tax_percent"`
 }
 
 // SubscriptionBillingThresholdsParams is a structure representing the parameters allowed to control
@@ -275,9 +271,6 @@ type Subscription struct {
 	TransferData                  *SubscriptionTransferData              `json:"transfer_data"`
 	TrialEnd                      int64                                  `json:"trial_end"`
 	TrialStart                    int64                                  `json:"trial_start"`
-
-	// This field is deprecated and we recommend that you use TaxRates instead.
-	TaxPercent float64 `json:"tax_percent"`
 }
 
 // SubscriptionBillingThresholds is a structure representing the billing thresholds for a subscription.

--- a/sub/client_test.go
+++ b/sub/client_test.go
@@ -91,9 +91,10 @@ func TestSubscriptionNew_WithItems(t *testing.T) {
 }
 
 func TestSubscriptionUpdate(t *testing.T) {
-	subscription, err := Update("sub_123", &stripe.SubscriptionParams{
-		Prorate: stripe.Bool(true),
-	})
+	params := &stripe.SubscriptionParams{
+		ProrationBehavior: stripe.String(string(stripe.SubscriptionProrationBehaviorNone)),
+	}
+	subscription, err := Update("sub_123", params)
 	assert.Nil(t, err)
 	assert.NotNil(t, subscription)
 }

--- a/subitem.go
+++ b/subitem.go
@@ -28,7 +28,6 @@ type SubscriptionItemParams struct {
 	Plan              *string                                  `form:"plan"`
 	Price             *string                                  `form:"price"`
 	PriceData         *SubscriptionItemPriceDataParams         `form:"price_data"`
-	Prorate           *bool                                    `form:"prorate"`
 	ProrationDate     *int64                                   `form:"proration_date"`
 	ProrationBehavior *string                                  `form:"proration_behavior"`
 	Quantity          *int64                                   `form:"quantity"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -97,28 +97,23 @@ type SubscriptionSchedulePhaseItemParams struct {
 // SubscriptionSchedulePhaseParams is a structure representing the parameters allowed to control
 // a phase on a subscription schedule.
 type SubscriptionSchedulePhaseParams struct {
-	AddInvoiceItems []*SubscriptionSchedulePhaseAddInvoiceItemParams `form:"add_invoice_items"`
-	// This parameter expects a *float64 but was defined as *int64 so we're adding support for both
-	// TODO: Remove in the next major
-	ApplicationFeePercent interface{}                                `form:"application_fee_percent"`
-	BillingCycleAnchor    *string                                    `form:"billing_cycle_anchor"`
-	BillingThresholds     *SubscriptionBillingThresholdsParams       `form:"billing_thresholds"`
-	CollectionMethod      *string                                    `form:"collection_method"`
-	Coupon                *string                                    `form:"coupon"`
-	DefaultPaymentMethod  *string                                    `form:"default_payment_method"`
-	DefaultTaxRates       []*string                                  `form:"default_tax_rates"`
-	EndDate               *int64                                     `form:"end_date"`
-	InvoiceSettings       *SubscriptionScheduleInvoiceSettingsParams `form:"invoice_settings"`
-	Iterations            *int64                                     `form:"iterations"`
-	Plans                 []*SubscriptionSchedulePhaseItemParams     `form:"plans"`
-	ProrationBehavior     *string                                    `form:"proration_behavior"`
-	StartDate             *int64                                     `form:"start_date"`
-	TransferData          *SubscriptionTransferDataParams            `form:"transfer_data"`
-	Trial                 *bool                                      `form:"trial"`
-	TrialEnd              *int64                                     `form:"trial_end"`
-
-	// This parameter is deprecated and we recommend that you use TaxRates instead.
-	TaxPercent *float64 `form:"tax_percent"`
+	AddInvoiceItems       []*SubscriptionSchedulePhaseAddInvoiceItemParams `form:"add_invoice_items"`
+	ApplicationFeePercent *float64                                         `form:"application_fee_percent"`
+	BillingCycleAnchor    *string                                          `form:"billing_cycle_anchor"`
+	BillingThresholds     *SubscriptionBillingThresholdsParams             `form:"billing_thresholds"`
+	CollectionMethod      *string                                          `form:"collection_method"`
+	Coupon                *string                                          `form:"coupon"`
+	DefaultPaymentMethod  *string                                          `form:"default_payment_method"`
+	DefaultTaxRates       []*string                                        `form:"default_tax_rates"`
+	EndDate               *int64                                           `form:"end_date"`
+	InvoiceSettings       *SubscriptionScheduleInvoiceSettingsParams       `form:"invoice_settings"`
+	Iterations            *int64                                           `form:"iterations"`
+	Items                 []*SubscriptionSchedulePhaseItemParams           `form:"items"`
+	ProrationBehavior     *string                                          `form:"proration_behavior"`
+	StartDate             *int64                                           `form:"start_date"`
+	TransferData          *SubscriptionTransferDataParams                  `form:"transfer_data"`
+	Trial                 *bool                                            `form:"trial"`
+	TrialEnd              *int64                                           `form:"trial_end"`
 }
 
 // SubscriptionScheduleParams is the set of parameters that can be used when creating or updating a
@@ -133,10 +128,6 @@ type SubscriptionScheduleParams struct {
 	Phases            []*SubscriptionSchedulePhaseParams         `form:"phases"`
 	StartDate         *int64                                     `form:"start_date"`
 	StartDateNow      *bool                                      `form:"-"` // See custom AppendTo
-
-	// TODO remove in the next major version
-	// This propery is considered deprecated. Use ProrationBehavior instead
-	Prorate *bool `form:"prorate"`
 }
 
 // AppendTo implements custom encoding logic for SubscriptionScheduleParams so that the special
@@ -228,13 +219,10 @@ type SubscriptionSchedulePhase struct {
 	DefaultTaxRates       []*TaxRate                                  `json:"default_tax_rates"`
 	EndDate               int64                                       `json:"end_date"`
 	InvoiceSettings       *SubscriptionScheduleInvoiceSettings        `json:"invoice_settings"`
-	Plans                 []*SubscriptionSchedulePhaseItem            `json:"plans"`
+	Items                 []*SubscriptionSchedulePhaseItem            `json:"items"`
 	StartDate             int64                                       `json:"start_date"`
 	TransferData          *SubscriptionTransferData                   `json:"transfer_data"`
 	TrialEnd              int64                                       `json:"trial_end"`
-
-	// This field is deprecated and we recommend that you use TaxRates instead.
-	TaxPercent float64 `json:"tax_percent"`
 }
 
 // SubscriptionSchedule is the resource representing a Stripe subscription schedule.

--- a/subschedule/client_test.go
+++ b/subschedule/client_test.go
@@ -45,7 +45,7 @@ func TestSubscriptionScheduleNew(t *testing.T) {
 		StartDateNow: stripe.Bool(true),
 		Phases: []*stripe.SubscriptionSchedulePhaseParams{
 			{
-				Plans: []*stripe.SubscriptionSchedulePhaseItemParams{
+				Items: []*stripe.SubscriptionSchedulePhaseItemParams{
 					{
 						Plan:     stripe.String("plan_123"),
 						Quantity: stripe.Int64(10),
@@ -58,37 +58,7 @@ func TestSubscriptionScheduleNew(t *testing.T) {
 				Trial: stripe.Bool(true),
 			},
 			{
-				Plans: []*stripe.SubscriptionSchedulePhaseItemParams{
-					{
-						Plan:     stripe.String("plan_789"),
-						Quantity: stripe.Int64(30),
-					},
-				},
-			},
-		},
-		EndBehavior: stripe.String(string(stripe.SubscriptionScheduleEndBehaviorCancel)),
-	}
-	schedule, err := New(params)
-	assert.Nil(t, err)
-	assert.NotNil(t, schedule)
-}
-func TestSubscriptionScheduleNew_ApplicationFeePercent(t *testing.T) {
-	params := &stripe.SubscriptionScheduleParams{
-		Customer:     stripe.String("cus_123"),
-		StartDateNow: stripe.Bool(true),
-		Phases: []*stripe.SubscriptionSchedulePhaseParams{
-			{
-				ApplicationFeePercent: stripe.Float64(10.123),
-				Plans: []*stripe.SubscriptionSchedulePhaseItemParams{
-					{
-						Plan:     stripe.String("plan_123"),
-						Quantity: stripe.Int64(10),
-					},
-				},
-			},
-			{
-				ApplicationFeePercent: stripe.Int64(10),
-				Plans: []*stripe.SubscriptionSchedulePhaseItemParams{
+				Items: []*stripe.SubscriptionSchedulePhaseItemParams{
 					{
 						Plan:     stripe.String("plan_789"),
 						Quantity: stripe.Int64(30),

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.95.0"
+	MockMinimumVersion = "0.96.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
Multiple API changes
  * Move to latest API version `2020-08-27`
  * Remove `Prorate` across Billing APIs in favor of `ProrationBehavior`
  * Remove `TaxPercent` across Billing APIs in favor of `TaxRate`-related parameters and properties
  * Remove `DisplayItems` on Checkout `Session` in favor of `LineItems`
  * Remove `FailureURL` and `SuccessURL` on `AccountLink` in favor of `RefreshURL` and `ReturnURL`
  * Remove `AccountLinkTypeCustomAccountUpdate ` and `AccountLinkTypeCustomAccountVerification ` on `AccountLink` in favor of `AccountLinkTypeAccountOnboarding ` and `AccountLinkTypeAccountUpdate `
  * Remove `Authenticated` and `Succeeded` on `ChargePaymentMethodDetailsCardThreeDSecure`
  * Remove `Plan`, `Quantity`, `TaxPercent` and `TrialEnd` from `Customer` creation or update in favor of the Subscription API
  * Rename `Plans` to `Items` on `SubscriptionSchedule`

r? @richardm-stripe 
cc @stripe/api-libraries 