### PR TITLE
codegen: charge, taxrate

### DIFF
--- a/address.go
+++ b/address.go
@@ -19,3 +19,12 @@ type Address struct {
 	PostalCode string `json:"postal_code"`
 	State      string `json:"state"`
 }
+
+// ShippingDetailsParams is the structure containing shipping information as parameters
+type ShippingDetailsParams struct {
+	Address        *AddressParams `form:"address"`
+	Carrier        *string        `form:"carrier"`
+	Name           *string        `form:"name"`
+	Phone          *string        `form:"phone"`
+	TrackingNumber *string        `form:"tracking_number"`
+}

--- a/charge.go
+++ b/charge.go
@@ -154,15 +154,6 @@ type ChargeParams struct {
 	TransferGroup             *string                   `form:"transfer_group"`
 }
 
-// ShippingDetailsParams is the structure containing shipping information as parameters
-type ShippingDetailsParams struct {
-	Address        *AddressParams `form:"address"`
-	Carrier        *string        `form:"carrier"`
-	Name           *string        `form:"name"`
-	Phone          *string        `form:"phone"`
-	TrackingNumber *string        `form:"tracking_number"`
-}
-
 // SetSource adds valid sources to a ChargeParams object,
 // returning an error for unsupported sources.
 func (p *ChargeParams) SetSource(sp interface{}) error {

--- a/charge.go
+++ b/charge.go
@@ -1,8 +1,12 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // ChargeFraudUserReport is the list of allowed values for reporting fraud.
 type ChargeFraudUserReport string
@@ -115,8 +119,8 @@ type ChargeLevel3Params struct {
 	LineItems          []*ChargeLevel3LineItemsParams `form:"line_items"`
 	MerchantReference  *string                        `form:"merchant_reference"`
 	ShippingAddressZip *string                        `form:"shipping_address_zip"`
-	ShippingFromZip    *string                        `form:"shipping_from_zip"`
 	ShippingAmount     *int64                         `form:"shipping_amount"`
+	ShippingFromZip    *string                        `form:"shipping_from_zip"`
 }
 
 // ChargeTransferDataParams is the set of parameters allowed for the transfer_data hash.
@@ -130,6 +134,7 @@ type ChargeTransferDataParams struct {
 type ChargeParams struct {
 	Params                    `form:"*"`
 	Amount                    *int64                    `form:"amount"`
+	ApplicationFee            *int64                    `form:"application_fee"`
 	ApplicationFeeAmount      *int64                    `form:"application_fee_amount"`
 	Capture                   *bool                     `form:"capture"`
 	Currency                  *string                   `form:"currency"`
@@ -191,13 +196,14 @@ type ChargeListParams struct {
 type CaptureParams struct {
 	Params                    `form:"*"`
 	Amount                    *int64                    `form:"amount"`
+	ApplicationFee            *int64                    `form:"application_fee"`
 	ApplicationFeeAmount      *int64                    `form:"application_fee_amount"`
 	ExchangeRate              *float64                  `form:"exchange_rate"`
 	ReceiptEmail              *string                   `form:"receipt_email"`
 	StatementDescriptor       *string                   `form:"statement_descriptor"`
 	StatementDescriptorSuffix *string                   `form:"statement_descriptor_suffix"`
-	TransferGroup             *string                   `form:"transfer_group"`
 	TransferData              *ChargeTransferDataParams `form:"transfer_data"`
+	TransferGroup             *string                   `form:"transfer_group"`
 }
 
 // ChargeLevel3LineItem represents a line item on level III data.
@@ -218,8 +224,8 @@ type ChargeLevel3 struct {
 	LineItems          []*ChargeLevel3LineItem `json:"line_items"`
 	MerchantReference  string                  `json:"merchant_reference"`
 	ShippingAddressZip string                  `json:"shipping_address_zip"`
-	ShippingFromZip    string                  `json:"shipping_from_zip"`
 	ShippingAmount     int64                   `json:"shipping_amount"`
+	ShippingFromZip    string                  `json:"shipping_from_zip"`
 }
 
 // ChargePaymentMethodDetailsAchCreditTransfer represents details about the ACH Credit Transfer
@@ -283,11 +289,11 @@ type ChargePaymentMethodDetailsBancontact struct {
 	BankCode                  string         `json:"bank_code"`
 	BankName                  string         `json:"bank_name"`
 	Bic                       string         `json:"bic"`
+	GeneratedSepaDebit        *PaymentMethod `json:"generated_sepa_debit"`
+	GeneratedSepaDebitMandate *Mandate       `json:"generated_sepa_debit_mandate"`
 	IbanLast4                 string         `json:"iban_last4"`
 	PreferredLanguage         string         `json:"preferred_language"`
 	VerifiedName              string         `json:"verified_name"`
-	GeneratedSepaDebit        *PaymentMethod `json:"generated_sepa_debit"`
-	GeneratedSepaDebitMandate *Mandate       `json:"generated_sepa_debit_mandate"`
 }
 
 // ChargePaymentMethodDetailsBoleto represents details about the Boleto PaymentMethod.
@@ -320,16 +326,13 @@ type ChargePaymentMethodDetailsCardThreeDSecure struct {
 
 // ChargePaymentMethodDetailsCardWalletAmexExpressCheckout represents the details of the Amex
 // Express Checkout wallet.
-type ChargePaymentMethodDetailsCardWalletAmexExpressCheckout struct {
-}
+type ChargePaymentMethodDetailsCardWalletAmexExpressCheckout struct{}
 
 // ChargePaymentMethodDetailsCardWalletApplePay represents the details of the Apple Pay wallet.
-type ChargePaymentMethodDetailsCardWalletApplePay struct {
-}
+type ChargePaymentMethodDetailsCardWalletApplePay struct{}
 
 // ChargePaymentMethodDetailsCardWalletGooglePay represents the details of the Google Pay wallet.
-type ChargePaymentMethodDetailsCardWalletGooglePay struct {
-}
+type ChargePaymentMethodDetailsCardWalletGooglePay struct{}
 
 // ChargePaymentMethodDetailsCardWalletMasterpass represents the details of the Masterpass wallet.
 type ChargePaymentMethodDetailsCardWalletMasterpass struct {
@@ -340,8 +343,7 @@ type ChargePaymentMethodDetailsCardWalletMasterpass struct {
 }
 
 // ChargePaymentMethodDetailsCardWalletSamsungPay represents the details of the Samsung Pay wallet.
-type ChargePaymentMethodDetailsCardWalletSamsungPay struct {
-}
+type ChargePaymentMethodDetailsCardWalletSamsungPay struct{}
 
 // ChargePaymentMethodDetailsCardWalletVisaCheckout represents the details of the Visa Checkout
 // wallet.
@@ -455,10 +457,10 @@ type ChargePaymentMethodDetailsGrabpay struct {
 type ChargePaymentMethodDetailsIdeal struct {
 	Bank                      string         `json:"bank"`
 	Bic                       string         `json:"bic"`
-	IbanLast4                 string         `json:"iban_last4"`
-	VerifiedName              string         `json:"verified_name"`
 	GeneratedSepaDebit        *PaymentMethod `json:"generated_sepa_debit"`
 	GeneratedSepaDebitMandate *Mandate       `json:"generated_sepa_debit_mandate"`
+	IbanLast4                 string         `json:"iban_last4"`
+	VerifiedName              string         `json:"verified_name"`
 }
 
 // ChargePaymentMethodDetailsInteracPresent represents details about the InteracPresent PaymentMethod.
@@ -500,8 +502,7 @@ type ChargePaymentMethodDetailsInteracPresentReceipt struct {
 
 // ChargePaymentMethodDetailsKlarna represents details for the Klarna
 // PaymentMethod.
-type ChargePaymentMethodDetailsKlarna struct {
-}
+type ChargePaymentMethodDetailsKlarna struct{}
 
 // ChargePaymentMethodDetailsMultibanco represents details about the Multibanco PaymentMethod.
 type ChargePaymentMethodDetailsMultibanco struct {
@@ -537,19 +538,18 @@ type ChargePaymentMethodDetailsSofort struct {
 	BankName                  string         `json:"bank_name"`
 	Bic                       string         `json:"bic"`
 	Country                   string         `json:"country"`
-	IbanLast4                 string         `json:"iban_last4"`
-	VerifiedName              string         `json:"verified_name"`
 	GeneratedSepaDebit        *PaymentMethod `json:"generated_sepa_debit"`
 	GeneratedSepaDebitMandate *Mandate       `json:"generated_sepa_debit_mandate"`
+	IbanLast4                 string         `json:"iban_last4"`
+	PreferredLanguage         string         `json:"preferred_language"`
+	VerifiedName              string         `json:"verified_name"`
 }
 
 // ChargePaymentMethodDetailsStripeAccount represents details about the StripeAccount PaymentMethod.
-type ChargePaymentMethodDetailsStripeAccount struct {
-}
+type ChargePaymentMethodDetailsStripeAccount struct{}
 
 // ChargePaymentMethodDetailsWechat represents details about the Wechat PaymentMethod.
-type ChargePaymentMethodDetailsWechat struct {
-}
+type ChargePaymentMethodDetailsWechat struct{}
 
 // ChargePaymentMethodDetailsWechatPay represents details about the WechatPay PaymentMethod.
 type ChargePaymentMethodDetailsWechatPay struct {
@@ -590,7 +590,7 @@ type ChargePaymentMethodDetails struct {
 
 // ChargeTransferData represents the information for the transfer_data associated with a charge.
 type ChargeTransferData struct {
-	Amount      int64    `form:"amount"`
+	Amount      int64    `json:"amount"`
 	Destination *Account `json:"destination"`
 }
 

--- a/charge/client.go
+++ b/charge/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke APIs related to charges.
+// Client is used to invoke /charges APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -28,12 +28,12 @@ func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 	return charge, err
 }
 
-// Get retrieves a charge.
+// Get returns the details of a charge.
 func Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	return getC().Get(id, params)
 }
 
-// Get retrieves a charge.
+// Get returns the details of a charge.
 func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/v1/charges/%s", id)
 	charge := &stripe.Charge{}
@@ -41,12 +41,12 @@ func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, err
 	return charge, err
 }
 
-// Update updates a charge.
+// Update updates a charge's properties.
 func Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a charge.
+// Update updates a charge's properties.
 func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/v1/charges/%s", id)
 	charge := &stripe.Charge{}
@@ -54,12 +54,12 @@ func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, 
 	return charge, err
 }
 
-// Capture captures a charge that's not yet captured.
+// Capture is the method for the `POST /v1/charges/{charge}/capture` API.
 func Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 	return getC().Capture(id, params)
 }
 
-// Capture captures a charge that's not yet captured.
+// Capture is the method for the `POST /v1/charges/{charge}/capture` API.
 func (c Client) Capture(id string, params *stripe.CaptureParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/v1/charges/%s/capture", id)
 	charge := &stripe.Charge{}
@@ -67,12 +67,12 @@ func (c Client) Capture(id string, params *stripe.CaptureParams) (*stripe.Charge
 	return charge, err
 }
 
-// List returns an iterator that iterates all charges.
+// List returns a list of charges.
 func List(params *stripe.ChargeListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns an iterator that iterates all charges.
+// List returns a list of charges.
 func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
@@ -99,9 +99,9 @@ func (i *Iter) Charge() *stripe.Charge {
 	return i.Current().(*stripe.Charge)
 }
 
-// ChargeList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// ChargeList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) ChargeList() *stripe.ChargeList {
 	return i.List().(*stripe.ChargeList)
 }

--- a/charge/client.go
+++ b/charge/client.go
@@ -1,6 +1,10 @@
-// Package charge provides API functions related to charges.
 //
-// For more details, see: https://stripe.com/docs/api/go#charges.
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package charge provides the /charges APIs
 package charge
 
 import (

--- a/quote.go
+++ b/quote.go
@@ -6,11 +6,8 @@
 
 package stripe
 
-import (
-	"encoding/json"
-
-	"github.com/stripe/stripe-go/v72/form"
-)
+import "encoding/json"
+import "github.com/stripe/stripe-go/v72/form"
 
 // The status of the most recent automated tax calculation for this quote.
 type QuoteAutomaticTaxStatus string

--- a/quote/client.go
+++ b/quote/client.go
@@ -4,7 +4,7 @@
 //
 //
 
-// Package quote provides the /quotes/{quote}/computed_upfront_line_items APIs
+// Package quote provides the /quotes APIs
 package quote
 
 import (
@@ -14,7 +14,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /quotes/{quote}/computed_upfront_line_items APIs.
+// Client is used to invoke /quotes APIs.
 type Client struct {
 	B          stripe.Backend
 	PDFBackend stripe.Backend

--- a/taxrate/client.go
+++ b/taxrate/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package taxrate provides the /tax_rates APIs
 package taxrate
 
@@ -14,16 +20,16 @@ type Client struct {
 	Key string
 }
 
-// New creates a new tr.
+// New creates a new tax rate.
 func New(params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 	return getC().New(params)
 }
 
-// New creates a new tr.
+// New creates a new tax rate.
 func (c Client) New(params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
-	tr := &stripe.TaxRate{}
-	err := c.B.Call(http.MethodPost, "/v1/tax_rates", c.Key, params, tr)
-	return tr, err
+	taxrate := &stripe.TaxRate{}
+	err := c.B.Call(http.MethodPost, "/v1/tax_rates", c.Key, params, taxrate)
+	return taxrate, err
 }
 
 // Get returns the details of a tax rate.
@@ -34,9 +40,9 @@ func Get(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 // Get returns the details of a tax rate.
 func (c Client) Get(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 	path := stripe.FormatURLPath("/v1/tax_rates/%s", id)
-	tr := &stripe.TaxRate{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, tr)
-	return tr, err
+	taxrate := &stripe.TaxRate{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, taxrate)
+	return taxrate, err
 }
 
 // Update updates a tax rate's properties.
@@ -47,9 +53,9 @@ func Update(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 // Update updates a tax rate's properties.
 func (c Client) Update(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 	path := stripe.FormatURLPath("/v1/tax_rates/%s", id)
-	tr := &stripe.TaxRate{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, tr)
-	return tr, err
+	taxrate := &stripe.TaxRate{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, taxrate)
+	return taxrate, err
 }
 
 // Del removes a tax rate.
@@ -60,44 +66,46 @@ func Del(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 // Del removes a tax rate.
 func (c Client) Del(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 	path := stripe.FormatURLPath("/v1/tax_rates/%s", id)
-	tr := &stripe.TaxRate{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, tr)
-	return tr, err
+	taxrate := &stripe.TaxRate{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, taxrate)
+	return taxrate, err
 }
 
-// List returns a list of trs.
+// List returns a list of tax rates.
 func List(params *stripe.TaxRateListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of trs.
+// List returns a list of tax rates.
 func (c Client) List(listParams *stripe.TaxRateListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.TaxRateList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/tax_rates", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.TaxRateList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/tax_rates", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
-// Iter is an iterator for trs.
+// Iter is an iterator for tax rates.
 type Iter struct {
 	*stripe.Iter
 }
 
-// TaxRate returns the tr which the iterator is currently pointing to.
+// TaxRate returns the tax rate which the iterator is currently pointing to.
 func (i *Iter) TaxRate() *stripe.TaxRate {
 	return i.Current().(*stripe.TaxRate)
 }
 
-// TaxRateList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// TaxRateList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) TaxRateList() *stripe.TaxRateList {
 	return i.List().(*stripe.TaxRateList)
 }


### PR DESCRIPTION
## Notify
r? @stripe/api-library-reviewers 
cc @stripe/api-libraries 

## Summary
* Updates `charge.go`, `charge/client.go` `taxrate/client.go` so that they are subject to codegen.
* Move ShippingDetailsParams from `charge.go` into `address.go`. This should be a no-op -- they are both package `stripe`.

Small, formatting changes to `quote.go` and `quote/client.go`.
## Changelog
* Add support for `ApplicationFee` on (Charge) `CaptureParams`
* Add support for `PreferredLanguage` on `ChargePaymentMethodDetailsSofort`
* Bugfix: correctly deserialize `amount` on `ChargeTransferData`
