### PR TITLE
codegen: add several client.go files

### DIFF
--- a/accountlink/client.go
+++ b/accountlink/client.go
@@ -1,6 +1,10 @@
-// Package accountlink provides API functions related to account links.
 //
-// For more details, see: https://stripe.com/docs/api/go#account_links.
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package accountlink provides the /account_links APIs
 package accountlink
 
 import (
@@ -9,7 +13,7 @@ import (
 	stripe "github.com/stripe/stripe-go/v72"
 )
 
-// Client is used to invoke APIs related to account links.
+// Client is used to invoke /account_links APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -22,9 +26,15 @@ func New(params *stripe.AccountLinkParams) (*stripe.AccountLink, error) {
 
 // New creates a new account link.
 func (c Client) New(params *stripe.AccountLinkParams) (*stripe.AccountLink, error) {
-	link := &stripe.AccountLink{}
-	err := c.B.Call(http.MethodPost, "/v1/account_links", c.Key, params, link)
-	return link, err
+	accountlink := &stripe.AccountLink{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/account_links",
+		c.Key,
+		params,
+		accountlink,
+	)
+	return accountlink, err
 }
 
 func getC() Client {

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package applepaydomain provides the /apple_pay/domains APIs
 package applepaydomain
 
@@ -8,56 +14,62 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /apple_pay/domains and Apple Pay domain-related APIs.
+// Client is used to invoke /apple_pay/domains APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// New creates a new Apple Pay domain.
+// New creates a new apple pay domain.
 func New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	return getC().New(params)
 }
 
-// New creates a new Apple Pay domain.
+// New creates a new apple pay domain.
 func (c Client) New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
-	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call(http.MethodPost, "/v1/apple_pay/domains", c.Key, params, domain)
-	return domain, err
+	applepaydomain := &stripe.ApplePayDomain{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/apple_pay/domains",
+		c.Key,
+		params,
+		applepaydomain,
+	)
+	return applepaydomain, err
 }
 
-// Get retrieves an Apple Pay domain.
+// Get returns the details of an apple pay domain.
 func Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	return getC().Get(id, params)
 }
 
-// Get retrieves an Apple Pay domain.
+// Get returns the details of an apple pay domain.
 func (c Client) Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	path := stripe.FormatURLPath("/v1/apple_pay/domains/%s", id)
-	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, domain)
-	return domain, err
+	applepaydomain := &stripe.ApplePayDomain{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, applepaydomain)
+	return applepaydomain, err
 }
 
-// Del removes an Apple Pay domain.
+// Del removes an apple pay domain.
 func Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	return getC().Del(id, params)
 }
 
-// Del removes an Apple Pay domain.
+// Del removes an apple pay domain.
 func (c Client) Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	path := stripe.FormatURLPath("/v1/apple_pay/domains/%s", id)
-	domain := &stripe.ApplePayDomain{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, domain)
-	return domain, err
+	applepaydomain := &stripe.ApplePayDomain{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, applepaydomain)
+	return applepaydomain, err
 }
 
-// List lists available Apple Pay domains.
+// List returns a list of apple pay domains.
 func List(params *stripe.ApplePayDomainListParams) *Iter {
 	return getC().List(params)
 }
 
-// List lists available Apple Pay domains.
+// List returns a list of apple pay domains.
 func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ApplePayDomainList{}
@@ -72,12 +84,12 @@ func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for Apple Pay domains.
+// Iter is an iterator for apple pay domains.
 type Iter struct {
 	*stripe.Iter
 }
 
-// ApplePayDomain returns the Apple Pay domain which the iterator is currently pointing to.
+// ApplePayDomain returns the apple pay domain which the iterator is currently pointing to.
 func (i *Iter) ApplePayDomain() *stripe.ApplePayDomain {
 	return i.Current().(*stripe.ApplePayDomain)
 }

--- a/balancetransaction/client.go
+++ b/balancetransaction/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package balancetransaction provides the /balance_transactions APIs
 package balancetransaction
 
@@ -22,9 +28,9 @@ func Get(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTra
 // Get returns the details of a balance transaction.
 func (c Client) Get(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
 	path := stripe.FormatURLPath("/v1/balance_transactions/%s", id)
-	transaction := &stripe.BalanceTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transaction)
-	return transaction, err
+	balancetransaction := &stripe.BalanceTransaction{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, balancetransaction)
+	return balancetransaction, err
 }
 
 // List returns a list of balance transactions.

--- a/billingportal/configuration/client.go
+++ b/billingportal/configuration/client.go
@@ -1,4 +1,10 @@
-// Package configuration provides API functions related to billing portal configurations.
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package configuration provides the /billing_portal/configurations APIs
 package configuration
 
 import (
@@ -22,7 +28,13 @@ func New(params *stripe.BillingPortalConfigurationParams) (*stripe.BillingPortal
 // New creates a new billing portal configuration.
 func (c Client) New(params *stripe.BillingPortalConfigurationParams) (*stripe.BillingPortalConfiguration, error) {
 	configuration := &stripe.BillingPortalConfiguration{}
-	err := c.B.Call(http.MethodPost, "/v1/billing_portal/configurations", c.Key, params, configuration)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/billing_portal/configurations",
+		c.Key,
+		params,
+		configuration,
+	)
 	return configuration, err
 }
 

--- a/billingportal/session/client.go
+++ b/billingportal/session/client.go
@@ -1,4 +1,10 @@
-// Package session provides API functions related to billing portal sessions.
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package session provides the /billing_portal/sessions APIs
 package session
 
 import (
@@ -13,15 +19,21 @@ type Client struct {
 	Key string
 }
 
-// New creates a new session.
+// New creates a new billing portal session.
 func New(params *stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error) {
 	return getC().New(params)
 }
 
-// New creates a new session.
+// New creates a new billing portal session.
 func (c Client) New(params *stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error) {
 	session := &stripe.BillingPortalSession{}
-	err := c.B.Call(http.MethodPost, "/v1/billing_portal/sessions", c.Key, params, session)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/billing_portal/sessions",
+		c.Key,
+		params,
+		session,
+	)
 	return session, err
 }
 

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package countryspec provides the /country_specs APIs
 package countryspec
 
@@ -8,31 +14,31 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /country_specs and countryspec-related APIs.
+// Client is used to invoke /country_specs APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// Get returns a Country Spec for a given country code.
-func Get(country string, params *stripe.CountrySpecParams) (*stripe.CountrySpec, error) {
-	return getC().Get(country, params)
+// Get returns the details of a country spec.
+func Get(id string, params *stripe.CountrySpecParams) (*stripe.CountrySpec, error) {
+	return getC().Get(id, params)
 }
 
-// Get returns a Country Spec for a given country code.
-func (c Client) Get(country string, params *stripe.CountrySpecParams) (*stripe.CountrySpec, error) {
-	path := stripe.FormatURLPath("/v1/country_specs/%s", country)
-	countrySpec := &stripe.CountrySpec{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, countrySpec)
-	return countrySpec, err
+// Get returns the details of a country spec.
+func (c Client) Get(id string, params *stripe.CountrySpecParams) (*stripe.CountrySpec, error) {
+	path := stripe.FormatURLPath("/v1/country_specs/%s", id)
+	countryspec := &stripe.CountrySpec{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, countryspec)
+	return countryspec, err
 }
 
-// List lists available Country Specs.
+// List returns a list of country specs.
 func List(params *stripe.CountrySpecListParams) *Iter {
 	return getC().List(params)
 }
 
-// List lists available Country Specs.
+// List returns a list of country specs.
 func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CountrySpecList{}
@@ -47,12 +53,12 @@ func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for Country Specs.
+// Iter is an iterator for country specs.
 type Iter struct {
 	*stripe.Iter
 }
 
-// CountrySpec returns the Country Spec which the iterator is currently pointing to.
+// CountrySpec returns the country spec which the iterator is currently pointing to.
 func (i *Iter) CountrySpec() *stripe.CountrySpec {
 	return i.Current().(*stripe.CountrySpec)
 }

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package coupon provides the /coupons APIs
 package coupon
 

--- a/event/client.go
+++ b/event/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package event provides the /events APIs
 package event
 
@@ -57,9 +63,9 @@ func (i *Iter) Event() *stripe.Event {
 	return i.Current().(*stripe.Event)
 }
 
-// EventList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// EventList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) EventList() *stripe.EventList {
 	return i.List().(*stripe.EventList)
 }

--- a/filelink/client.go
+++ b/filelink/client.go
@@ -1,6 +1,10 @@
-// Package filelink provides API functions related to file links.
 //
-// For more details, see: https://stripe.com/docs/api/go#file_links.
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package filelink provides the /file_links APIs
 package filelink
 
 import (
@@ -10,7 +14,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke APIs related to file links.
+// Client is used to invoke /file_links APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -23,43 +27,43 @@ func New(params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 
 // New creates a new file link.
 func (c Client) New(params *stripe.FileLinkParams) (*stripe.FileLink, error) {
-	fileLink := &stripe.FileLink{}
-	err := c.B.Call(http.MethodPost, "/v1/file_links", c.Key, params, fileLink)
-	return fileLink, err
+	filelink := &stripe.FileLink{}
+	err := c.B.Call(http.MethodPost, "/v1/file_links", c.Key, params, filelink)
+	return filelink, err
 }
 
-// Get retrieves a file link.
+// Get returns the details of a file link.
 func Get(id string, params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 	return getC().Get(id, params)
 }
 
-// Get retrieves a file link.
+// Get returns the details of a file link.
 func (c Client) Get(id string, params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 	path := stripe.FormatURLPath("/v1/file_links/%s", id)
-	fileLink := &stripe.FileLink{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, fileLink)
-	return fileLink, err
+	filelink := &stripe.FileLink{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, filelink)
+	return filelink, err
 }
 
-// Update updates a file link.
+// Update updates a file link's properties.
 func Update(id string, params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a file link.
+// Update updates a file link's properties.
 func (c Client) Update(id string, params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 	path := stripe.FormatURLPath("/v1/file_links/%s", id)
-	fileLink := &stripe.FileLink{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, fileLink)
-	return fileLink, err
+	filelink := &stripe.FileLink{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, filelink)
+	return filelink, err
 }
 
-// List returns an iterator that iterates all file links.
+// List returns a list of file links.
 func List(params *stripe.FileLinkListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns an iterator that iterates all file links.
+// List returns a list of file links.
 func (c Client) List(listParams *stripe.FileLinkListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.FileLinkList{}
@@ -84,9 +88,9 @@ func (i *Iter) FileLink() *stripe.FileLink {
 	return i.Current().(*stripe.FileLink)
 }
 
-// FileLinkList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// FileLinkList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) FileLinkList() *stripe.FileLinkList {
 	return i.List().(*stripe.FileLinkList)
 }

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package invoiceitem provides the /invoiceitems APIs
 package invoiceitem
 
@@ -21,9 +27,15 @@ func New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 
 // New creates a new invoice item.
 func (c Client) New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
-	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call(http.MethodPost, "/v1/invoiceitems", c.Key, params, invoiceItem)
-	return invoiceItem, err
+	invoiceitem := &stripe.InvoiceItem{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/invoiceitems",
+		c.Key,
+		params,
+		invoiceitem,
+	)
+	return invoiceitem, err
 }
 
 // Get returns the details of an invoice item.
@@ -34,22 +46,22 @@ func Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 // Get returns the details of an invoice item.
 func (c Client) Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/v1/invoiceitems/%s", id)
-	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, invoiceItem)
-	return invoiceItem, err
+	invoiceitem := &stripe.InvoiceItem{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, invoiceitem)
+	return invoiceitem, err
 }
 
-// Update updates an invoice item.
+// Update updates an invoice item's properties.
 func Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates an invoice item.
+// Update updates an invoice item's properties.
 func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/v1/invoiceitems/%s", id)
-	invoiceItem := &stripe.InvoiceItem{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoiceItem)
-	return invoiceItem, err
+	invoiceitem := &stripe.InvoiceItem{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, invoiceitem)
+	return invoiceitem, err
 }
 
 // Del removes an invoice item.
@@ -60,9 +72,9 @@ func Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 // Del removes an invoice item.
 func (c Client) Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/v1/invoiceitems/%s", id)
-	ii := &stripe.InvoiceItem{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, ii)
-	return ii, err
+	invoiceitem := &stripe.InvoiceItem{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, invoiceitem)
+	return invoiceitem, err
 }
 
 // List returns a list of invoice items.

--- a/issuing/card/client.go
+++ b/issuing/card/client.go
@@ -1,6 +1,10 @@
-// Package card provides API functions related to issuing cards.
 //
-// For more details, see: https://stripe.com/docs/api/go#issuing_cards
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package card provides the /issuing/cards APIs
 package card
 
 import (
@@ -41,12 +45,12 @@ func (c Client) Get(id string, params *stripe.IssuingCardParams) (*stripe.Issuin
 	return card, err
 }
 
-// Update updates an issuing card.
+// Update updates an issuing card's properties.
 func Update(id string, params *stripe.IssuingCardParams) (*stripe.IssuingCard, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates an issuing card.
+// Update updates an issuing card's properties.
 func (c Client) Update(id string, params *stripe.IssuingCardParams) (*stripe.IssuingCard, error) {
 	path := stripe.FormatURLPath("/v1/issuing/cards/%s", id)
 	card := &stripe.IssuingCard{}

--- a/issuing/cardholder/client.go
+++ b/issuing/cardholder/client.go
@@ -5,7 +5,6 @@
 //
 
 // Package cardholder provides the /issuing/cardholders APIs
-
 // For more details, see: https://stripe.com/docs/api/go#issuing_cardholders
 package cardholder
 

--- a/issuing/cardholder/client.go
+++ b/issuing/cardholder/client.go
@@ -1,5 +1,11 @@
-// Package cardholder provides API functions related to issuing cardholders.
 //
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package cardholder provides the /issuing/cardholders APIs
+
 // For more details, see: https://stripe.com/docs/api/go#issuing_cardholders
 package cardholder
 
@@ -24,7 +30,13 @@ func New(params *stripe.IssuingCardholderParams) (*stripe.IssuingCardholder, err
 // New creates a new issuing cardholder.
 func (c Client) New(params *stripe.IssuingCardholderParams) (*stripe.IssuingCardholder, error) {
 	cardholder := &stripe.IssuingCardholder{}
-	err := c.B.Call(http.MethodPost, "/v1/issuing/cardholders", c.Key, params, cardholder)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/issuing/cardholders",
+		c.Key,
+		params,
+		cardholder,
+	)
 	return cardholder, err
 }
 
@@ -41,12 +53,12 @@ func (c Client) Get(id string, params *stripe.IssuingCardholderParams) (*stripe.
 	return cardholder, err
 }
 
-// Update updates an issuing cardholder.
+// Update updates an issuing cardholder's properties.
 func Update(id string, params *stripe.IssuingCardholderParams) (*stripe.IssuingCardholder, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates an issuing cardholder.
+// Update updates an issuing cardholder's properties.
 func (c Client) Update(id string, params *stripe.IssuingCardholderParams) (*stripe.IssuingCardholder, error) {
 	path := stripe.FormatURLPath("/v1/issuing/cardholders/%s", id)
 	cardholder := &stripe.IssuingCardholder{}

--- a/issuing/transaction/client.go
+++ b/issuing/transaction/client.go
@@ -1,6 +1,10 @@
-// Package transaction provides API functions related to issuing transactions.
 //
-// For more details, see: https://stripe.com/docs/api/go#issuing_transactions
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package transaction provides the /issuing/transactions APIs
 package transaction
 
 import (
@@ -29,12 +33,12 @@ func (c Client) Get(id string, params *stripe.IssuingTransactionParams) (*stripe
 	return transaction, err
 }
 
-// Update updates an issuing transaction.
+// Update updates an issuing transaction's properties.
 func Update(id string, params *stripe.IssuingTransactionParams) (*stripe.IssuingTransaction, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates an issuing transaction.
+// Update updates an issuing transaction's properties.
 func (c Client) Update(id string, params *stripe.IssuingTransactionParams) (*stripe.IssuingTransaction, error) {
 	path := stripe.FormatURLPath("/v1/issuing/transactions/%s", id)
 	transaction := &stripe.IssuingTransaction{}

--- a/mandate/client.go
+++ b/mandate/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package mandate provides the /mandates APIs
 package mandate
 
@@ -7,18 +13,18 @@ import (
 	stripe "github.com/stripe/stripe-go/v72"
 )
 
-// Client is used to invoke mandates APIs.
+// Client is used to invoke /mandates APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// Get returns the details of a Mandate.
+// Get returns the details of a mandate.
 func Get(id string, params *stripe.MandateParams) (*stripe.Mandate, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a Mandate.
+// Get returns the details of a mandate.
 func (c Client) Get(id string, params *stripe.MandateParams) (*stripe.Mandate, error) {
 	path := stripe.FormatURLPath("/v1/mandates/%s", id)
 	mandate := &stripe.Mandate{}

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -1,3 +1,10 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package orderreturn provides the /order_returns APIs
 package orderreturn
 
 import (
@@ -7,23 +14,23 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /orders APIs.
+// Client is used to invoke /order_returns APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// Get returns the details of an order return
+// Get returns the details of an order return.
 func Get(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of an order return
+// Get returns the details of an order return.
 func (c Client) Get(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
 	path := stripe.FormatURLPath("/v1/order_returns/%s", id)
-	orderReturn := &stripe.OrderReturn{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, orderReturn)
-	return orderReturn, err
+	orderreturn := &stripe.OrderReturn{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, orderreturn)
+	return orderreturn, err
 }
 
 // List returns a list of order returns.

--- a/plan/client.go
+++ b/plan/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package plan provides the /plans APIs
 package plan
 
@@ -95,9 +101,9 @@ func (i *Iter) Plan() *stripe.Plan {
 	return i.Current().(*stripe.Plan)
 }
 
-// PlanList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// PlanList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) PlanList() *stripe.PlanList {
 	return i.List().(*stripe.PlanList)
 }

--- a/price/client.go
+++ b/price/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package price provides the /prices APIs
 package price
 
@@ -82,9 +88,9 @@ func (i *Iter) Price() *stripe.Price {
 	return i.Current().(*stripe.Price)
 }
 
-// PriceList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// PriceList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) PriceList() *stripe.PriceList {
 	return i.List().(*stripe.PriceList)
 }

--- a/product/client.go
+++ b/product/client.go
@@ -1,3 +1,10 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package product provides the /products APIs
 package product
 
 import (
@@ -20,22 +27,9 @@ func New(params *stripe.ProductParams) (*stripe.Product, error) {
 
 // New creates a new product.
 func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
-	p := &stripe.Product{}
-	err := c.B.Call(http.MethodPost, "/v1/products", c.Key, params, p)
-	return p, err
-}
-
-// Update updates a product's properties.
-func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	return getC().Update(id, params)
-}
-
-// Update updates a product's properties.
-func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	path := stripe.FormatURLPath("/v1/products/%s", id)
-	p := &stripe.Product{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, p)
-	return p, err
+	product := &stripe.Product{}
+	err := c.B.Call(http.MethodPost, "/v1/products", c.Key, params, product)
+	return product, err
 }
 
 // Get returns the details of a product.
@@ -46,9 +40,35 @@ func Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 // Get returns the details of a product.
 func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/v1/products/%s", id)
-	p := &stripe.Product{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, p)
-	return p, err
+	product := &stripe.Product{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, product)
+	return product, err
+}
+
+// Update updates a product's properties.
+func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
+	return getC().Update(id, params)
+}
+
+// Update updates a product's properties.
+func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
+	path := stripe.FormatURLPath("/v1/products/%s", id)
+	product := &stripe.Product{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, product)
+	return product, err
+}
+
+// Del removes a product.
+func Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
+	return getC().Del(id, params)
+}
+
+// Del removes a product.
+func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
+	path := stripe.FormatURLPath("/v1/products/%s", id)
+	product := &stripe.Product{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, product)
+	return product, err
 }
 
 // List returns a list of products.
@@ -71,20 +91,6 @@ func (c Client) List(listParams *stripe.ProductListParams) *Iter {
 	})}
 }
 
-// Del deletes a product
-func Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	return getC().Del(id, params)
-}
-
-// Del deletes a product.
-func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
-	path := stripe.FormatURLPath("/v1/products/%s", id)
-	p := &stripe.Product{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, p)
-
-	return p, err
-}
-
 // Iter is an iterator for products.
 type Iter struct {
 	*stripe.Iter
@@ -95,9 +101,9 @@ func (i *Iter) Product() *stripe.Product {
 	return i.Current().(*stripe.Product)
 }
 
-// ProductList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// ProductList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) ProductList() *stripe.ProductList {
 	return i.List().(*stripe.ProductList)
 }

--- a/promotioncode/client.go
+++ b/promotioncode/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package promotioncode provides the /promotion_codes APIs
 package promotioncode
 
@@ -21,9 +27,15 @@ func New(params *stripe.PromotionCodeParams) (*stripe.PromotionCode, error) {
 
 // New creates a new promotion code.
 func (c Client) New(params *stripe.PromotionCodeParams) (*stripe.PromotionCode, error) {
-	pc := &stripe.PromotionCode{}
-	err := c.B.Call(http.MethodPost, "/v1/promotion_codes", c.Key, params, pc)
-	return pc, err
+	promotioncode := &stripe.PromotionCode{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/promotion_codes",
+		c.Key,
+		params,
+		promotioncode,
+	)
+	return promotioncode, err
 }
 
 // Get returns the details of a promotion code.
@@ -34,9 +46,9 @@ func Get(id string, params *stripe.PromotionCodeParams) (*stripe.PromotionCode, 
 // Get returns the details of a promotion code.
 func (c Client) Get(id string, params *stripe.PromotionCodeParams) (*stripe.PromotionCode, error) {
 	path := stripe.FormatURLPath("/v1/promotion_codes/%s", id)
-	pc := &stripe.PromotionCode{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, pc)
-	return pc, err
+	promotioncode := &stripe.PromotionCode{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, promotioncode)
+	return promotioncode, err
 }
 
 // Update updates a promotion code's properties.
@@ -47,9 +59,9 @@ func Update(id string, params *stripe.PromotionCodeParams) (*stripe.PromotionCod
 // Update updates a promotion code's properties.
 func (c Client) Update(id string, params *stripe.PromotionCodeParams) (*stripe.PromotionCode, error) {
 	path := stripe.FormatURLPath("/v1/promotion_codes/%s", id)
-	pc := &stripe.PromotionCode{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, pc)
-	return pc, err
+	promotioncode := &stripe.PromotionCode{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, promotioncode)
+	return promotioncode, err
 }
 
 // List returns a list of promotion codes.

--- a/radar/valuelistitem/client.go
+++ b/radar/valuelistitem/client.go
@@ -1,6 +1,10 @@
-// Package valuelistitem provides API functions related to value list items.
 //
-// For more details, see: https://stripe.com/docs/api/radar/list_items?lang=go
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package valuelistitem provides the /radar/value_list_items APIs
 package valuelistitem
 
 import (
@@ -16,50 +20,56 @@ type Client struct {
 	Key string
 }
 
-// New creates a new value list item.
+// New creates a new radar value list item.
 func New(params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
 	return getC().New(params)
 }
 
-// New creates a new value list item.
+// New creates a new radar value list item.
 func (c Client) New(params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
-	vli := &stripe.RadarValueListItem{}
-	err := c.B.Call(http.MethodPost, "/v1/radar/value_list_items", c.Key, params, vli)
-	return vli, err
+	valuelistitem := &stripe.RadarValueListItem{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/radar/value_list_items",
+		c.Key,
+		params,
+		valuelistitem,
+	)
+	return valuelistitem, err
 }
 
-// Get returns the details of a value list item.
+// Get returns the details of a radar value list item.
 func Get(id string, params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a value list item.
+// Get returns the details of a radar value list item.
 func (c Client) Get(id string, params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_list_items/%s", id)
-	vli := &stripe.RadarValueListItem{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, vli)
-	return vli, err
+	valuelistitem := &stripe.RadarValueListItem{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, valuelistitem)
+	return valuelistitem, err
 }
 
-// Del removes a value list item.
+// Del removes a radar value list item.
 func Del(id string, params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
 	return getC().Del(id, params)
 }
 
-// Del removes a value list item.
+// Del removes a radar value list item.
 func (c Client) Del(id string, params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_list_items/%s", id)
-	vli := &stripe.RadarValueListItem{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, vli)
-	return vli, err
+	valuelistitem := &stripe.RadarValueListItem{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, valuelistitem)
+	return valuelistitem, err
 }
 
-// List returns a list of vlis.
+// List returns a list of radar value list items.
 func List(params *stripe.RadarValueListItemListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of vlis.
+// List returns a list of radar value list items.
 func (c Client) List(listParams *stripe.RadarValueListItemListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.RadarValueListItemList{}
@@ -74,12 +84,12 @@ func (c Client) List(listParams *stripe.RadarValueListItemListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for vlis.
+// Iter is an iterator for radar value list items.
 type Iter struct {
 	*stripe.Iter
 }
 
-// RadarValueListItem returns the vli which the iterator is currently pointing to.
+// RadarValueListItem returns the radar value list item which the iterator is currently pointing to.
 func (i *Iter) RadarValueListItem() *stripe.RadarValueListItem {
 	return i.Current().(*stripe.RadarValueListItem)
 }

--- a/setupattempt/client.go
+++ b/setupattempt/client.go
@@ -5,7 +5,6 @@
 //
 
 // Package setupattempt provides the /setup_attempts APIs
-
 // For more details, see: https://stripe.com/docs/api/go#setup_attempts
 package setupattempt
 

--- a/setupattempt/client.go
+++ b/setupattempt/client.go
@@ -1,6 +1,12 @@
-// Package setupattempt provides API functions related to setup attempts.
 //
-// For more details, see: https://stripe.com/docs/api/go#setup_attempts.
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package setupattempt provides the /setup_attempts APIs
+
+// For more details, see: https://stripe.com/docs/api/go#setup_attempts
 package setupattempt
 
 import (
@@ -10,7 +16,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke APIs related to setup attempts.
+// Client is used to invoke /setup_attempts APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string

--- a/sigma/scheduledqueryrun/client.go
+++ b/sigma/scheduledqueryrun/client.go
@@ -5,7 +5,6 @@
 //
 
 // Package scheduledqueryrun provides the /sigma/scheduled_query_runs APIs
-
 // For more details, see: https://stripe.com/docs/api#scheduled_queries
 package scheduledqueryrun
 

--- a/sigma/scheduledqueryrun/client.go
+++ b/sigma/scheduledqueryrun/client.go
@@ -1,5 +1,11 @@
-// Package scheduledqueryrun provides API functions related to scheduled query runs.
 //
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package scheduledqueryrun provides the /sigma/scheduled_query_runs APIs
+
 // For more details, see: https://stripe.com/docs/api#scheduled_queries
 package scheduledqueryrun
 
@@ -16,25 +22,25 @@ type Client struct {
 	Key string
 }
 
-// Get returns the details of an scheduled query run.
+// Get returns the details of a sigma scheduled query run.
 func Get(id string, params *stripe.SigmaScheduledQueryRunParams) (*stripe.SigmaScheduledQueryRun, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of an scheduled query run.
+// Get returns the details of a sigma scheduled query run.
 func (c Client) Get(id string, params *stripe.SigmaScheduledQueryRunParams) (*stripe.SigmaScheduledQueryRun, error) {
 	path := stripe.FormatURLPath("/v1/sigma/scheduled_query_runs/%s", id)
-	run := &stripe.SigmaScheduledQueryRun{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, run)
-	return run, err
+	scheduledqueryrun := &stripe.SigmaScheduledQueryRun{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, scheduledqueryrun)
+	return scheduledqueryrun, err
 }
 
-// List returns a list of scheduled query runs.
+// List returns a list of sigma scheduled query runs.
 func List(params *stripe.SigmaScheduledQueryRunListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of scheduled query runs.
+// List returns a list of sigma scheduled query runs.
 func (c Client) List(listParams *stripe.SigmaScheduledQueryRunListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SigmaScheduledQueryRunList{}
@@ -49,19 +55,19 @@ func (c Client) List(listParams *stripe.SigmaScheduledQueryRunListParams) *Iter 
 	})}
 }
 
-// Iter is an iterator for scheduled query runs.
+// Iter is an iterator for sigma scheduled query runs.
 type Iter struct {
 	*stripe.Iter
 }
 
-// SigmaScheduledQueryRun returns the scheduled query run which the iterator is currently pointing to.
+// SigmaScheduledQueryRun returns the sigma scheduled query run which the iterator is currently pointing to.
 func (i *Iter) SigmaScheduledQueryRun() *stripe.SigmaScheduledQueryRun {
 	return i.Current().(*stripe.SigmaScheduledQueryRun)
 }
 
-// SigmaScheduledQueryRunList returns the current list object which the
-// iterator is currently using. List objects will change as new API calls are
-// made to continue pagination.
+// SigmaScheduledQueryRunList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) SigmaScheduledQueryRunList() *stripe.SigmaScheduledQueryRunList {
 	return i.List().(*stripe.SigmaScheduledQueryRunList)
 }

--- a/sku/client.go
+++ b/sku/client.go
@@ -1,3 +1,10 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package sku provides the /skus APIs
 package sku
 
 import (
@@ -13,50 +20,63 @@ type Client struct {
 	Key string
 }
 
-// New creates a new SKU.
+// New creates a new sku.
 func New(params *stripe.SKUParams) (*stripe.SKU, error) {
 	return getC().New(params)
 }
 
-// New creates a new SKU.
+// New creates a new sku.
 func (c Client) New(params *stripe.SKUParams) (*stripe.SKU, error) {
-	s := &stripe.SKU{}
-	err := c.B.Call(http.MethodPost, "/v1/skus", c.Key, params, s)
-	return s, err
+	sku := &stripe.SKU{}
+	err := c.B.Call(http.MethodPost, "/v1/skus", c.Key, params, sku)
+	return sku, err
 }
 
-// Update updates a SKU's properties.
-func Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	return getC().Update(id, params)
-}
-
-// Update updates a SKU's properties.
-func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	path := stripe.FormatURLPath("/v1/skus/%s", id)
-	s := &stripe.SKU{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, s)
-	return s, err
-}
-
-// Get returns the details of a SKU.
+// Get returns the details of a sku.
 func Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a SKU.
+// Get returns the details of a sku.
 func (c Client) Get(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
 	path := stripe.FormatURLPath("/v1/skus/%s", id)
-	s := &stripe.SKU{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, s)
-	return s, err
+	sku := &stripe.SKU{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, sku)
+	return sku, err
 }
 
-// List returns a list of SKUs.
+// Update updates a sku's properties.
+func Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
+	return getC().Update(id, params)
+}
+
+// Update updates a sku's properties.
+func (c Client) Update(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
+	path := stripe.FormatURLPath("/v1/skus/%s", id)
+	sku := &stripe.SKU{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, sku)
+	return sku, err
+}
+
+// Del removes a sku.
+func Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
+	return getC().Del(id, params)
+}
+
+// Del removes a sku.
+func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
+	path := stripe.FormatURLPath("/v1/skus/%s", id)
+	sku := &stripe.SKU{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, sku)
+	return sku, err
+}
+
+// List returns a list of skus.
 func List(params *stripe.SKUListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of SKUs.
+// List returns a list of skus.
 func (c Client) List(listParams *stripe.SKUListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.SKUList{}
@@ -71,33 +91,19 @@ func (c Client) List(listParams *stripe.SKUListParams) *Iter {
 	})}
 }
 
-// Del removes a SKU.
-func Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	return getC().Del(id, params)
-}
-
-// Del removes a SKU.
-func (c Client) Del(id string, params *stripe.SKUParams) (*stripe.SKU, error) {
-	path := stripe.FormatURLPath("/v1/skus/%s", id)
-	s := &stripe.SKU{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, s)
-
-	return s, err
-}
-
-// Iter is an iterator for SKUs.
+// Iter is an iterator for skus.
 type Iter struct {
 	*stripe.Iter
 }
 
-// SKU returns the SKU which the iterator is currently pointing to.
+// SKU returns the sku which the iterator is currently pointing to.
 func (i *Iter) SKU() *stripe.SKU {
 	return i.Current().(*stripe.SKU)
 }
 
-// SKUList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// SKUList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) SKUList() *stripe.SKUList {
 	return i.List().(*stripe.SKUList)
 }

--- a/terminal/connectiontoken/client.go
+++ b/terminal/connectiontoken/client.go
@@ -1,4 +1,10 @@
-// Package connectiontoken provides API functions related to terminal connection tokens
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package connectiontoken provides the /terminal/connection_tokens APIs
 package connectiontoken
 
 import (
@@ -21,7 +27,13 @@ func New(params *stripe.TerminalConnectionTokenParams) (*stripe.TerminalConnecti
 // New creates a new terminal connection token.
 func (c Client) New(params *stripe.TerminalConnectionTokenParams) (*stripe.TerminalConnectionToken, error) {
 	connectiontoken := &stripe.TerminalConnectionToken{}
-	err := c.B.Call(http.MethodPost, "/v1/terminal/connection_tokens", c.Key, params, connectiontoken)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/terminal/connection_tokens",
+		c.Key,
+		params,
+		connectiontoken,
+	)
 	return connectiontoken, err
 }
 

--- a/terminal/location/client.go
+++ b/terminal/location/client.go
@@ -1,4 +1,10 @@
-// Package location provides API functions related to terminal locations
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package location provides the /terminal/locations APIs
 package location
 
 import (
@@ -8,7 +14,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invokte /terminal/locations APIs
+// Client is used to invoke /terminal/locations APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -22,7 +28,13 @@ func New(params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error
 // New creates a new terminal location.
 func (c Client) New(params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	location := &stripe.TerminalLocation{}
-	err := c.B.Call(http.MethodPost, "/v1/terminal/locations", c.Key, params, location)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/terminal/locations",
+		c.Key,
+		params,
+		location,
+	)
 	return location, err
 }
 
@@ -39,12 +51,12 @@ func (c Client) Get(id string, params *stripe.TerminalLocationParams) (*stripe.T
 	return location, err
 }
 
-// Update updates a terminal location.
+// Update updates a terminal location's properties.
 func Update(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a terminal location.
+// Update updates a terminal location's properties.
 func (c Client) Update(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	path := stripe.FormatURLPath("/v1/terminal/locations/%s", id)
 	location := &stripe.TerminalLocation{}
@@ -52,12 +64,12 @@ func (c Client) Update(id string, params *stripe.TerminalLocationParams) (*strip
 	return location, err
 }
 
-// Del removes a location.
+// Del removes a terminal location.
 func Del(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	return getC().Del(id, params)
 }
 
-// Del removes a location.
+// Del removes a terminal location.
 func (c Client) Del(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	path := stripe.FormatURLPath("/v1/terminal/locations/%s", id)
 	location := &stripe.TerminalLocation{}
@@ -65,12 +77,12 @@ func (c Client) Del(id string, params *stripe.TerminalLocationParams) (*stripe.T
 	return location, err
 }
 
-// List returns a list of terminal location.
+// List returns a list of terminal locations.
 func List(params *stripe.TerminalLocationListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of terminal location.
+// List returns a list of terminal locations.
 func (c Client) List(listParams *stripe.TerminalLocationListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.TerminalLocationList{}

--- a/token/client.go
+++ b/token/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package token provides the /tokens APIs
 package token
 
@@ -20,9 +26,9 @@ func New(params *stripe.TokenParams) (*stripe.Token, error) {
 
 // New creates a new token.
 func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
-	tok := &stripe.Token{}
-	err := c.B.Call(http.MethodPost, "/v1/tokens", c.Key, params, tok)
-	return tok, err
+	token := &stripe.Token{}
+	err := c.B.Call(http.MethodPost, "/v1/tokens", c.Key, params, token)
+	return token, err
 }
 
 // Get returns the details of a token.
@@ -35,7 +41,6 @@ func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error
 	path := stripe.FormatURLPath("/v1/tokens/%s", id)
 	token := &stripe.Token{}
 	err := c.B.Call(http.MethodGet, path, c.Key, params, token)
-
 	return token, err
 }
 

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package transfer provides the /transfers APIs
 package transfer
 
@@ -82,9 +88,9 @@ func (i *Iter) Transfer() *stripe.Transfer {
 	return i.Current().(*stripe.Transfer)
 }
 
-// TransferList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// TransferList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) TransferList() *stripe.TransferList {
 	return i.List().(*stripe.TransferList)
 }

--- a/usagerecordsummary/client.go
+++ b/usagerecordsummary/client.go
@@ -1,4 +1,10 @@
-// Package usagerecordsummary provides the /subscription_items/{SUBSCRIPTION_ITEM_ID}/usage_record_summaries APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package usagerecordsummary provides the /subscription_items/{subscription_item}/usage_record_summaries APIs
 package usagerecordsummary
 
 import (
@@ -8,21 +14,24 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke APIs related to usage record summaries.
+// Client is used to invoke /subscription_items/{subscription_item}/usage_record_summaries APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// List returns an iterator that iterates all usage record summaries.
+// List returns a list of usage record summaries.
 func List(params *stripe.UsageRecordSummaryListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns an iterator that iterates all usage record summaries.
+// List returns a list of usage record summaries.
 func (c Client) List(listParams *stripe.UsageRecordSummaryListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		path := stripe.FormatURLPath("/v1/subscription_items/%s/usage_record_summaries", stripe.StringValue(listParams.SubscriptionItem))
+		path := stripe.FormatURLPath(
+			"/v1/subscription_items/%s/usage_record_summaries",
+			stripe.StringValue(listParams.SubscriptionItem),
+		)
 		list := &stripe.UsageRecordSummaryList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 

--- a/webhookendpoint/client.go
+++ b/webhookendpoint/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package webhookendpoint provides the /webhook_endpoints APIs
 package webhookendpoint
 
@@ -14,16 +20,22 @@ type Client struct {
 	Key string
 }
 
-// New creates a new webhook_endpoint.
+// New creates a new webhook endpoint.
 func New(params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
 	return getC().New(params)
 }
 
-// New creates a new webhook_endpoint.
+// New creates a new webhook endpoint.
 func (c Client) New(params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
-	endpoint := &stripe.WebhookEndpoint{}
-	err := c.B.Call(http.MethodPost, "/v1/webhook_endpoints", c.Key, params, endpoint)
-	return endpoint, err
+	webhookendpoint := &stripe.WebhookEndpoint{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/webhook_endpoints",
+		c.Key,
+		params,
+		webhookendpoint,
+	)
+	return webhookendpoint, err
 }
 
 // Get returns the details of a webhook endpoint.
@@ -34,9 +46,9 @@ func Get(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoi
 // Get returns the details of a webhook endpoint.
 func (c Client) Get(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
 	path := stripe.FormatURLPath("/v1/webhook_endpoints/%s", id)
-	endpoint := &stripe.WebhookEndpoint{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, endpoint)
-	return endpoint, err
+	webhookendpoint := &stripe.WebhookEndpoint{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, webhookendpoint)
+	return webhookendpoint, err
 }
 
 // Update updates a webhook endpoint's properties.
@@ -47,9 +59,9 @@ func Update(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEnd
 // Update updates a webhook endpoint's properties.
 func (c Client) Update(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
 	path := stripe.FormatURLPath("/v1/webhook_endpoints/%s", id)
-	endpoint := &stripe.WebhookEndpoint{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, endpoint)
-	return endpoint, err
+	webhookendpoint := &stripe.WebhookEndpoint{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, webhookendpoint)
+	return webhookendpoint, err
 }
 
 // Del removes a webhook endpoint.
@@ -60,17 +72,17 @@ func Del(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoi
 // Del removes a webhook endpoint.
 func (c Client) Del(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
 	path := stripe.FormatURLPath("/v1/webhook_endpoints/%s", id)
-	endpoint := &stripe.WebhookEndpoint{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, endpoint)
-	return endpoint, err
+	webhookendpoint := &stripe.WebhookEndpoint{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, webhookendpoint)
+	return webhookendpoint, err
 }
 
-// List returns a list of webhook_endpoints.
+// List returns a list of webhook endpoints.
 func List(params *stripe.WebhookEndpointListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of webhook_endpoints.
+// List returns a list of webhook endpoints.
 func (c Client) List(listParams *stripe.WebhookEndpointListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.WebhookEndpointList{}
@@ -85,12 +97,12 @@ func (c Client) List(listParams *stripe.WebhookEndpointListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for webhook_endpoints.
+// Iter is an iterator for webhook endpoints.
 type Iter struct {
 	*stripe.Iter
 }
 
-// WebhookEndpoint returns the endpoint which the iterator is currently pointing to.
+// WebhookEndpoint returns the webhook endpoint which the iterator is currently pointing to.
 func (i *Iter) WebhookEndpoint() *stripe.WebhookEndpoint {
 	return i.Current().(*stripe.WebhookEndpoint)
 }


### PR DESCRIPTION
Converts several `client.go` files to the codegenned format. This should be a complete noop. Most of the diff is changing variable names, arbitrary comment content, and some whitespace/ordering changes.