### PR TITLE
Add the deprecation note to the total_count field

### DIFF
--- a/params.go
+++ b/params.go
@@ -75,7 +75,7 @@ type ListContainer interface {
 
 // ListMeta is the structure that contains the common properties
 // of List iterators. The Count property is only populated if the
-// total_count include option is passed in (see tests for example).
+// total_count is a deprecated option that doesn't work anymore.
 type ListMeta struct {
 	HasMore    bool   `json:"has_more"`
 	TotalCount uint32 `json:"total_count"`


### PR DESCRIPTION
total_count property is not available anymore becuse it was removed in May 26th 2020