### PR TITLE
Remove too-opinionated docstring linter rule

### DIFF
--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,1 +1,1 @@
-checks = ["all", "-ST1005"]
+checks = ["all", "-ST1005", "-ST1021"]


### PR DESCRIPTION
## Notify
r? @dcr-stripe 

## Summary
We are beginning to generate docstrings based on the Openapi specification. These docstrings don't begin with the name of the Go struct representing what they describe, so the Golang convention of starting your docstrings this way isn't going to fly. This PR removes that linter rule from the `staticcheck` (our linter) config.

See https://staticcheck.io/docs/checks#ST1021