### PR TITLE
[wip] Add PaymentBehavior to subscription data for Checkout

### DIFF
--- a/checkout/session/client_test.go
+++ b/checkout/session/client_test.go
@@ -59,6 +59,7 @@ func TestCheckoutSessionNew(t *testing.T) {
 				"attr1": "val1",
 				"attr2": "val2",
 			},
+			PaymentBehavior: stripe.String("allow_incomplete"),
 		},
 		SuccessURL: stripe.String("https://stripe.com/success"),
 	}

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -142,6 +142,7 @@ type CheckoutSessionSubscriptionDataParams struct {
 	DefaultTaxRates       []*string                                     `form:"default_tax_rates"`
 	Items                 []*CheckoutSessionSubscriptionDataItemsParams `form:"items"`
 	Metadata              map[string]string                             `form:"metadata"`
+	PaymentBehavior       *string                                       `form:"payment_behavior"`
 	TrialEnd              *int64                                        `form:"trial_end"`
 	TrialFromPlan         *bool                                         `form:"trial_from_plan"`
 	TrialPeriodDays       *int64                                        `form:"trial_period_days"`


### PR DESCRIPTION
This commit attempts to add the `payment_behavior` attribute to `subscription_data`
for a Checkout Session in order to allow users to create Subscriptions through Checkout 
that will opt-in to the allow incomplete functionality.

Documented here: https://stripe.com/docs/payments/checkout/incomplete-subscriptions#checkout-client-server-integration 