### PR TITLE
Add ShippingRates and AmountShipping

### DIFF
--- a/checkout_session.go
+++ b/checkout_session.go
@@ -229,8 +229,9 @@ type CheckoutSessionParams struct {
 	PaymentMethodTypes        []*string                                       `form:"payment_method_types"`
 	SetupIntentData           *CheckoutSessionSetupIntentDataParams           `form:"setup_intent_data"`
 	ShippingAddressCollection *CheckoutSessionShippingAddressCollectionParams `form:"shipping_address_collection"`
-	SubscriptionData          *CheckoutSessionSubscriptionDataParams          `form:"subscription_data"`
+	ShippingRates             []*string                                       `form:"shipping_rates"`
 	SubmitType                *string                                         `form:"submit_type"`
+	SubscriptionData          *CheckoutSessionSubscriptionDataParams          `form:"subscription_data"`
 	SuccessURL                *string                                         `form:"success_url"`
 }
 
@@ -292,6 +293,7 @@ type CheckoutSessionTotalDetailsBreakdown struct {
 // CheckoutSessionTotalDetails is the set of properties detailing how the amounts were calculated.
 type CheckoutSessionTotalDetails struct {
 	AmountDiscount int64                                 `json:"amount_discount"`
+	AmountShipping int64                                 `json:"amount_shipping"`
 	AmountTax      int64                                 `json:"amount_tax"`
 	Breakdown      *CheckoutSessionTotalDetailsBreakdown `json:"breakdown"`
 }


### PR DESCRIPTION
r? @remi-stripe 
## Changelog
* Add support for `ShippingRates` on `CheckoutSessionParams`
* Add support for `AmountShipping`on `CheckoutSessionTotalDetails`

[typescript diff](https://github.com/stripe/stripe-node/pull/1132/files#diff-f684ac17bf6ba3c816191ac9bb75357e7a6d6fdea74b5c686bb57b0dd952e3dd)
[openapi release](https://github.com/stripe/openapi/releases/tag/v23)