### PR TITLE
Fix the constant names for `BankAccountAvailablePayoutMethod`

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -12,8 +12,8 @@ type BankAccountAvailablePayoutMethod string
 
 // List of values that CardAvailablePayoutMethod can take.
 const (
-	BankAccountAvailablePayoutMethodAvailablePayoutMethodInstant  BankAccountAvailablePayoutMethod = "instant"
-	BankAccountAvailablePayoutMethodAvailablePayoutMethodStandard BankAccountAvailablePayoutMethod = "standard"
+	BankAccountAvailablePayoutMethodInstant  BankAccountAvailablePayoutMethod = "instant"
+	BankAccountAvailablePayoutMethodStandard BankAccountAvailablePayoutMethod = "standard"
 )
 
 // BankAccountStatus is the list of allowed values for the bank account's status.


### PR DESCRIPTION
Fixes the issue introduced in https://github.com/stripe/stripe-go/pull/1177

r? @cjavilla-stripe 
cc @stripe/api-libraries 