### PR TITLE
Add configuration API to billingportal_session.go

### DIFF
--- a/billingportal_session.go
+++ b/billingportal_session.go
@@ -6,21 +6,25 @@ import (
 
 // BillingPortalSessionParams is the set of parameters that can be used when creating a billing portal session.
 type BillingPortalSessionParams struct {
-	Params    `form:"*"`
-	Customer  *string `form:"customer"`
-	ReturnURL *string `form:"return_url"`
+	Params        `form:"*"`
+	Configuration *string `form:"configuration"`
+	Customer      *string `form:"customer"`
+	OnBehalfOf    *string `form:"on_behalf_of"`
+	ReturnURL     *string `form:"return_url"`
 }
 
 // BillingPortalSession is the resource representing a billing portal session.
 type BillingPortalSession struct {
 	APIResource
-	Created   int64  `json:"created"`
-	Customer  string `json:"customer"`
-	ID        string `json:"id"`
-	Livemode  bool   `json:"livemode"`
-	Object    string `json:"object"`
-	ReturnURL string `json:"return_url"`
-	URL       string `json:"url"`
+	Created       int64                       `json:"created"`
+	Configuration *BillingPortalConfiguration `json:"configuration"`
+	Customer      string                      `json:"customer"`
+	ID            string                      `json:"id"`
+	Livemode      bool                        `json:"livemode"`
+	Object        string                      `json:"object"`
+	OnBehalfOf    string                      `json:"on_behalf_of"`
+	ReturnURL     string                      `json:"return_url"`
+	URL           string                      `json:"url"`
 }
 
 // UnmarshalJSON handles deserialization of a billing portal session.


### PR DESCRIPTION
I added the new configuration resource in [the previous release](https://github.com/stripe/stripe-go/pull/1254/files), but neglected to ship the corresponding updates to billingportal_session.go. Realized this while working on codegen. Compare to [stripe-node](https://github.com/stripe/stripe-node/commit/a80a93e3cd3cfc9709042a37d52ac8d023a87f48#diff-caa95f00428a023bac8606e7a9103678ebdb7f5cc781e6af0fda0ee165f38203).