### PR TITLE
Codegen 10 more files

### DIFF
--- a/applepaydomain.go
+++ b/applepaydomain.go
@@ -1,8 +1,20 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // ApplePayDomainParams is the set of parameters that can be used when creating an ApplePayDomain object.
 type ApplePayDomainParams struct {
 	Params     `form:"*"`
+	DomainName *string `form:"domain_name"`
+}
+
+// ApplePayDomainListParams are the parameters allowed during ApplePayDomain listing.
+type ApplePayDomainListParams struct {
+	ListParams `form:"*"`
 	DomainName *string `form:"domain_name"`
 }
 
@@ -14,11 +26,7 @@ type ApplePayDomain struct {
 	DomainName string `json:"domain_name"`
 	ID         string `json:"id"`
 	Livemode   bool   `json:"livemode"`
-}
-
-// ApplePayDomainListParams are the parameters allowed during ApplePayDomain listing.
-type ApplePayDomainListParams struct {
-	ListParams `form:"*"`
+	Object     string `json:"object"`
 }
 
 // ApplePayDomainList is a list of ApplePayDomains as returned from a list endpoint.

--- a/application.go
+++ b/application.go
@@ -1,11 +1,17 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
 
-// Application describes the properties for an Application.
 type Application struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Object string `json:"object"`
 }
 
 // UnmarshalJSON handles deserialization of an Application.

--- a/application.go
+++ b/application.go
@@ -8,6 +8,7 @@ package stripe
 
 import "encoding/json"
 
+// Application describes the properties for an Application.
 type Application struct {
 	ID     string `json:"id"`
 	Name   string `json:"name"`

--- a/billingportal_configuration.go
+++ b/billingportal_configuration.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -224,12 +230,12 @@ type BillingPortalConfigurationList struct {
 	Data []*BillingPortalConfiguration `json:"data"`
 }
 
-// UnmarshalJSON handles deserialization of a BillingPortalConfiguration. This
-// custom unmarshaling is needed because the resulting property may be an id or
-// the full struct if it was expanded.
-func (c *BillingPortalConfiguration) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON handles deserialization of a BillingPortalConfiguration.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (b *BillingPortalConfiguration) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		c.ID = id
+		b.ID = id
 		return nil
 	}
 
@@ -239,6 +245,6 @@ func (c *BillingPortalConfiguration) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*c = BillingPortalConfiguration(v)
+	*b = BillingPortalConfiguration(v)
 	return nil
 }

--- a/customerbalancetransaction.go
+++ b/customerbalancetransaction.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -14,6 +20,8 @@ const (
 	CustomerBalanceTransactionTypeInitial               CustomerBalanceTransactionType = "initial"
 	CustomerBalanceTransactionTypeInvoiceTooLarge       CustomerBalanceTransactionType = "invoice_too_large"
 	CustomerBalanceTransactionTypeInvoiceTooSmall       CustomerBalanceTransactionType = "invoice_too_small"
+	CustomerBalanceTransactionTypeMigration             CustomerBalanceTransactionType = "migration"
+	CustomerBalanceTransactionTypeUnappliedFromInvoice  CustomerBalanceTransactionType = "unapplied_from_invoice"
 	CustomerBalanceTransactionTypeUnspentReceiverCredit CustomerBalanceTransactionType = "unspent_receiver_credit"
 )
 
@@ -22,8 +30,8 @@ const (
 // For more details see https://stripe.com/docs/api/customers/create_customer_balance_transaction
 type CustomerBalanceTransactionParams struct {
 	Params      `form:"*"`
+	Customer    *string `form:"-"` // Included in URL
 	Amount      *int64  `form:"amount"`
-	Customer    *string `form:"-"`
 	Currency    *string `form:"currency"`
 	Description *string `form:"description"`
 }
@@ -33,7 +41,7 @@ type CustomerBalanceTransactionParams struct {
 // For more detail see https://stripe.com/docs/api/customers/customer_balance_transactions
 type CustomerBalanceTransactionListParams struct {
 	ListParams `form:"*"`
-	Customer   *string `form:"-"`
+	Customer   *string `form:"-"` // Included in URL
 }
 
 // CustomerBalanceTransaction is the resource representing a customer balance transaction.
@@ -72,8 +80,8 @@ func (c *CustomerBalanceTransaction) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	type transaction CustomerBalanceTransaction
-	var v transaction
+	type customerBalanceTransaction CustomerBalanceTransaction
+	var v customerBalanceTransaction
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}

--- a/feerefund.go
+++ b/feerefund.go
@@ -1,22 +1,26 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // FeeRefundParams is the set of parameters that can be used when refunding an application fee.
 // For more details see https://stripe.com/docs/api#fee_refund.
 type FeeRefundParams struct {
 	Params         `form:"*"`
+	ApplicationFee *string `form:"-"` // Included in URL
 	Amount         *int64  `form:"amount"`
-	ApplicationFee *string `form:"-"` // Included in the URL
 }
 
 // FeeRefundListParams is the set of parameters that can be used when listing application fee refunds.
 // For more details see https://stripe.com/docs/api#list_fee_refunds.
 type FeeRefundListParams struct {
 	ListParams     `form:"*"`
-	ApplicationFee *string `form:"-"` // Included in the URL
+	ApplicationFee *string `form:"-"` // Included in URL
 }
 
 // FeeRefund is the resource representing a Stripe application fee refund.
@@ -30,6 +34,7 @@ type FeeRefund struct {
 	Fee                *ApplicationFee     `json:"fee"`
 	ID                 string              `json:"id"`
 	Metadata           map[string]string   `json:"metadata"`
+	Object             string              `json:"object"`
 }
 
 // FeeRefundList is a list object for application fee refunds.
@@ -42,9 +47,9 @@ type FeeRefundList struct {
 // UnmarshalJSON handles deserialization of a FeeRefund.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (r *FeeRefund) UnmarshalJSON(data []byte) error {
+func (f *FeeRefund) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		r.ID = id
+		f.ID = id
 		return nil
 	}
 
@@ -54,6 +59,6 @@ func (r *FeeRefund) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*r = FeeRefund(v)
+	*f = FeeRefund(v)
 	return nil
 }

--- a/promotioncode.go
+++ b/promotioncode.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -67,18 +73,18 @@ type PromotionCodeList struct {
 // UnmarshalJSON handles deserialization of a PromotionCode.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (c *PromotionCode) UnmarshalJSON(data []byte) error {
+func (p *PromotionCode) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		c.ID = id
+		p.ID = id
 		return nil
 	}
 
-	type pc PromotionCode
-	var v pc
+	type promotionCode PromotionCode
+	var v promotionCode
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*c = PromotionCode(v)
+	*p = PromotionCode(v)
 	return nil
 }

--- a/taxrate.go
+++ b/taxrate.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -55,18 +61,18 @@ type TaxRateList struct {
 // UnmarshalJSON handles deserialization of a TaxRate.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (c *TaxRate) UnmarshalJSON(data []byte) error {
+func (t *TaxRate) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		c.ID = id
+		t.ID = id
 		return nil
 	}
 
-	type taxrate TaxRate
-	var v taxrate
+	type taxRate TaxRate
+	var v taxRate
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*c = TaxRate(v)
+	*t = TaxRate(v)
 	return nil
 }

--- a/terminal_connectiontoken.go
+++ b/terminal_connectiontoken.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // TerminalConnectionTokenParams is the set of parameters that can be used when creating a terminal connection token.

--- a/terminal_location.go
+++ b/terminal_location.go
@@ -21,13 +21,13 @@ type TerminalLocationListParams struct {
 // TerminalLocation is the resource representing a Stripe terminal location.
 type TerminalLocation struct {
 	APIResource
-	Address     *AccountAddress   `json:"address"`
-	Deleted     bool              `json:"deleted"`
-	DisplayName string            `json:"display_name"`
-	ID          string            `json:"id"`
-	Livemode    bool              `json:"livemode"`
-	Metadata    map[string]string `json:"metadata"`
-	Object      string            `json:"object"`
+	Address     *AccountAddressParams `json:"address"`
+	Deleted     bool                  `json:"deleted"`
+	DisplayName string                `json:"display_name"`
+	ID          string                `json:"id"`
+	Livemode    bool                  `json:"livemode"`
+	Metadata    map[string]string     `json:"metadata"`
+	Object      string                `json:"object"`
 }
 
 // TerminalLocationList is a list of terminal readers as retrieved from a list endpoint.

--- a/terminal_location.go
+++ b/terminal_location.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // TerminalLocationParams is the set of parameters that can be used when creating or updating a terminal location.
@@ -15,13 +21,13 @@ type TerminalLocationListParams struct {
 // TerminalLocation is the resource representing a Stripe terminal location.
 type TerminalLocation struct {
 	APIResource
-	Address     *AccountAddressParams `json:"address"`
-	Deleted     bool                  `json:"deleted"`
-	DisplayName string                `json:"display_name"`
-	ID          string                `json:"id"`
-	Livemode    bool                  `json:"livemode"`
-	Metadata    map[string]string     `json:"metadata"`
-	Object      string                `json:"object"`
+	Address     *AccountAddress   `json:"address"`
+	Deleted     bool              `json:"deleted"`
+	DisplayName string            `json:"display_name"`
+	ID          string            `json:"id"`
+	Livemode    bool              `json:"livemode"`
+	Metadata    map[string]string `json:"metadata"`
+	Object      string            `json:"object"`
 }
 
 // TerminalLocationList is a list of terminal readers as retrieved from a list endpoint.

--- a/usagerecord.go
+++ b/usagerecord.go
@@ -1,10 +1,25 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-// Possible values for the action parameter on usage record creation.
 const (
 	UsageRecordActionIncrement string = "increment"
 	UsageRecordActionSet       string = "set"
 )
+
+// UsageRecordParams create a usage record for a specified subscription item
+// and date, and fills it with a quantity.
+type UsageRecordParams struct {
+	Params           `form:"*"`
+	SubscriptionItem *string `form:"-"` // Included in URL
+	Action           *string `form:"action"`
+	Quantity         *int64  `form:"quantity"`
+	Timestamp        *int64  `form:"timestamp"`
+}
 
 // UsageRecord represents a usage record.
 // See https://stripe.com/docs/api#usage_records
@@ -12,17 +27,8 @@ type UsageRecord struct {
 	APIResource
 	ID               string `json:"id"`
 	Livemode         bool   `json:"livemode"`
+	Object           string `json:"object"`
 	Quantity         int64  `json:"quantity"`
 	SubscriptionItem string `json:"subscription_item"`
 	Timestamp        int64  `json:"timestamp"`
-}
-
-// UsageRecordParams create a usage record for a specified subscription item
-// and date, and fills it with a quantity.
-type UsageRecordParams struct {
-	Params           `form:"*"`
-	Action           *string `form:"action"`
-	Quantity         *int64  `form:"quantity"`
-	SubscriptionItem *string `form:"-"` // passed in the URL
-	Timestamp        *int64  `form:"timestamp"`
 }

--- a/usagerecord.go
+++ b/usagerecord.go
@@ -6,6 +6,7 @@
 
 package stripe
 
+// Possible values for the action parameter on usage record creation.
 const (
 	UsageRecordActionIncrement string = "increment"
 	UsageRecordActionSet       string = "set"

--- a/usagerecordsummary.go
+++ b/usagerecordsummary.go
@@ -1,4 +1,16 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
+
+// UsageRecordSummaryListParams is the set of parameters that can be used when listing charges.
+type UsageRecordSummaryListParams struct {
+	ListParams       `form:"*"`
+	SubscriptionItem *string `form:"-"` // Included in URL
+}
 
 // UsageRecordSummary represents a usage record summary.
 // See https://stripe.com/docs/api#usage_records
@@ -10,12 +22,6 @@ type UsageRecordSummary struct {
 	Period           *Period `json:"period"`
 	SubscriptionItem string  `json:"subscription_item"`
 	TotalUsage       int64   `json:"total_usage"`
-}
-
-// UsageRecordSummaryListParams is the set of parameters that can be used when listing charges.
-type UsageRecordSummaryListParams struct {
-	ListParams       `form:"*"`
-	SubscriptionItem *string `form:"-"` // Sent in with the URL
 }
 
 // UsageRecordSummaryList is a list of usage record summaries as retrieved from a list endpoint.


### PR DESCRIPTION
r? @remi-stripe - removed the potential breaking change, this is ready for a real review

- `applepaydomain.go`
  - Add a missing `DomainName` field to the ListParams.
  https://github.com/stripe/stripe-go/pull/1264/files#diff-cbfd212f7ddc855ea5f8d193fa576a280cc362cd76c23e619917129eaffbbdf3R18
  - Add missing `Object` field
 - `application.go`
   - Add missing `Object` field
 - `customerbalancetransaction.go`
   - Add two missing members to `CustomerBalanceTransactionType` enum
 - `feerefund.go`
   - Add missing `Object` field
 - `loginlink.go`
   - Add missing `Object` field
 - `product.go`
   - Add missing `Object` and `Deleted` field
 - `terminal_location.go`
   - ~Corrected `*AccountAddressParams` reference in resource, should have been `*AccountAddress`. https://github.com/stripe/stripe-go/pull/1264/files#diff-1cec9d2aed3b04955c7fb6b3e5c43d9146271bbbf65e010fc5cf63e331210902R24 (is this a breaking bugfix? I don't think so because this didn't have `json:` form annotations, so anybody trying to read this would already be broken)~ (postponing this until the major)
 - `usagerecord.go`
   - Added missing `Object` field