### PR TITLE
Add support for more verification documents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `testing/testing.go`.
-    - STRIPE_MOCK_VERSION=0.101.0
+    - STRIPE_MOCK_VERSION=0.102.0
 
 go:
   - "1.10.x"

--- a/account.go
+++ b/account.go
@@ -333,15 +333,52 @@ type AccountDeclineSettingsParams struct {
 	CVCFailure *bool `form:"cvc_failure"`
 }
 
-// AccountDocumentsBankAccountOwnershipVerificationParams represents the parameters allowed for passing
-// bank account ownership verification documents on an account.
+// AccountDocumentsBankAccountOwnershipVerificationParams represents the
+// parameters allowed for passing bank account ownership verification documents
+// on an account.
 type AccountDocumentsBankAccountOwnershipVerificationParams struct {
+	Files []*string `form:"files"`
+}
+
+// AccountDocumentsCompanyLicenseParams represents the parameters allowed for
+// passing company license verification documents on an account.
+type AccountDocumentsCompanyLicenseParams struct {
+	Files []*string `form:"files"`
+}
+
+// AccountDocumentsCompanyMemorandumOfAssociationParams represents the
+// parameters allowed for passing company memorandum of association documents
+// on an account.
+type AccountDocumentsCompanyMemorandumOfAssociationParams struct {
+	Files []*string `form:"files"`
+}
+
+// AccountDocumentsCompanyMinisterialDecreeParams represents the parameters
+// allowed for passing company ministerial decree documents on an account.
+type AccountDocumentsCompanyMinisterialDecreeParams struct {
+	Files []*string `form:"files"`
+}
+
+// AccountDocumentsCompanyRegistrationVerificationParams represents the
+// parameters allowed for passing company registration verification documents.
+type AccountDocumentsCompanyRegistrationVerificationParams struct {
+	Files []*string `form:"files"`
+}
+
+// AccountDocumentsCompanyTaxIdVerificationParams represents the parameters
+// allowed for passing company tax id verification documents on an account.
+type AccountDocumentsCompanyTaxIdVerificationParams struct {
 	Files []*string `form:"files"`
 }
 
 // AccountDocumentsParams represents the parameters allowed for passing additional documents on an account.
 type AccountDocumentsParams struct {
 	BankAccountOwnershipVerification *AccountDocumentsBankAccountOwnershipVerificationParams `form:"bank_account_ownership_verification"`
+	CompanyLicense                   *AccountDocumentsCompanyLicenseParams                   `form:"company_license"`
+	CompanyMemorandumOfAssocation    *AccountDocumentsCompanyMemorandumOfAssociationParams   `form:"company_memorandum_of_association"`
+	CompanyMinisterialDecree         *AccountDocumentsCompanyMinisterialDecreeParams         `form:"company_ministerial_decree"`
+	CompanyRegistrationVerification  *AccountDocumentsCompanyRegistrationVerificationParams  `form:"company_registration_verification"`
+	ComparyTaxIdVerification         *AccountDocumentsCompanyTaxIdVerificationParams         `form:"company_tax_id_verification"`
 }
 
 // AccountSettingsBrandingParams represent allowed parameters to configure settings specific to the

--- a/account.go
+++ b/account.go
@@ -365,9 +365,9 @@ type AccountDocumentsCompanyRegistrationVerificationParams struct {
 	Files []*string `form:"files"`
 }
 
-// AccountDocumentsCompanyTaxIdVerificationParams represents the parameters
+// AccountDocumentsCompanyTaxIDVerificationParams represents the parameters
 // allowed for passing company tax id verification documents on an account.
-type AccountDocumentsCompanyTaxIdVerificationParams struct {
+type AccountDocumentsCompanyTaxIDVerificationParams struct {
 	Files []*string `form:"files"`
 }
 
@@ -378,7 +378,7 @@ type AccountDocumentsParams struct {
 	CompanyMemorandumOfAssocation    *AccountDocumentsCompanyMemorandumOfAssociationParams   `form:"company_memorandum_of_association"`
 	CompanyMinisterialDecree         *AccountDocumentsCompanyMinisterialDecreeParams         `form:"company_ministerial_decree"`
 	CompanyRegistrationVerification  *AccountDocumentsCompanyRegistrationVerificationParams  `form:"company_registration_verification"`
-	ComparyTaxIdVerification         *AccountDocumentsCompanyTaxIdVerificationParams         `form:"company_tax_id_verification"`
+	CompanyTaxIIVerification         *AccountDocumentsCompanyTaxIDVerificationParams         `form:"company_tax_id_verification"`
 }
 
 // AccountSettingsBrandingParams represent allowed parameters to configure settings specific to the

--- a/account.go
+++ b/account.go
@@ -378,7 +378,7 @@ type AccountDocumentsParams struct {
 	CompanyMemorandumOfAssocation    *AccountDocumentsCompanyMemorandumOfAssociationParams   `form:"company_memorandum_of_association"`
 	CompanyMinisterialDecree         *AccountDocumentsCompanyMinisterialDecreeParams         `form:"company_ministerial_decree"`
 	CompanyRegistrationVerification  *AccountDocumentsCompanyRegistrationVerificationParams  `form:"company_registration_verification"`
-	CompanyTaxIIVerification         *AccountDocumentsCompanyTaxIDVerificationParams         `form:"company_tax_id_verification"`
+	CompanyTaxIDVerification         *AccountDocumentsCompanyTaxIDVerificationParams         `form:"company_tax_id_verification"`
 }
 
 // AccountSettingsBrandingParams represent allowed parameters to configure settings specific to the

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -63,6 +63,11 @@ func TestAccountNew(t *testing.T) {
 				},
 			},
 		},
+		Documents: &stripe.AccountDocumentsParams{
+			CompanyLicense: &stripe.AccountDocumentsCompanyLicenseParams{
+				Files: []*string{stripe.String("file_xyz")},
+			},
+		},
 		Country: stripe.String("CA"),
 		ExternalAccount: &stripe.AccountExternalAccountParams{
 			Token: stripe.String("tok_123"),

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -25,7 +25,7 @@ const (
 	// added in a more recent version of stripe-mock, we can show people a
 	// better error message instead of the test suite crashing with a bunch of
 	// confusing 404 errors or the like.
-	MockMinimumVersion = "0.101.0"
+	MockMinimumVersion = "0.102.0"
 
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.


### PR DESCRIPTION
re-r? @brandur-stripe 

Adds support for passing `company_registration_verification`, `company_ministerial_decree`, `company_memorandum_of_association`, `company_license` and `company_tax_id_verification` on `Documents` in `AccountParams`, [recently released](https://github.com/stripe/openapi/commit/383c876178bce75266c9abddcb65f355bacfe86b) to the Stripe API.