### PR TITLE
API Updates

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -290,6 +290,11 @@ type ChargePaymentMethodDetailsBancontact struct {
 	GeneratedSepaDebitMandate *Mandate       `json:"generated_sepa_debit_mandate"`
 }
 
+// ChargePaymentMethodDetailsBoleto represents details about the Boleto PaymentMethod.
+type ChargePaymentMethodDetailsBoleto struct {
+	TaxID string `json:"tax_id"`
+}
+
 // ChargePaymentMethodDetailsCardChecks represents the checks associated with the charge's Card
 // PaymentMethod.
 type ChargePaymentMethodDetailsCardChecks struct {
@@ -557,6 +562,7 @@ type ChargePaymentMethodDetails struct {
 	AUBECSDebit       *ChargePaymentMethodDetailsAUBECSDebit       `json:"au_becs_debit"`
 	BACSDebit         *ChargePaymentMethodDetailsBACSDebit         `json:"bacs_debit"`
 	Bancontact        *ChargePaymentMethodDetailsBancontact        `json:"bancontact"`
+	Boleto            *ChargePaymentMethodDetailsBoleto            `json:"boleto"`
 	Card              *ChargePaymentMethodDetailsCard              `json:"card"`
 	CardPresent       *ChargePaymentMethodDetailsCardPresent       `json:"card_present"`
 	Eps               *ChargePaymentMethodDetailsEps               `json:"eps"`

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -27,6 +27,7 @@ const (
 	CheckoutSessionCustomerDetailsTaxIDsTypeGBVAT    CheckoutSessionCustomerDetailsTaxIDsType = "gb_vat"
 	CheckoutSessionCustomerDetailsTaxIDsTypeHKBR     CheckoutSessionCustomerDetailsTaxIDsType = "hk_br"
 	CheckoutSessionCustomerDetailsTaxIDsTypeIDNPWP   CheckoutSessionCustomerDetailsTaxIDsType = "id_npwp"
+	CheckoutSessionCustomerDetailsTaxIDsTypeILVAT    CheckoutSessionCustomerDetailsTaxIDsType = "il_vat"
 	CheckoutSessionCustomerDetailsTaxIDsTypeINGST    CheckoutSessionCustomerDetailsTaxIDsType = "in_gst"
 	CheckoutSessionCustomerDetailsTaxIDsTypeJPCN     CheckoutSessionCustomerDetailsTaxIDsType = "jp_cn"
 	CheckoutSessionCustomerDetailsTaxIDsTypeJPRN     CheckoutSessionCustomerDetailsTaxIDsType = "jp_rn"

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -202,6 +202,7 @@ type PaymentIntentPaymentMethodDataParams struct {
 	Alipay           *PaymentMethodAlipayParams           `form:"alipay"`
 	AUBECSDebit      *PaymentMethodAUBECSDebitParams      `form:"au_becs_debit"`
 	BillingDetails   *BillingDetailsParams                `form:"billing_details"`
+	Boleto           *PaymentMethodBoletoParams           `form:"boleto"`
 	Card             *PaymentMethodCardParams             `form:"card"`
 	EPS              *PaymentMethodEPSParams              `form:"eps"`
 	FPX              *PaymentMethodFPXParams              `form:"fpx"`
@@ -244,6 +245,12 @@ type PaymentIntentPaymentMethodOptionsAlipayParams struct {
 // applied to a PaymentIntent.
 type PaymentIntentPaymentMethodOptionsBancontactParams struct {
 	PreferredLanguage *string `form:"preferred_language"`
+}
+
+// PaymentIntentPaymentMethodOptionsBoletoParams represents the boleto-specific options
+// applied to a PaymentIntent.
+type PaymentIntentPaymentMethodOptionsBoletoParams struct {
+	ExpiresAfterDays *int64 `form:"expires_after_days"`
 }
 
 // PaymentIntentPaymentMethodOptionsCardInstallmentsPlanParams represents details about the
@@ -290,6 +297,7 @@ type PaymentIntentPaymentMethodOptionsParams struct {
 	AfterpayClearpay *PaymentIntentPaymentMethodOptionsAfterpayClearpayParams `form:"afterpay_clearpay"`
 	Alipay           *PaymentIntentPaymentMethodOptionsAlipayParams           `form:"alipay"`
 	Bancontact       *PaymentIntentPaymentMethodOptionsBancontactParams       `form:"bancontact"`
+	Boleto           *PaymentIntentPaymentMethodOptionsBoletoParams           `form:"boleto"`
 	Card             *PaymentIntentPaymentMethodOptionsCardParams             `form:"card"`
 	OXXO             *PaymentIntentPaymentMethodOptionsOXXOParams             `form:"oxxo"`
 	Sofort           *PaymentIntentPaymentMethodOptionsSofortParams           `form:"sofort"`
@@ -352,6 +360,15 @@ type PaymentIntentNextActionAlipayHandleRedirect struct {
 	URL        string `json:"url"`
 }
 
+// PaymentIntentNextActionBoletoDisplayDetails represents the resource for the next action of type
+// "boleto_display_details".
+type PaymentIntentNextActionBoletoDisplayDetails struct {
+	ExpiresAt        int64  `json:"expires_at"`
+	HostedVoucherURL string `json:"hosted_voucher_url"`
+	Number           string `json:"number"`
+	PDF              string `json:"pdf"`
+}
+
 // PaymentIntentNextActionOXXODisplayDetails represents the resource for the next action of type
 // "oxxo_display_details".
 type PaymentIntentNextActionOXXODisplayDetails struct {
@@ -381,11 +398,16 @@ type PaymentIntentNextActionVerifyWithMicrodeposits struct {
 // PaymentIntentNextAction represents the type of action to take on a payment intent.
 type PaymentIntentNextAction struct {
 	AlipayHandleRedirect    *PaymentIntentNextActionAlipayHandleRedirect    `json:"alipay_handle_redirect"`
+	BoletoDisplayDetails    *PaymentIntentNextActionBoletoDisplayDetails    `json:"boleto_display_details"`
 	OXXODisplayDetails      *PaymentIntentNextActionOXXODisplayDetails      `json:"oxxo_display_details"`
 	RedirectToURL           *PaymentIntentNextActionRedirectToURL           `json:"redirect_to_url"`
 	Type                    PaymentIntentNextActionType                     `json:"type"`
 	UseStripeSDK            *PaymentIntentNextActionUseStripeSDK            `json:"use_stripe_sdk"`
 	VerifyWithMicrodeposits *PaymentIntentNextActionVerifyWithMicrodeposits `json:"verify_with_microdeposits"`
+}
+
+type PaymentIntentPaymentMethodOptionsBoleto struct {
+	ExpiresAfterDays int64 `json:"expires_after_days"`
 }
 
 // PaymentIntentPaymentMethodOptionsCardInstallmentsPlan describe a specific card installment plan.
@@ -463,6 +485,7 @@ type PaymentIntentPaymentMethodOptions struct {
 	AfterpayClearpay *PaymentIntentPaymentMethodOptionsAfterpayClearpay `json:"afterpay_clearpay"`
 	Alipay           *PaymentIntentPaymentMethodOptionsAlipay           `json:"alipay"`
 	Bancontact       *PaymentIntentPaymentMethodOptionsBancontact       `json:"bancontact"`
+	Boleto           *PaymentIntentPaymentMethodOptionsBoleto           `json:"boleto"`
 	Card             *PaymentIntentPaymentMethodOptionsCard             `json:"card"`
 	OXXO             *PaymentIntentPaymentMethodOptionsOXXO             `json:"oxxo"`
 	Sofort           *PaymentIntentPaymentMethodOptionsSofort           `json:"sofort"`

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -22,6 +22,7 @@ const (
 	PaymentMethodTypeAUBECSDebit      PaymentMethodType = "au_becs_debit"
 	PaymentMethodTypeBACSDebit        PaymentMethodType = "bacs_debit"
 	PaymentMethodTypeBancontact       PaymentMethodType = "bancontact"
+	PaymentMethodTypeBoleto           PaymentMethodType = "boleto"
 	PaymentMethodTypeCard             PaymentMethodType = "card"
 	PaymentMethodTypeCardPresent      PaymentMethodType = "card_present"
 	PaymentMethodTypeEPS              PaymentMethodType = "eps"
@@ -126,6 +127,11 @@ type PaymentMethodBACSDebitParams struct {
 type PaymentMethodBancontactParams struct {
 }
 
+// PaymentMethod of type Boleto
+type PaymentMethodBoletoParams struct {
+	TaxID *string `form:"tax_id"`
+}
+
 // PaymentMethodCardParams is the set of parameters allowed for the `card` hash when creating a
 // PaymentMethod of type card.
 type PaymentMethodCardParams struct {
@@ -204,6 +210,7 @@ type PaymentMethodParams struct {
 	AUBECSDebit      *PaymentMethodAUBECSDebitParams      `form:"au_becs_debit"`
 	BACSDebit        *PaymentMethodBACSDebitParams        `form:"bacs_debit"`
 	Bancontact       *PaymentMethodBancontactParams       `form:"bancontact"`
+	Boleto           *PaymentMethodBoletoParams           `form:"boleto"`
 	BillingDetails   *BillingDetailsParams                `form:"billing_details"`
 	Card             *PaymentMethodCardParams             `form:"card"`
 	EPS              *PaymentMethodEPSParams              `form:"eps"`
@@ -284,6 +291,11 @@ type PaymentMethodBACSDebit struct {
 
 // PaymentMethodBancontact represents the Bancontact properties.
 type PaymentMethodBancontact struct {
+}
+
+// PaymentMethodBancontact represents the Boleto properties.
+type PaymentMethodBoleto struct {
+	TaxID string `json:"tax_id"`
 }
 
 // PaymentMethodCardChecks represents the checks associated with a Card PaymentMethod.
@@ -407,6 +419,7 @@ type PaymentMethod struct {
 	BACSDebit        *PaymentMethodBACSDebit        `json:"bacs_debit"`
 	Bancontact       *PaymentMethodBancontact       `json:"bancontact"`
 	BillingDetails   *BillingDetails                `json:"billing_details"`
+	Boleto           *PaymentMethodBoleto           `json:"boleto"`
 	Card             *PaymentMethodCard             `json:"card"`
 	CardPresent      *PaymentMethodCardPresent      `json:"card_present"`
 	Created          int64                          `json:"created"`

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -127,6 +127,7 @@ type PaymentMethodBACSDebitParams struct {
 type PaymentMethodBancontactParams struct {
 }
 
+// PaymentMethodBoletoParams is the set of parameters allowed for the `boleto` hash when creating a
 // PaymentMethod of type Boleto
 type PaymentMethodBoletoParams struct {
 	TaxID *string `form:"tax_id"`
@@ -293,7 +294,7 @@ type PaymentMethodBACSDebit struct {
 type PaymentMethodBancontact struct {
 }
 
-// PaymentMethodBancontact represents the Boleto properties.
+// PaymentMethodBoleto represents the Boleto properties.
 type PaymentMethodBoleto struct {
 	TaxID string `json:"tax_id"`
 }

--- a/taxid.go
+++ b/taxid.go
@@ -30,6 +30,7 @@ const (
 	TaxIDTypeGBVAT    TaxIDType = "gb_vat"
 	TaxIDTypeHKBR     TaxIDType = "hk_br"
 	TaxIDTypeIDNPWP   TaxIDType = "id_npwp"
+	TaxIDTypeILVAT    TaxIDType = "il_vat"
 	TaxIDTypeINGST    TaxIDType = "in_gst"
 	TaxIDTypeJPCN     TaxIDType = "jp_cn"
 	TaxIDTypeJPRN     TaxIDType = "jp_rn"


### PR DESCRIPTION
## Notify
cc @stripe/api-libraries 

## Changelog
* Add support for `boleto` as a `PaymentMethodType`
* Add support for `Boleto` on `ChargePaymentMethodDetails`, `PaymentMethod`, `PaymentMethodParams`, `PaymentIntentPaymentMethodOptions`, `PaymentIntentPaymentMethodDataParams`, and `PaymentIntentPaymentMethodOptionsParams`
* Add support for `BoletoDisplayDetails` on `PaymentIntentNextAction`
* Add support for `il_vat` on enums `CheckoutSessionCustomerDetailsTaxIDsType` and `TaxIDType`
