### PR TITLE
Add support for bank on eps/p24

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -417,6 +417,7 @@ type ChargePaymentMethodDetailsCardPresent struct {
 
 // ChargePaymentMethodDetailsEps represents details about the EPS PaymentMethod.
 type ChargePaymentMethodDetailsEps struct {
+	Bank         string `json:"bank"`
 	VerifiedName string `json:"verified_name"`
 }
 
@@ -505,6 +506,7 @@ type ChargePaymentMethodDetailsOXXO struct {
 
 // ChargePaymentMethodDetailsP24 represents details about the P24 PaymentMethod.
 type ChargePaymentMethodDetailsP24 struct {
+	Bank         string `json:"bank"`
 	Reference    string `json:"reference"`
 	VerifiedName string `json:"verified_name"`
 }

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -172,10 +172,12 @@ type PaymentIntentPaymentMethodDataParams struct {
 	AUBECSDebit    *PaymentMethodAUBECSDebitParams `form:"au_becs_debit"`
 	BillingDetails *BillingDetailsParams           `form:"billing_details"`
 	Card           *PaymentMethodCardParams        `form:"card"`
+	EPS            *PaymentMethodEPSParams         `form:"eps"`
 	FPX            *PaymentMethodFPXParams         `form:"fpx"`
 	Grabpay        *PaymentMethodGrabpayParams     `form:"grabpay"`
 	Ideal          *PaymentMethodIdealParams       `form:"ideal"`
 	OXXO           *PaymentMethodOXXOParams        `form:"oxxo"`
+	P24            *PaymentMethodP24Params         `form:"p24"`
 	SepaDebit      *PaymentMethodSepaDebitParams   `form:"sepa_debit"`
 	Type           *string                         `form:"type"`
 }

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -126,6 +126,7 @@ type PaymentMethodCardParams struct {
 // PaymentMethodEPSParams is the set of parameters allowed for the `eps` hash when creating a
 // PaymentMethod of type EPS.
 type PaymentMethodEPSParams struct {
+	Bank *string `form:"bank"`
 }
 
 // PaymentMethodFPXParams is the set of parameters allowed for the `fpx` hash when creating a
@@ -164,7 +165,8 @@ type PaymentMethodOXXOParams struct {
 // PaymentMethodP24Params is the set of parameters allowed for the `p24` hash when creating a
 // PaymentMethod of type P24.
 type PaymentMethodP24Params struct {
-	Bank *string `form:"bank"`
+	Bank                *string `form:"bank"`
+	TOSShownAndAccepted *bool   `from:"tos_shown_and_accepted"`
 }
 
 // PaymentMethodSepaDebitParams is the set of parameters allowed for the `sepa_debit` hash when
@@ -308,6 +310,7 @@ type PaymentMethodCardPresent struct {
 
 // PaymentMethodEPS represents the EPS properties.
 type PaymentMethodEPS struct {
+	Bank string `json:"bank"`
 }
 
 // PaymentMethodFPX represents FPX-specific properties (Malaysia Only).

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -166,7 +166,7 @@ type PaymentMethodOXXOParams struct {
 // PaymentMethod of type P24.
 type PaymentMethodP24Params struct {
 	Bank                *string `form:"bank"`
-	TOSShownAndAccepted *bool   `from:"tos_shown_and_accepted"`
+	TOSShownAndAccepted *bool   `form:"tos_shown_and_accepted"`
 }
 
 // PaymentMethodSepaDebitParams is the set of parameters allowed for the `sepa_debit` hash when

--- a/subschedule.go
+++ b/subschedule.go
@@ -46,13 +46,14 @@ type SubscriptionScheduleInvoiceSettingsParams struct {
 // SubscriptionScheduleDefaultSettingsParams is the set of parameters
 // representing the subscription schedule’s default settings.
 type SubscriptionScheduleDefaultSettingsParams struct {
-	Params               `form:"*"`
-	BillingCycleAnchor   *string                                    `form:"billing_cycle_anchor"`
-	BillingThresholds    *SubscriptionBillingThresholdsParams       `form:"billing_thresholds"`
-	CollectionMethod     *string                                    `form:"collection_method"`
-	DefaultPaymentMethod *string                                    `form:"default_payment_method"`
-	InvoiceSettings      *SubscriptionScheduleInvoiceSettingsParams `form:"invoice_settings"`
-	TransferData         *SubscriptionTransferDataParams            `form:"transfer_data"`
+	Params                `form:"*"`
+	ApplicationFeePercent *float64                                   `form:"application_fee_percent,high_precision"`
+	BillingCycleAnchor    *string                                    `form:"billing_cycle_anchor"`
+	BillingThresholds     *SubscriptionBillingThresholdsParams       `form:"billing_thresholds"`
+	CollectionMethod      *string                                    `form:"collection_method"`
+	DefaultPaymentMethod  *string                                    `form:"default_payment_method"`
+	InvoiceSettings       *SubscriptionScheduleInvoiceSettingsParams `form:"invoice_settings"`
+	TransferData          *SubscriptionTransferDataParams            `form:"transfer_data"`
 }
 
 // SubscriptionSchedulePhaseAddInvoiceItemPriceDataRecurringParams is a structure representing the
@@ -185,12 +186,13 @@ type SubscriptionScheduleInvoiceSettings struct {
 // SubscriptionScheduleDefaultSettings is a structure representing the
 // subscription schedule’s default settings.
 type SubscriptionScheduleDefaultSettings struct {
-	BillingCycleAnchor   SubscriptionSchedulePhaseBillingCycleAnchor `json:"billing_cycle_anchor"`
-	BillingThresholds    *SubscriptionBillingThresholds              `json:"billing_thresholds"`
-	CollectionMethod     SubscriptionCollectionMethod                `json:"collection_method"`
-	DefaultPaymentMethod *PaymentMethod                              `json:"default_payment_method"`
-	InvoiceSettings      *SubscriptionScheduleInvoiceSettings        `json:"invoice_settings"`
-	TransferData         *SubscriptionTransferData                   `json:"transfer_data"`
+	ApplicationFeePercent float64                                     `json:"application_fee_percent,string"`
+	BillingCycleAnchor    SubscriptionSchedulePhaseBillingCycleAnchor `json:"billing_cycle_anchor"`
+	BillingThresholds     *SubscriptionBillingThresholds              `json:"billing_thresholds"`
+	CollectionMethod      SubscriptionCollectionMethod                `json:"collection_method"`
+	DefaultPaymentMethod  *PaymentMethod                              `json:"default_payment_method"`
+	InvoiceSettings       *SubscriptionScheduleInvoiceSettings        `json:"invoice_settings"`
+	TransferData          *SubscriptionTransferData                   `json:"transfer_data"`
 }
 
 // SubscriptionSchedulePhaseAddInvoiceItem represents the invoice items to add when the phase starts.


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-library-reviewers 

Add support for `Bank` for eps and p24 on Charge and PaymentMethod.
Add support for `TOSShownAndAccepted` on `PaymentMethodP24Params`