### PR TITLE
Add `Metadata` on `WebhookEndpoint`

### DIFF
--- a/webhookendpoint.go
+++ b/webhookendpoint.go
@@ -29,19 +29,20 @@ type WebhookEndpointListParams struct {
 // For more details see https://stripe.com/docs/api#webhook_endpoints.
 type WebhookEndpoint struct {
 	APIResource
-	APIVersion    string   `json:"api_version"`
-	Application   string   `json:"application"`
-	Connect       bool     `json:"connect"`
-	Created       int64    `json:"created"`
-	Deleted       bool     `json:"deleted"`
-	Description   string   `json:"description"`
-	EnabledEvents []string `json:"enabled_events"`
-	ID            string   `json:"id"`
-	Livemode      bool     `json:"livemode"`
-	Object        string   `json:"object"`
-	Secret        string   `json:"secret"`
-	Status        string   `json:"status"`
-	URL           string   `json:"url"`
+	APIVersion    string            `json:"api_version"`
+	Application   string            `json:"application"`
+	Connect       bool              `json:"connect"`
+	Created       int64             `json:"created"`
+	Deleted       bool              `json:"deleted"`
+	Description   string            `json:"description"`
+	EnabledEvents []string          `json:"enabled_events"`
+	ID            string            `json:"id"`
+	Livemode      bool              `json:"livemode"`
+	Metadata      map[string]string `json:"metadata"`
+	Object        string            `json:"object"`
+	Secret        string            `json:"secret"`
+	Status        string            `json:"status"`
+	URL           string            `json:"url"`
 }
 
 // WebhookEndpointList is a list of webhook endpoints as retrieved from a list endpoint.


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-go/issues/1181

r? @cjavilla-stripe 
cc @stripe/api-libraries 