### PR TITLE
Fix deserialization of Error on Sigma ScheduledQueryRun

### DIFF
--- a/sigma_scheduledqueryrun.go
+++ b/sigma_scheduledqueryrun.go
@@ -23,12 +23,17 @@ type SigmaScheduledQueryRunListParams struct {
 	ListParams `form:"*"`
 }
 
+// SigmaScheduledQueryRunError is the resource representing an error on a scheduled query run.
+type SigmaScheduledQueryRunError struct {
+	Message string `json:"message"`
+}
+
 // SigmaScheduledQueryRun is the resource representing a scheduled query run.
 type SigmaScheduledQueryRun struct {
 	APIResource
 	Created              int64                        `json:"created"`
 	DataLoadTime         int64                        `json:"data_load_time"`
-	Error                string                       `json:"error"`
+	Error                *SigmaScheduledQueryRunError `json:"error"`
 	File                 *File                        `json:"file"`
 	ID                   string                       `json:"id"`
 	Livemode             bool                         `json:"livemode"`


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-go/issues/1307

This is a breaking change, but the library would crash on any case of a `ScheduledQueryRun` that has `Error` set so maybe it's worth releasing a patch? We could otherwise shelve until the next major.

r? @richardm-stripe 
cc @stripe/api-libraries 