### PR TITLE
Codegen more client.go files

### DIFF
--- a/capability/client.go
+++ b/capability/client.go
@@ -1,4 +1,10 @@
-// Package capability provides the /accounts/capabilities APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package capability provides the /accounts/{account}/capabilities APIs
 package capability
 
 import (
@@ -9,53 +15,62 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /accounts/capabilities APIs.
+// Client is used to invoke /accounts/{account}/capabilities APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// Get returns the details of a account capability.
+// Get returns the details of a capability.
 func Get(id string, params *stripe.CapabilityParams) (*stripe.Capability, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a account capability.
+// Get returns the details of a capability.
 func (c Client) Get(id string, params *stripe.CapabilityParams) (*stripe.Capability, error) {
 	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Account must be set")
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Account must be set",
+		)
 	}
-
-	path := stripe.FormatURLPath("/v1/accounts/%s/capabilities/%s",
-		stripe.StringValue(params.Account), id)
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/capabilities/%s",
+		stripe.StringValue(params.Account),
+		id,
+	)
 	capability := &stripe.Capability{}
 	err := c.B.Call(http.MethodGet, path, c.Key, params, capability)
 	return capability, err
 }
 
-// Update updates a account capability's properties.
+// Update updates a capability's properties.
 func Update(id string, params *stripe.CapabilityParams) (*stripe.Capability, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a account capability's properties.
+// Update updates a capability's properties.
 func (c Client) Update(id string, params *stripe.CapabilityParams) (*stripe.Capability, error) {
-	path := stripe.FormatURLPath("/v1/accounts/%s/capabilities/%s",
-		stripe.StringValue(params.Account), id)
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/capabilities/%s",
+		stripe.StringValue(params.Account),
+		id,
+	)
 	capability := &stripe.Capability{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, capability)
 	return capability, err
 }
 
-// List returns a list of account capabilities.
+// List returns a list of capabilities.
 func List(params *stripe.CapabilityListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of account capabilities.
+// List returns a list of capabilities.
 func (c Client) List(listParams *stripe.CapabilityListParams) *Iter {
-	path := stripe.FormatURLPath("/v1/accounts/%s/capabilities", stripe.StringValue(listParams.Account))
-
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/capabilities",
+		stripe.StringValue(listParams.Account),
+	)
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CapabilityList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -69,12 +84,12 @@ func (c Client) List(listParams *stripe.CapabilityListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for account capabilities.
+// Iter is an iterator for capabilities.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Capability returns the account capability which the iterator is currently pointing to.
+// Capability returns the capability which the iterator is currently pointing to.
 func (i *Iter) Capability() *stripe.Capability {
 	return i.Current().(*stripe.Capability)
 }

--- a/customerbalancetransaction/client.go
+++ b/customerbalancetransaction/client.go
@@ -1,4 +1,10 @@
-// Package customerbalancetransaction provides the /balance_transactions APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package customerbalancetransaction provides the /customers/{customer}/balance_transactions APIs
 package customerbalancetransaction
 
 import (
@@ -9,7 +15,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /balance_transactions APIs.
+// Client is used to invoke /customers/{customer}/balance_transactions APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -23,13 +29,23 @@ func New(params *stripe.CustomerBalanceTransactionParams) (*stripe.CustomerBalan
 // New creates a new customer balance transaction.
 func (c Client) New(params *stripe.CustomerBalanceTransactionParams) (*stripe.CustomerBalanceTransaction, error) {
 	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Customer must be set")
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Customer must be set",
+		)
 	}
-
-	path := stripe.FormatURLPath("/v1/customers/%s/balance_transactions", stripe.StringValue(params.Customer))
-	transaction := &stripe.CustomerBalanceTransaction{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transaction)
-	return transaction, err
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/balance_transactions",
+		stripe.StringValue(params.Customer),
+	)
+	customerbalancetransaction := &stripe.CustomerBalanceTransaction{}
+	err := c.B.Call(
+		http.MethodPost,
+		path,
+		c.Key,
+		params,
+		customerbalancetransaction,
+	)
+	return customerbalancetransaction, err
 }
 
 // Get returns the details of a customer balance transaction.
@@ -40,13 +56,47 @@ func Get(id string, params *stripe.CustomerBalanceTransactionParams) (*stripe.Cu
 // Get returns the details of a customer balance transaction.
 func (c Client) Get(id string, params *stripe.CustomerBalanceTransactionParams) (*stripe.CustomerBalanceTransaction, error) {
 	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Customer must be set")
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Customer must be set",
+		)
 	}
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/balance_transactions/%s",
+		stripe.StringValue(params.Customer),
+		id,
+	)
+	customerbalancetransaction := &stripe.CustomerBalanceTransaction{}
+	err := c.B.Call(
+		http.MethodGet,
+		path,
+		c.Key,
+		params,
+		customerbalancetransaction,
+	)
+	return customerbalancetransaction, err
+}
 
-	path := stripe.FormatURLPath("/v1/customers/%s/balance_transactions/%s", stripe.StringValue(params.Customer), id)
-	transaction := &stripe.CustomerBalanceTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transaction)
-	return transaction, err
+// Update updates a customer balance transaction's properties.
+func Update(id string, params *stripe.CustomerBalanceTransactionParams) (*stripe.CustomerBalanceTransaction, error) {
+	return getC().Update(id, params)
+}
+
+// Update updates a customer balance transaction's properties.
+func (c Client) Update(id string, params *stripe.CustomerBalanceTransactionParams) (*stripe.CustomerBalanceTransaction, error) {
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/balance_transactions/%s",
+		stripe.StringValue(params.Customer),
+		id,
+	)
+	customerbalancetransaction := &stripe.CustomerBalanceTransaction{}
+	err := c.B.Call(
+		http.MethodPost,
+		path,
+		c.Key,
+		params,
+		customerbalancetransaction,
+	)
+	return customerbalancetransaction, err
 }
 
 // List returns a list of customer balance transactions.
@@ -56,8 +106,10 @@ func List(params *stripe.CustomerBalanceTransactionListParams) *Iter {
 
 // List returns a list of customer balance transactions.
 func (c Client) List(listParams *stripe.CustomerBalanceTransactionListParams) *Iter {
-	path := stripe.FormatURLPath("/v1/customers/%s/balance_transactions", stripe.StringValue(listParams.Customer))
-
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/balance_transactions",
+		stripe.StringValue(listParams.Customer),
+	)
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CustomerBalanceTransactionList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -71,33 +123,19 @@ func (c Client) List(listParams *stripe.CustomerBalanceTransactionListParams) *I
 	})}
 }
 
-// Update updates a customer balance transaction.
-func Update(id string, params *stripe.CustomerBalanceTransactionParams) (*stripe.CustomerBalanceTransaction, error) {
-	return getC().Update(id, params)
-}
-
-// Update updates a customer balance transaction.
-func (c Client) Update(id string, params *stripe.CustomerBalanceTransactionParams) (*stripe.CustomerBalanceTransaction, error) {
-	path := stripe.FormatURLPath("/v1/customers/%s/balance_transactions/%s", stripe.StringValue(params.Customer), id)
-	transaction := &stripe.CustomerBalanceTransaction{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transaction)
-	return transaction, err
-}
-
 // Iter is an iterator for customer balance transactions.
 type Iter struct {
 	*stripe.Iter
 }
 
-// CustomerBalanceTransaction returns the customer balance transaction which the iterator is
-// currently pointing to.
+// CustomerBalanceTransaction returns the customer balance transaction which the iterator is currently pointing to.
 func (i *Iter) CustomerBalanceTransaction() *stripe.CustomerBalanceTransaction {
 	return i.Current().(*stripe.CustomerBalanceTransaction)
 }
 
-// CustomerBalanceTransactionList returns the current list object which the
-// iterator is currently using. List objects will change as new API calls are
-// made to continue pagination.
+// CustomerBalanceTransactionList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) CustomerBalanceTransactionList() *stripe.CustomerBalanceTransactionList {
 	return i.List().(*stripe.CustomerBalanceTransactionList)
 }

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -1,4 +1,10 @@
-// Package feerefund provides the /application_fees/refunds APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package feerefund provides the /application_fees/{id}/refunds APIs
 package feerefund
 
 import (
@@ -9,18 +15,18 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /application_fees/refunds APIs.
+// Client is used to invoke /application_fees/{id}/refunds APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// New creates an application fee refund.
+// New creates a new fee refund.
 func New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	return getC().New(params)
 }
 
-// New creates an application fee refund.
+// New creates a new fee refund.
 func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
@@ -28,20 +34,21 @@ func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
-
-	path := stripe.FormatURLPath("/v1/application_fees/%s/refunds",
-		stripe.StringValue(params.ApplicationFee))
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, refund)
-	return refund, err
+	path := stripe.FormatURLPath(
+		"/v1/application_fees/%s/refunds",
+		stripe.StringValue(params.ApplicationFee),
+	)
+	feerefund := &stripe.FeeRefund{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, feerefund)
+	return feerefund, err
 }
 
-// Get returns the details of an application fee refund.
+// Get returns the details of a fee refund.
 func Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of an application fee refund.
+// Get returns the details of a fee refund.
 func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
@@ -49,20 +56,22 @@ func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefun
 	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
-
-	path := stripe.FormatURLPath("/v1/application_fees/%s/refunds/%s",
-		stripe.StringValue(params.ApplicationFee), id)
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, refund)
-	return refund, err
+	path := stripe.FormatURLPath(
+		"/v1/application_fees/%s/refunds/%s",
+		stripe.StringValue(params.ApplicationFee),
+		id,
+	)
+	feerefund := &stripe.FeeRefund{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, feerefund)
+	return feerefund, err
 }
 
-// Update updates an application fee refund.
+// Update updates a fee refund's properties.
 func Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates an application fee refund.
+// Update updates a fee refund's properties.
 func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
@@ -70,25 +79,27 @@ func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRe
 	if params.ApplicationFee == nil {
 		return nil, fmt.Errorf("params.ApplicationFee must be set")
 	}
-
-	path := stripe.FormatURLPath("/v1/application_fees/%s/refunds/%s",
-		stripe.StringValue(params.ApplicationFee), id)
-	refund := &stripe.FeeRefund{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, refund)
-
-	return refund, err
+	path := stripe.FormatURLPath(
+		"/v1/application_fees/%s/refunds/%s",
+		stripe.StringValue(params.ApplicationFee),
+		id,
+	)
+	feerefund := &stripe.FeeRefund{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, feerefund)
+	return feerefund, err
 }
 
-// List returns a list of application fee refunds.
+// List returns a list of fee refunds.
 func List(params *stripe.FeeRefundListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of application fee refunds.
+// List returns a list of fee refunds.
 func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
-	path := stripe.FormatURLPath("/v1/application_fees/%s/refunds",
-		stripe.StringValue(listParams.ApplicationFee))
-
+	path := stripe.FormatURLPath(
+		"/v1/application_fees/%s/refunds",
+		stripe.StringValue(listParams.ApplicationFee),
+	)
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.FeeRefundList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -102,12 +113,12 @@ func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for application fee refunds.
+// Iter is an iterator for fee refunds.
 type Iter struct {
 	*stripe.Iter
 }
 
-// FeeRefund returns the application fee refund which the iterator is currently pointing to.
+// FeeRefund returns the fee refund which the iterator is currently pointing to.
 func (i *Iter) FeeRefund() *stripe.FeeRefund {
 	return i.Current().(*stripe.FeeRefund)
 }

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -1,34 +1,42 @@
-// Package loginlink provides the /login_links APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package loginlink provides the /accounts/{account}/login_links APIs
 package loginlink
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go/v72"
 )
 
-// Client is used to invoke /login_links APIs.
+// Client is used to invoke /accounts/{account}/login_links APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// New creates a login link for an account.
+// New creates a new login link.
 func New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 	return getC().New(params)
 }
 
-// New creates a login link for an account.
+// New creates a new login link.
 func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 	if params.Account == nil {
-		return nil, errors.New("Invalid login link params: Account must be set")
+		return nil, fmt.Errorf("Invalid login link params: Account must be set")
 	}
-
-	path := stripe.FormatURLPath("/v1/accounts/%s/login_links", stripe.StringValue(params.Account))
-	loginLink := &stripe.LoginLink{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, loginLink)
-	return loginLink, err
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/login_links",
+		stripe.StringValue(params.Account),
+	)
+	loginlink := &stripe.LoginLink{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, loginlink)
+	return loginlink, err
 }
 
 func getC() Client {

--- a/person/client.go
+++ b/person/client.go
@@ -1,4 +1,10 @@
-// Package person provides the /accounts/persons APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package person provides the /accounts/{account}/persons APIs
 package person
 
 import (
@@ -9,52 +15,62 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /accounts/persons APIs.
+// Client is used to invoke /accounts/{account}/persons APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// New creates a new account person.
+// New creates a new person.
 func New(params *stripe.PersonParams) (*stripe.Person, error) {
 	return getC().New(params)
 }
 
-// New creates a new account person.
+// New creates a new person.
 func (c Client) New(params *stripe.PersonParams) (*stripe.Person, error) {
-	path := stripe.FormatURLPath("/v1/accounts/%s/persons", stripe.StringValue(params.Account))
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/persons",
+		stripe.StringValue(params.Account),
+	)
 	person := &stripe.Person{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, person)
 	return person, err
 }
 
-// Get returns the details of a account person.
+// Get returns the details of a person.
 func Get(id string, params *stripe.PersonParams) (*stripe.Person, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a account person.
+// Get returns the details of a person.
 func (c Client) Get(id string, params *stripe.PersonParams) (*stripe.Person, error) {
 	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Account must be set")
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Account must be set",
+		)
 	}
-
-	path := stripe.FormatURLPath("/v1/accounts/%s/persons/%s",
-		stripe.StringValue(params.Account), id)
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/persons/%s",
+		stripe.StringValue(params.Account),
+		id,
+	)
 	person := &stripe.Person{}
 	err := c.B.Call(http.MethodGet, path, c.Key, params, person)
 	return person, err
 }
 
-// Update updates a account person's properties.
+// Update updates a person's properties.
 func Update(id string, params *stripe.PersonParams) (*stripe.Person, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a account person's properties.
+// Update updates a person's properties.
 func (c Client) Update(id string, params *stripe.PersonParams) (*stripe.Person, error) {
-	path := stripe.FormatURLPath("/v1/accounts/%s/persons/%s",
-		stripe.StringValue(params.Account), id)
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/persons/%s",
+		stripe.StringValue(params.Account),
+		id,
+	)
 	person := &stripe.Person{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, person)
 	return person, err
@@ -67,22 +83,27 @@ func Del(id string, params *stripe.PersonParams) (*stripe.Person, error) {
 
 // Del removes a person.
 func (c Client) Del(id string, params *stripe.PersonParams) (*stripe.Person, error) {
-	path := stripe.FormatURLPath("/v1/accounts/%s/persons/%s",
-		stripe.StringValue(params.Account), id)
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/persons/%s",
+		stripe.StringValue(params.Account),
+		id,
+	)
 	person := &stripe.Person{}
 	err := c.B.Call(http.MethodDelete, path, c.Key, params, person)
 	return person, err
 }
 
-// List returns a list of account persons.
+// List returns a list of persons.
 func List(params *stripe.PersonListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of account persons.
+// List returns a list of persons.
 func (c Client) List(listParams *stripe.PersonListParams) *Iter {
-	path := stripe.FormatURLPath("/v1/accounts/%s/persons", stripe.StringValue(listParams.Account))
-
+	path := stripe.FormatURLPath(
+		"/v1/accounts/%s/persons",
+		stripe.StringValue(listParams.Account),
+	)
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.PersonList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -96,19 +117,19 @@ func (c Client) List(listParams *stripe.PersonListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for account persons.
+// Iter is an iterator for persons.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Person returns the account person which the iterator is currently pointing to.
+// Person returns the person which the iterator is currently pointing to.
 func (i *Iter) Person() *stripe.Person {
 	return i.Current().(*stripe.Person)
 }
 
-// PersonList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// PersonList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) PersonList() *stripe.PersonList {
 	return i.List().(*stripe.PersonList)
 }

--- a/reversal/client.go
+++ b/reversal/client.go
@@ -1,4 +1,10 @@
-// Package reversal provides the /transfers/reversals APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package reversal provides the /transfers/{id}/reversals APIs
 package reversal
 
 import (
@@ -9,66 +15,78 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /transfers/reversals APIs.
+// Client is used to invoke /transfers/{id}/reversals APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// New creates a new transfer reversal.
+// New creates a new reversal.
 func New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	return getC().New(params)
 }
 
-// New creates a new transfer reversal.
+// New creates a new reversal.
 func (c Client) New(params *stripe.ReversalParams) (*stripe.Reversal, error) {
-	path := stripe.FormatURLPath("/v1/transfers/%s/reversals", stripe.StringValue(params.Transfer))
+	path := stripe.FormatURLPath(
+		"/v1/transfers/%s/reversals",
+		stripe.StringValue(params.Transfer),
+	)
 	reversal := &stripe.Reversal{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, reversal)
 	return reversal, err
 }
 
-// Get returns the details of a transfer reversal.
+// Get returns the details of a reversal.
 func Get(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a transfer reversal.
+// Get returns the details of a reversal.
 func (c Client) Get(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Transfer must be set")
+		return nil, fmt.Errorf(
+			"params cannnot be nil, and params.Transfer must be set",
+		)
 	}
-
-	path := stripe.FormatURLPath("/v1/transfers/%s/reversals/%s",
-		stripe.StringValue(params.Transfer), id)
+	path := stripe.FormatURLPath(
+		"/v1/transfers/%s/reversals/%s",
+		stripe.StringValue(params.Transfer),
+		id,
+	)
 	reversal := &stripe.Reversal{}
 	err := c.B.Call(http.MethodGet, path, c.Key, params, reversal)
 	return reversal, err
 }
 
-// Update updates a transfer reversal's properties.
+// Update updates a reversal's properties.
 func Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a transfer reversal's properties.
+// Update updates a reversal's properties.
 func (c Client) Update(id string, params *stripe.ReversalParams) (*stripe.Reversal, error) {
-	path := stripe.FormatURLPath("/v1/transfers/%s/reversals/%s",
-		stripe.StringValue(params.Transfer), id)
+	path := stripe.FormatURLPath(
+		"/v1/transfers/%s/reversals/%s",
+		stripe.StringValue(params.Transfer),
+		id,
+	)
 	reversal := &stripe.Reversal{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, reversal)
 	return reversal, err
 }
 
-// List returns a list of transfer reversals.
+// List returns a list of reversals.
 func List(params *stripe.ReversalListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of transfer reversals.
+// List returns a list of reversals.
 func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
-	path := stripe.FormatURLPath("/v1/transfers/%s/reversals", stripe.StringValue(listParams.Transfer))
-
+	path := stripe.FormatURLPath(
+		"/v1/transfers/%s/reversals",
+		stripe.StringValue(listParams.Transfer),
+	)
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.ReversalList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -82,12 +100,12 @@ func (c Client) List(listParams *stripe.ReversalListParams) *Iter {
 	})}
 }
 
-// Iter is an iterator for transfer reversals.
+// Iter is an iterator for reversals.
 type Iter struct {
 	*stripe.Iter
 }
 
-// Reversal returns the transfer reversal which the iterator is currently pointing to.
+// Reversal returns the reversal which the iterator is currently pointing to.
 func (i *Iter) Reversal() *stripe.Reversal {
 	return i.Current().(*stripe.Reversal)
 }

--- a/taxid/client.go
+++ b/taxid/client.go
@@ -1,4 +1,10 @@
-// Package taxid provides the /customers/cus_1 APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package taxid provides the /customers/{customer}/tax_ids APIs
 package taxid
 
 import (
@@ -9,7 +15,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /tax_ids APIs.
+// Client is used to invoke /customers/{customer}/tax_ids APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -23,10 +29,14 @@ func New(params *stripe.TaxIDParams) (*stripe.TaxID, error) {
 // New creates a new tax id.
 func (c Client) New(params *stripe.TaxIDParams) (*stripe.TaxID, error) {
 	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Customer must be set")
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Customer must be set",
+		)
 	}
-
-	path := stripe.FormatURLPath("/v1/customers/%s/tax_ids", stripe.StringValue(params.Customer))
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/tax_ids",
+		stripe.StringValue(params.Customer),
+	)
 	taxid := &stripe.TaxID{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, taxid)
 	return taxid, err
@@ -40,10 +50,15 @@ func Get(id string, params *stripe.TaxIDParams) (*stripe.TaxID, error) {
 // Get returns the details of a tax id.
 func (c Client) Get(id string, params *stripe.TaxIDParams) (*stripe.TaxID, error) {
 	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Customer must be set")
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Customer must be set",
+		)
 	}
-
-	path := stripe.FormatURLPath("/v1/customers/%s/tax_ids/%s", stripe.StringValue(params.Customer), id)
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/tax_ids/%s",
+		stripe.StringValue(params.Customer),
+		id,
+	)
 	taxid := &stripe.TaxID{}
 	err := c.B.Call(http.MethodGet, path, c.Key, params, taxid)
 	return taxid, err
@@ -57,10 +72,15 @@ func Del(id string, params *stripe.TaxIDParams) (*stripe.TaxID, error) {
 // Del removes a tax id.
 func (c Client) Del(id string, params *stripe.TaxIDParams) (*stripe.TaxID, error) {
 	if params == nil {
-		return nil, fmt.Errorf("params cannot be nil, and params.Customer must be set")
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Customer must be set",
+		)
 	}
-
-	path := stripe.FormatURLPath("/v1/customers/%s/tax_ids/%s", stripe.StringValue(params.Customer), id)
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/tax_ids/%s",
+		stripe.StringValue(params.Customer),
+		id,
+	)
 	taxid := &stripe.TaxID{}
 	err := c.B.Call(http.MethodDelete, path, c.Key, params, taxid)
 	return taxid, err
@@ -73,8 +93,10 @@ func List(params *stripe.TaxIDListParams) *Iter {
 
 // List returns a list of tax ids.
 func (c Client) List(listParams *stripe.TaxIDListParams) *Iter {
-	path := stripe.FormatURLPath("/v1/customers/%s/tax_ids", stripe.StringValue(listParams.Customer))
-
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/tax_ids",
+		stripe.StringValue(listParams.Customer),
+	)
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.TaxIDList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
@@ -98,9 +120,9 @@ func (i *Iter) TaxID() *stripe.TaxID {
 	return i.Current().(*stripe.TaxID)
 }
 
-// TaxIDList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// TaxIDList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) TaxIDList() *stripe.TaxIDList {
 	return i.List().(*stripe.TaxIDList)
 }

--- a/usagerecord/client.go
+++ b/usagerecord/client.go
@@ -1,4 +1,10 @@
-// Package usagerecord provides the /subscription_items/{SUBSCRIPTION_ITEM_ID}/usage_records APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package usagerecord provides the /subscription_items/{subscription_item}/usage_records APIs
 package usagerecord
 
 import (
@@ -7,7 +13,7 @@ import (
 	stripe "github.com/stripe/stripe-go/v72"
 )
 
-// Client is used to invoke APIs related to usage records.
+// Client is used to invoke /subscription_items/{subscription_item}/usage_records APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -20,10 +26,13 @@ func New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
 
 // New creates a new usage record.
 func (c Client) New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, error) {
-	path := stripe.FormatURLPath("/v1/subscription_items/%s/usage_records", stripe.StringValue(params.SubscriptionItem))
-	record := &stripe.UsageRecord{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, record)
-	return record, err
+	path := stripe.FormatURLPath(
+		"/v1/subscription_items/%s/usage_records",
+		stripe.StringValue(params.SubscriptionItem),
+	)
+	usagerecord := &stripe.UsageRecord{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, usagerecord)
+	return usagerecord, err
 }
 
 func getC() Client {

--- a/usagerecordsummary/client.go
+++ b/usagerecordsummary/client.go
@@ -27,11 +27,11 @@ func List(params *stripe.UsageRecordSummaryListParams) *Iter {
 
 // List returns a list of usage record summaries.
 func (c Client) List(listParams *stripe.UsageRecordSummaryListParams) *Iter {
+	path := stripe.FormatURLPath(
+		"/v1/subscription_items/%s/usage_record_summaries",
+		stripe.StringValue(listParams.SubscriptionItem),
+	)
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		path := stripe.FormatURLPath(
-			"/v1/subscription_items/%s/usage_record_summaries",
-			stripe.StringValue(listParams.SubscriptionItem),
-		)
 		list := &stripe.UsageRecordSummaryList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 


### PR DESCRIPTION
Codegens nine more `client.go` files.

All changes except for two are formatting/ordering/variable naming/docstring changes that have no behavior effect.

Those two are:
  * I replaced one `errors.New(...)` with `fmt.Errorf(...)` -- shouldn't make a difference -- these functions behave essentially identically
  * In `usagerecordsummary/client.go` I move the assignment of `path := ...` outside of the inner `Iter` to be consistent with how the other Iter methods are written. This is technically a behavior change: with the previous code, if you mutated `listParams.SubscriptionID` halfway through pagination, things would switch to making requests on a different subscription -- in the new code mutating listParams will have no effect. I can't imagine anybody actually desires the old behavior.