### PR TITLE
API Updates

### DIFF
--- a/account.go
+++ b/account.go
@@ -200,6 +200,11 @@ type AccountCapabilitiesBancontactPaymentsParams struct {
 	Requested *bool `form:"requested"`
 }
 
+// AccountCapabilitiesBoletoPaymentsParams represent allowed parameters to configure the boleto payments capability on an account.
+type AccountCapabilitiesBoletoPaymentsParams struct {
+	Requested *bool `form:"requested"`
+}
+
 // AccountCapabilitiesCardIssuingParams represent allowed parameters to configure the Issuing capability on an account.
 type AccountCapabilitiesCardIssuingParams struct {
 	Requested *bool `form:"requested"`
@@ -291,6 +296,7 @@ type AccountCapabilitiesParams struct {
 	AUBECSDebitPayments     *AccountCapabilitiesAUBECSDebitPaymentsParams     `form:"au_becs_debit_payments"`
 	BACSDebitPayments       *AccountCapabilitiesBACSDebitPaymentsParams       `form:"bacs_debit_payments"`
 	BancontactPayments      *AccountCapabilitiesBancontactPaymentsParams      `form:"bancontact_payments"`
+	BoletoPayments          *AccountCapabilitiesBoletoPaymentsParams          `form:"boleto_payments"`
 	CardIssuing             *AccountCapabilitiesCardIssuingParams             `form:"card_issuing"`
 	CardPayments            *AccountCapabilitiesCardPaymentsParams            `form:"card_payments"`
 	CartesBancairesPayments *AccountCapabilitiesCartesBancairesPaymentsParams `form:"cartes_bancaires_payments"`

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -243,9 +243,21 @@ type CheckoutSessionPaymentMethodOptionsACSSDebitParams struct {
 	VerificationMethod *string                                                           `form:"verification_method"`
 }
 
+// CheckoutSessionPaymentMethodOptionsBoletoParams is the set of parameters allowed for boleto on payment_method_options.
+type CheckoutSessionPaymentMethodOptionsBoletoParams struct {
+	ExpiresAfterDays *int64 `form:"expires_after_days"`
+}
+
+// CheckoutSessionPaymentMethodOptionsOXXOParams is the set of parameters allowed for boleto on payment_method_options.
+type CheckoutSessionPaymentMethodOptionsOXXOParams struct {
+	ExpiresAfterDays *int64 `form:"expires_after_days"`
+}
+
 // CheckoutSessionPaymentMethodOptionsParams is the set of allowed parameters for payment_method_options on a checkout session.
 type CheckoutSessionPaymentMethodOptionsParams struct {
 	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebitParams `form:"acss_debit"`
+	Boleto    *CheckoutSessionPaymentMethodOptionsBoletoParams    `form:"boleto"`
+	OXXO      *CheckoutSessionPaymentMethodOptionsOXXOParams      `form:"oxxo"`
 }
 
 // CheckoutSessionSetupIntentDataParams is the set of parameters allowed for the setup intent
@@ -375,9 +387,21 @@ type CheckoutSessionPaymentMethodOptionsACSSDebit struct {
 	VerificationMethod CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
 }
 
+// CheckoutSessionPaymentMethodOptionsBoleto represent the options for boleto on payment_method_options.
+type CheckoutSessionPaymentMethodOptionsBoleto struct {
+	ExpiresAfterDays int64 `json:"expires_after_days"`
+}
+
+// CheckoutSessionPaymentMethodOptionsOXXO represent the options for oxxo on payment_method_options.
+type CheckoutSessionPaymentMethodOptionsOXXO struct {
+	ExpiresAfterDays int64 `json:"expires_after_days"`
+}
+
 // CheckoutSessionPaymentMethodOptions represent payment-method-specific options for a checkout session.
 type CheckoutSessionPaymentMethodOptions struct {
 	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebit `json:"acss_debit"`
+	Boleto    *CheckoutSessionPaymentMethodOptionsBoleto    `json:"boleto"`
+	OXXO      *CheckoutSessionPaymentMethodOptionsOXXO      `json:"oxxo"`
 }
 
 // CheckoutSessionShippingAddressCollection is the set of parameters allowed for the


### PR DESCRIPTION
## Notify
cc @stripe/api-libraries 

## Changelog
* Add support for `Boleto` and `OXXO` on `CheckoutSessionPaymentMethodOptionsParams` and `CheckoutSessionPaymentMethodOptions`.
* Add support for `BoletoPayments` on `AccountCapabilities`

