### PR TITLE
Support `SubscriptionTrialEndNow` on the Retrieve Upcoming Invoice API

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -190,6 +190,7 @@ type InvoiceParams struct {
 	SubscriptionQuantity                    *int64                              `form:"subscription_quantity"`
 	SubscriptionStartDate                   *int64                              `form:"subscription_start_date"`
 	SubscriptionTrialEnd                    *int64                              `form:"subscription_trial_end"`
+	SubscriptionTrialEndNow                 *bool                               `form:"-"` // See custom AppendTo
 	SubscriptionTrialFromPlan               *bool                               `form:"subscription_trial_from_plan"`
 }
 
@@ -203,6 +204,10 @@ func (p *InvoiceParams) AppendTo(body *form.Values, keyParts []string) {
 
 	if BoolValue(p.SubscriptionBillingCycleAnchorUnchanged) {
 		body.Add(form.FormatKey(append(keyParts, "subscription_billing_cycle_anchor")), "unchanged")
+	}
+
+	if BoolValue(p.SubscriptionTrialEndNow) {
+		body.Add(form.FormatKey(append(keyParts, "subscription_trial_end")), "now")
 	}
 }
 

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -24,6 +24,14 @@ func TestInvoiceParams_AppendTo(t *testing.T) {
 		t.Logf("body = %+v", body)
 		assert.Equal(t, []string{"unchanged"}, body.Get("subscription_billing_cycle_anchor"))
 	}
+
+	{
+		params := &InvoiceParams{SubscriptionTrialEndNow: Bool(true)}
+		body := &form.Values{}
+		form.AppendTo(body, params)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"now"}, body.Get("subscription_trial_end"))
+	}
 }
 
 func TestInvoice_Unmarshal(t *testing.T) {


### PR DESCRIPTION
While we don't document this well in the API Reference, `subscription_trial_end: 'now'` is supported. It's present in stripe-java [here](https://github.com/stripe/stripe-java/blob/master/src/main/java/com/stripe/param/InvoiceUpcomingParams.java#L610)

r? @richardm-stripe 
cc @stripe/api-libraries @ksinder-stripe