### PR TITLE
Add missing constants for existing types on `PaymentMethod`

### DIFF
--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -16,11 +16,15 @@ type PaymentMethodType string
 
 // List of values that PaymentMethodType can take.
 const (
+	PaymentMethodTypeAlipay         PaymentMethodType = "alipay"
 	PaymentMethodTypeAUBECSDebit    PaymentMethodType = "au_becs_debit"
 	PaymentMethodTypeBACSDebit      PaymentMethodType = "bacs_debit"
+	PaymentMethodTypeBancontact     PaymentMethodType = "bancontact"
 	PaymentMethodTypeCard           PaymentMethodType = "card"
 	PaymentMethodTypeCardPresent    PaymentMethodType = "card_present"
+	PaymentMethodTypeEPS            PaymentMethodType = "eps"
 	PaymentMethodTypeFPX            PaymentMethodType = "fpx"
+	PaymentMethodTypeGiropay        PaymentMethodType = "giropay"
 	PaymentMethodTypeIdeal          PaymentMethodType = "ideal"
 	PaymentMethodTypeInteracPresent PaymentMethodType = "interac_present"
 	PaymentMethodTypeOXXO           PaymentMethodType = "oxxo"


### PR DESCRIPTION
While reviewing a PR for code examples in the docs, I realized we didn't have a constant in go for the EPS payment method type and then noticed I just missed a bunch of them.
I added what was missing based on the list here: https://stripe.com/docs/api/payment_methods/object#payment_method_object-type and I also kept `card_present` and `interac_present` which should really be in that list.

r? @ctrudeau-stripe 
cc @stripe/api-libraries