### PR TITLE
Fix edge case panic in ParseID

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -977,6 +977,11 @@ func ParseID(data []byte) (string, bool) {
 		return "", false
 	}
 
+	// Edge case that should never happen; found via fuzzing
+	if s == "\"" {
+		return "", false
+	}
+
 	return s[1 : len(s)-1], true
 }
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -777,6 +777,13 @@ func TestParseID(t *testing.T) {
 		assert.Equal(t, "", id)
 		assert.False(t, ok)
 	}
+
+	// Edge case that should never happen; found via fuzzing
+	{
+		id, ok := ParseID([]byte(`"`))
+		assert.Equal(t, "", id)
+		assert.False(t, ok)
+	}
 }
 
 // TestMultipleAPICalls will fail the test run if a race condition is thrown while running multiple NewRequest calls.


### PR DESCRIPTION
This PR fixes panic in `stripe.ParseID`, which could happen for a particular input (`"`):
```
panic: runtime error: slice bounds out of range [1:0]
```

I highly doubt that this is a real-world case, but since panic is a pretty bad thing I believe it's worth to fix it.
Also added a test case for it.


Found this with the help of [go-fuzz](https://github.com/dvyukov/go-fuzz).