### PR TITLE
Add support for CheckoutSessionSubscriptionDataParams.transfer_data

### DIFF
--- a/checkout_session.go
+++ b/checkout_session.go
@@ -195,19 +195,24 @@ type CheckoutSessionSubscriptionDataItemsParams struct {
 	Quantity *int64    `form:"quantity"`
 	TaxRates []*string `form:"tax_rates"`
 }
+type CheckoutSessionSubscriptionDataTransferDataParams struct {
+	AmountPercent *float64 `form:"amount_percent"`
+	Destination   *string  `form:"destination"`
+}
 
 // CheckoutSessionSubscriptionDataParams is the set of parameters allowed for the subscription
 // creation on a checkout session.
 type CheckoutSessionSubscriptionDataParams struct {
 	Params                `form:"*"`
-	ApplicationFeePercent *float64                                      `form:"application_fee_percent"`
-	Coupon                *string                                       `form:"coupon"`
-	DefaultTaxRates       []*string                                     `form:"default_tax_rates"`
-	Items                 []*CheckoutSessionSubscriptionDataItemsParams `form:"items"`
-	Metadata              map[string]string                             `form:"metadata"`
-	TrialEnd              *int64                                        `form:"trial_end"`
-	TrialFromPlan         *bool                                         `form:"trial_from_plan"`
-	TrialPeriodDays       *int64                                        `form:"trial_period_days"`
+	ApplicationFeePercent *float64                                           `form:"application_fee_percent"`
+	Coupon                *string                                            `form:"coupon"`
+	DefaultTaxRates       []*string                                          `form:"default_tax_rates"`
+	Items                 []*CheckoutSessionSubscriptionDataItemsParams      `form:"items"`
+	Metadata              map[string]string                                  `form:"metadata"`
+	TransferData          *CheckoutSessionSubscriptionDataTransferDataParams `form:"transfer_data"`
+	TrialEnd              *int64                                             `form:"trial_end"`
+	TrialFromPlan         *bool                                              `form:"trial_from_plan"`
+	TrialPeriodDays       *int64                                             `form:"trial_period_days"`
 }
 
 // CheckoutSessionParams is the set of parameters that can be used when creating

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -195,6 +195,9 @@ type CheckoutSessionSubscriptionDataItemsParams struct {
 	Quantity *int64    `form:"quantity"`
 	TaxRates []*string `form:"tax_rates"`
 }
+
+// CheckoutSessionSubscriptionDataTransferDataParams is the set of parameters allowed
+// for the transfer_data hash.
 type CheckoutSessionSubscriptionDataTransferDataParams struct {
 	AmountPercent *float64 `form:"amount_percent"`
 	Destination   *string  `form:"destination"`


### PR DESCRIPTION
r? @remi-stripe 
Corresponds to openapi [v26](https://github.com/stripe/openapi/releases/tag/v26), analog to [this commit on stripe-node]( https://github.com/stripe/stripe-node/commit/0960599bf2bae4a9f38a2558f04b0807858f4856)

## Changelog
* Add support for `transfer_data` on CheckoutSessionSubscriptionDataParams