### PR TITLE
Explicit iter property

### DIFF
--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -71,17 +71,19 @@ func List(params *stripe.ApplePayDomainListParams) *Iter {
 
 // List returns a list of apple pay domains.
 func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.ApplePayDomainList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/apple_pay/domains", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.ApplePayDomainList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/apple_pay/domains", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for apple pay domains.

--- a/balancetransaction/client.go
+++ b/balancetransaction/client.go
@@ -40,17 +40,19 @@ func List(params *stripe.BalanceTransactionListParams) *Iter {
 
 // List returns a list of balance transactions.
 func (c Client) List(listParams *stripe.BalanceTransactionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.BalanceTransactionList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/balance_transactions", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.BalanceTransactionList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/balance_transactions", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for balance transactions.

--- a/billingportal/configuration/client.go
+++ b/billingportal/configuration/client.go
@@ -71,17 +71,19 @@ func List(params *stripe.BillingPortalConfigurationListParams) *Iter {
 
 // List returns a list of billing portal configurations.
 func (c Client) List(listParams *stripe.BillingPortalConfigurationListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.BillingPortalConfigurationList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/billing_portal/configurations", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.BillingPortalConfigurationList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/billing_portal/configurations", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for billing portal configurations.

--- a/capability/client.go
+++ b/capability/client.go
@@ -71,17 +71,19 @@ func (c Client) List(listParams *stripe.CapabilityListParams) *Iter {
 		"/v1/accounts/%s/capabilities",
 		stripe.StringValue(listParams.Account),
 	)
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CapabilityList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CapabilityList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for capabilities.

--- a/charge/client.go
+++ b/charge/client.go
@@ -74,17 +74,19 @@ func List(params *stripe.ChargeListParams) *Iter {
 
 // List returns an iterator that iterates all charges.
 func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.ChargeList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/charges", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.ChargeList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/charges", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for charges.

--- a/checkout/session/client.go
+++ b/checkout/session/client.go
@@ -59,17 +59,19 @@ func List(params *stripe.CheckoutSessionListParams) *Iter {
 
 // List returns a list of checkout sessions.
 func (c Client) List(listParams *stripe.CheckoutSessionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CheckoutSessionList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/checkout/sessions", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CheckoutSessionList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/checkout/sessions", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for checkout sessions.
@@ -97,17 +99,19 @@ func ListLineItems(id string, params *stripe.CheckoutSessionListLineItemsParams)
 // ListLineItems is the method for the `GET /v1/checkout/sessions/{session}/line_items` API.
 func (c Client) ListLineItems(id string, listParams *stripe.CheckoutSessionListLineItemsParams) *LineItemIter {
 	path := stripe.FormatURLPath("/v1/checkout/sessions/%s/line_items", id)
-	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.LineItemList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &LineItemIter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.LineItemList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 type LineItemIter = lineitem.Iter

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -40,17 +40,19 @@ func List(params *stripe.CountrySpecListParams) *Iter {
 
 // List returns a list of country specs.
 func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CountrySpecList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/country_specs", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CountrySpecList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/country_specs", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for country specs.

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -78,17 +78,19 @@ func List(params *stripe.CouponListParams) *Iter {
 
 // List returns a list of coupons.
 func (c Client) List(listParams *stripe.CouponListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CouponList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/coupons", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CouponList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/coupons", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for coupons.

--- a/customer/client.go
+++ b/customer/client.go
@@ -78,17 +78,19 @@ func List(params *stripe.CustomerListParams) *Iter {
 
 // List returns a list of customers.
 func (c Client) List(listParams *stripe.CustomerListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CustomerList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/customers", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CustomerList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/customers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for customers.

--- a/customerbalancetransaction/client.go
+++ b/customerbalancetransaction/client.go
@@ -110,17 +110,19 @@ func (c Client) List(listParams *stripe.CustomerBalanceTransactionListParams) *I
 		"/v1/customers/%s/balance_transactions",
 		stripe.StringValue(listParams.Customer),
 	)
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CustomerBalanceTransactionList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CustomerBalanceTransactionList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for customer balance transactions.

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -66,17 +66,19 @@ func List(params *stripe.DisputeListParams) *Iter {
 
 // List returns a list of disputes.
 func (c Client) List(listParams *stripe.DisputeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.DisputeList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/disputes", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.DisputeList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/disputes", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for disputes.

--- a/event/client.go
+++ b/event/client.go
@@ -40,17 +40,19 @@ func List(params *stripe.EventListParams) *Iter {
 
 // List returns a list of events.
 func (c Client) List(listParams *stripe.EventListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.EventList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/events", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.EventList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/events", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for events.

--- a/fee/client.go
+++ b/fee/client.go
@@ -40,17 +40,19 @@ func List(params *stripe.ApplicationFeeListParams) *Iter {
 
 // List returns a list of application fees.
 func (c Client) List(listParams *stripe.ApplicationFeeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.ApplicationFeeList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/application_fees", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.ApplicationFeeList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/application_fees", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for application fees.

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -100,17 +100,19 @@ func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
 		"/v1/application_fees/%s/refunds",
 		stripe.StringValue(listParams.ApplicationFee),
 	)
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.FeeRefundList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.FeeRefundList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for fee refunds.

--- a/filelink/client.go
+++ b/filelink/client.go
@@ -65,17 +65,19 @@ func List(params *stripe.FileLinkListParams) *Iter {
 
 // List returns a list of file links.
 func (c Client) List(listParams *stripe.FileLinkListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.FileLinkList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/file_links", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.FileLinkList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/file_links", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for file links.

--- a/identity/verificationreport/client.go
+++ b/identity/verificationreport/client.go
@@ -40,17 +40,19 @@ func List(params *stripe.IdentityVerificationReportListParams) *Iter {
 
 // List returns a list of identity verification reports.
 func (c Client) List(listParams *stripe.IdentityVerificationReportListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.IdentityVerificationReportList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/identity/verification_reports", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.IdentityVerificationReportList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/identity/verification_reports", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for identity verification reports.

--- a/identity/verificationsession/client.go
+++ b/identity/verificationsession/client.go
@@ -103,17 +103,19 @@ func List(params *stripe.IdentityVerificationSessionListParams) *Iter {
 
 // List returns a list of identity verification sessions.
 func (c Client) List(listParams *stripe.IdentityVerificationSessionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.IdentityVerificationSessionList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/identity/verification_sessions", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.IdentityVerificationSessionList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/identity/verification_sessions", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for identity verification sessions.

--- a/issuing/card/client.go
+++ b/issuing/card/client.go
@@ -65,17 +65,19 @@ func List(params *stripe.IssuingCardListParams) *Iter {
 
 // List returns a list of issuing cards.
 func (c Client) List(listParams *stripe.IssuingCardListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.IssuingCardList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/cards", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.IssuingCardList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/cards", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for issuing cards.

--- a/issuing/cardholder/client.go
+++ b/issuing/cardholder/client.go
@@ -72,17 +72,19 @@ func List(params *stripe.IssuingCardholderListParams) *Iter {
 
 // List returns a list of issuing cardholders.
 func (c Client) List(listParams *stripe.IssuingCardholderListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.IssuingCardholderList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/cardholders", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.IssuingCardholderList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/cardholders", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for issuing cardholders.

--- a/issuing/transaction/client.go
+++ b/issuing/transaction/client.go
@@ -53,17 +53,19 @@ func List(params *stripe.IssuingTransactionListParams) *Iter {
 
 // List returns a list of issuing transactions.
 func (c Client) List(listParams *stripe.IssuingTransactionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.IssuingTransactionList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/transactions", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.IssuingTransactionList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/transactions", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for issuing transactions.

--- a/orderreturn/client.go
+++ b/orderreturn/client.go
@@ -40,17 +40,19 @@ func List(params *stripe.OrderReturnListParams) *Iter {
 
 // List returns a list of order returns.
 func (c Client) List(listParams *stripe.OrderReturnListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.OrderReturnList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/order_returns", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.OrderReturnList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/order_returns", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for order returns.

--- a/payout/client.go
+++ b/payout/client.go
@@ -91,17 +91,19 @@ func List(params *stripe.PayoutListParams) *Iter {
 
 // List returns a list of payouts.
 func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.PayoutList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/payouts", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.PayoutList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/payouts", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for payouts.

--- a/person/client.go
+++ b/person/client.go
@@ -104,17 +104,19 @@ func (c Client) List(listParams *stripe.PersonListParams) *Iter {
 		"/v1/accounts/%s/persons",
 		stripe.StringValue(listParams.Account),
 	)
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.PersonList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.PersonList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for persons.

--- a/plan/client.go
+++ b/plan/client.go
@@ -78,17 +78,19 @@ func List(params *stripe.PlanListParams) *Iter {
 
 // List returns a list of plans.
 func (c Client) List(listParams *stripe.PlanListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.PlanList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/plans", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.PlanList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/plans", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for plans.

--- a/price/client.go
+++ b/price/client.go
@@ -65,17 +65,19 @@ func List(params *stripe.PriceListParams) *Iter {
 
 // List returns a list of prices.
 func (c Client) List(listParams *stripe.PriceListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.PriceList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/prices", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.PriceList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/prices", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for prices.

--- a/product/client.go
+++ b/product/client.go
@@ -78,17 +78,19 @@ func List(params *stripe.ProductListParams) *Iter {
 
 // List returns a list of products.
 func (c Client) List(listParams *stripe.ProductListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.ProductList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/products", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.ProductList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/products", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for products.

--- a/quote/client.go
+++ b/quote/client.go
@@ -118,17 +118,19 @@ func List(params *stripe.QuoteListParams) *Iter {
 
 // List returns a list of quotes.
 func (c Client) List(listParams *stripe.QuoteListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.QuoteList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/quotes", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.QuoteList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/quotes", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for quotes.
@@ -159,17 +161,19 @@ func (c Client) ListComputedUpfrontLineItems(listParams *stripe.QuoteListCompute
 		"/v1/quotes/%s/computed_upfront_line_items",
 		stripe.StringValue(listParams.Quote),
 	)
-	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.LineItemList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &LineItemIter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.LineItemList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // ListLineItems is the method for the `GET /v1/quotes/{quote}/line_items` API.
@@ -183,17 +187,19 @@ func (c Client) ListLineItems(listParams *stripe.QuoteListLineItemsParams) *Line
 		"/v1/quotes/%s/line_items",
 		stripe.StringValue(listParams.Quote),
 	)
-	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.LineItemList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &LineItemIter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.LineItemList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // LineItemIter is an iterator for line items.

--- a/refund/client.go
+++ b/refund/client.go
@@ -65,17 +65,19 @@ func List(params *stripe.RefundListParams) *Iter {
 
 // List returns a list of refunds.
 func (c Client) List(listParams *stripe.RefundListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.RefundList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/refunds", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.RefundList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/refunds", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for refunds.

--- a/setupattempt/client.go
+++ b/setupattempt/client.go
@@ -28,17 +28,19 @@ func List(params *stripe.SetupAttemptListParams) *Iter {
 
 // List returns a list of setup attempts.
 func (c Client) List(listParams *stripe.SetupAttemptListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SetupAttemptList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/setup_attempts", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.SetupAttemptList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/setup_attempts", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for setup attempts.

--- a/sigma/scheduledqueryrun/client.go
+++ b/sigma/scheduledqueryrun/client.go
@@ -41,17 +41,19 @@ func List(params *stripe.SigmaScheduledQueryRunListParams) *Iter {
 
 // List returns a list of sigma scheduled query runs.
 func (c Client) List(listParams *stripe.SigmaScheduledQueryRunListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SigmaScheduledQueryRunList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/sigma/scheduled_query_runs", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.SigmaScheduledQueryRunList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/sigma/scheduled_query_runs", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for sigma scheduled query runs.

--- a/sku/client.go
+++ b/sku/client.go
@@ -78,17 +78,19 @@ func List(params *stripe.SKUListParams) *Iter {
 
 // List returns a list of skus.
 func (c Client) List(listParams *stripe.SKUListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SKUList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/skus", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.SKUList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/skus", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for skus.

--- a/sub/client.go
+++ b/sub/client.go
@@ -84,17 +84,19 @@ func List(params *stripe.SubscriptionListParams) *Iter {
 
 // List returns a list of subscriptions.
 func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SubscriptionList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/subscriptions", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.SubscriptionList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/subscriptions", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for subscriptions.

--- a/subitem/client.go
+++ b/subitem/client.go
@@ -84,17 +84,19 @@ func List(params *stripe.SubscriptionItemListParams) *Iter {
 
 // List returns a list of subscription items.
 func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SubscriptionItemList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/subscription_items", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.SubscriptionItemList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/subscription_items", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for subscription items.

--- a/taxcode/client.go
+++ b/taxcode/client.go
@@ -40,17 +40,19 @@ func List(params *stripe.TaxCodeListParams) *Iter {
 
 // List returns a list of tax codes.
 func (c Client) List(listParams *stripe.TaxCodeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.TaxCodeList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/tax_codes", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.TaxCodeList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/tax_codes", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for tax codes.

--- a/taxid/client.go
+++ b/taxid/client.go
@@ -97,17 +97,19 @@ func (c Client) List(listParams *stripe.TaxIDListParams) *Iter {
 		"/v1/customers/%s/tax_ids",
 		stripe.StringValue(listParams.Customer),
 	)
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.TaxIDList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.TaxIDList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for tax ids.

--- a/terminal/location/client.go
+++ b/terminal/location/client.go
@@ -84,17 +84,19 @@ func List(params *stripe.TerminalLocationListParams) *Iter {
 
 // List returns a list of terminal locations.
 func (c Client) List(listParams *stripe.TerminalLocationListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.TerminalLocationList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/terminal/locations", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.TerminalLocationList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/terminal/locations", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for terminal locations.

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -65,17 +65,19 @@ func List(params *stripe.TransferListParams) *Iter {
 
 // List returns a list of transfers.
 func (c Client) List(listParams *stripe.TransferListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.TransferList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/transfers", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.TransferList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/transfers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for transfers.

--- a/usagerecordsummary/client.go
+++ b/usagerecordsummary/client.go
@@ -31,17 +31,19 @@ func (c Client) List(listParams *stripe.UsageRecordSummaryListParams) *Iter {
 		"/v1/subscription_items/%s/usage_record_summaries",
 		stripe.StringValue(listParams.SubscriptionItem),
 	)
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.UsageRecordSummaryList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.UsageRecordSummaryList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for usage record summaries.

--- a/webhookendpoint/client.go
+++ b/webhookendpoint/client.go
@@ -84,17 +84,19 @@ func List(params *stripe.WebhookEndpointListParams) *Iter {
 
 // List returns a list of webhook endpoints.
 func (c Client) List(listParams *stripe.WebhookEndpointListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.WebhookEndpointList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/webhook_endpoints", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.WebhookEndpointList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/webhook_endpoints", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for webhook endpoints.


### PR DESCRIPTION
## Notify
r? @ramon-stripe 
## Summary
In codegenned files, moves away from the shorthand syntax when defining `Iter` structs and explicitly names the `Iter` property. This is a no-op.