### PR TITLE
handle idempotence key randomness error

### DIFF
--- a/params.go
+++ b/params.go
@@ -268,7 +268,9 @@ type RangeQueryParams struct {
 func NewIdempotencyKey() string {
 	now := time.Now().UnixNano()
 	buf := make([]byte, 4)
-	rand.Read(buf)
+	if _, err := rand.Read(buf); err != nil {
+		panic(err)
+	}
 	return fmt.Sprintf("%v_%v", now, base64.URLEncoding.EncodeToString(buf)[:6])
 }
 


### PR DESCRIPTION
reading from rand can return an error and fail to read bytes, this
leads to the second component not being random.

This solution panics in that case, similar to getting a new uuid
https://github.com/google/uuid/blob/master/version4.go#L13-L15

the side effect is, in the case the second component is not random (an
error happened) we are now panicing instead of continuing

alternatives: 
- continue as before (maybe leave a comment)
- change the function signature to return an error, more invasive 
change and makes the function API less nice to work with
 

Signed-off-by: Andrew Klotz <agc.klotz@gmail.com>