### PR TITLE
Use correct Amount type for InstantAvailable

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -37,7 +37,7 @@ type Balance struct {
 	APIResource
 	Available        []*Amount       `json:"available"`
 	ConnectReserved  []*Amount       `json:"connect_reserved"`
-	InstantAvailable *BalanceDetails `json:"instant_available"`
+	InstantAvailable []*Amount       `json:"instant_available"`
 	Issuing          *BalanceDetails `json:"issuing"`
 	Livemode         bool            `json:"livemode"`
 	Object           string          `json:"object"`


### PR DESCRIPTION
Fixes #1202 

> [ERROR] Couldn't deserialize JSON (response status: 200, body sample: '{\n "object": "balance",\n "available": [\n {\n "amount": 118300,\n "currency": "usd",\n "source_types": {\n "card": 118300\n }\n }\n ],\n "instant_available": [\n {\n "amount": 118300,\n "currency": "usd",\n "source_types": {\n "card": 118300\n }\n }\n ],\n "livemode": false,\n "pending": [\n {\n "amount": 0,\n "currency": "usd",\n "source_types": {\n "card": 0\n }\n }\n ]\n}\n'): json: cannot unmarshal array into Go struct field Balance.instant_available of type stripe.BalanceDetails


It needs to be `[]*Amount` instead of `*BalanceDetails`