### PR TITLE
Add support for Wechat Pay

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -551,6 +551,10 @@ type ChargePaymentMethodDetailsStripeAccount struct {
 type ChargePaymentMethodDetailsWechat struct {
 }
 
+// ChargePaymentMethodDetailsWechatPay represents details about the WechatPay PaymentMethod.
+type ChargePaymentMethodDetailsWechatPay struct {
+}
+
 // ChargePaymentMethodDetails represents the details about the PaymentMethod associated with the
 // charge.
 type ChargePaymentMethodDetails struct {
@@ -579,6 +583,7 @@ type ChargePaymentMethodDetails struct {
 	StripeAccount     *ChargePaymentMethodDetailsStripeAccount     `json:"stripe_account"`
 	Type              ChargePaymentMethodDetailsType               `json:"type"`
 	Wechat            *ChargePaymentMethodDetailsWechat            `json:"wechat"`
+	WechatPay         *ChargePaymentMethodDetailsWechatPay         `json:"wechat_pay"`
 }
 
 // ChargeTransferData represents the information for the transfer_data associated with a charge.

--- a/charge.go
+++ b/charge.go
@@ -553,6 +553,8 @@ type ChargePaymentMethodDetailsWechat struct {
 
 // ChargePaymentMethodDetailsWechatPay represents details about the WechatPay PaymentMethod.
 type ChargePaymentMethodDetailsWechatPay struct {
+	Fingerprint   string `json:"fingerprint"`
+	TransactionID string `json:"transaction_id"`
 }
 
 // ChargePaymentMethodDetails represents the details about the PaymentMethod associated with the

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -248,9 +248,15 @@ type CheckoutSessionPaymentMethodOptionsBoletoParams struct {
 	ExpiresAfterDays *int64 `form:"expires_after_days"`
 }
 
-// CheckoutSessionPaymentMethodOptionsOXXOParams is the set of parameters allowed for boleto on payment_method_options.
+// CheckoutSessionPaymentMethodOptionsOXXOParams is the set of parameters allowed for oxxo on payment_method_options.
 type CheckoutSessionPaymentMethodOptionsOXXOParams struct {
 	ExpiresAfterDays *int64 `form:"expires_after_days"`
+}
+
+// CheckoutSessionPaymentMethodOptionsWechatPayParams is the set of parameters allowed for wechat_pay on payment_method_options.
+type CheckoutSessionPaymentMethodOptionsWechatPayParams struct {
+	AppID  *string `form:"app_id"`
+	Client *string `form:"client"`
 }
 
 // CheckoutSessionPaymentMethodOptionsParams is the set of allowed parameters for payment_method_options on a checkout session.
@@ -258,6 +264,7 @@ type CheckoutSessionPaymentMethodOptionsParams struct {
 	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebitParams `form:"acss_debit"`
 	Boleto    *CheckoutSessionPaymentMethodOptionsBoletoParams    `form:"boleto"`
 	OXXO      *CheckoutSessionPaymentMethodOptionsOXXOParams      `form:"oxxo"`
+	WechatPay *CheckoutSessionPaymentMethodOptionsWechatPayParams `form:"wechat_pay"`
 }
 
 // CheckoutSessionSetupIntentDataParams is the set of parameters allowed for the setup intent

--- a/invoice.go
+++ b/invoice.go
@@ -64,6 +64,7 @@ const (
 	InvoicePaymentSettingsPaymentMethodTypeSepaCreditTransfer InvoicePaymentSettingsPaymentMethodType = "sepa_credit_transfer"
 	InvoicePaymentSettingsPaymentMethodTypeSepaDebit          InvoicePaymentSettingsPaymentMethodType = "sepa_debit"
 	InvoicePaymentSettingsPaymentMethodTypeSofort             InvoicePaymentSettingsPaymentMethodType = "sofort"
+	InvoicePaymentSettingsPaymentMethodTypeWechatPay          InvoicePaymentSettingsPaymentMethodType = "wechat_pay"
 )
 
 // InvoiceStatus is the reason why a given invoice was created

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -114,7 +114,7 @@ type PaymentIntentPaymentMethodOptionsWechatPayClient string
 
 const (
 	PaymentIntentPaymentMethodOptionsWechatPayClientAndroid PaymentIntentPaymentMethodOptionsWechatPayClient = "android"
-	PaymentIntentPaymentMethodOptionsWechatPayClientIos     PaymentIntentPaymentMethodOptionsWechatPayClient = "ios"
+	PaymentIntentPaymentMethodOptionsWechatPayClientIOS     PaymentIntentPaymentMethodOptionsWechatPayClient = "ios"
 	PaymentIntentPaymentMethodOptionsWechatPayClientWeb     PaymentIntentPaymentMethodOptionsWechatPayClient = "web"
 )
 
@@ -448,7 +448,7 @@ type PaymentIntentNextAction struct {
 	VerifyWithMicrodeposits       *PaymentIntentNextActionVerifyWithMicrodeposits       `json:"verify_with_microdeposits"`
 	WechatPayDisplayQrCode        *PaymentIntentNextActionWechatPayDisplayQRCode        `json:"wechat_pay_display_qr_code"`
 	WechatPayRedirectToAndroidApp *PaymentIntentNextActionWechatPayRedirectToAndroidApp `json:"wechat_pay_redirect_to_android_app"`
-	WechatPayRedirectToIosApp     *PaymentIntentNextActionWechatPayRedirectToIOSApp     `json:"wechat_pay_redirect_to_ios_app"`
+	WechatPayRedirectToIOSApp     *PaymentIntentNextActionWechatPayRedirectToIOSApp     `json:"wechat_pay_redirect_to_ios_app"`
 }
 
 type PaymentIntentPaymentMethodOptionsBoleto struct {

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -110,6 +110,14 @@ const (
 	PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureAutomatic PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
 )
 
+type PaymentIntentPaymentMethodOptionsWechatPayClient string
+
+const (
+	PaymentIntentPaymentMethodOptionsWechatPayClientAndroid PaymentIntentPaymentMethodOptionsWechatPayClient = "android"
+	PaymentIntentPaymentMethodOptionsWechatPayClientIos     PaymentIntentPaymentMethodOptionsWechatPayClient = "ios"
+	PaymentIntentPaymentMethodOptionsWechatPayClientWeb     PaymentIntentPaymentMethodOptionsWechatPayClient = "web"
+)
+
 // PaymentIntentSetupFutureUsage is the list of allowed values for SetupFutureUsage.
 type PaymentIntentSetupFutureUsage string
 
@@ -211,6 +219,7 @@ type PaymentIntentPaymentMethodDataParams struct {
 	OXXO             *PaymentMethodOXXOParams             `form:"oxxo"`
 	P24              *PaymentMethodP24Params              `form:"p24"`
 	SepaDebit        *PaymentMethodSepaDebitParams        `form:"sepa_debit"`
+	WechatPay        *PaymentMethodWechatPayParams        `form:"sepa_debit"`
 	Type             *string                              `form:"type"`
 }
 
@@ -290,6 +299,13 @@ type PaymentIntentPaymentMethodOptionsSofortParams struct {
 	PreferredLanguage *string `form:"preferred_language"`
 }
 
+// PaymentIntentPaymentMethodOptionsWechatPayParams represents the wechat_pay-specific options applied to a
+// PaymentIntent.
+type PaymentIntentPaymentMethodOptionsWechatPayParams struct {
+	AppID  *string `form:"app_id"`
+	Client *string `form:"client"`
+}
+
 // PaymentIntentPaymentMethodOptionsParams represents the type-specific payment method options
 // applied to a PaymentIntent.
 type PaymentIntentPaymentMethodOptionsParams struct {
@@ -301,6 +317,7 @@ type PaymentIntentPaymentMethodOptionsParams struct {
 	Card             *PaymentIntentPaymentMethodOptionsCardParams             `form:"card"`
 	OXXO             *PaymentIntentPaymentMethodOptionsOXXOParams             `form:"oxxo"`
 	Sofort           *PaymentIntentPaymentMethodOptionsSofortParams           `form:"sofort"`
+	WechatPay        *PaymentIntentPaymentMethodOptionsWechatPayParams        `form:"sofort"`
 }
 
 // PaymentIntentTransferDataParams is the set of parameters allowed for the transfer hash.
@@ -395,15 +412,43 @@ type PaymentIntentNextActionVerifyWithMicrodeposits struct {
 	HostedVerificationURL string `json:"hosted_verification_url"`
 }
 
+// PaymentIntentNextActionWechatPayDisplayQRCode represents the resource for the next action of type
+// "wechat_pay_display_qr_code"
+type PaymentIntentNextActionWechatPayDisplayQRCode struct {
+	Data         string `json:"data"`
+	ImageDataURL string `json:"image_data_url"`
+}
+
+// PaymentIntentNextActionWechatPayRedirectToAndroidApp represents the resource for the next action of type
+// "wechat_pay_redirect_to_android_app"
+type PaymentIntentNextActionWechatPayRedirectToAndroidApp struct {
+	AppID     string `json:"app_id"`
+	NonceStr  string `json:"nonce_str"`
+	Package   string `json:"package"`
+	PartnerID string `json:"partner_id"`
+	PrepayID  string `json:"prepay_id"`
+	Sign      string `json:"sign"`
+	Timestamp string `json:"timestamp"`
+}
+
+// PaymentIntentNextActionWechatPayRedirectToIOSApp represents the resource for the next action of type
+// "wechat_pay_redirect_to_ios_app"
+type PaymentIntentNextActionWechatPayRedirectToIOSApp struct {
+	NativeURL string `json:"native_url"`
+}
+
 // PaymentIntentNextAction represents the type of action to take on a payment intent.
 type PaymentIntentNextAction struct {
-	AlipayHandleRedirect    *PaymentIntentNextActionAlipayHandleRedirect    `json:"alipay_handle_redirect"`
-	BoletoDisplayDetails    *PaymentIntentNextActionBoletoDisplayDetails    `json:"boleto_display_details"`
-	OXXODisplayDetails      *PaymentIntentNextActionOXXODisplayDetails      `json:"oxxo_display_details"`
-	RedirectToURL           *PaymentIntentNextActionRedirectToURL           `json:"redirect_to_url"`
-	Type                    PaymentIntentNextActionType                     `json:"type"`
-	UseStripeSDK            *PaymentIntentNextActionUseStripeSDK            `json:"use_stripe_sdk"`
-	VerifyWithMicrodeposits *PaymentIntentNextActionVerifyWithMicrodeposits `json:"verify_with_microdeposits"`
+	AlipayHandleRedirect          *PaymentIntentNextActionAlipayHandleRedirect          `json:"alipay_handle_redirect"`
+	BoletoDisplayDetails          *PaymentIntentNextActionBoletoDisplayDetails          `json:"boleto_display_details"`
+	OXXODisplayDetails            *PaymentIntentNextActionOXXODisplayDetails            `json:"oxxo_display_details"`
+	RedirectToURL                 *PaymentIntentNextActionRedirectToURL                 `json:"redirect_to_url"`
+	Type                          PaymentIntentNextActionType                           `json:"type"`
+	UseStripeSDK                  *PaymentIntentNextActionUseStripeSDK                  `json:"use_stripe_sdk"`
+	VerifyWithMicrodeposits       *PaymentIntentNextActionVerifyWithMicrodeposits       `json:"verify_with_microdeposits"`
+	WechatPayDisplayQrCode        *PaymentIntentNextActionWechatPayDisplayQRCode        `json:"wechat_pay_display_qr_code"`
+	WechatPayRedirectToAndroidApp *PaymentIntentNextActionWechatPayRedirectToAndroidApp `json:"wechat_pay_redirect_to_android_app"`
+	WechatPayRedirectToIosApp     *PaymentIntentNextActionWechatPayRedirectToIOSApp     `json:"wechat_pay_redirect_to_ios_app"`
 }
 
 type PaymentIntentPaymentMethodOptionsBoleto struct {
@@ -478,6 +523,13 @@ type PaymentIntentPaymentMethodOptionsSofort struct {
 	PreferredLanguage string `json:"preferred_language"`
 }
 
+// PaymentIntentPaymentMethodOptionsWechatPay is the set of wechat_pay-specific options associated
+// with that payment intent.
+type PaymentIntentPaymentMethodOptionsWechatPay struct {
+	AppID  string                                           `json:"app_id"`
+	Client PaymentIntentPaymentMethodOptionsWechatPayClient `json:"client"`
+}
+
 // PaymentIntentPaymentMethodOptions is the set of payment method-specific options associated with
 // that payment intent.
 type PaymentIntentPaymentMethodOptions struct {
@@ -489,6 +541,7 @@ type PaymentIntentPaymentMethodOptions struct {
 	Card             *PaymentIntentPaymentMethodOptionsCard             `json:"card"`
 	OXXO             *PaymentIntentPaymentMethodOptionsOXXO             `json:"oxxo"`
 	Sofort           *PaymentIntentPaymentMethodOptionsSofort           `json:"sofort"`
+	WechatPay        *PaymentIntentPaymentMethodOptionsWechatPay        `json:"wechat_pay"`
 }
 
 // PaymentIntentTransferData represents the information for the transfer associated with a payment intent.

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -446,7 +446,7 @@ type PaymentIntentNextAction struct {
 	Type                          PaymentIntentNextActionType                           `json:"type"`
 	UseStripeSDK                  *PaymentIntentNextActionUseStripeSDK                  `json:"use_stripe_sdk"`
 	VerifyWithMicrodeposits       *PaymentIntentNextActionVerifyWithMicrodeposits       `json:"verify_with_microdeposits"`
-	WechatPayDisplayQrCode        *PaymentIntentNextActionWechatPayDisplayQRCode        `json:"wechat_pay_display_qr_code"`
+	WechatPayDisplayQRCode        *PaymentIntentNextActionWechatPayDisplayQRCode        `json:"wechat_pay_display_qr_code"`
 	WechatPayRedirectToAndroidApp *PaymentIntentNextActionWechatPayRedirectToAndroidApp `json:"wechat_pay_redirect_to_android_app"`
 	WechatPayRedirectToIOSApp     *PaymentIntentNextActionWechatPayRedirectToIOSApp     `json:"wechat_pay_redirect_to_ios_app"`
 }

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -35,6 +35,7 @@ const (
 	PaymentMethodTypeP24              PaymentMethodType = "p24"
 	PaymentMethodTypeSepaDebit        PaymentMethodType = "sepa_debit"
 	PaymentMethodTypeSofort           PaymentMethodType = "sofort"
+	PaymentMethodTypeWechatPay        PaymentMethodType = "wechat_pay"
 )
 
 // PaymentMethodCardBrand is the list of allowed values for the brand property on a
@@ -201,6 +202,10 @@ type PaymentMethodSofortParams struct {
 	Country *string `form:"country"`
 }
 
+// PaymentMethodWechatPayParams is the set of parameters allowed for the `wechat_pay` hash when
+// creating a PaymentMethod of type wechat_pay.
+type PaymentMethodWechatPayParams struct{}
+
 // PaymentMethodParams is the set of parameters that can be used when creating or updating a
 // PaymentMethod.
 type PaymentMethodParams struct {
@@ -224,6 +229,7 @@ type PaymentMethodParams struct {
 	P24              *PaymentMethodP24Params              `form:"p24"`
 	SepaDebit        *PaymentMethodSepaDebitParams        `form:"sepa_debit"`
 	Sofort           *PaymentMethodSofortParams           `form:"sofort"`
+	WechatPay        *PaymentMethodWechatPayParams        `form:"wechat_pay"`
 	Type             *string                              `form:"type"`
 
 	// The following parameters are used when cloning a PaymentMethod to the connected account
@@ -410,6 +416,10 @@ type PaymentMethodSofort struct {
 	Country string `json:"country"`
 }
 
+// PaymentMethodWechatPay represents the WeChatPay-specific properties.
+type PaymentMethodWechatPay struct {
+}
+
 // PaymentMethod is the resource representing a PaymentMethod.
 type PaymentMethod struct {
 	APIResource
@@ -440,6 +450,7 @@ type PaymentMethod struct {
 	SepaDebit        *PaymentMethodSepaDebit        `json:"sepa_debit"`
 	Sofort           *PaymentMethodSofort           `json:"sofort"`
 	Type             PaymentMethodType              `json:"type"`
+	WechatPay        *PaymentMethodWechatPay        `json:"wechat_pay"`
 }
 
 // PaymentMethodList is a list of PaymentMethods as retrieved from a list endpoint.


### PR DESCRIPTION
## Changelog
* Add support for `WechatPay` on `ChargePaymentMethodDetails`, `CheckoutSessionPaymentMethodOptionsParams`, `PaymentIntentPaymentMethodDataParams`, `PaymentIntentPaymentMethodOptionsParams`, `PaymentIntentPaymentMethodOptions`, `PaymentMethodParams`, and `PaymentMethod`
* Add support for new value `wechat_pay` on enums `InvoicePaymentSettingsPaymentMethodType` and `PaymentMethodType`
* Add support for `WechatPayDisplayQRCode`, `WechatPayRedirectToAndroidApp`, and `WechatPayRedirectToIOSApp` on `PaymentIntentNextAction`
