### PR TITLE
API updates

### DIFF
--- a/account.go
+++ b/account.go
@@ -89,6 +89,7 @@ const (
 	AccountCompanyStructurePublicCompany                      AccountCompanyStructure = "public_company"
 	AccountCompanyStructurePublicCorporation                  AccountCompanyStructure = "public_corporation"
 	AccountCompanyStructurePublicPartnership                  AccountCompanyStructure = "public_partnership"
+	AccountCompanyStructureSingleMemberLLC                    AccountCompanyStructure = "single_member_llc"
 	AccountCompanyStructureSoleProprietorship                 AccountCompanyStructure = "sole_proprietorship"
 	AccountCompanyStructureTaxExemptGovernmentInstrumentality AccountCompanyStructure = "tax_exempt_government_instrumentality"
 	AccountCompanyStructureUnincorporatedAssociation          AccountCompanyStructure = "unincorporated_association"

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -30,8 +30,10 @@ type IssuingCardShippingCarrier string
 
 // List of values that IssuingCardShippingCarrier can take.
 const (
-	IssuingCardShippingCarrierFEDEX IssuingCardShippingCarrier = "fedex"
-	IssuingCardShippingCarrierUSPS  IssuingCardShippingCarrier = "usps"
+	IssuingCardShippingCarrierDHL       IssuingCardShippingCarrier = "dhl"
+	IssuingCardShippingCarrierFEDEX     IssuingCardShippingCarrier = "fedex"
+	IssuingCardShippingCarrierRoyalMail IssuingCardShippingCarrier = "royal_mail"
+	IssuingCardShippingCarrierUSPS      IssuingCardShippingCarrier = "usps"
 )
 
 // IssuingCardShippingService is the shipment service for a card.


### PR DESCRIPTION
r? @remi-stripe 
Contains API changes related to [v30](https://github.com/stripe/openapi/releases/tag/v30) of our OpenAPI spec.
* Add support for `dhl` and `royal_mail` as enum members of `IssuingCardShippingCarrier`.
* Add support for `single_member_llc` as an enum member of `AccountCompanyStructure`.