### PR TITLE
Fix `LineItemTax` to deserialize `Rate` properly

### DIFF
--- a/lineitem.go
+++ b/lineitem.go
@@ -12,7 +12,11 @@ type LineItemDiscount struct {
 
 // LineItemTax represent the details of one tax rate applied to a line item.
 type LineItemTax struct {
-	Amount  int64    `json:"amount"`
+	Amount int64    `json:"amount"`
+	Rate   *TaxRate `json:"rate"`
+
+	// This property never worked. Use Rate instead.
+	// TODO: Remove in the next major version
 	TaxRate *TaxRate `json:"tax_rate"`
 }
 


### PR DESCRIPTION
This fixes this property: https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-line_items-data-taxes-rate

r? @richardm-stripe 
cc @stripe/api-libraries 