### PR TITLE
codegen: 13 more files

### DIFF
--- a/accountlink.go
+++ b/accountlink.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // AccountLinkType is the type of an account link.

--- a/billingportal_session.go
+++ b/billingportal_session.go
@@ -1,8 +1,12 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // BillingPortalSessionParams is the set of parameters that can be used when creating a billing portal session.
 type BillingPortalSessionParams struct {
@@ -16,8 +20,8 @@ type BillingPortalSessionParams struct {
 // BillingPortalSession is the resource representing a billing portal session.
 type BillingPortalSession struct {
 	APIResource
-	Created       int64                       `json:"created"`
 	Configuration *BillingPortalConfiguration `json:"configuration"`
+	Created       int64                       `json:"created"`
 	Customer      string                      `json:"customer"`
 	ID            string                      `json:"id"`
 	Livemode      bool                        `json:"livemode"`
@@ -27,21 +31,21 @@ type BillingPortalSession struct {
 	URL           string                      `json:"url"`
 }
 
-// UnmarshalJSON handles deserialization of a billing portal session.
+// UnmarshalJSON handles deserialization of a BillingPortalSession.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (p *BillingPortalSession) UnmarshalJSON(data []byte) error {
+func (b *BillingPortalSession) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		p.ID = id
+		b.ID = id
 		return nil
 	}
 
-	type session BillingPortalSession
-	var v session
+	type billingPortalSession BillingPortalSession
+	var v billingPortalSession
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*p = BillingPortalSession(v)
+	*b = BillingPortalSession(v)
 	return nil
 }

--- a/countryspec.go
+++ b/countryspec.go
@@ -1,7 +1,23 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // Country is the list of supported countries
 type Country string
+
+// CountrySpecParams are the parameters allowed during CountrySpec retrieval.
+type CountrySpecParams struct {
+	Params `form:"*"`
+}
+
+// CountrySpecListParams are the parameters allowed during CountrySpec listing.
+type CountrySpecListParams struct {
+	ListParams `form:"*"`
+}
 
 // VerificationFieldsList lists the fields needed for an account verification.
 // For more details see https://stripe.com/docs/api#country_spec_object-verification_fields.
@@ -16,6 +32,7 @@ type CountrySpec struct {
 	APIResource
 	DefaultCurrency                Currency                                        `json:"default_currency"`
 	ID                             string                                          `json:"id"`
+	Object                         string                                          `json:"object"`
 	SupportedBankAccountCurrencies map[Currency][]Country                          `json:"supported_bank_account_currencies"`
 	SupportedPaymentCurrencies     []Currency                                      `json:"supported_payment_currencies"`
 	SupportedPaymentMethods        []string                                        `json:"supported_payment_methods"`
@@ -23,19 +40,9 @@ type CountrySpec struct {
 	VerificationFields             map[AccountBusinessType]*VerificationFieldsList `json:"verification_fields"`
 }
 
-// CountrySpecParams are the parameters allowed during CountrySpec retrieval.
-type CountrySpecParams struct {
-	Params `form:"*"`
-}
-
 // CountrySpecList is a list of country specs as retrieved from a list endpoint.
 type CountrySpecList struct {
 	APIResource
 	ListMeta
 	Data []*CountrySpec `json:"data"`
-}
-
-// CountrySpecListParams are the parameters allowed during CountrySpec listing.
-type CountrySpecListParams struct {
-	ListParams `form:"*"`
 }

--- a/filelink.go
+++ b/filelink.go
@@ -20,7 +20,7 @@ type FileLinkParams struct {
 // AppendTo implements custom encoding logic for FileLinkParams.
 func (f *FileLinkParams) AppendTo(body *form.Values, keyParts []string) {
 	if BoolValue(f.ExpiresAtNow) {
-		body.Add(form.FormatKey(append(keyParts, "ExpiresAt")), "now")
+		body.Add(form.FormatKey(append(keyParts, "expires_at")), "now")
 	}
 }
 

--- a/filelink.go
+++ b/filelink.go
@@ -1,14 +1,27 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
+import "github.com/stripe/stripe-go/v72/form"
 
 // FileLinkParams is the set of parameters that can be used when creating or updating a file link.
 type FileLinkParams struct {
-	Params    `form:"*"`
-	ExpiresAt *int64  `form:"expires_at"`
-	File      *string `form:"file"`
+	Params       `form:"*"`
+	ExpiresAt    *int64  `form:"expires_at"`
+	ExpiresAtNow *bool   `form:"-"` // See custom AppendTo
+	File         *string `form:"file"`
+}
+
+// AppendTo implements custom encoding logic for FileLinkParams.
+func (f *FileLinkParams) AppendTo(body *form.Values, keyParts []string) {
+	if BoolValue(f.ExpiresAtNow) {
+		body.Add(form.FormatKey(append(keyParts, "ExpiresAt")), "now")
+	}
 }
 
 // FileLinkListParams is the set of parameters that can be used when listing file links.
@@ -35,12 +48,12 @@ type FileLink struct {
 	URL       string            `json:"url"`
 }
 
-// UnmarshalJSON handles deserialization of a file link.
+// UnmarshalJSON handles deserialization of a FileLink.
 // This custom unmarshaling is needed because the resulting
-// property may be an ID or the full struct if it was expanded.
-func (c *FileLink) UnmarshalJSON(data []byte) error {
+// property may be an id or the full struct if it was expanded.
+func (f *FileLink) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		c.ID = id
+		f.ID = id
 		return nil
 	}
 
@@ -50,7 +63,7 @@ func (c *FileLink) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*c = FileLink(v)
+	*f = FileLink(v)
 	return nil
 }
 

--- a/filelink_test.go
+++ b/filelink_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v72/form"
 )
 
 func TestFileLink_UnmarshalJSON(t *testing.T) {
@@ -25,5 +26,15 @@ func TestFileLink_UnmarshalJSON(t *testing.T) {
 		err = json.Unmarshal(data, &v)
 		assert.NoError(t, err)
 		assert.Equal(t, "link_123", v.ID)
+	}
+}
+
+func TestFileLinkParams_AppendTo(t *testing.T) {
+	{
+		params := &FileLinkParams{ExpiresAtNow: Bool(true)}
+		body := &form.Values{}
+		form.AppendTo(body, params)
+		t.Logf("body = %+v", body)
+		assert.Equal(t, []string{"now"}, body.Get("expires_at"))
 	}
 }

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -70,22 +76,17 @@ type InvoiceItem struct {
 	Invoice           *Invoice          `json:"invoice"`
 	Livemode          bool              `json:"livemode"`
 	Metadata          map[string]string `json:"metadata"`
+	Object            string            `json:"object"`
 	Period            *Period           `json:"period"`
 	Plan              *Plan             `json:"plan"`
 	Price             *Price            `json:"price"`
 	Proration         bool              `json:"proration"`
 	Quantity          int64             `json:"quantity"`
 	Subscription      *Subscription     `json:"subscription"`
+	SubscriptionItem  string            `json:"subscription_item"`
 	TaxRates          []*TaxRate        `json:"tax_rates"`
 	UnitAmount        int64             `json:"unit_amount"`
 	UnitAmountDecimal float64           `json:"unit_amount_decimal,string"`
-}
-
-// InvoiceItemList is a list of invoice items as retrieved from a list endpoint.
-type InvoiceItemList struct {
-	APIResource
-	ListMeta
-	Data []*InvoiceItem `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of an InvoiceItem.
@@ -105,4 +106,11 @@ func (i *InvoiceItem) UnmarshalJSON(data []byte) error {
 
 	*i = InvoiceItem(v)
 	return nil
+}
+
+// InvoiceItemList is a list of invoice items as retrieved from a list endpoint.
+type InvoiceItemList struct {
+	APIResource
+	ListMeta
+	Data []*InvoiceItem `json:"data"`
 }

--- a/issuing_transaction.go
+++ b/issuing_transaction.go
@@ -1,15 +1,12 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
-
-// IssuingTransactionType is the type of an issuing transaction.
-type IssuingTransactionType string
-
-// List of values that IssuingTransactionType can take.
-const (
-	IssuingTransactionTypeCapture IssuingTransactionType = "capture"
-	IssuingTransactionTypeRefund  IssuingTransactionType = "refund"
-)
 
 // IssuingTransactionPurchaseDetailsFuelType is the type of fuel purchased in a transaction.
 type IssuingTransactionPurchaseDetailsFuelType string
@@ -30,6 +27,15 @@ type IssuingTransactionPurchaseDetailsFuelUnit string
 const (
 	IssuingTransactionPurchaseDetailsFuelUnitLiter    IssuingTransactionPurchaseDetailsFuelUnit = "liter"
 	IssuingTransactionPurchaseDetailsFuelUnitUSGallon IssuingTransactionPurchaseDetailsFuelUnit = "us_gallon"
+)
+
+// IssuingTransactionType is the type of an issuing transaction.
+type IssuingTransactionType string
+
+// List of values that IssuingTransactionType can take.
+const (
+	IssuingTransactionTypeCapture IssuingTransactionType = "capture"
+	IssuingTransactionTypeRefund  IssuingTransactionType = "refund"
 )
 
 // IssuingTransactionParams is the set of parameters that can be used when creating or updating an issuing transaction.
@@ -116,9 +122,9 @@ type IssuingTransaction struct {
 	Dispute            *IssuingDispute                    `json:"dispute"`
 	ID                 string                             `json:"id"`
 	Livemode           bool                               `json:"livemode"`
-	MerchantData       *IssuingAuthorizationMerchantData  `json:"merchant_data"`
 	MerchantAmount     int64                              `json:"merchant_amount"`
 	MerchantCurrency   Currency                           `json:"merchant_currency"`
+	MerchantData       *IssuingAuthorizationMerchantData  `json:"merchant_data"`
 	Metadata           map[string]string                  `json:"metadata"`
 	Object             string                             `json:"object"`
 	PurchaseDetails    *IssuingTransactionPurchaseDetails `json:"purchase_details"`

--- a/radar_earlyfraudwarning.go
+++ b/radar_earlyfraudwarning.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // RadarEarlyFraudWarningFraudType are strings that map to the type of fraud labelled by the issuer.
@@ -29,14 +35,6 @@ type RadarEarlyFraudWarningListParams struct {
 	Charge     *string `form:"charge"`
 }
 
-// RadarEarlyFraudWarningList is a list of early fraud warnings as retrieved from a
-// list endpoint.
-type RadarEarlyFraudWarningList struct {
-	APIResource
-	ListMeta
-	Values []*RadarEarlyFraudWarning `json:"data"`
-}
-
 // RadarEarlyFraudWarning is the resource representing an early fraud warning. For
 // more details see https://stripe.com/docs/api/early_fraud_warnings/object.
 type RadarEarlyFraudWarning struct {
@@ -47,4 +45,13 @@ type RadarEarlyFraudWarning struct {
 	FraudType  RadarEarlyFraudWarningFraudType `json:"fraud_type"`
 	ID         string                          `json:"id"`
 	Livemode   bool                            `json:"livemode"`
+	Object     string                          `json:"object"`
+}
+
+// RadarEarlyFraudWarningList is a list of early fraud warnings as retrieved from a
+// list endpoint.
+type RadarEarlyFraudWarningList struct {
+	APIResource
+	ListMeta
+	Data []*RadarEarlyFraudWarning `json:"data"`
 }

--- a/radar_earlyfraudwarning.go
+++ b/radar_earlyfraudwarning.go
@@ -53,5 +53,6 @@ type RadarEarlyFraudWarning struct {
 type RadarEarlyFraudWarningList struct {
 	APIResource
 	ListMeta
-	Data []*RadarEarlyFraudWarning `json:"data"`
+	// TODO: rename `Values` to `Data` in a future major version for consistency with other List structs
+	Values []*RadarEarlyFraudWarning `json:"data"`
 }

--- a/radar_valuelistitem.go
+++ b/radar_valuelistitem.go
@@ -1,10 +1,16 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // RadarValueListItemParams is the set of parameters that can be used when creating a value list item.
 type RadarValueListItemParams struct {
 	Params         `form:"*"`
-	Value          *string `form:"value"`
 	RadarValueList *string `form:"value_list"`
+	Value          *string `form:"value"`
 }
 
 // RadarValueListItemListParams is the set of parameters that can be used when listing value list items.
@@ -26,8 +32,8 @@ type RadarValueListItem struct {
 	Livemode       bool   `json:"livemode"`
 	Name           string `json:"name"`
 	Object         string `json:"object"`
-	Value          string `json:"value"`
 	RadarValueList string `json:"value_list"`
+	Value          string `json:"value"`
 }
 
 // RadarValueListItemList is a list of value list items as retrieved from a list endpoint.

--- a/reporting_reporttype.go
+++ b/reporting_reporttype.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // ReportTypeListParams is the set of parameters that can be used when listing report types.
@@ -13,10 +19,10 @@ type ReportTypeParams struct {
 // ReportType is the resource representing a report type.
 type ReportType struct {
 	APIResource
-	DefaultColumns     []string `json:"default_columns"`
 	Created            int64    `json:"created"`
 	DataAvailableEnd   int64    `json:"data_available_end"`
 	DataAvailableStart int64    `json:"data_available_start"`
+	DefaultColumns     []string `json:"default_columns"`
 	ID                 string   `json:"id"`
 	Name               string   `json:"name"`
 	Object             string   `json:"object"`

--- a/subitem.go
+++ b/subitem.go
@@ -52,11 +52,8 @@ type SubscriptionItemBillingThresholdsParams struct {
 // SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
 type SubscriptionItemListParams struct {
-	EndingBefore  *string   `form:"ending_before"`
-	Expand        []*string `form:"expand"`
-	Limit         *int64    `form:"limit"`
-	StartingAfter *string   `form:"starting_after"`
-	Subscription  *string   `form:"subscription"`
+	ListParams   `form:"*"`
+	Subscription *string `form:"subscription"`
 }
 
 // SubscriptionItem is the resource representing a Stripe subscription item.

--- a/subitem.go
+++ b/subitem.go
@@ -29,7 +29,7 @@ type SubscriptionItemParams struct {
 	Params            `form:"*"`
 	BillingThresholds *SubscriptionItemBillingThresholdsParams `form:"billing_thresholds"`
 	ClearUsage        *bool                                    `form:"clear_usage"`
-	OffSession        *bool                                    `form:"off_session"`
+	UsageGTE          *bool                                    `form:"off_session"` // Only supported on update
 	PaymentBehavior   *string                                  `form:"payment_behavior"`
 	Plan              *string                                  `form:"plan"`
 	Price             *string                                  `form:"price"`
@@ -60,23 +60,23 @@ type SubscriptionItemListParams struct {
 // For more details see https://stripe.com/docs/api#subscription_items.
 type SubscriptionItem struct {
 	APIResource
-	BillingThresholds *SubscriptionItemBillingThresholds `json:"billing_thresholds"`
-	Created           int64                              `json:"created"`
-	Deleted           bool                               `json:"deleted"`
-	ID                string                             `json:"id"`
-	Metadata          map[string]string                  `json:"metadata"`
-	Object            string                             `json:"object"`
-	Plan              *Plan                              `json:"plan"`
-	Price             *Price                             `json:"price"`
-	Quantity          int64                              `json:"quantity"`
-	Subscription      string                             `json:"subscription"`
-	TaxRates          []*TaxRate                         `json:"tax_rates"`
+	BillingThresholds SubscriptionItemBillingThresholds `json:"billing_thresholds"`
+	Created           int64                             `json:"created"`
+	Deleted           bool                              `json:"deleted"`
+	ID                string                            `json:"id"`
+	Metadata          map[string]string                 `json:"metadata"`
+	Object            string                            `json:"object"`
+	Plan              *Plan                             `json:"plan"`
+	Price             *Price                            `json:"price"`
+	Quantity          int64                             `json:"quantity"`
+	Subscription      string                            `json:"subscription"`
+	TaxRates          []*TaxRate                        `json:"tax_rates"`
 }
 
 // SubscriptionItemBillingThresholds is a structure representing the billing thresholds for a
 // subscription item.
 type SubscriptionItemBillingThresholds struct {
-	UsageGTE int64 `json:"usage_gte"`
+	UsageGTE int64 `form:"usage_gte"`
 }
 
 // SubscriptionItemList is a list of invoice items as retrieved from a list endpoint.

--- a/subitem.go
+++ b/subitem.go
@@ -29,7 +29,7 @@ type SubscriptionItemParams struct {
 	Params            `form:"*"`
 	BillingThresholds *SubscriptionItemBillingThresholdsParams `form:"billing_thresholds"`
 	ClearUsage        *bool                                    `form:"clear_usage"`
-	UsageGTE          *bool                                    `form:"off_session"` // Only supported on update
+	OffSession        *bool                                    `form:"off_session"` // Only supported on update
 	PaymentBehavior   *string                                  `form:"payment_behavior"`
 	Plan              *string                                  `form:"plan"`
 	Price             *string                                  `form:"price"`

--- a/subitem.go
+++ b/subitem.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // SubscriptionItemPriceDataRecurringParams is a structure representing the parameters to create
@@ -21,21 +27,20 @@ type SubscriptionItemPriceDataParams struct {
 // For more details see https://stripe.com/docs/api#create_subscription_item and https://stripe.com/docs/api#update_subscription_item.
 type SubscriptionItemParams struct {
 	Params            `form:"*"`
-	ID                *string                                  `form:"-"` // Handled in URL
 	BillingThresholds *SubscriptionItemBillingThresholdsParams `form:"billing_thresholds"`
 	ClearUsage        *bool                                    `form:"clear_usage"`
+	OffSession        *bool                                    `form:"off_session"`
 	PaymentBehavior   *string                                  `form:"payment_behavior"`
 	Plan              *string                                  `form:"plan"`
 	Price             *string                                  `form:"price"`
 	PriceData         *SubscriptionItemPriceDataParams         `form:"price_data"`
-	ProrationDate     *int64                                   `form:"proration_date"`
 	ProrationBehavior *string                                  `form:"proration_behavior"`
+	ProrationDate     *int64                                   `form:"proration_date"`
 	Quantity          *int64                                   `form:"quantity"`
 	Subscription      *string                                  `form:"subscription"`
 	TaxRates          []*string                                `form:"tax_rates"`
 
-	// The following parameters are only supported on updates
-	OffSession *bool `form:"off_session"`
+	ID *string `form:"-"` // Deprecated
 }
 
 // SubscriptionItemBillingThresholdsParams is a structure representing the parameters allowed to
@@ -47,30 +52,34 @@ type SubscriptionItemBillingThresholdsParams struct {
 // SubscriptionItemListParams is the set of parameters that can be used when listing invoice items.
 // For more details see https://stripe.com/docs/api#list_invoiceitems.
 type SubscriptionItemListParams struct {
-	ListParams   `form:"*"`
-	Subscription *string `form:"subscription"`
+	EndingBefore  *string   `form:"ending_before"`
+	Expand        []*string `form:"expand"`
+	Limit         *int64    `form:"limit"`
+	StartingAfter *string   `form:"starting_after"`
+	Subscription  *string   `form:"subscription"`
 }
 
 // SubscriptionItem is the resource representing a Stripe subscription item.
 // For more details see https://stripe.com/docs/api#subscription_items.
 type SubscriptionItem struct {
 	APIResource
-	BillingThresholds SubscriptionItemBillingThresholds `json:"billing_thresholds"`
-	Created           int64                             `json:"created"`
-	Deleted           bool                              `json:"deleted"`
-	ID                string                            `json:"id"`
-	Metadata          map[string]string                 `json:"metadata"`
-	Plan              *Plan                             `json:"plan"`
-	Price             *Price                            `json:"price"`
-	Quantity          int64                             `json:"quantity"`
-	Subscription      string                            `json:"subscription"`
-	TaxRates          []*TaxRate                        `json:"tax_rates"`
+	BillingThresholds *SubscriptionItemBillingThresholds `json:"billing_thresholds"`
+	Created           int64                              `json:"created"`
+	Deleted           bool                               `json:"deleted"`
+	ID                string                             `json:"id"`
+	Metadata          map[string]string                  `json:"metadata"`
+	Object            string                             `json:"object"`
+	Plan              *Plan                              `json:"plan"`
+	Price             *Price                             `json:"price"`
+	Quantity          int64                              `json:"quantity"`
+	Subscription      string                             `json:"subscription"`
+	TaxRates          []*TaxRate                         `json:"tax_rates"`
 }
 
 // SubscriptionItemBillingThresholds is a structure representing the billing thresholds for a
 // subscription item.
 type SubscriptionItemBillingThresholds struct {
-	UsageGTE int64 `form:"usage_gte"`
+	UsageGTE int64 `json:"usage_gte"`
 }
 
 // SubscriptionItemList is a list of invoice items as retrieved from a list endpoint.

--- a/taxid.go
+++ b/taxid.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -26,21 +32,21 @@ const (
 	TaxIDTypeKRBRN   TaxIDType = "kr_brn"
 	TaxIDTypeLIUID   TaxIDType = "li_uid"
 	TaxIDTypeMXRFC   TaxIDType = "mx_rfc"
-	TaxIDTypeMYITN   TaxIDType = "my_itn"
 	TaxIDTypeMYFRP   TaxIDType = "my_frp"
+	TaxIDTypeMYITN   TaxIDType = "my_itn"
 	TaxIDTypeMYSST   TaxIDType = "my_sst"
 	TaxIDTypeNOVAT   TaxIDType = "no_vat"
 	TaxIDTypeNZGST   TaxIDType = "nz_gst"
 	TaxIDTypeRUINN   TaxIDType = "ru_inn"
 	TaxIDTypeRUKPP   TaxIDType = "ru_kpp"
 	TaxIDTypeSAVAT   TaxIDType = "sa_vat"
-	TaxIDTypeSGUEN   TaxIDType = "sg_uen"
 	TaxIDTypeSGGST   TaxIDType = "sg_gst"
+	TaxIDTypeSGUEN   TaxIDType = "sg_uen"
 	TaxIDTypeTHVAT   TaxIDType = "th_vat"
 	TaxIDTypeTWVAT   TaxIDType = "tw_vat"
+	TaxIDTypeUnknown TaxIDType = "unknown"
 	TaxIDTypeUSEIN   TaxIDType = "us_ein"
 	TaxIDTypeZAVAT   TaxIDType = "za_vat"
-	TaxIDTypeUnknown TaxIDType = "unknown"
 )
 
 // TaxIDVerificationStatus is the list of allowed values for the tax id's verification status..
@@ -58,7 +64,7 @@ const (
 // For more details see https://stripe.com/docs/api/customers/create_tax_id
 type TaxIDParams struct {
 	Params   `form:"*"`
-	Customer *string `form:"-"`
+	Customer *string `form:"-"` // Included in URL
 	Type     *string `form:"type"`
 	Value    *string `form:"value"`
 }
@@ -67,7 +73,7 @@ type TaxIDParams struct {
 // For more detail see https://stripe.com/docs/api/customers/tax_ids
 type TaxIDListParams struct {
 	ListParams `form:"*"`
-	Customer   *string `form:"-"`
+	Customer   *string `form:"-"` // Included in URL
 }
 
 // TaxIDVerification represents the verification details of a customer's tax id.
@@ -103,18 +109,18 @@ type TaxIDList struct {
 // UnmarshalJSON handles deserialization of a TaxID.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (c *TaxID) UnmarshalJSON(data []byte) error {
+func (t *TaxID) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		c.ID = id
+		t.ID = id
 		return nil
 	}
 
-	type taxid TaxID
-	var v taxid
+	type taxID TaxID
+	var v taxID
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*c = TaxID(v)
+	*t = TaxID(v)
 	return nil
 }

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -1,4 +1,17 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
+
+type TerminalReaderDeviceType string
+
+const (
+	TerminalReaderDeviceTypeBBPOSChipper2X TerminalReaderDeviceType = "bbpos_chipper2x"
+	TerminalReaderDeviceTypeVerifoneP400   TerminalReaderDeviceType = "verifone_P400"
+)
 
 // TerminalReaderParams is the set of parameters that can be used for creating or updating a terminal reader.
 type TerminalReaderParams struct {
@@ -24,18 +37,18 @@ type TerminalReaderListParams struct {
 // TerminalReader is the resource representing a Stripe terminal reader.
 type TerminalReader struct {
 	APIResource
-	Deleted         bool              `json:"deleted"`
-	DeviceSwVersion string            `json:"device_sw_version"`
-	DeviceType      string            `json:"device_type"`
-	ID              string            `json:"id"`
-	IPAddress       string            `json:"ip_address"`
-	Label           string            `json:"label"`
-	Livemode        bool              `json:"livemode"`
-	Location        string            `json:"location"`
-	Metadata        map[string]string `json:"metadata"`
-	Object          string            `json:"object"`
-	SerialNumber    string            `json:"serial_number"`
-	Status          string            `json:"status"`
+	Deleted         bool                     `json:"deleted"`
+	DeviceSwVersion string                   `json:"device_sw_version"`
+	DeviceType      TerminalReaderDeviceType `json:"device_type"`
+	ID              string                   `json:"id"`
+	IPAddress       string                   `json:"ip_address"`
+	Label           string                   `json:"label"`
+	Livemode        bool                     `json:"livemode"`
+	Location        string                   `json:"location"`
+	Metadata        map[string]string        `json:"metadata"`
+	Object          string                   `json:"object"`
+	SerialNumber    string                   `json:"serial_number"`
+	Status          string                   `json:"status"`
 }
 
 // TerminalReaderList is a list of terminal readers as retrieved from a list endpoint.

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -6,8 +6,10 @@
 
 package stripe
 
+// TerminalReaderDeviceType is the type of the terminal read.er device.
 type TerminalReaderDeviceType string
 
+// List of values that TerminalReaderDeviceType can take
 const (
 	TerminalReaderDeviceTypeBBPOSChipper2X TerminalReaderDeviceType = "bbpos_chipper2x"
 	TerminalReaderDeviceTypeVerifoneP400   TerminalReaderDeviceType = "verifone_P400"

--- a/topup.go
+++ b/topup.go
@@ -1,4 +1,24 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
+
+import "encoding/json"
+
+// TopupStatus is a status of a Topup.
+type TopupStatus string
+
+// List of values that TopupStatus can take.
+const (
+	TopupStatusCanceled  TopupStatus = "canceled"
+	TopupStatusFailed    TopupStatus = "failed"
+	TopupStatusPending   TopupStatus = "pending"
+	TopupStatusReversed  TopupStatus = "reversed"
+	TopupStatusSucceeded TopupStatus = "succeeded"
+)
 
 // TopupParams is the set of parameters that can be used when creating or updating a top-up.
 // For more details see https://stripe.com/docs/api#create_topup and https://stripe.com/docs/api#update_topup.
@@ -7,9 +27,9 @@ type TopupParams struct {
 	Amount              *int64        `form:"amount"`
 	Currency            *string       `form:"currency"`
 	Description         *string       `form:"description"`
-	Source              *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 	StatementDescriptor *string       `form:"statement_descriptor"`
 	TransferGroup       *string       `form:"transfer_group"`
+	Source              *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 
 // SetSource adds valid sources to a TopupParams object,
@@ -24,15 +44,11 @@ func (p *TopupParams) SetSource(sp interface{}) error {
 // For more details see https://stripe.com/docs/api#list_topups.
 type TopupListParams struct {
 	ListParams   `form:"*"`
+	Amount       *int64            `form:"amount"`
+	AmountRange  *RangeQueryParams `form:"amount"`
 	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
-}
-
-// TopupList is a list of top-ups as retrieved from a list endpoint.
-type TopupList struct {
-	APIResource
-	ListMeta
-	Data []*Topup `json:"data"`
+	Status       *string           `form:"status"`
 }
 
 // Topup is the resource representing a Stripe top-up.
@@ -53,9 +69,35 @@ type Topup struct {
 	Object                   string              `json:"object"`
 	Source                   *PaymentSource      `json:"source"`
 	StatementDescriptor      string              `json:"statement_descriptor"`
-	Status                   string              `json:"status"`
+	Status                   TopupStatus         `json:"status"`
 	TransferGroup            string              `json:"transfer_group"`
-
 	// The following property is deprecated
+
 	ArrivalDate int64 `json:"arrival_date"`
+}
+
+// TopupList is a list of top-ups as retrieved from a list endpoint.
+type TopupList struct {
+	APIResource
+	ListMeta
+	Data []*Topup `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a Topup.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (t *Topup) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		t.ID = id
+		return nil
+	}
+
+	type topup Topup
+	var v topup
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*t = Topup(v)
+	return nil
 }

--- a/topup.go
+++ b/topup.go
@@ -27,9 +27,9 @@ type TopupParams struct {
 	Amount              *int64        `form:"amount"`
 	Currency            *string       `form:"currency"`
 	Description         *string       `form:"description"`
+	Source              *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 	StatementDescriptor *string       `form:"statement_descriptor"`
 	TransferGroup       *string       `form:"transfer_group"`
-	Source              *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 
 // SetSource adds valid sources to a TopupParams object,

--- a/topup.go
+++ b/topup.go
@@ -71,8 +71,8 @@ type Topup struct {
 	StatementDescriptor      string              `json:"statement_descriptor"`
 	Status                   TopupStatus         `json:"status"`
 	TransferGroup            string              `json:"transfer_group"`
-	// The following property is deprecated
 
+	// The following property is deprecated
 	ArrivalDate int64 `json:"arrival_date"`
 }
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-library-reviewers 

Contains changes for 13 files to be compatible with codegenned output, bringing the total to 28/74 resource files (`client.go` files and index files are still outstanding).

None of these changes should be breaking. See conversation about `string -> enum` being the non-breaking addition of a type alias.

* accountlink.go - noop
* billingportal_session.go - noop
* countryspec.go
  * Add support for `Object` to `CountrySpec`
* filelink.go
  * Add support `ExpiresAtNow` to `FileLinkParams`
* invoiceitem.go
  * Add support for `Object` and `SubscriptionItem` to `InvoiceItem`
* issuing_transaction.go - noop
* radar_earlyfraudwarning.go - noop
* rader_valuelistitem.go - noop
* reporting_reporttype.go - noop
* subitem.go
  * Add support for `Object` to `SubscriptionItem`
* taxid.go - noop
* terminal_reader.go
  * Add enum definitions for `TerminalReader.DeviceType`
* topup.go
  * Add enum definitions for `Topup.Status`
  * Add support for `Amount`, `AmountRange`, and `Status` to `TopupListParams`.
  * Added custom `UnmarshalJSON` method for `Topup`

Re: UnmarshalJSON for `Topup` -- Codegen is calculating that this is needed because according to the API definition it looks like `Topup` can be returned in unexpanded form on BalanceTransaction.Source, but it looks like [support for that is incomplete](https://github.com/stripe/stripe-go/blob/master/balancetransaction.go#L82) in balancetransaction.go.