### PR TITLE
codegen: 14 more files

### DIFF
--- a/checkout/session/client.go
+++ b/checkout/session/client.go
@@ -1,4 +1,10 @@
-// Package session provides API functions related to checkout sessions.
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package session provides the /checkout/sessions APIs
 package session
 
 import (
@@ -9,30 +15,36 @@ import (
 	"github.com/stripe/stripe-go/v72/lineitem"
 )
 
-// Client is used to invoke /checkout_sessions APIs.
+// Client is used to invoke /checkout/sessions APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// New creates a new session.
+// New creates a new checkout session.
 func New(params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
 	return getC().New(params)
 }
 
-// New creates a new session.
+// New creates a new checkout session.
 func (c Client) New(params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
 	session := &stripe.CheckoutSession{}
-	err := c.B.Call(http.MethodPost, "/v1/checkout/sessions", c.Key, params, session)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/checkout/sessions",
+		c.Key,
+		params,
+		session,
+	)
 	return session, err
 }
 
-// Get retrieves a session.
+// Get returns the details of a checkout session.
 func Get(id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
 	return getC().Get(id, params)
 }
 
-// Get retrieves a session.
+// Get returns the details of a checkout session.
 func (c Client) Get(id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
 	path := stripe.FormatURLPath("/v1/checkout/sessions/%s", id)
 	session := &stripe.CheckoutSession{}
@@ -40,12 +52,12 @@ func (c Client) Get(id string, params *stripe.CheckoutSessionParams) (*stripe.Ch
 	return session, err
 }
 
-// List returns a list of sessions.
+// List returns a list of checkout sessions.
 func List(params *stripe.CheckoutSessionListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of sessions.
+// List returns a list of checkout sessions.
 func (c Client) List(listParams *stripe.CheckoutSessionListParams) *Iter {
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.CheckoutSessionList{}
@@ -60,15 +72,32 @@ func (c Client) List(listParams *stripe.CheckoutSessionListParams) *Iter {
 	})}
 }
 
-// ListLineItems returns a list of line items on a session.
-func ListLineItems(id string, params *stripe.CheckoutSessionListLineItemsParams) *lineitem.Iter {
+// Iter is an iterator for checkout sessions.
+type Iter struct {
+	*stripe.Iter
+}
+
+// CheckoutSession returns the checkout session which the iterator is currently pointing to.
+func (i *Iter) CheckoutSession() *stripe.CheckoutSession {
+	return i.Current().(*stripe.CheckoutSession)
+}
+
+// CheckoutSessionList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) CheckoutSessionList() *stripe.CheckoutSessionList {
+	return i.List().(*stripe.CheckoutSessionList)
+}
+
+// ListLineItems is the method for the `GET /v1/checkout/sessions/{session}/line_items` API.
+func ListLineItems(id string, params *stripe.CheckoutSessionListLineItemsParams) *LineItemIter {
 	return getC().ListLineItems(id, params)
 }
 
-// ListLineItems returns a list of line items on a session.
-func (c Client) ListLineItems(id string, listParams *stripe.CheckoutSessionListLineItemsParams) *lineitem.Iter {
+// ListLineItems is the method for the `GET /v1/checkout/sessions/{session}/line_items` API.
+func (c Client) ListLineItems(id string, listParams *stripe.CheckoutSessionListLineItemsParams) *LineItemIter {
 	path := stripe.FormatURLPath("/v1/checkout/sessions/%s/line_items", id)
-	return &lineitem.Iter{Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 		list := &stripe.LineItemList{}
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
@@ -81,22 +110,7 @@ func (c Client) ListLineItems(id string, listParams *stripe.CheckoutSessionListL
 	})}
 }
 
-// Iter is an iterator for sessions.
-type Iter struct {
-	*stripe.Iter
-}
-
-// CheckoutSession returns the session which the iterator is currently pointing to.
-func (i *Iter) CheckoutSession() *stripe.CheckoutSession {
-	return i.Current().(*stripe.CheckoutSession)
-}
-
-// CheckoutSessionList returns the current list object which the iterator is
-// currently using. List objects will change as new API calls are made to
-// continue pagination.
-func (i *Iter) CheckoutSessionList() *stripe.CheckoutSessionList {
-	return i.List().(*stripe.CheckoutSessionList)
-}
+type LineItemIter lineitem.Iter
 
 func getC() Client {
 	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}

--- a/checkout/session/client.go
+++ b/checkout/session/client.go
@@ -110,7 +110,7 @@ func (c Client) ListLineItems(id string, listParams *stripe.CheckoutSessionListL
 	})}
 }
 
-type LineItemIter lineitem.Iter
+type LineItemIter = lineitem.Iter
 
 func getC() Client {
 	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}

--- a/dispute.go
+++ b/dispute.go
@@ -1,8 +1,12 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // DisputeReason is the list of allowed values for a discount's reason.
 type DisputeReason string
@@ -99,16 +103,11 @@ type Dispute struct {
 	IsChargeRefundable  bool                  `json:"is_charge_refundable"`
 	Livemode            bool                  `json:"livemode"`
 	Metadata            map[string]string     `json:"metadata"`
+	NetworkReasonCode   string                `json:"network_reason_code"`
+	Object              string                `json:"object"`
 	PaymentIntent       *PaymentIntent        `json:"payment_intent"`
 	Reason              DisputeReason         `json:"reason"`
 	Status              DisputeStatus         `json:"status"`
-}
-
-// DisputeList is a list of disputes as retrieved from a list endpoint.
-type DisputeList struct {
-	APIResource
-	ListMeta
-	Data []*Dispute `json:"data"`
 }
 
 // EvidenceDetails is the structure representing more details about
@@ -152,6 +151,13 @@ type DisputeEvidence struct {
 	ShippingTrackingNumber       string `json:"shipping_tracking_number"`
 	UncategorizedFile            *File  `json:"uncategorized_file"`
 	UncategorizedText            string `json:"uncategorized_text"`
+}
+
+// DisputeList is a list of disputes as retrieved from a list endpoint.
+type DisputeList struct {
+	APIResource
+	ListMeta
+	Data []*Dispute `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Dispute.

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -1,3 +1,10 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package dispute provides the /disputes APIs
 package dispute
 
 import (
@@ -7,7 +14,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke dispute-related APIs.
+// Client is used to invoke /disputes APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -23,6 +30,32 @@ func (c Client) Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, e
 	path := stripe.FormatURLPath("/v1/disputes/%s", id)
 	dispute := &stripe.Dispute{}
 	err := c.B.Call(http.MethodGet, path, c.Key, params, dispute)
+	return dispute, err
+}
+
+// Update updates a dispute's properties.
+func Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
+	return getC().Update(id, params)
+}
+
+// Update updates a dispute's properties.
+func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
+	path := stripe.FormatURLPath("/v1/disputes/%s", id)
+	dispute := &stripe.Dispute{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
+	return dispute, err
+}
+
+// Close is the method for the `POST /v1/disputes/{dispute}/close` API.
+func Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
+	return getC().Close(id, params)
+}
+
+// Close is the method for the `POST /v1/disputes/{dispute}/close` API.
+func (c Client) Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
+	path := stripe.FormatURLPath("/v1/disputes/%s/close", id)
+	dispute := &stripe.Dispute{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
 	return dispute, err
 }
 
@@ -46,32 +79,6 @@ func (c Client) List(listParams *stripe.DisputeListParams) *Iter {
 	})}
 }
 
-// Update updates a dispute.
-func Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	return getC().Update(id, params)
-}
-
-// Update updates a dispute.
-func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	path := stripe.FormatURLPath("/v1/disputes/%s", id)
-	dispute := &stripe.Dispute{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
-	return dispute, err
-}
-
-// Close dismisses a dispute in the customer's favor.
-func Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	return getC().Close(id, params)
-}
-
-// Close dismisses a dispute in the customer's favor.
-func (c Client) Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
-	path := stripe.FormatURLPath("/v1/disputes/%s/close", id)
-	dispute := &stripe.Dispute{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
-	return dispute, err
-}
-
 // Iter is an iterator for disputes.
 type Iter struct {
 	*stripe.Iter
@@ -82,9 +89,9 @@ func (i *Iter) Dispute() *stripe.Dispute {
 	return i.Current().(*stripe.Dispute)
 }
 
-// DisputeList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// DisputeList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) DisputeList() *stripe.DisputeList {
 	return i.List().(*stripe.DisputeList)
 }

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -15,18 +21,16 @@ type EphemeralKeyParams struct {
 // to for example manage a Customer's payment methods.
 type EphemeralKey struct {
 	APIResource
-
 	AssociatedObjects []struct {
 		ID   string `json:"id"`
 		Type string `json:"type"`
 	} `json:"associated_objects"`
-
 	Created  int64  `json:"created"`
 	Expires  int64  `json:"expires"`
 	ID       string `json:"id"`
 	Livemode bool   `json:"livemode"`
+	Object   string `json:"object"`
 	Secret   string `json:"secret"`
-
 	// RawJSON is provided so that it may be passed back to the frontend
 	// unchanged.  Ephemeral keys are issued on behalf of another client which
 	// may be running a different version of the bindings and thus expect a
@@ -39,6 +43,7 @@ type EphemeralKey struct {
 // UnmarshalJSON handles deserialization of an EphemeralKey.
 // This custom unmarshaling is needed because we need to store the
 // raw JSON on the object so it may be passed back to the frontend.
+
 func (e *EphemeralKey) UnmarshalJSON(data []byte) error {
 	type ephemeralKey EphemeralKey
 	var ee ephemeralKey

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package ephemeralkey provides the /ephemeral_keys APIs
 package ephemeralkey
 
@@ -14,12 +20,12 @@ type Client struct {
 	Key string
 }
 
-// New create a new ephemeral key.
+// New creates a new ephemeral key.
 func New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
 	return getC().New(params)
 }
 
-// New create a new ephemeral key.
+// New creates a new ephemeral key.
 func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
 	if params.StripeVersion == nil || len(stripe.StringValue(params.StripeVersion)) == 0 {
 		return nil, fmt.Errorf("params.StripeVersion must be specified")
@@ -30,9 +36,15 @@ func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 	}
 	params.Headers.Add("Stripe-Version", stripe.StringValue(params.StripeVersion))
 
-	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call(http.MethodPost, "/v1/ephemeral_keys", c.Key, params, ephemeralKey)
-	return ephemeralKey, err
+	ephemeralkey := &stripe.EphemeralKey{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/ephemeral_keys",
+		c.Key,
+		params,
+		ephemeralkey,
+	)
+	return ephemeralkey, err
 }
 
 // Del removes an ephemeral key.
@@ -43,9 +55,9 @@ func Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 // Del removes an ephemeral key.
 func (c Client) Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
 	path := stripe.FormatURLPath("/v1/ephemeral_keys/%s", id)
-	ephemeralKey := &stripe.EphemeralKey{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, ephemeralKey)
-	return ephemeralKey, err
+	ephemeralkey := &stripe.EphemeralKey{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, ephemeralkey)
+	return ephemeralkey, err
 }
 
 func getC() Client {

--- a/fee.go
+++ b/fee.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -31,12 +37,13 @@ type ApplicationFee struct {
 	Currency               Currency            `json:"currency"`
 	ID                     string              `json:"id"`
 	Livemode               bool                `json:"livemode"`
+	Object                 string              `json:"object"`
 	OriginatingTransaction *Charge             `json:"originating_transaction"`
 	Refunded               bool                `json:"refunded"`
 	Refunds                *FeeRefundList      `json:"refunds"`
 }
 
-//ApplicationFeeList is a list of application fees as retrieved from a list endpoint.
+// ApplicationFeeList is a list of application fees as retrieved from a list endpoint.
 type ApplicationFeeList struct {
 	APIResource
 	ListMeta
@@ -46,9 +53,9 @@ type ApplicationFeeList struct {
 // UnmarshalJSON handles deserialization of an ApplicationFee.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (f *ApplicationFee) UnmarshalJSON(data []byte) error {
+func (a *ApplicationFee) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		f.ID = id
+		a.ID = id
 		return nil
 	}
 
@@ -58,6 +65,6 @@ func (f *ApplicationFee) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*f = ApplicationFee(v)
+	*a = ApplicationFee(v)
 	return nil
 }

--- a/fee/client.go
+++ b/fee/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package fee provides the /application_fees APIs
 package fee
 
@@ -8,7 +14,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke application_fees APIs.
+// Client is used to invoke /application_fees APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -22,9 +28,9 @@ func Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee
 // Get returns the details of an application fee.
 func (c Client) Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
 	path := stripe.FormatURLPath("/v1/application_fees/%s", id)
-	fee := &stripe.ApplicationFee{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, fee)
-	return fee, err
+	applicationfee := &stripe.ApplicationFee{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, applicationfee)
+	return applicationfee, err
 }
 
 // List returns a list of application fees.

--- a/issuing_cardholder.go
+++ b/issuing_cardholder.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -33,6 +39,7 @@ type IssuingCardholderStatus string
 // List of values that IssuingCardholderStatus can take.
 const (
 	IssuingCardholderStatusActive   IssuingCardholderStatus = "active"
+	IssuingCardholderStatusBlocked  IssuingCardholderStatus = "blocked"
 	IssuingCardholderStatusInactive IssuingCardholderStatus = "inactive"
 )
 

--- a/lineitem.go
+++ b/lineitem.go
@@ -1,8 +1,12 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // LineItemDiscount represent the details of one discount applied to a line item.
 type LineItemDiscount struct {
@@ -26,9 +30,9 @@ type LineItem struct {
 	AmountSubtotal int64               `json:"amount_subtotal"`
 	AmountTotal    int64               `json:"amount_total"`
 	Currency       Currency            `json:"currency"`
+	Deleted        bool                `json:"deleted"`
 	Description    string              `json:"description"`
 	Discounts      []*LineItemDiscount `json:"discounts"`
-	Deleted        bool                `json:"deleted"`
 	ID             string              `json:"id"`
 	Object         string              `json:"object"`
 	Price          *Price              `json:"price"`
@@ -36,28 +40,28 @@ type LineItem struct {
 	Taxes          []*LineItemTax      `json:"taxes"`
 }
 
+// UnmarshalJSON handles deserialization of a LineItem.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (l *LineItem) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		l.ID = id
+		return nil
+	}
+
+	type lineItem LineItem
+	var v lineItem
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*l = LineItem(v)
+	return nil
+}
+
 // LineItemList is a list of prices as returned from a list endpoint.
 type LineItemList struct {
 	APIResource
 	ListMeta
 	Data []*LineItem `json:"data"`
-}
-
-// UnmarshalJSON handles deserialization of a LineItem.
-// This custom unmarshaling is needed because the resulting
-// property may be an id or the full struct if it was expanded.
-func (s *LineItem) UnmarshalJSON(data []byte) error {
-	if id, ok := ParseID(data); ok {
-		s.ID = id
-		return nil
-	}
-
-	type price LineItem
-	var v price
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-
-	*s = LineItem(v)
-	return nil
 }

--- a/lineitem/client.go
+++ b/lineitem/client.go
@@ -1,11 +1,17 @@
-// Package lineitem provides the tools needs to interact with the LineItem resource.
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package lineitem provides the /checkout/sessions/{session}/line_items APIs
 package lineitem
 
 import (
 	stripe "github.com/stripe/stripe-go/v72"
 )
 
-// Iter is an iterator for line items across various resources.
+// Iter is an iterator for line items.
 type Iter struct {
 	*stripe.Iter
 }
@@ -15,7 +21,9 @@ func (i *Iter) LineItem() *stripe.LineItem {
 	return i.Current().(*stripe.LineItem)
 }
 
-// LineItemList returns the line item which the iterator is currently pointing to.
+// LineItemList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) LineItemList() *stripe.LineItemList {
 	return i.List().(*stripe.LineItemList)
 }

--- a/payout/client.go
+++ b/payout/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package payout provides the /payouts APIs
 package payout
 
@@ -52,12 +58,12 @@ func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, 
 	return payout, err
 }
 
-// Cancel cancels a pending payout.
+// Cancel is the method for the `POST /v1/payouts/{payout}/cancel` API.
 func Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	return getC().Cancel(id, params)
 }
 
-// Cancel cancels a pending payout.
+// Cancel is the method for the `POST /v1/payouts/{payout}/cancel` API.
 func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/v1/payouts/%s/cancel", id)
 	payout := &stripe.Payout{}
@@ -65,12 +71,12 @@ func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, 
 	return payout, err
 }
 
-// Reverse reverses a pending payout.
+// Reverse is the method for the `POST /v1/payouts/{payout}/reverse` API.
 func Reverse(id string, params *stripe.PayoutReverseParams) (*stripe.Payout, error) {
 	return getC().Reverse(id, params)
 }
 
-// Reverse reverses a pending payout.
+// Reverse is the method for the `POST /v1/payouts/{payout}/reverse` API.
 func (c Client) Reverse(id string, params *stripe.PayoutReverseParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/v1/payouts/%s/reverse", id)
 	payout := &stripe.Payout{}

--- a/refund.go
+++ b/refund.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -65,8 +71,9 @@ type Refund struct {
 	Charge                    *Charge             `json:"charge"`
 	Created                   int64               `json:"created"`
 	Currency                  Currency            `json:"currency"`
-	FailureReason             RefundFailureReason `json:"failure_reason"`
+	Description               string              `json:"description"`
 	FailureBalanceTransaction *BalanceTransaction `json:"failure_balance_transaction"`
+	FailureReason             RefundFailureReason `json:"failure_reason"`
 	ID                        string              `json:"id"`
 	Metadata                  map[string]string   `json:"metadata"`
 	Object                    string              `json:"object"`

--- a/refund/client.go
+++ b/refund/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package refund provides the /refunds APIs
 package refund
 
@@ -14,12 +20,12 @@ type Client struct {
 	Key string
 }
 
-// New creates a refund.
+// New creates a new refund.
 func New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	return getC().New(params)
 }
 
-// New creates a refund.
+// New creates a new refund.
 func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	refund := &stripe.Refund{}
 	err := c.B.Call(http.MethodPost, "/v1/refunds", c.Key, params, refund)
@@ -82,9 +88,9 @@ func (i *Iter) Refund() *stripe.Refund {
 	return i.Current().(*stripe.Refund)
 }
 
-// RefundList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// RefundList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) RefundList() *stripe.RefundList {
 	return i.List().(*stripe.RefundList)
 }

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package subitem provides the /subscription_items APIs
 package subitem
 
@@ -8,7 +14,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /subscriptions APIs.
+// Client is used to invoke /subscription_items APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -21,9 +27,15 @@ func New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error
 
 // New creates a new subscription item.
 func (c Client) New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
-	item := &stripe.SubscriptionItem{}
-	err := c.B.Call(http.MethodPost, "/v1/subscription_items", c.Key, params, item)
-	return item, err
+	subscriptionitem := &stripe.SubscriptionItem{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/subscription_items",
+		c.Key,
+		params,
+		subscriptionitem,
+	)
+	return subscriptionitem, err
 }
 
 // Get returns the details of a subscription item.
@@ -34,9 +46,9 @@ func Get(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 // Get returns the details of a subscription item.
 func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/v1/subscription_items/%s", id)
-	item := &stripe.SubscriptionItem{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, item)
-	return item, err
+	subscriptionitem := &stripe.SubscriptionItem{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, subscriptionitem)
+	return subscriptionitem, err
 }
 
 // Update updates a subscription item's properties.
@@ -47,9 +59,9 @@ func Update(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscript
 // Update updates a subscription item's properties.
 func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/v1/subscription_items/%s", id)
-	subi := &stripe.SubscriptionItem{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, subi)
-	return subi, err
+	subscriptionitem := &stripe.SubscriptionItem{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, subscriptionitem)
+	return subscriptionitem, err
 }
 
 // Del removes a subscription item.
@@ -60,10 +72,9 @@ func Del(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 // Del removes a subscription item.
 func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/v1/subscription_items/%s", id)
-	item := &stripe.SubscriptionItem{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, item)
-
-	return item, err
+	subscriptionitem := &stripe.SubscriptionItem{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, subscriptionitem)
+	return subscriptionitem, err
 }
 
 // List returns a list of subscription items.


### PR DESCRIPTION
## Notify
r? @stripe/api-library-reviewers 

## Summary
Makes 14 more files eligible for codegen. This includes adding a number of missing fields (see below).

The most involved thing here is the type alias `LineItemItem` introduced in `checkout/session/client.go`, the type alias ensures that this will not be a breaking change.

There is a go vet error that I will fix in a follow-up, please don't block on that.

## Changelog
  * Add support for `BillingAddressCollection` to `CheckoutSession`
  * Add support for `NetworkReasonCode` to `DisputeReason`
  * Add support for `Object` to `EphemeralKey`, `ApplicationFee`, and `DisputeReason`
  * Add support for `Description` to `Refund`
  * Add const definition for value `blocked` on enum `IssuingCardholderStatus`
  * Bugfix: add support for `Rate` on `CheckoutSessionTotalDetailsBreakdownTax` -- the existing field `TaxRate` has the wrong json annotation and should be deprecated.