### PR TITLE
CI: github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
      strategy:
        matrix:
          go:
+           - "1.16"
            - "1.15"
            - "1.14"
            - "1.13"
@@ -80,4 +81,3 @@ jobs:
               cd $DIR/$MAJOR_VERSION &&
               go get -u "golang.org/x/net/http2" &&
               make build
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    name: Lint
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: golint & go vet
+        run: |
+          go get -u golang.org/x/lint/golint &&
+          $HOME/go/bin/golint -set_exit_status ./... &&
+          make vet
+
+  test:
+     runs-on: ubuntu-latest
+     strategy:
+       matrix:
+         go:
+           - "1.15"
+           - "1.14"
+           - "1.13"
+     name: "Test: go v${{ matrix.go }}"
+     steps:
+       - uses: actions/checkout@v2
+       - name: Setup go
+         uses: actions/setup-go@v1
+         with:
+           go-version: ${{ matrix.go }}
+       - name: Start stripe-mock
+         run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5
+       - name: Test
+         run: make test &&
+              make bench &&
+              make check-api-clients
+
+  compile-only:
+     runs-on: ubuntu-latest
+     strategy:
+       matrix:
+         go:
+           - "1.12"
+           - "1.11"
+     name: "Compile: go v${{ matrix.go }}"
+     steps:
+       - uses: actions/checkout@v2
+       - name: Setup go
+         uses: actions/setup-go@v1
+         with:
+           go-version: ${{ matrix.go }}
+       - name: Compile
+         run: make build
+
+  # go 1.10 is the last version to require the source code
+  # to be located under the GOPATH
+  compile-only-1_10:
+     runs-on: ubuntu-latest
+     name: "Compile: go v1.10"
+     steps:
+       - uses: actions/checkout@v2
+       - name: Setup go
+         uses: actions/setup-go@v1
+         with:
+           go-version: 1.10
+       - name: Compile
+         run: MAJOR_VERSION="v$(awk 'BEGIN {FS="."};{print $1}' < VERSION)" &&
+              DIR="$HOME/go/src/github.com/stripe/stripe-go" &&
+              echo "dir=$DIR;major_version=$MAJOR_VERSION" &&
+              mkdir -p $DIR &&
+              cp -r ./ $DIR/$MAJOR_VERSION &&
+              cd $DIR/$MAJOR_VERSION &&
+              go get -u "golang.org/x/net/http2" &&
+              make build
+

--- a/billingportal_configuration.go
+++ b/billingportal_configuration.go
@@ -25,8 +25,8 @@ const (
 	BillingPortalConfigurationFeaturesSubscriptionCancelModeImmediately BillingPortalConfigurationFeaturesSubscriptionCancelMode = "immediately"
 )
 
-// BillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior
-// describes whether to create prorations when canceling subscriptions.
+// BillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior describes
+// whether to create prorations when canceling subscriptions.
 type BillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior string
 
 // List of values that BillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior can take.
@@ -36,9 +36,8 @@ const (
 	BillingPortalConfigurationFeaturesSubscriptionCancelProrationBehaviorNone             BillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior = "none"
 )
 
-// BillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdate
-// describes a type of subscription update that may be supported on a portal
-// configuration.
+// BillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdate describes
+// a type of subscription update that may be supported on a portal configuration.
 type BillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdate string
 
 // List of values that BillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdate can take.
@@ -48,8 +47,8 @@ const (
 	BillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdateQuantity      BillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdate = "quantity"
 )
 
-// BillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior
-// determines how to handle prorations resulting from subscription updates.
+// BillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior determines
+// how to handle prorations resulting from subscription updates.
 type BillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior string
 
 // List of values that BillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior can take.
@@ -82,7 +81,7 @@ type BillingPortalConfigurationFeaturesCustomerUpdateParams struct {
 	Enabled        *bool     `form:"enabled"`
 }
 
-// BillingPortalConfigurationFeaturesCustomerUpdateParams lets you pass the
+// BillingPortalConfigurationFeaturesInvoiceHistoryParams lets you pass the
 // invoice history details on a portal configuration.
 type BillingPortalConfigurationFeaturesInvoiceHistoryParams struct {
 	Enabled *bool `form:"enabled"`


### PR DESCRIPTION
r? @ob-stripe 
Introduces github actions for CI.

- skips goveralls
- skips testing on "tip" which isn't supported (yet) by the setup-go action: https://github.com/actions/setup-go/issues/21
  - Unfortunately GHA seems to lack an exact analog to "allowed failures" in Travis, so testing on tip wouldn't really work as desired anyway.
  
Also fixes some linter errors. Travis isn't failing when golint fails, for some reason, and so there were some lingering lint problems that need to be fixed.