### PR TITLE
Add support for ACSS debit payment method

### DIFF
--- a/account.go
+++ b/account.go
@@ -170,6 +170,11 @@ type AccountBusinessProfileParams struct {
 	URL                *string        `form:"url"`
 }
 
+// AccountCapabilitiesACSSDebitPaymentsParams represent allowed parameters to configure the ACSS Debit capability on an account.
+type AccountCapabilitiesACSSDebitPaymentsParams struct {
+	Requested *bool `form:"requested"`
+}
+
 // AccountCapabilitiesAUBECSDebitPaymentsParams represent allowed parameters to configure the AU BECS Debit capability on an account.
 type AccountCapabilitiesAUBECSDebitPaymentsParams struct {
 	Requested *bool `form:"requested"`
@@ -272,6 +277,7 @@ type AccountCapabilitiesTransfersParams struct {
 
 // AccountCapabilitiesParams represent allowed parameters to configure capabilities on an account.
 type AccountCapabilitiesParams struct {
+	ACSSDebitPayments       *AccountCapabilitiesACSSDebitPaymentsParams       `form:"acss_debit_payments"`
 	AUBECSDebitPayments     *AccountCapabilitiesAUBECSDebitPaymentsParams     `form:"au_becs_debit_payments"`
 	BACSDebitPayments       *AccountCapabilitiesBACSDebitPaymentsParams       `form:"bacs_debit_payments"`
 	BancontactPayments      *AccountCapabilitiesBancontactPaymentsParams      `form:"bancontact_payments"`
@@ -553,6 +559,7 @@ type AccountBusinessProfile struct {
 
 // AccountCapabilities is the resource representing the capabilities enabled on that account.
 type AccountCapabilities struct {
+	ACSSDebitPayments       AccountCapabilityStatus `json:"acss_debit_payments"`
 	AUBECSDebitPayments     AccountCapabilityStatus `json:"au_becs_debit_payments"`
 	BACSDebitPayments       AccountCapabilityStatus `json:"bacs_debit_payments"`
 	BancontactPayments      AccountCapabilityStatus `json:"bancontact_payments"`

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -334,6 +334,7 @@ type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions struct {
 
 // CheckoutSessionPaymentMethodOptionsACSSDebit represent the options for acss debit on payment_method_options.
 type CheckoutSessionPaymentMethodOptionsACSSDebit struct {
+	Currency           string                                                         `json:"currency"`
 	MandateOptions     *CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
 	VerificationMethod CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
 }

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -67,7 +67,7 @@ const (
 	CheckoutSessionModeSubscription CheckoutSessionMode = "subscription"
 )
 
-// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule TODO
+// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule is the list of allowed values for payment_schedule
 type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
 
 // List of values that CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule can take
@@ -77,7 +77,7 @@ const (
 	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleSporadic CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "sporadic"
 )
 
-// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType TODO
+// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType is the list of allowed values for transaction_type
 type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType string
 
 // List of values that CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType can take
@@ -86,7 +86,7 @@ const (
 	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypePersonal CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "personal"
 )
 
-// CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod TODO
+// CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod is the list of allowed values for verification_method
 type CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod string
 
 // List of values that CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod can take
@@ -203,7 +203,7 @@ type CheckoutSessionPaymentIntentDataParams struct {
 	TransferGroup             *string                                             `form:"transfer_group"`
 }
 
-// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams TODO
+// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams is the set of parameters allowed for mandate_options for acss debit.
 type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
 	CustomMandateURL    *string `form:"custom_mandate_url"`
 	IntervalDescription *string `form:"interval_description"`
@@ -211,14 +211,14 @@ type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
 	TransactionType     *string `form:"transaction_type"`
 }
 
-// CheckoutSessionPaymentMethodOptionsACSSDebitParams TODO
+// CheckoutSessionPaymentMethodOptionsACSSDebitParams is the set of parameters allowed for acss_debit on payment_method_options.
 type CheckoutSessionPaymentMethodOptionsACSSDebitParams struct {
 	Currency           *string                                                           `form:"currency"`
 	MandateOptions     *CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams `form:"mandate_options"`
 	VerificationMethod *string                                                           `form:"verification_method"`
 }
 
-// CheckoutSessionPaymentMethodOptionsParams TODO
+// CheckoutSessionPaymentMethodOptionsParams is the set of allowed parameters for payment_method_options on a checkout session.
 type CheckoutSessionPaymentMethodOptionsParams struct {
 	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebitParams `form:"acss_debit"`
 }
@@ -324,7 +324,7 @@ type CheckoutSessionCustomerDetails struct {
 	TaxIDs    []*CheckoutSessionCustomerDetailsTaxIDs `json:"tax_ids"`
 }
 
-// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions TODO
+// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions represent mandate options for acss debit.
 type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions struct {
 	CustomMandateURL    string                                                                    `json:"custom_mandate_url"`
 	IntervalDescription string                                                                    `json:"interval_description"`
@@ -332,13 +332,13 @@ type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions struct {
 	TransactionType     CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
 }
 
-// CheckoutSessionPaymentMethodOptionsACSSDebit TODO
+// CheckoutSessionPaymentMethodOptionsACSSDebit represent the options for acss debit on payment_method_options.
 type CheckoutSessionPaymentMethodOptionsACSSDebit struct {
 	MandateOptions     *CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
 	VerificationMethod CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
 }
 
-// CheckoutSessionPaymentMethodOptions TODO
+// CheckoutSessionPaymentMethodOptions represent payment-method-specific options for a checkout session.
 type CheckoutSessionPaymentMethodOptions struct {
 	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebit `json:"acss_debit"`
 }

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -67,6 +67,35 @@ const (
 	CheckoutSessionModeSubscription CheckoutSessionMode = "subscription"
 )
 
+// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule TODO
+type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
+
+// List of values that CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule can take
+const (
+	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleCombined CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "combined"
+	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleInterval CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "interval"
+	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleSporadic CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "sporadic"
+)
+
+// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType TODO
+type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType string
+
+// List of values that CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType can take
+const (
+	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypeBusiness CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "business"
+	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypePersonal CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "personal"
+)
+
+// CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod TODO
+type CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod string
+
+// List of values that CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod can take
+const (
+	CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethodAutomatic     CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod = "automatic"
+	CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethodInstant       CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod = "instant"
+	CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
+)
+
 // CheckoutSessionPaymentStatus is the list of allowed values for the payment status on a Session.`
 type CheckoutSessionPaymentStatus string
 
@@ -174,6 +203,26 @@ type CheckoutSessionPaymentIntentDataParams struct {
 	TransferGroup             *string                                             `form:"transfer_group"`
 }
 
+// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams TODO
+type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
+	CustomMandateURL    *string `form:"custom_mandate_url"`
+	IntervalDescription *string `form:"interval_description"`
+	PaymentSchedule     *string `form:"payment_schedule"`
+	TransactionType     *string `form:"transaction_type"`
+}
+
+// CheckoutSessionPaymentMethodOptionsACSSDebitParams TODO
+type CheckoutSessionPaymentMethodOptionsACSSDebitParams struct {
+	Currency           *string                                                           `form:"currency"`
+	MandateOptions     *CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams `form:"mandate_options"`
+	VerificationMethod *string                                                           `form:"verification_method"`
+}
+
+// CheckoutSessionPaymentMethodOptionsParams TODO
+type CheckoutSessionPaymentMethodOptionsParams struct {
+	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebitParams `form:"acss_debit"`
+}
+
 // CheckoutSessionSetupIntentDataParams is the set of parameters allowed for the setup intent
 // creation on a checkout session.
 type CheckoutSessionSetupIntentDataParams struct {
@@ -234,6 +283,7 @@ type CheckoutSessionParams struct {
 	Locale                    *string                                         `form:"locale"`
 	Mode                      *string                                         `form:"mode"`
 	PaymentIntentData         *CheckoutSessionPaymentIntentDataParams         `form:"payment_intent_data"`
+	PaymentMethodOptions      *CheckoutSessionPaymentMethodOptionsParams      `form:"payment_method_options"`
 	PaymentMethodTypes        []*string                                       `form:"payment_method_types"`
 	SetupIntentData           *CheckoutSessionSetupIntentDataParams           `form:"setup_intent_data"`
 	ShippingAddressCollection *CheckoutSessionShippingAddressCollectionParams `form:"shipping_address_collection"`
@@ -272,6 +322,25 @@ type CheckoutSessionCustomerDetails struct {
 	Email     string                                  `json:"email"`
 	TaxExempt CheckoutSessionCustomerDetailsTaxExempt `json:"tax_exempt"`
 	TaxIDs    []*CheckoutSessionCustomerDetailsTaxIDs `json:"tax_ids"`
+}
+
+// CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions TODO
+type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions struct {
+	CustomMandateURL    string                                                                    `json:"custom_mandate_url"`
+	IntervalDescription string                                                                    `json:"interval_description"`
+	PaymentSchedule     CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule `json:"payment_schedule"`
+	TransactionType     CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
+}
+
+// CheckoutSessionPaymentMethodOptionsACSSDebit TODO
+type CheckoutSessionPaymentMethodOptionsACSSDebit struct {
+	MandateOptions     *CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
+	VerificationMethod CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
+}
+
+// CheckoutSessionPaymentMethodOptions TODO
+type CheckoutSessionPaymentMethodOptions struct {
+	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebit `json:"acss_debit"`
 }
 
 // CheckoutSessionShippingAddressCollection is the set of parameters allowed for the
@@ -328,6 +397,7 @@ type CheckoutSession struct {
 	Mode                      CheckoutSessionMode                       `json:"mode"`
 	Object                    string                                    `json:"object"`
 	PaymentIntent             *PaymentIntent                            `json:"payment_intent"`
+	PaymentMethodOptions      *CheckoutSessionPaymentMethodOptions      `json:"payment_method_options"`
 	PaymentMethodTypes        []string                                  `json:"payment_method_types"`
 	PaymentStatus             CheckoutSessionPaymentStatus              `json:"payment_status"`
 	SetupIntent               *SetupIntent                              `json:"setup_intent"`

--- a/mandate.go
+++ b/mandate.go
@@ -19,6 +19,25 @@ const (
 	MandateStatusPending  MandateStatus = "pending"
 )
 
+// MandatePaymentMethodDetailsACSSDebitPaymentSchedule TODO
+type MandatePaymentMethodDetailsACSSDebitPaymentSchedule string
+
+// List of values that MandatePaymentMethodDetailsACSSDebitPaymentSchedule can take
+const (
+	MandatePaymentMethodDetailsACSSDebitPaymentScheduleCombined MandatePaymentMethodDetailsACSSDebitPaymentSchedule = "combined"
+	MandatePaymentMethodDetailsACSSDebitPaymentScheduleInterval MandatePaymentMethodDetailsACSSDebitPaymentSchedule = "interval"
+	MandatePaymentMethodDetailsACSSDebitPaymentScheduleSporadic MandatePaymentMethodDetailsACSSDebitPaymentSchedule = "sporadic"
+)
+
+// MandatePaymentMethodDetailsACSSDebitTransactionType TODO
+type MandatePaymentMethodDetailsACSSDebitTransactionType string
+
+// List of values that MandatePaymentMethodDetailsACSSDebitTransactionType can take
+const (
+	MandatePaymentMethodDetailsACSSDebitTransactionTypeBusiness MandatePaymentMethodDetailsACSSDebitTransactionType = "business"
+	MandatePaymentMethodDetailsACSSDebitTransactionTypePersonal MandatePaymentMethodDetailsACSSDebitTransactionType = "personal"
+)
+
 // MandatePaymentMethodDetailsBACSDebitNetworkStatus is the list of allowed values for the status
 // with the network for a given mandate.
 type MandatePaymentMethodDetailsBACSDebitNetworkStatus string
@@ -72,6 +91,13 @@ type MandateCustomerAcceptance struct {
 type MandateMultiUse struct {
 }
 
+// MandatePaymentMethodDetailsACSSDebit TODO
+type MandatePaymentMethodDetailsACSSDebit struct {
+	IntervalDescription string                                              `json:"interval_description"`
+	PaymentSchedule     MandatePaymentMethodDetailsACSSDebitPaymentSchedule `json:"payment_schedule"`
+	TransactionType     MandatePaymentMethodDetailsACSSDebitTransactionType `json:"transaction_type"`
+}
+
 // MandatePaymentMethodDetailsAUBECSDebit represents details about the Australia BECS debit account
 // associated with this mandate.
 type MandatePaymentMethodDetailsAUBECSDebit struct {
@@ -100,6 +126,7 @@ type MandatePaymentMethodDetailsSepaDebit struct {
 // MandatePaymentMethodDetails represents details about the payment method associated with this
 // mandate.
 type MandatePaymentMethodDetails struct {
+	ACSSDebit   *MandatePaymentMethodDetailsACSSDebit   `json:"acss_debit"`
 	AUBECSDebit *MandatePaymentMethodDetailsAUBECSDebit `json:"au_becs_debit"`
 	BACSDebit   *MandatePaymentMethodDetailsBACSDebit   `json:"bacs_debit"`
 	Card        *MandatePaymentMethodDetailsCard        `json:"card"`

--- a/mandate.go
+++ b/mandate.go
@@ -19,7 +19,7 @@ const (
 	MandateStatusPending  MandateStatus = "pending"
 )
 
-// MandatePaymentMethodDetailsACSSDebitPaymentSchedule TODO
+// MandatePaymentMethodDetailsACSSDebitPaymentSchedule is the list of allowed values for an acss debit payment_schedule on payment_method_details
 type MandatePaymentMethodDetailsACSSDebitPaymentSchedule string
 
 // List of values that MandatePaymentMethodDetailsACSSDebitPaymentSchedule can take
@@ -29,7 +29,7 @@ const (
 	MandatePaymentMethodDetailsACSSDebitPaymentScheduleSporadic MandatePaymentMethodDetailsACSSDebitPaymentSchedule = "sporadic"
 )
 
-// MandatePaymentMethodDetailsACSSDebitTransactionType TODO
+// MandatePaymentMethodDetailsACSSDebitTransactionType is the list of allowed values for an acss debit transaction type
 type MandatePaymentMethodDetailsACSSDebitTransactionType string
 
 // List of values that MandatePaymentMethodDetailsACSSDebitTransactionType can take
@@ -91,7 +91,7 @@ type MandateCustomerAcceptance struct {
 type MandateMultiUse struct {
 }
 
-// MandatePaymentMethodDetailsACSSDebit TODO
+// MandatePaymentMethodDetailsACSSDebit represent details about the acss debit associated with this mandate.
 type MandatePaymentMethodDetailsACSSDebit struct {
 	IntervalDescription string                                              `json:"interval_description"`
 	PaymentSchedule     MandatePaymentMethodDetailsACSSDebitPaymentSchedule `json:"payment_schedule"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -36,6 +36,35 @@ const (
 	PaymentIntentConfirmationMethodManual    PaymentIntentConfirmationMethod = "manual"
 )
 
+// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule TODO
+type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
+
+// List of values that PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule can take
+const (
+	PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleCombined PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "combined"
+	PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleInterval PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "interval"
+	PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleSporadic PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "sporadic"
+)
+
+// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType TODO
+type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType string
+
+// List of values that PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType can take
+const (
+	PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypeBusiness PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "business"
+	PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypePersonal PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "personal"
+)
+
+// PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod TODO
+type PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod string
+
+// List of values that PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod can take
+const (
+	PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethodAutomatic     PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod = "automatic"
+	PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethodInstant       PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod = "instant"
+	PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
+)
+
 // PaymentIntentNextActionType is the list of allowed values for the next action's type.
 type PaymentIntentNextActionType string
 
@@ -168,6 +197,7 @@ type PaymentIntentMandateDataParams struct {
 // PaymentIntentPaymentMethodDataParams represents the type-specific parameters associated with a
 // payment method on payment intent.
 type PaymentIntentPaymentMethodDataParams struct {
+	ACSSDebit        *PaymentMethodACSSDebitParams        `form:"acss_debit"`
 	AfterpayClearpay *PaymentMethodAfterpayClearpayParams `form:"afterpay_clearpay"`
 	Alipay           *PaymentMethodAlipayParams           `form:"alipay"`
 	AUBECSDebit      *PaymentMethodAUBECSDebitParams      `form:"au_becs_debit"`
@@ -181,6 +211,20 @@ type PaymentIntentPaymentMethodDataParams struct {
 	P24              *PaymentMethodP24Params              `form:"p24"`
 	SepaDebit        *PaymentMethodSepaDebitParams        `form:"sepa_debit"`
 	Type             *string                              `form:"type"`
+}
+
+// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsParams TODO
+type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
+	CustomMandateURL    *string `form:"custom_mandate_url"`
+	IntervalDescription *string `form:"interval_description"`
+	PaymentSchedule     *string `form:"payment_schedule"`
+	TransactionType     *string `form:"transaction_type"`
+}
+
+// PaymentIntentPaymentMethodOptionsACSSDebitParams TODO
+type PaymentIntentPaymentMethodOptionsACSSDebitParams struct {
+	MandateOptions     *PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsParams `form:"mandate_options"`
+	VerificationMethod *string                                                         `form:"verification_method"`
 }
 
 // PaymentIntentPaymentMethodOptionsAlipayParams represents the Alipay-specific options
@@ -234,6 +278,7 @@ type PaymentIntentPaymentMethodOptionsSofortParams struct {
 // PaymentIntentPaymentMethodOptionsParams represents the type-specific payment method options
 // applied to a PaymentIntent.
 type PaymentIntentPaymentMethodOptionsParams struct {
+	ACSSDebit  *PaymentIntentPaymentMethodOptionsACSSDebitParams  `form:"acss_debit"`
 	Alipay     *PaymentIntentPaymentMethodOptionsAlipayParams     `form:"alipay"`
 	Bancontact *PaymentIntentPaymentMethodOptionsBancontactParams `form:"bancontact"`
 	Card       *PaymentIntentPaymentMethodOptionsCardParams       `form:"card"`
@@ -313,12 +358,24 @@ type PaymentIntentNextActionRedirectToURL struct {
 	URL       string `json:"url"`
 }
 
+// PaymentIntentNextActionUseStripeSDK TODO
+type PaymentIntentNextActionUseStripeSDK struct {
+}
+
+// PaymentIntentNextActionVerifyWithMicrodeposits TODO
+type PaymentIntentNextActionVerifyWithMicrodeposits struct {
+	ArrivalDate           int64  `json:"arrival_date"`
+	HostedVerificationURL string `json:"hosted_verification_url"`
+}
+
 // PaymentIntentNextAction represents the type of action to take on a payment intent.
 type PaymentIntentNextAction struct {
-	AlipayHandleRedirect *PaymentIntentNextActionAlipayHandleRedirect `json:"alipay_handle_redirect"`
-	OXXODisplayDetails   *PaymentIntentNextActionOXXODisplayDetails   `json:"oxxo_display_details"`
-	RedirectToURL        *PaymentIntentNextActionRedirectToURL        `json:"redirect_to_url"`
-	Type                 PaymentIntentNextActionType                  `json:"type"`
+	AlipayHandleRedirect    *PaymentIntentNextActionAlipayHandleRedirect    `json:"alipay_handle_redirect"`
+	OXXODisplayDetails      *PaymentIntentNextActionOXXODisplayDetails      `json:"oxxo_display_details"`
+	RedirectToURL           *PaymentIntentNextActionRedirectToURL           `json:"redirect_to_url"`
+	Type                    PaymentIntentNextActionType                     `json:"type"`
+	UseStripeSDK            *PaymentIntentNextActionUseStripeSDK            `json:"use_stripe_sdk"`
+	VerifyWithMicrodeposits *PaymentIntentNextActionVerifyWithMicrodeposits `json:"verify_with_microdeposits"`
 }
 
 // PaymentIntentPaymentMethodOptionsCardInstallmentsPlan describe a specific card installment plan.
@@ -334,6 +391,20 @@ type PaymentIntentPaymentMethodOptionsCardInstallments struct {
 	AvailablePlans []*PaymentIntentPaymentMethodOptionsCardInstallmentsPlan `json:"available_plans"`
 	Enabled        bool                                                     `json:"enabled"`
 	Plan           *PaymentIntentPaymentMethodOptionsCardInstallmentsPlan   `json:"plan"`
+}
+
+// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptions TODO
+type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptions struct {
+	CustomMandateURL    string                                                                  `json:"custom_mandate_url"`
+	IntervalDescription string                                                                  `json:"interval_description"`
+	PaymentSchedule     PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule `json:"payment_schedule"`
+	TransactionType     PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
+}
+
+// PaymentIntentPaymentMethodOptionsACSSDebit TODO
+type PaymentIntentPaymentMethodOptionsACSSDebit struct {
+	MandateOptions     *PaymentIntentPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
+	VerificationMethod PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
 }
 
 // PaymentIntentPaymentMethodOptionsAlipay is the set of Alipay-specific options associated
@@ -370,6 +441,7 @@ type PaymentIntentPaymentMethodOptionsSofort struct {
 // PaymentIntentPaymentMethodOptions is the set of payment method-specific options associated with
 // that payment intent.
 type PaymentIntentPaymentMethodOptions struct {
+	ACSSDebit  *PaymentIntentPaymentMethodOptionsACSSDebit  `json:"acss_debit"`
 	Alipay     *PaymentIntentPaymentMethodOptionsAlipay     `json:"alipay"`
 	Bancontact *PaymentIntentPaymentMethodOptionsBancontact `json:"bancontact"`
 	Card       *PaymentIntentPaymentMethodOptionsCard       `json:"card"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -36,7 +36,7 @@ const (
 	PaymentIntentConfirmationMethodManual    PaymentIntentConfirmationMethod = "manual"
 )
 
-// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule TODO
+// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule is the list of allowed values for payment_schedule.
 type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
 
 // List of values that PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule can take
@@ -46,7 +46,7 @@ const (
 	PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleSporadic PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "sporadic"
 )
 
-// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType TODO
+// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType is the list of allowed values for transaction_type.
 type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType string
 
 // List of values that PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType can take
@@ -55,7 +55,7 @@ const (
 	PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypePersonal PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "personal"
 )
 
-// PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod TODO
+// PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod is the list of allowed values for verification_method.
 type PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod string
 
 // List of values that PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod can take
@@ -213,7 +213,8 @@ type PaymentIntentPaymentMethodDataParams struct {
 	Type             *string                              `form:"type"`
 }
 
-// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsParams TODO
+// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsParams represents the mandate options
+// for ACSS on the payment intent.
 type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
 	CustomMandateURL    *string `form:"custom_mandate_url"`
 	IntervalDescription *string `form:"interval_description"`
@@ -221,7 +222,8 @@ type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
 	TransactionType     *string `form:"transaction_type"`
 }
 
-// PaymentIntentPaymentMethodOptionsACSSDebitParams TODO
+// PaymentIntentPaymentMethodOptionsACSSDebitParams represents the ACSS debit-specific options
+// applieed to a PaymentIntent
 type PaymentIntentPaymentMethodOptionsACSSDebitParams struct {
 	MandateOptions     *PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsParams `form:"mandate_options"`
 	VerificationMethod *string                                                         `form:"verification_method"`
@@ -358,11 +360,12 @@ type PaymentIntentNextActionRedirectToURL struct {
 	URL       string `json:"url"`
 }
 
-// PaymentIntentNextActionUseStripeSDK TODO
+// PaymentIntentNextActionUseStripeSDK represents the resource for the next action of typee "use_stripe_sdk".
 type PaymentIntentNextActionUseStripeSDK struct {
 }
 
-// PaymentIntentNextActionVerifyWithMicrodeposits TODO
+// PaymentIntentNextActionVerifyWithMicrodeposits represents the resource for the next action of type
+// "verify_with_microdeposits".
 type PaymentIntentNextActionVerifyWithMicrodeposits struct {
 	ArrivalDate           int64  `json:"arrival_date"`
 	HostedVerificationURL string `json:"hosted_verification_url"`
@@ -393,7 +396,8 @@ type PaymentIntentPaymentMethodOptionsCardInstallments struct {
 	Plan           *PaymentIntentPaymentMethodOptionsCardInstallmentsPlan   `json:"plan"`
 }
 
-// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptions TODO
+// PaymentIntentPaymentMethodOptionsACSSDebitMandateOptions describe the mandate options for acss debit
+// associated with that payment intent.
 type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptions struct {
 	CustomMandateURL    string                                                                  `json:"custom_mandate_url"`
 	IntervalDescription string                                                                  `json:"interval_description"`
@@ -401,7 +405,8 @@ type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptions struct {
 	TransactionType     PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
 }
 
-// PaymentIntentPaymentMethodOptionsACSSDebit TODO
+// PaymentIntentPaymentMethodOptionsACSSDebit describes the ACSS debit-specific options associated
+// with that payment intent.
 type PaymentIntentPaymentMethodOptionsACSSDebit struct {
 	MandateOptions     *PaymentIntentPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
 	VerificationMethod PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -16,6 +16,7 @@ type PaymentMethodType string
 
 // List of values that PaymentMethodType can take.
 const (
+	PaymentMethodTypeACSSDebit        PaymentMethodType = "acss_debit"
 	PaymentMethodTypeAfterpayClearpay PaymentMethodType = "afterpay_clearpay"
 	PaymentMethodTypeAlipay           PaymentMethodType = "alipay"
 	PaymentMethodTypeAUBECSDebit      PaymentMethodType = "au_becs_debit"
@@ -89,6 +90,13 @@ type BillingDetailsParams struct {
 	Email   *string        `form:"email"`
 	Name    *string        `form:"name"`
 	Phone   *string        `form:"phone"`
+}
+
+// PaymentMethodACSSDebitParams TODO
+type PaymentMethodACSSDebitParams struct {
+	AccountNumber     *string `form:"account_number"`
+	InstitutionNumber *string `form:"institution_number"`
+	TransitNumber     *string `form:"transit_number"`
 }
 
 // PaymentMethodAfterpayClearpayParams is the set of parameters allowed for the
@@ -190,6 +198,7 @@ type PaymentMethodSofortParams struct {
 // PaymentMethod.
 type PaymentMethodParams struct {
 	Params           `form:"*"`
+	ACSSDebit        *PaymentMethodACSSDebitParams        `form:"acss_debit"`
 	AfterpayClearpay *PaymentMethodAfterpayClearpayParams `form:"afterpay_clearpay"`
 	Alipay           *PaymentMethodAlipayParams           `form:"alipay"`
 	AUBECSDebit      *PaymentMethodAUBECSDebitParams      `form:"au_becs_debit"`
@@ -240,6 +249,15 @@ type BillingDetails struct {
 	Email   string   `json:"email"`
 	Name    string   `json:"name"`
 	Phone   string   `json:"phone"`
+}
+
+// PaymentMethodACSSDebit TODO
+type PaymentMethodACSSDebit struct {
+	BankName          string `json:"bank_name"`
+	Fingerprint       string `json:"fingerprint"`
+	InstitutionNumber string `json:"institution_number"`
+	Last4             string `json:"last4"`
+	TransitNumber     string `json:"transit_number"`
 }
 
 // PaymentMethodAfterpayClearpay represents the AfterpayClearpay properties.
@@ -382,6 +400,7 @@ type PaymentMethodSofort struct {
 // PaymentMethod is the resource representing a PaymentMethod.
 type PaymentMethod struct {
 	APIResource
+	ACSSDebit        *PaymentMethodACSSDebit        `json:"acss_debit"`
 	AfterpayClearpay *PaymentMethodAfterpayClearpay `json:"afterpay_clearpay"`
 	Alipay           *PaymentMethodAlipay           `json:"alipay"`
 	AUBECSDebit      *PaymentMethodAUBECSDebit      `json:"au_becs_debit"`

--- a/setupintent.go
+++ b/setupintent.go
@@ -23,6 +23,35 @@ const (
 	SetupIntentNextActionTypeRedirectToURL SetupIntentNextActionType = "redirect_to_url"
 )
 
+// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule TODO
+type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
+
+// List of values that SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule can take.
+const (
+	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleCombined SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "combined"
+	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleInterval SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "interval"
+	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleSporadic SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "sporadic"
+)
+
+// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType TODO
+type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType string
+
+// List of values that SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType can take.
+const (
+	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypeBusiness SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "business"
+	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypePersonal SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "personal"
+)
+
+// SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod TODO
+type SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod string
+
+// List of values that SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod can take.
+const (
+	SetupIntentPaymentMethodOptionsACSSDebitVerificationMethodAutomatic     SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod = "automatic"
+	SetupIntentPaymentMethodOptionsACSSDebitVerificationMethodInstant       SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod = "instant"
+	SetupIntentPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
+)
+
 // SetupIntentPaymentMethodOptionsCardRequestThreeDSecure is the list of allowed values controlling
 // when to request 3D Secure on a SetupIntent.
 type SetupIntentPaymentMethodOptionsCardRequestThreeDSecure string
@@ -91,6 +120,21 @@ type SetupIntentMandateDataCustomerAcceptanceParams struct {
 	Type       MandateCustomerAcceptanceType                          `form:"type"`
 }
 
+// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams TODO
+type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
+	CustomMandateURL    *string `form:"custom_mandate_url"`
+	IntervalDescription *string `form:"interval_description"`
+	PaymentSchedule     *string `form:"payment_schedule"`
+	TransactionType     *string `form:"transaction_type"`
+}
+
+// SetupIntentPaymentMethodOptionsACSSDebitParams TODO
+type SetupIntentPaymentMethodOptionsACSSDebitParams struct {
+	Currency           *string                                                       `form:"currency"`
+	MandateOptions     *SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams `form:"mandate_options"`
+	VerificationMethod *string                                                       `form:"verification_method"`
+}
+
 // SetupIntentMandateDataParams is the set of parameters controlling the creation of the mandate
 // associated with this SetupIntent.
 type SetupIntentMandateDataParams struct {
@@ -107,7 +151,8 @@ type SetupIntentPaymentMethodOptionsCardParams struct {
 // SetupIntentPaymentMethodOptionsParams represents the type-specific payment method options
 // applied to a SetupIntent.
 type SetupIntentPaymentMethodOptionsParams struct {
-	Card *SetupIntentPaymentMethodOptionsCardParams `form:"card"`
+	ACSSDebit *SetupIntentPaymentMethodOptionsACSSDebitParams `form:"acss_debit"`
+	Card      *SetupIntentPaymentMethodOptionsCardParams      `form:"card"`
 }
 
 // SetupIntentSingleUseParams represents the single-use mandate-specific parameters.
@@ -149,10 +194,35 @@ type SetupIntentNextActionRedirectToURL struct {
 	URL       string `json:"url"`
 }
 
+// SetupIntentNextActionUseStripeSDK TODO
+type SetupIntentNextActionUseStripeSDK struct{}
+
+// SetupIntentNextActionVerifyWithMicrodeposits TODO
+type SetupIntentNextActionVerifyWithMicrodeposits struct {
+	ArrivalDate           int64  `json:"arrival_date"`
+	HostedVerificationURL string `json:"hosted_verification_url"`
+}
+
 // SetupIntentNextAction represents the type of action to take on a setup intent.
 type SetupIntentNextAction struct {
-	RedirectToURL *SetupIntentNextActionRedirectToURL `json:"redirect_to_url"`
-	Type          SetupIntentNextActionType           `json:"type"`
+	RedirectToURL           *SetupIntentNextActionRedirectToURL           `json:"redirect_to_url"`
+	Type                    SetupIntentNextActionType                     `json:"type"`
+	UseStripeSDK            *SetupIntentNextActionUseStripeSDK            `json:"use_stripe_sdk"`
+	VerifyWithMicrodeposits *SetupIntentNextActionVerifyWithMicrodeposits `json:"verify_with_microdeposits"`
+}
+
+type SetupIntentPaymentMethodOptionsACSSDebitMandateOptions struct {
+	CustomMandateURL    string                                                                `json:"custom_mandate_url"`
+	IntervalDescription string                                                                `json:"interval_description"`
+	PaymentSchedule     SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule `json:"payment_schedule"`
+	TransactionType     SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
+}
+
+// SetupIntentPaymentMethodOptionsACSSDebit TODO
+type SetupIntentPaymentMethodOptionsACSSDebit struct {
+	Currency           SetupIntentPaymentMethodOptionsACSSDebitCurrency           `json:"currency"`
+	MandateOptions     *SetupIntentPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
+	VerificationMethod SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
 }
 
 // SetupIntentPaymentMethodOptionsCard represents the card-specific options applied to a
@@ -164,7 +234,8 @@ type SetupIntentPaymentMethodOptionsCard struct {
 // SetupIntentPaymentMethodOptions represents the type-specific payment method options applied to a
 // SetupIntent.
 type SetupIntentPaymentMethodOptions struct {
-	Card *SetupIntentPaymentMethodOptionsCard `json:"card"`
+	ACSSDebit *SetupIntentPaymentMethodOptionsACSSDebit `json:"acss_debit"`
+	Card      *SetupIntentPaymentMethodOptionsCard      `json:"card"`
 }
 
 // SetupIntent is the resource representing a Stripe payout.

--- a/setupintent.go
+++ b/setupintent.go
@@ -220,7 +220,7 @@ type SetupIntentPaymentMethodOptionsACSSDebitMandateOptions struct {
 
 // SetupIntentPaymentMethodOptionsACSSDebit TODO
 type SetupIntentPaymentMethodOptionsACSSDebit struct {
-	Currency           SetupIntentPaymentMethodOptionsACSSDebitCurrency           `json:"currency"`
+	Currency           string                                                     `json:"currency"`
 	MandateOptions     *SetupIntentPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
 	VerificationMethod SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
 }

--- a/setupintent.go
+++ b/setupintent.go
@@ -23,7 +23,8 @@ const (
 	SetupIntentNextActionTypeRedirectToURL SetupIntentNextActionType = "redirect_to_url"
 )
 
-// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule TODO
+// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule is the list of allowed values
+// for payment_schedule on mandate_options.
 type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
 
 // List of values that SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule can take.
@@ -33,7 +34,8 @@ const (
 	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentScheduleSporadic SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule = "sporadic"
 )
 
-// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType TODO
+// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType is the list of allowed values for
+// transaction_type on mandate_options.
 type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType string
 
 // List of values that SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType can take.
@@ -42,7 +44,8 @@ const (
 	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypePersonal SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "personal"
 )
 
-// SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod TODO
+// SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod is the list of allowed values for
+// verification_method on acss_debit.
 type SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod string
 
 // List of values that SetupIntentPaymentMethodOptionsACSSDebitVerificationMethod can take.
@@ -120,7 +123,8 @@ type SetupIntentMandateDataCustomerAcceptanceParams struct {
 	Type       MandateCustomerAcceptanceType                          `form:"type"`
 }
 
-// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams TODO
+// SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams is the set of parameters for
+// mandate_options on acss_debit.
 type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
 	CustomMandateURL    *string `form:"custom_mandate_url"`
 	IntervalDescription *string `form:"interval_description"`
@@ -128,7 +132,8 @@ type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
 	TransactionType     *string `form:"transaction_type"`
 }
 
-// SetupIntentPaymentMethodOptionsACSSDebitParams TODO
+// SetupIntentPaymentMethodOptionsACSSDebitParams is the set of parameters for acss debit on
+// payment_method_options.
 type SetupIntentPaymentMethodOptionsACSSDebitParams struct {
 	Currency           *string                                                       `form:"currency"`
 	MandateOptions     *SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams `form:"mandate_options"`
@@ -194,10 +199,12 @@ type SetupIntentNextActionRedirectToURL struct {
 	URL       string `json:"url"`
 }
 
-// SetupIntentNextActionUseStripeSDK TODO
+// SetupIntentNextActionUseStripeSDK represents the resource for the next action of type
+// "use_stripe_sdk".
 type SetupIntentNextActionUseStripeSDK struct{}
 
-// SetupIntentNextActionVerifyWithMicrodeposits TODO
+// SetupIntentNextActionVerifyWithMicrodeposits represents the resource for the next action
+// of type "verify_with_microdeposits".
 type SetupIntentNextActionVerifyWithMicrodeposits struct {
 	ArrivalDate           int64  `json:"arrival_date"`
 	HostedVerificationURL string `json:"hosted_verification_url"`
@@ -218,7 +225,8 @@ type SetupIntentPaymentMethodOptionsACSSDebitMandateOptions struct {
 	TransactionType     SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
 }
 
-// SetupIntentPaymentMethodOptionsACSSDebit TODO
+// SetupIntentPaymentMethodOptionsACSSDebit represents the ACSS debit-specific options applied
+// to a SetupIntent.
 type SetupIntentPaymentMethodOptionsACSSDebit struct {
 	Currency           string                                                     `json:"currency"`
 	MandateOptions     *SetupIntentPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`

--- a/setupintent.go
+++ b/setupintent.go
@@ -218,6 +218,8 @@ type SetupIntentNextAction struct {
 	VerifyWithMicrodeposits *SetupIntentNextActionVerifyWithMicrodeposits `json:"verify_with_microdeposits"`
 }
 
+// SetupIntentPaymentMethodOptionsACSSDebitMandateOptions describe the mandate options for
+// acss debit associated with a setup intent.
 type SetupIntentPaymentMethodOptionsACSSDebitMandateOptions struct {
 	CustomMandateURL    string                                                                `json:"custom_mandate_url"`
 	IntervalDescription string                                                                `json:"interval_description"`


### PR DESCRIPTION
* Add support for `acss_debit` as value for `PaymentMethodType`.
* Add support for `ACSSDebit` on `PaymentMethod`, `PaymentMethodParams`, `PaymentIntentPaymentMethodOptions`,  `PaymentIntentPaymentMethodOptionsParams`, `MandatePaymentMethodDetails`, `SetupIntentPaymentMethodOptions`, and `SetupIntentPaymentOptionsParams`.
* Add support for `ACSSDebitPayments` on `AccountCapabilities`
* Add support for `PaymentMethodOptions` on `CheckoutSession`
* Add support for `verify_with_microdeposits` and `use_stripe_sdk` on `PaymentIntentNextAction` and `SetupIntentNextAction`
