### PR TITLE
Fix names of SubscriptionScheduleStatus constants

### DIFF
--- a/subschedule.go
+++ b/subschedule.go
@@ -20,11 +20,11 @@ type SubscriptionScheduleStatus string
 
 // List of values that SubscriptionScheduleStatus can take.
 const (
-	SubscriptionScheduleStatusActive    SubscriptionScheduleStatus = "active"
-	SubscriptionScheduleStatusCanceled  SubscriptionScheduleStatus = "canceled"
-	SubscriptionScheduleStatusCompleted SubscriptionScheduleStatus = "completed"
-	SubscriptionScheduleStatusPastDue   SubscriptionScheduleStatus = "not_started"
-	SubscriptionScheduleStatusTrialing  SubscriptionScheduleStatus = "released"
+	SubscriptionScheduleStatusActive     SubscriptionScheduleStatus = "active"
+	SubscriptionScheduleStatusCanceled   SubscriptionScheduleStatus = "canceled"
+	SubscriptionScheduleStatusCompleted  SubscriptionScheduleStatus = "completed"
+	SubscriptionScheduleStatusNotStarted SubscriptionScheduleStatus = "not_started"
+	SubscriptionScheduleStatusReleased   SubscriptionScheduleStatus = "released"
 )
 
 // SubscriptionSchedulePhaseBillingCycleAnchor is the list of allowed values for the


### PR DESCRIPTION
This PR updates the names of the `SubscriptionScheduleStatusPastDue` and `SubscriptionScheduleStatusTrialing` constants to match their underlying values. For some reason these are off, which caused some slight confusion when working with them.