### PR TITLE
Add streaming requests

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -439,57 +439,21 @@ func resetBodyReader(body *bytes.Buffer, req *http.Request) {
 	}
 }
 
-func (s *BackendImplementation) handleResponse(res *http.Response, err error) ([]byte, error) {
-	var resBody []byte
-	if err == nil {
-		resBody, err = ioutil.ReadAll(res.Body)
-		res.Body.Close()
-	}
-
-	if err != nil {
-		s.LeveledLogger.Errorf("Request failed with error: %v", err)
-	} else if res.StatusCode >= 400 {
-		err = s.ResponseToError(res, resBody)
-
-		if stripeErr, ok := err.(*Error); ok {
-			// The Stripe API makes a distinction between errors that were
-			// caused by invalid parameters or something else versus those
-			// that occurred *despite* valid parameters, the latter coming
-			// back with status 402.
-			//
-			// On a 402, log to info so as to not make an integration's log
-			// noisy with error messages that they don't have much control
-			// over.
-			//
-			// Note I use the constant 402 instead of an `http.Status*`
-			// constant because technically 402 is "Payment required". The
-			// Stripe API doesn't comply to the letter of the specification
-			// and uses it in a broader sense.
-			if res.StatusCode == 402 {
-				s.LeveledLogger.Infof("User-compelled request error from Stripe (status %v): %v",
-					res.StatusCode, stripeErr.redact())
-			} else {
-				s.LeveledLogger.Errorf("Request error from Stripe (status %v): %v",
-					res.StatusCode, stripeErr.redact())
-			}
-		} else {
-			s.LeveledLogger.Errorf("Error decoding error from Stripe: %v", err)
-		}
-	}
-
-	return resBody, err
-}
-
 // Do is used by Call to execute an API request and parse the response. It uses
 // the backend's HTTP client to execute the request and unmarshals the response
 // into v. It also handles unmarshaling errors returned by the API.
-func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v LastResponseSetter) error {
+func (s *BackendImplementation) execute(
+	req *http.Request,
+	body *bytes.Buffer,
+	handleResponse func(*http.Response, error) (interface{}, error),
+	handleResult func(*http.Response, interface{}) error,
+) error {
 	s.LeveledLogger.Infof("Requesting %v %v%v", req.Method, req.URL.Host, req.URL.Path)
 	s.maybeSetTelemetryHeader(req)
 	var res *http.Response
 	var err error
 	var requestDuration time.Duration
-	var resBody []byte
+	var result interface{}
 	for retry := 0; ; {
 		start := time.Now()
 		resetBodyReader(body, req)
@@ -499,7 +463,7 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v Last
 		requestDuration = time.Since(start)
 		s.LeveledLogger.Infof("Request completed in %v (retry: %v)", requestDuration, retry)
 
-		resBody, err = s.handleResponse(res, err)
+		result, err = handleResponse(res, err)
 
 		// If the response was okay, or an error that shouldn't be retried,
 		// we're done, and it's safe to leave the retry loop.
@@ -525,12 +489,61 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v Last
 		return err
 	}
 
-	s.LeveledLogger.Debugf("Response: %s", string(resBody))
+	return handleResult(res, result)
+}
 
-	err = s.UnmarshalJSONVerbose(res.StatusCode, resBody, v)
-	v.SetLastResponse(newAPIResponse(res, resBody))
+// Do is used by Call to execute an API request and parse the response. It uses
+// the backend's HTTP client to execute the request and unmarshals the response
+// into v. It also handles unmarshaling errors returned by the API.
+func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v LastResponseSetter) error {
+	handleResponse := func(res *http.Response, err error) (interface{}, error) {
+		var resBody []byte
+		if err == nil {
+			resBody, err = ioutil.ReadAll(res.Body)
+			res.Body.Close()
+		}
 
-	return err
+		if err != nil {
+			s.LeveledLogger.Errorf("Request failed with error: %v", err)
+		} else if res.StatusCode >= 400 {
+			err = s.ResponseToError(res, resBody)
+
+			if stripeErr, ok := err.(*Error); ok {
+				// The Stripe API makes a distinction between errors that were
+				// caused by invalid parameters or something else versus those
+				// that occurred *despite* valid parameters, the latter coming
+				// back with status 402.
+				//
+				// On a 402, log to info so as to not make an integration's log
+				// noisy with error messages that they don't have much control
+				// over.
+				//
+				// Note I use the constant 402 instead of an `http.Status*`
+				// constant because technically 402 is "Payment required". The
+				// Stripe API doesn't comply to the letter of the specification
+				// and uses it in a broader sense.
+				if res.StatusCode == 402 {
+					s.LeveledLogger.Infof("User-compelled request error from Stripe (status %v): %v",
+						res.StatusCode, stripeErr.redact())
+				} else {
+					s.LeveledLogger.Errorf("Request error from Stripe (status %v): %v",
+						res.StatusCode, stripeErr.redact())
+				}
+			} else {
+				s.LeveledLogger.Errorf("Error decoding error from Stripe: %v", err)
+			}
+		}
+
+		return resBody, err
+	}
+	handleResult := func(res *http.Response, result interface{}) error {
+		resBody := result.([]byte)
+		s.LeveledLogger.Debugf("Response: %s", string(resBody))
+		err := s.UnmarshalJSONVerbose(res.StatusCode, resBody, v)
+		v.SetLastResponse(newAPIResponse(res, resBody))
+		return err
+	}
+	return s.execute(req, body, handleResponse, handleResult)
 }
 
 // ResponseToError converts a stripe response to an Error.

--- a/stripe.go
+++ b/stripe.go
@@ -591,6 +591,10 @@ func (s *BackendImplementation) logError(statusCode int, err error) {
 	}
 }
 
+// DoStreaming is used by CallStreaming to execute an API request. It uses the
+// backend's HTTP client to execure the request.  In successful cases, it sets
+// a StreamingLastResponse onto v, but in unsuccessful cases handles unmarshaling
+// errors returned by the API.
 func (s *BackendImplementation) DoStreaming(req *http.Request, body *bytes.Buffer, v StreamingLastResponseSetter) error {
 	handleResponse := func(res *http.Response, err error) (interface{}, error) {
 

--- a/stripe.go
+++ b/stripe.go
@@ -151,7 +151,7 @@ type APIResource struct {
 
 // APIStream is a type assigned to streaming responses that may come from Stripe API
 type APIStream struct {
-	LastResponse *StreamingAPIResponse `json:"-"`
+	LastResponse *StreamingAPIResponse
 }
 
 // SetLastResponse sets the HTTP response that returned the API resource.

--- a/stripe.go
+++ b/stripe.go
@@ -111,7 +111,7 @@ type APIResponse struct {
 // Stripe API whose body can be streamed. This is used for "file downloads", and
 // the `Body` property is an io.ReadCloser, so the user can stream it to another
 // location such as a file or network request without buffering the entire body
-// into meemory.
+// into memory.
 type StreamingAPIResponse struct {
 	Header         http.Header
 	IdempotencyKey string

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -789,9 +789,6 @@ func TestDoStreaming_ParsableError(t *testing.T) {
 }
 
 func TestDoStreaming_UnparsableError(t *testing.T) {
-	type testServerResponse struct {
-		Error *Error `json:"error"`
-	}
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(400)
 		var data []byte


### PR DESCRIPTION
## Notify
r? @dcr-stripe 
cc @stripe/api-libraries 

## Description
Implements support for streaming requests.

How this will be used

```go
// In foo/client.go, something like:
func (c Client) PDF(id string, params *stripe.FooPDFParams) (*stripe.APIStream, error) {
	path := stripe.FormatURLPath("/v1/foo/%s/pdf", id)
	stream := &stripe.APIStream{}
	err := c.B.CallStreaming(http.MethodGet, path, c.Key, params, stream)
	return stream, err
}
```
and then the user can
```go
stream, err := stripe.foo.PDF("foo_xyz", nil)
if err != nil {
  return err  
}
writer, err := os.Create("/tmp/foo.pdf")
defer writer.Close()
io.Copy(writer, stream.LastResponse.Body)
```

It might help to review this commit-by-commit. There's some refactoring into helper functions.