### PR TITLE
Adds ErrorType idempotency_error

### DIFF
--- a/error.go
+++ b/error.go
@@ -14,6 +14,7 @@ const (
 	ErrorTypeInvalidRequest ErrorType = "invalid_request_error"
 	ErrorTypePermission     ErrorType = "more_permissions_required"
 	ErrorTypeRateLimit      ErrorType = "rate_limit_error"
+	ErrorTypeIdempotency    ErrorType = "idempotency_error"
 )
 
 // ErrorCode is the list of allowed values for the error's code.
@@ -292,6 +293,17 @@ type RateLimitError struct {
 
 // Error serializes the error object to JSON and returns it as a string.
 func (e *RateLimitError) Error() string {
+	return e.stripeErr.Error()
+}
+
+// IdempotencyError occurs when an Idempotency-Key is re-used on a request
+// that does not match the first request's API endpoint and parameters.
+type IdempotencyError struct {
+	stripeErr *Error
+}
+
+// Error serializes the error object to JSON and returns it as a string.
+func (e *IdempotencyError) Error() string {
 	return e.stripeErr.Error()
 }
 

--- a/error.go
+++ b/error.go
@@ -11,10 +11,10 @@ const (
 	ErrorTypeAPIConnection  ErrorType = "api_connection_error"
 	ErrorTypeAuthentication ErrorType = "authentication_error"
 	ErrorTypeCard           ErrorType = "card_error"
+	ErrorTypeIdempotency    ErrorType = "idempotency_error"
 	ErrorTypeInvalidRequest ErrorType = "invalid_request_error"
 	ErrorTypePermission     ErrorType = "more_permissions_required"
 	ErrorTypeRateLimit      ErrorType = "rate_limit_error"
-	ErrorTypeIdempotency    ErrorType = "idempotency_error"
 )
 
 // ErrorCode is the list of allowed values for the error's code.

--- a/stripe.go
+++ b/stripe.go
@@ -566,6 +566,8 @@ func (s *BackendImplementation) ResponseToError(res *http.Response, resBody []by
 		typedError = &PermissionError{stripeErr: raw.Error}
 	case ErrorTypeRateLimit:
 		typedError = &RateLimitError{stripeErr: raw.Error}
+	case ErrorTypeIdempotency:
+		typedError = &IdempotencyError{stripeErr: raw.Error}
 	}
 	raw.Error.Err = typedError
 

--- a/stripe.go
+++ b/stripe.go
@@ -560,14 +560,14 @@ func (s *BackendImplementation) ResponseToError(res *http.Response, resBody []by
 		}
 
 		typedError = cardErr
+	case ErrorTypeIdempotency:
+		typedError = &IdempotencyError{stripeErr: raw.Error}
 	case ErrorTypeInvalidRequest:
 		typedError = &InvalidRequestError{stripeErr: raw.Error}
 	case ErrorTypePermission:
 		typedError = &PermissionError{stripeErr: raw.Error}
 	case ErrorTypeRateLimit:
 		typedError = &RateLimitError{stripeErr: raw.Error}
-	case ErrorTypeIdempotency:
-		typedError = &IdempotencyError{stripeErr: raw.Error}
 	}
 	raw.Error.Err = typedError
 


### PR DESCRIPTION
Hi Stripe folk 👋

**This PR adds the `ErrorType` `ErrorTypeIdempotency`**

As a consumer of your go SDK I ran into some idempotency errors and while trying to gracefully handle them on my end I noticed the error type `idempotency_error` wasn't mapped to your other `ErrorType`s

All the other main errors seem to be mapped:
![](https://i.imgur.com/p7NUQlE.png)

Adding this as an error type will allow consumers to cleanly do stripe error type assertions in their code, eg.

```go
pi, err := stripe.somePaymentIntentThing(paymentIntentID)
if err != nil {
    if se, ok := err.(*stripe.Error); ok {
    switch se.Type {
    case stripe.ErrorTypeAPIConnection:
        // handle this kind of error
    case stripe.ErrorTypeIdempotency:
        // handle this kind of error
    case ....    
    }
} 	

```

Currently you instead have to do something like: 

```go
pi, err := stripe.somePaymentIntentThing(paymentIntentID)
if err != nil {
    if se, ok := err.(*stripe.Error); ok {
    switch se.Type {
    case stripe.ErrorTypeAPIConnection:
        // handle this kind of error
    case stripe.ErrorType("idempotency_error"):
        // handle this kind of error
    case ....
    }
} 	
```

Thanks!