### PR TITLE
API Updates

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -251,6 +251,9 @@ type ChargePaymentMethodDetailsAcssDebit struct {
 	TransitNumber     string `json:"transit_number"`
 }
 
+// ChargePaymentMethodDetailsAfterpayClearpay represents details about the AfterpayClearpay PaymentMethod.
+type ChargePaymentMethodDetailsAfterpayClearpay struct{}
+
 // ChargePaymentMethodDetailsAlipay represents details about the Alipay PaymentMethod.
 type ChargePaymentMethodDetailsAlipay struct {
 	Fingerprint   string `json:"fingerprint"`
@@ -547,6 +550,7 @@ type ChargePaymentMethodDetails struct {
 	AchCreditTransfer *ChargePaymentMethodDetailsAchCreditTransfer `json:"ach_credit_transfer"`
 	AchDebit          *ChargePaymentMethodDetailsAchDebit          `json:"ach_debit"`
 	AcssDebit         *ChargePaymentMethodDetailsAcssDebit         `json:"acss_debit"`
+	AfterpayClearpay  *ChargePaymentMethodDetailsAfterpayClearpay  `json:"afterpay_clearpay"`
 	Alipay            *ChargePaymentMethodDetailsAlipay            `json:"alipay"`
 	AUBECSDebit       *ChargePaymentMethodDetailsAUBECSDebit       `json:"au_becs_debit"`
 	BACSDebit         *ChargePaymentMethodDetailsBACSDebit         `json:"bacs_debit"`

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -88,6 +88,14 @@ const (
 	CheckoutSessionSubmitTypePay    CheckoutSessionSubmitType = "pay"
 )
 
+// CheckoutSessionLineItemAdjustableQuantityParams represents the parameters for
+// an adjustable quantity on a checkout session's line items.
+type CheckoutSessionLineItemAdjustableQuantityParams struct {
+	Enabled *bool  `form:"enabled"`
+	Maximum *int64 `form:"maximum"`
+	Minimum *int64 `form:"minimum"`
+}
+
 // CheckoutSessionLineItemPriceDataProductDataParams is the set of parameters that can be used when
 // creating a product created inline for a line item.
 type CheckoutSessionLineItemPriceDataProductDataParams struct {
@@ -128,16 +136,17 @@ type CheckoutSessionDiscountParams struct {
 // CheckoutSessionLineItemParams is the set of parameters allowed for a line item
 // on a checkout session.
 type CheckoutSessionLineItemParams struct {
-	Amount          *int64                                  `form:"amount"`
-	Currency        *string                                 `form:"currency"`
-	Description     *string                                 `form:"description"`
-	DynamicTaxRates []*string                               `form:"dynamic_tax_rates"`
-	Images          []*string                               `form:"images"`
-	Name            *string                                 `form:"name"`
-	Price           *string                                 `form:"price"`
-	PriceData       *CheckoutSessionLineItemPriceDataParams `form:"price_data"`
-	Quantity        *int64                                  `form:"quantity"`
-	TaxRates        []*string                               `form:"tax_rates"`
+	AdjustableQuantity *CheckoutSessionLineItemAdjustableQuantityParams `form:"adjustable_quantity"`
+	Amount             *int64                                           `form:"amount"`
+	Currency           *string                                          `form:"currency"`
+	Description        *string                                          `form:"description"`
+	DynamicTaxRates    []*string                                        `form:"dynamic_tax_rates"`
+	Images             []*string                                        `form:"images"`
+	Name               *string                                          `form:"name"`
+	Price              *string                                          `form:"price"`
+	PriceData          *CheckoutSessionLineItemPriceDataParams          `form:"price_data"`
+	Quantity           *int64                                           `form:"quantity"`
+	TaxRates           []*string                                        `form:"tax_rates"`
 }
 
 // CheckoutSessionPaymentIntentDataTransferDataParams is the set of parameters allowed for the

--- a/invoice.go
+++ b/invoice.go
@@ -166,6 +166,7 @@ type InvoiceParams struct {
 	Discounts            []*InvoiceDiscountParams      `form:"discounts"`
 	DueDate              *int64                        `form:"due_date"`
 	Footer               *string                       `form:"footer"`
+	OnBehalfOf           *string                       `form:"on_behalf_of"`
 	Paid                 *bool                         `form:"paid"`
 	PaymentSettings      *InvoicePaymentSettingsParams `form:"payment_settings"`
 	StatementDescriptor  *string                       `form:"statement_descriptor"`
@@ -315,6 +316,7 @@ type Invoice struct {
 	NextPaymentAttempt           int64                    `json:"next_payment_attempt"`
 	Number                       string                   `json:"number"`
 	Object                       string                   `json:"object"`
+	OnBehalfOf                   *Account                 `json:"on_behalf_of"`
 	Paid                         bool                     `json:"paid"`
 	PaymentIntent                *PaymentIntent           `json:"payment_intent"`
 	PaymentSettings              *InvoicePaymentSettings  `json:"payment_settings"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -168,18 +168,19 @@ type PaymentIntentMandateDataParams struct {
 // PaymentIntentPaymentMethodDataParams represents the type-specific parameters associated with a
 // payment method on payment intent.
 type PaymentIntentPaymentMethodDataParams struct {
-	Alipay         *PaymentMethodAlipayParams      `form:"alipay"`
-	AUBECSDebit    *PaymentMethodAUBECSDebitParams `form:"au_becs_debit"`
-	BillingDetails *BillingDetailsParams           `form:"billing_details"`
-	Card           *PaymentMethodCardParams        `form:"card"`
-	EPS            *PaymentMethodEPSParams         `form:"eps"`
-	FPX            *PaymentMethodFPXParams         `form:"fpx"`
-	Grabpay        *PaymentMethodGrabpayParams     `form:"grabpay"`
-	Ideal          *PaymentMethodIdealParams       `form:"ideal"`
-	OXXO           *PaymentMethodOXXOParams        `form:"oxxo"`
-	P24            *PaymentMethodP24Params         `form:"p24"`
-	SepaDebit      *PaymentMethodSepaDebitParams   `form:"sepa_debit"`
-	Type           *string                         `form:"type"`
+	AfterpayClearpay *PaymentMethodAfterpayClearpayParams `form:"afterpay_clearpay"`
+	Alipay           *PaymentMethodAlipayParams           `form:"alipay"`
+	AUBECSDebit      *PaymentMethodAUBECSDebitParams      `form:"au_becs_debit"`
+	BillingDetails   *BillingDetailsParams                `form:"billing_details"`
+	Card             *PaymentMethodCardParams             `form:"card"`
+	EPS              *PaymentMethodEPSParams              `form:"eps"`
+	FPX              *PaymentMethodFPXParams              `form:"fpx"`
+	Grabpay          *PaymentMethodGrabpayParams          `form:"grabpay"`
+	Ideal            *PaymentMethodIdealParams            `form:"ideal"`
+	OXXO             *PaymentMethodOXXOParams             `form:"oxxo"`
+	P24              *PaymentMethodP24Params              `form:"p24"`
+	SepaDebit        *PaymentMethodSepaDebitParams        `form:"sepa_debit"`
+	Type             *string                              `form:"type"`
 }
 
 // PaymentIntentPaymentMethodOptionsAlipayParams represents the Alipay-specific options

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -16,22 +16,23 @@ type PaymentMethodType string
 
 // List of values that PaymentMethodType can take.
 const (
-	PaymentMethodTypeAlipay         PaymentMethodType = "alipay"
-	PaymentMethodTypeAUBECSDebit    PaymentMethodType = "au_becs_debit"
-	PaymentMethodTypeBACSDebit      PaymentMethodType = "bacs_debit"
-	PaymentMethodTypeBancontact     PaymentMethodType = "bancontact"
-	PaymentMethodTypeCard           PaymentMethodType = "card"
-	PaymentMethodTypeCardPresent    PaymentMethodType = "card_present"
-	PaymentMethodTypeEPS            PaymentMethodType = "eps"
-	PaymentMethodTypeFPX            PaymentMethodType = "fpx"
-	PaymentMethodTypeGiropay        PaymentMethodType = "giropay"
-	PaymentMethodTypeGrabpay        PaymentMethodType = "grabpay"
-	PaymentMethodTypeIdeal          PaymentMethodType = "ideal"
-	PaymentMethodTypeInteracPresent PaymentMethodType = "interac_present"
-	PaymentMethodTypeOXXO           PaymentMethodType = "oxxo"
-	PaymentMethodTypeP24            PaymentMethodType = "p24"
-	PaymentMethodTypeSepaDebit      PaymentMethodType = "sepa_debit"
-	PaymentMethodTypeSofort         PaymentMethodType = "sofort"
+	PaymentMethodTypeAfterpayClearpay PaymentMethodType = "afterpay_clearpay"
+	PaymentMethodTypeAlipay           PaymentMethodType = "alipay"
+	PaymentMethodTypeAUBECSDebit      PaymentMethodType = "au_becs_debit"
+	PaymentMethodTypeBACSDebit        PaymentMethodType = "bacs_debit"
+	PaymentMethodTypeBancontact       PaymentMethodType = "bancontact"
+	PaymentMethodTypeCard             PaymentMethodType = "card"
+	PaymentMethodTypeCardPresent      PaymentMethodType = "card_present"
+	PaymentMethodTypeEPS              PaymentMethodType = "eps"
+	PaymentMethodTypeFPX              PaymentMethodType = "fpx"
+	PaymentMethodTypeGiropay          PaymentMethodType = "giropay"
+	PaymentMethodTypeGrabpay          PaymentMethodType = "grabpay"
+	PaymentMethodTypeIdeal            PaymentMethodType = "ideal"
+	PaymentMethodTypeInteracPresent   PaymentMethodType = "interac_present"
+	PaymentMethodTypeOXXO             PaymentMethodType = "oxxo"
+	PaymentMethodTypeP24              PaymentMethodType = "p24"
+	PaymentMethodTypeSepaDebit        PaymentMethodType = "sepa_debit"
+	PaymentMethodTypeSofort           PaymentMethodType = "sofort"
 )
 
 // PaymentMethodCardBrand is the list of allowed values for the brand property on a
@@ -89,6 +90,10 @@ type BillingDetailsParams struct {
 	Name    *string        `form:"name"`
 	Phone   *string        `form:"phone"`
 }
+
+// PaymentMethodAfterpayClearpay is the set of parameters allowed for the `afterpay_clearpay`
+// hash when creating a PaymentMethod of type AfterpayClearpay.
+type PaymentMethodAfterpayClearpayParams struct{}
 
 // PaymentMethodAlipayParams is the set of parameters allowed for the `alipay` hash when creating a
 // PaymentMethod of type Alipay.
@@ -184,24 +189,25 @@ type PaymentMethodSofortParams struct {
 // PaymentMethodParams is the set of parameters that can be used when creating or updating a
 // PaymentMethod.
 type PaymentMethodParams struct {
-	Params         `form:"*"`
-	Alipay         *PaymentMethodAlipayParams         `form:"alipay"`
-	AUBECSDebit    *PaymentMethodAUBECSDebitParams    `form:"au_becs_debit"`
-	BACSDebit      *PaymentMethodBACSDebitParams      `form:"bacs_debit"`
-	Bancontact     *PaymentMethodBancontactParams     `form:"bancontact"`
-	BillingDetails *BillingDetailsParams              `form:"billing_details"`
-	Card           *PaymentMethodCardParams           `form:"card"`
-	EPS            *PaymentMethodEPSParams            `form:"eps"`
-	FPX            *PaymentMethodFPXParams            `form:"fpx"`
-	Giropay        *PaymentMethodGiropayParams        `form:"giropay"`
-	Grabpay        *PaymentMethodGrabpayParams        `form:"grabpay"`
-	Ideal          *PaymentMethodIdealParams          `form:"ideal"`
-	InteracPresent *PaymentMethodInteracPresentParams `form:"interac_present"`
-	OXXO           *PaymentMethodOXXOParams           `form:"oxxo"`
-	P24            *PaymentMethodP24Params            `form:"p24"`
-	SepaDebit      *PaymentMethodSepaDebitParams      `form:"sepa_debit"`
-	Sofort         *PaymentMethodSofortParams         `form:"sofort"`
-	Type           *string                            `form:"type"`
+	Params           `form:"*"`
+	AfterpayClearpay *PaymentMethodAfterpayClearpayParams `form:"afterpay_clearpay"`
+	Alipay           *PaymentMethodAlipayParams           `form:"alipay"`
+	AUBECSDebit      *PaymentMethodAUBECSDebitParams      `form:"au_becs_debit"`
+	BACSDebit        *PaymentMethodBACSDebitParams        `form:"bacs_debit"`
+	Bancontact       *PaymentMethodBancontactParams       `form:"bancontact"`
+	BillingDetails   *BillingDetailsParams                `form:"billing_details"`
+	Card             *PaymentMethodCardParams             `form:"card"`
+	EPS              *PaymentMethodEPSParams              `form:"eps"`
+	FPX              *PaymentMethodFPXParams              `form:"fpx"`
+	Giropay          *PaymentMethodGiropayParams          `form:"giropay"`
+	Grabpay          *PaymentMethodGrabpayParams          `form:"grabpay"`
+	Ideal            *PaymentMethodIdealParams            `form:"ideal"`
+	InteracPresent   *PaymentMethodInteracPresentParams   `form:"interac_present"`
+	OXXO             *PaymentMethodOXXOParams             `form:"oxxo"`
+	P24              *PaymentMethodP24Params              `form:"p24"`
+	SepaDebit        *PaymentMethodSepaDebitParams        `form:"sepa_debit"`
+	Sofort           *PaymentMethodSofortParams           `form:"sofort"`
+	Type             *string                              `form:"type"`
 
 	// The following parameters are used when cloning a PaymentMethod to the connected account
 	Customer      *string `form:"customer"`
@@ -234,6 +240,10 @@ type BillingDetails struct {
 	Email   string   `json:"email"`
 	Name    string   `json:"name"`
 	Phone   string   `json:"phone"`
+}
+
+// PaymentMethodAfterpayClearpay represents the AfterpayClearpay properties.
+type PaymentMethodAfterpayClearpay struct {
 }
 
 // PaymentMethodAlipay represents the Alipay properties.
@@ -372,30 +382,31 @@ type PaymentMethodSofort struct {
 // PaymentMethod is the resource representing a PaymentMethod.
 type PaymentMethod struct {
 	APIResource
-	Alipay         *PaymentMethodAlipay         `json:"alipay"`
-	AUBECSDebit    *PaymentMethodAUBECSDebit    `json:"au_becs_debit"`
-	BACSDebit      *PaymentMethodBACSDebit      `json:"bacs_debit"`
-	Bancontact     *PaymentMethodBancontact     `json:"bancontact"`
-	BillingDetails *BillingDetails              `json:"billing_details"`
-	Card           *PaymentMethodCard           `json:"card"`
-	CardPresent    *PaymentMethodCardPresent    `json:"card_present"`
-	Created        int64                        `json:"created"`
-	Customer       *Customer                    `json:"customer"`
-	EPS            *PaymentMethodEPS            `json:"eps"`
-	FPX            *PaymentMethodFPX            `json:"fpx"`
-	Giropay        *PaymentMethodGiropay        `json:"giropay"`
-	Grabpay        *PaymentMethodGrabpay        `json:"grabpay"`
-	ID             string                       `json:"id"`
-	Ideal          *PaymentMethodIdeal          `json:"ideal"`
-	InteracPresent *PaymentMethodInteracPresent `json:"interac_present"`
-	Livemode       bool                         `json:"livemode"`
-	Metadata       map[string]string            `json:"metadata"`
-	Object         string                       `json:"object"`
-	OXXO           *PaymentMethodOXXO           `json:"oxxo"`
-	P24            *PaymentMethodP24            `json:"p24"`
-	SepaDebit      *PaymentMethodSepaDebit      `json:"sepa_debit"`
-	Sofort         *PaymentMethodSofort         `json:"sofort"`
-	Type           PaymentMethodType            `json:"type"`
+	AfterpayClearpay *PaymentMethodAfterpayClearpay `json:"afterpay_clearpay"`
+	Alipay           *PaymentMethodAlipay           `json:"alipay"`
+	AUBECSDebit      *PaymentMethodAUBECSDebit      `json:"au_becs_debit"`
+	BACSDebit        *PaymentMethodBACSDebit        `json:"bacs_debit"`
+	Bancontact       *PaymentMethodBancontact       `json:"bancontact"`
+	BillingDetails   *BillingDetails                `json:"billing_details"`
+	Card             *PaymentMethodCard             `json:"card"`
+	CardPresent      *PaymentMethodCardPresent      `json:"card_present"`
+	Created          int64                          `json:"created"`
+	Customer         *Customer                      `json:"customer"`
+	EPS              *PaymentMethodEPS              `json:"eps"`
+	FPX              *PaymentMethodFPX              `json:"fpx"`
+	Giropay          *PaymentMethodGiropay          `json:"giropay"`
+	Grabpay          *PaymentMethodGrabpay          `json:"grabpay"`
+	ID               string                         `json:"id"`
+	Ideal            *PaymentMethodIdeal            `json:"ideal"`
+	InteracPresent   *PaymentMethodInteracPresent   `json:"interac_present"`
+	Livemode         bool                           `json:"livemode"`
+	Metadata         map[string]string              `json:"metadata"`
+	Object           string                         `json:"object"`
+	OXXO             *PaymentMethodOXXO             `json:"oxxo"`
+	P24              *PaymentMethodP24              `json:"p24"`
+	SepaDebit        *PaymentMethodSepaDebit        `json:"sepa_debit"`
+	Sofort           *PaymentMethodSofort           `json:"sofort"`
+	Type             PaymentMethodType              `json:"type"`
 }
 
 // PaymentMethodList is a list of PaymentMethods as retrieved from a list endpoint.


### PR DESCRIPTION
Contains changes from [openapi releases](https://github.com/stripe/openapi/releases) [v18](https://github.com/stripe/openapi/releases/tag/v18) and [v17](https://github.com/stripe/openapi/releases/tag/v17)
## Changelog
* Add support for `afterpay_clearpay` on `PaymentMethod`, `PaymentMethodParams`, `PaymentIntentPaymentMethodDataParams`, and `ChargePaymentMethodDetails`
* Added `afterpay_clearpay` as an enum member on `PaymentMethodType` 
* Added support for `adjustable_quantity` on `CheckoutSessionLineItemParams`
* Added support for `on_behalf_of` on `InvoiceParams` and `Invoice`
