### PR TITLE
Fix transfer.go

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -115,6 +115,6 @@ func (t *TransferDestination) UnmarshalJSON(data []byte) error {
 	}
 
 	*t = TransferDestination(v)
-	err = json.Unmarshal(data, &d.Account)
+	err := json.Unmarshal(data, &t.Account)
 	return err
 }


### PR DESCRIPTION
Fixes small errors introduced by https://github.com/stripe/stripe-go/pull/1289. CI didn't run properly on this branch because  it wasn't based off of master, and I forgot this and merged them all together.