### PR TITLE
Add support for Account and Person Tokens creation

### DIFF
--- a/token.go
+++ b/token.go
@@ -17,14 +17,28 @@ type TokenCVCUpdateParams struct {
 	CVC *string `form:"cvc"`
 }
 
+// TokenAccountParams is the set of parameters that can be used when creating a Account token.
+type TokenAccountParams struct {
+	BusinessType        *string               `form:"business_type"`
+	Company             *AccountCompanyParams `form:"company"`
+	Individual          *PersonParams         `form:"individual"`
+	TOSShownAndAccepted *bool                 `form:"tos_shown_and_accepted"`
+}
+
 // TokenParams is the set of parameters that can be used when creating a token.
-// For more details see https://stripe.com/docs/api#create_card_token and https://stripe.com/docs/api#create_bank_account_token.
+// For more details see:
+// - https://stripe.com/docs/api#create_card_token
+// - https://stripe.com/docs/api#create_bank_account_token
+// - https://stripe.com/docs/api/tokens/create_account
+// - https://stripe.com/docs/api/tokens/create_person
 type TokenParams struct {
 	Params      `form:"*"`
+	Account     *TokenAccountParams   `form:"account"`
 	BankAccount *BankAccountParams    `form:"bank_account"`
 	Card        *CardParams           `form:"card"`
 	Customer    *string               `form:"customer"`
 	CVCUpdate   *TokenCVCUpdateParams `form:"cvc_update"`
+	Person      *PersonParams         `form:"person"`
 
 	// Email is an undocumented parameter used by Stripe Checkout
 	// It may be removed from the API without notice.

--- a/token/client_test.go
+++ b/token/client_test.go
@@ -60,3 +60,31 @@ func TestTokenNew_SharedCustomerCard(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, token)
 }
+
+func TestTokenNew_WithAccount(t *testing.T) {
+	token, err := New(&stripe.TokenParams{
+		Account: &stripe.TokenAccountParams{
+			Individual: &stripe.PersonParams{
+				FirstName: stripe.String("Jane"),
+				LastName:  stripe.String("Doe"),
+			},
+			TOSShownAndAccepted: stripe.Bool(true),
+		},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, token)
+}
+
+func TestTokenNew_WithPerson(t *testing.T) {
+	token, err := New(&stripe.TokenParams{
+		Person: &stripe.PersonParams{
+			FirstName: stripe.String("Jane"),
+			LastName:  stripe.String("Doe"),
+			Relationship: &stripe.RelationshipParams{
+				Owner: stripe.Bool(true),
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, token)
+}


### PR DESCRIPTION
Fixes #1226

Tested using Golang Testing tool and with my own project

Log of my project, I correctly get my account token
```sh
2020/11/19 12:21:43 token: &{{0xc000108ba0} <nil> <nil> <nil> 1.2.3.4 1605788503  ct_1HpC8xCMhQMU3AqAy65DO2ku false account false}
2020/11/19 12:21:43 token.ID: ct_1HpC8xCMhQMU3AqAy65DO2ku
2020/11/19 12:21:43 token.TYPE: account
```