### PR TITLE
Add support for Sofort on `PaymentMethod` and `PaymentIntent`

### DIFF
--- a/paymentintent.go
+++ b/paymentintent.go
@@ -211,12 +211,19 @@ type PaymentIntentPaymentMethodOptionsCardParams struct {
 	RequestThreeDSecure *string                                                  `form:"request_three_d_secure"`
 }
 
+// PaymentIntentPaymentMethodOptionsSofortParams represents the sofort-specific options applied to a
+// PaymentIntent.
+type PaymentIntentPaymentMethodOptionsSofortParams struct {
+	PreferredLanguage *string `form:"preferred_language"`
+}
+
 // PaymentIntentPaymentMethodOptionsParams represents the type-specific payment method options
 // applied to a PaymentIntent.
 type PaymentIntentPaymentMethodOptionsParams struct {
 	Alipay     *PaymentIntentPaymentMethodOptionsAlipayParams     `form:"alipay"`
 	Bancontact *PaymentIntentPaymentMethodOptionsBancontactParams `form:"bancontact"`
 	Card       *PaymentIntentPaymentMethodOptionsCardParams       `form:"card"`
+	Sofort     *PaymentIntentPaymentMethodOptionsSofortParams     `form:"sofort"`
 }
 
 // PaymentIntentTransferDataParams is the set of parameters allowed for the transfer hash.
@@ -324,12 +331,19 @@ type PaymentIntentPaymentMethodOptionsCard struct {
 	RequestThreeDSecure PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure `json:"request_three_d_secure"`
 }
 
+// PaymentIntentPaymentMethodOptionsSofort is the set of sofort-specific options associated
+// with that payment intent.
+type PaymentIntentPaymentMethodOptionsSofort struct {
+	PreferredLanguage string `json:"preferred_language"`
+}
+
 // PaymentIntentPaymentMethodOptions is the set of payment method-specific options associated with
 // that payment intent.
 type PaymentIntentPaymentMethodOptions struct {
 	Alipay     *PaymentIntentPaymentMethodOptionsAlipay     `json:"alipay"`
 	Bancontact *PaymentIntentPaymentMethodOptionsBancontact `json:"bancontact"`
 	Card       *PaymentIntentPaymentMethodOptionsCard       `json:"card"`
+	Sofort     *PaymentIntentPaymentMethodOptionsSofort     `json:"sofort"`
 }
 
 // PaymentIntentTransferData represents the information for the transfer associated with a payment intent.

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -25,6 +25,7 @@ const (
 	PaymentMethodTypeInteracPresent PaymentMethodType = "interac_present"
 	PaymentMethodTypeP24            PaymentMethodType = "p24"
 	PaymentMethodTypeSepaDebit      PaymentMethodType = "sepa_debit"
+	PaymentMethodTypeSofort         PaymentMethodType = "sofort"
 )
 
 // PaymentMethodCardBrand is the list of allowed values for the brand property on a
@@ -155,6 +156,12 @@ type PaymentMethodSepaDebitParams struct {
 	Iban *string `form:"iban"`
 }
 
+// PaymentMethodSofortParams is the set of parameters allowed for the `sofort` hash when
+// creating a PaymentMethod of type sofort.
+type PaymentMethodSofortParams struct {
+	Country *string `form:"country"`
+}
+
 // PaymentMethodParams is the set of parameters that can be used when creating or updating a
 // PaymentMethod.
 type PaymentMethodParams struct {
@@ -172,6 +179,7 @@ type PaymentMethodParams struct {
 	InteracPresent *PaymentMethodInteracPresentParams `form:"interac_present"`
 	P24            *PaymentMethodP24Params            `form:"p24"`
 	SepaDebit      *PaymentMethodSepaDebitParams      `form:"sepa_debit"`
+	Sofort         *PaymentMethodSofortParams         `form:"sofort"`
 	Type           *string                            `form:"type"`
 
 	// The following parameters are used when cloning a PaymentMethod to the connected account
@@ -317,6 +325,11 @@ type PaymentMethodSepaDebit struct {
 	Last4       string `json:"last4"`
 }
 
+// PaymentMethodSofort represents the Sofort-specific properties.
+type PaymentMethodSofort struct {
+	Country string `json:"country"`
+}
+
 // PaymentMethod is the resource representing a PaymentMethod.
 type PaymentMethod struct {
 	APIResource
@@ -340,6 +353,7 @@ type PaymentMethod struct {
 	Object         string                       `json:"object"`
 	P24            *PaymentMethodP24            `json:"p24"`
 	SepaDebit      *PaymentMethodSepaDebit      `json:"sepa_debit"`
+	Sofort         *PaymentMethodSofort         `json:"sofort"`
 	Type           PaymentMethodType            `json:"type"`
 }
 


### PR DESCRIPTION
Same as https://github.com/stripe/stripe-go/pull/1125 but it was missing the `payment_method_options` changes

r? @cjavilla-stripe 
cc @stripe/api-libraries 