### PR TITLE
codegen: api.go

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package client provides a Stripe client for invoking APIs across all resources
 package client
 
@@ -28,15 +34,16 @@ import (
 	"github.com/stripe/stripe-go/v72/feerefund"
 	"github.com/stripe/stripe-go/v72/file"
 	"github.com/stripe/stripe-go/v72/filelink"
-	"github.com/stripe/stripe-go/v72/identity/verificationreport"
-	"github.com/stripe/stripe-go/v72/identity/verificationsession"
+	identityverificationreport "github.com/stripe/stripe-go/v72/identity/verificationreport"
+	identityverificationsession "github.com/stripe/stripe-go/v72/identity/verificationsession"
 	"github.com/stripe/stripe-go/v72/invoice"
 	"github.com/stripe/stripe-go/v72/invoiceitem"
-	"github.com/stripe/stripe-go/v72/issuing/authorization"
+	issuingauthorization "github.com/stripe/stripe-go/v72/issuing/authorization"
 	issuingcard "github.com/stripe/stripe-go/v72/issuing/card"
-	"github.com/stripe/stripe-go/v72/issuing/cardholder"
+	issuingcardholder "github.com/stripe/stripe-go/v72/issuing/cardholder"
 	issuingdispute "github.com/stripe/stripe-go/v72/issuing/dispute"
-	"github.com/stripe/stripe-go/v72/issuing/transaction"
+	issuingtransaction "github.com/stripe/stripe-go/v72/issuing/transaction"
+	"github.com/stripe/stripe-go/v72/lineitem"
 	"github.com/stripe/stripe-go/v72/loginlink"
 	"github.com/stripe/stripe-go/v72/mandate"
 	"github.com/stripe/stripe-go/v72/oauth"
@@ -52,17 +59,17 @@ import (
 	"github.com/stripe/stripe-go/v72/product"
 	"github.com/stripe/stripe-go/v72/promotioncode"
 	"github.com/stripe/stripe-go/v72/quote"
-	"github.com/stripe/stripe-go/v72/radar/earlyfraudwarning"
-	"github.com/stripe/stripe-go/v72/radar/valuelist"
-	"github.com/stripe/stripe-go/v72/radar/valuelistitem"
+	radarearlyfraudwarning "github.com/stripe/stripe-go/v72/radar/earlyfraudwarning"
+	radarvaluelist "github.com/stripe/stripe-go/v72/radar/valuelist"
+	radarvaluelistitem "github.com/stripe/stripe-go/v72/radar/valuelistitem"
 	"github.com/stripe/stripe-go/v72/refund"
-	"github.com/stripe/stripe-go/v72/reporting/reportrun"
-	"github.com/stripe/stripe-go/v72/reporting/reporttype"
+	reportingreportrun "github.com/stripe/stripe-go/v72/reporting/reportrun"
+	reportingreporttype "github.com/stripe/stripe-go/v72/reporting/reporttype"
 	"github.com/stripe/stripe-go/v72/reversal"
 	"github.com/stripe/stripe-go/v72/review"
 	"github.com/stripe/stripe-go/v72/setupattempt"
 	"github.com/stripe/stripe-go/v72/setupintent"
-	"github.com/stripe/stripe-go/v72/sigma/scheduledqueryrun"
+	sigmascheduledqueryrun "github.com/stripe/stripe-go/v72/sigma/scheduledqueryrun"
 	"github.com/stripe/stripe-go/v72/sku"
 	"github.com/stripe/stripe-go/v72/source"
 	"github.com/stripe/stripe-go/v72/sourcetransaction"
@@ -87,7 +94,7 @@ import (
 type API struct {
 	// Account is the client used to invoke /accounts APIs.
 	Account *account.Client
-	// AccountLink is the client used to invoke /account_links APIs.
+	// AccountLinks is the client used to invoke /account_links APIs.
 	AccountLinks *accountlink.Client
 	// ApplePayDomains is the client used to invoke /apple_pay/domains APIs.
 	ApplePayDomains *applepaydomain.Client
@@ -95,13 +102,13 @@ type API struct {
 	Balance *balance.Client
 	// BalanceTransaction is the client used to invoke /balance_transactions APIs.
 	BalanceTransaction *balancetransaction.Client
-	// BankAccounts is the client used to invoke bank account related APIs.
+	// BankAccounts is the client used to invoke bankaccount related APIs.
 	BankAccounts *bankaccount.Client
-	// BillingPortalSessions is the client used to invoke /billing_portal/sessions APIs.
-	BillingPortalSessions *billingportalsession.Client
 	// BillingPortalConfigurations is the client used to invoke /billing_portal/configurations APIs.
 	BillingPortalConfigurations *billingportalconfiguration.Client
-	// Capabilities is the client used to invoke capability related APIs.
+	// BillingPortalSessions is the client used to invoke /billing_portal/sessions APIs.
+	BillingPortalSessions *billingportalsession.Client
+	// Capabilities is the client used to invoke /accounts/{account}/capabilities APIs.
 	Capabilities *capability.Client
 	// Cards is the client used to invoke card related APIs.
 	Cards *card.Client
@@ -115,10 +122,10 @@ type API struct {
 	Coupons *coupon.Client
 	// CreditNotes is the client used to invoke /credit_notes APIs.
 	CreditNotes *creditnote.Client
+	// CustomerBalanceTransactions is the client used to invoke /customers/{customer}/balance_transactions APIs.
+	CustomerBalanceTransactions *customerbalancetransaction.Client
 	// Customers is the client used to invoke /customers APIs.
 	Customers *customer.Client
-	// CustomerBalanceTransactions is the client used to invoke /customers/balance_transactions APIs.
-	CustomerBalanceTransactions *customerbalancetransaction.Client
 	// Discounts is the client used to invoke discount related APIs.
 	Discounts *discount.Client
 	// Disputes is the client used to invoke /disputes APIs.
@@ -127,51 +134,51 @@ type API struct {
 	EphemeralKeys *ephemeralkey.Client
 	// Events is the client used to invoke /events APIs.
 	Events *event.Client
+	// FeeRefunds is the client used to invoke /application_fees/{id}/refunds APIs.
+	FeeRefunds *feerefund.Client
 	// Fees is the client used to invoke /application_fees APIs.
 	Fees *fee.Client
-	// FeeRefunds is the client used to invoke /application_fees/refunds APIs.
-	FeeRefunds *feerefund.Client
-	// Files is the client used to invoke the /files APIs.
-	Files *file.Client
-	// FileLinks is the client used to invoke the /file_links APIs.
+	// FileLinks is the client used to invoke /file_links APIs.
 	FileLinks *filelink.Client
-	// IdentityVerificationReports is the client used to invoke the /identity/verification_reports APIs.
-	IdentityVerificationReports *verificationreport.Client
-	// IdentityVerificationSessions is the client used to invoke the /identity/verification_sessions APIs.
-	IdentityVerificationSessions *verificationsession.Client
-	// Invoices is the client used to invoke /invoices APIs.
-	Invoices *invoice.Client
+	// Files is the client used to invoke /files APIs.
+	Files *file.Client
+	// IdentityVerificationReports is the client used to invoke /identity/verification_reports APIs.
+	IdentityVerificationReports *identityverificationreport.Client
+	// IdentityVerificationSessions is the client used to invoke /identity/verification_sessions APIs.
+	IdentityVerificationSessions *identityverificationsession.Client
 	// InvoiceItems is the client used to invoke /invoiceitems APIs.
 	InvoiceItems *invoiceitem.Client
+	// Invoices is the client used to invoke /invoices APIs.
+	Invoices *invoice.Client
 	// IssuingAuthorizations is the client used to invoke /issuing/authorizations APIs.
-	IssuingAuthorizations *authorization.Client
+	IssuingAuthorizations *issuingauthorization.Client
 	// IssuingCardholders is the client used to invoke /issuing/cardholders APIs.
-	IssuingCardholders *cardholder.Client
+	IssuingCardholders *issuingcardholder.Client
 	// IssuingCards is the client used to invoke /issuing/cards APIs.
 	IssuingCards *issuingcard.Client
 	// IssuingDisputes is the client used to invoke /issuing/disputes APIs.
 	IssuingDisputes *issuingdispute.Client
 	// IssuingTransactions is the client used to invoke /issuing/transactions APIs.
-	IssuingTransactions *transaction.Client
-	// LoginLinks is the client used to invoke login link related APIs.
+	IssuingTransactions *issuingtransaction.Client
+	// LoginLinks is the client used to invoke /accounts/{account}/login_links APIs.
 	LoginLinks *loginlink.Client
-	// Mandates is the client used to invoke mandates related APIs.
+	// Mandates is the client used to invoke /mandates APIs.
 	Mandates *mandate.Client
-	// OAuth is the client used to invoke /oauth APIs.
+	// OAuth is the client used to invoke /oauth APIs
 	OAuth *oauth.Client
-	// Orders is the client used to invoke /orders APIs.
-	Orders *order.Client
 	// OrderReturns is the client used to invoke /order_returns APIs.
 	OrderReturns *orderreturn.Client
+	// Orders is the client used to invoke /orders APIs.
+	Orders *order.Client
 	// PaymentIntents is the client used to invoke /payment_intents APIs.
 	PaymentIntents *paymentintent.Client
 	// PaymentMethods is the client used to invoke /payment_methods APIs.
 	PaymentMethods *paymentmethod.Client
-	// PaymentSource is used to invoke customer sources related APIs.
+	// PaymentSource is the client used to invoke /customers/{customer}/sources APIs.
 	PaymentSource *paymentsource.Client
 	// Payouts is the client used to invoke /payouts APIs.
 	Payouts *payout.Client
-	// Persons is the client used to invoke /account/persons APIs.
+	// Persons is the client used to invoke /accounts/{account}/persons APIs.
 	Persons *person.Client
 	// Plans is the client used to invoke /plans APIs.
 	Plans *plan.Client
@@ -181,21 +188,21 @@ type API struct {
 	Products *product.Client
 	// PromotionCodes is the client used to invoke /promotion_codes APIs.
 	PromotionCodes *promotioncode.Client
-	// Quote is the client used to invoke /quotes APIs.
+	// Quotes is the client used to invoke /quotes APIs.
 	Quotes *quote.Client
 	// RadarEarlyFraudWarnings is the client used to invoke /radar/early_fraud_warnings APIs.
-	RadarEarlyFraudWarnings *earlyfraudwarning.Client
-	// RadarValueLists is the client used to invoke /radar/value_lists APIs.
-	RadarValueLists *valuelist.Client
+	RadarEarlyFraudWarnings *radarearlyfraudwarning.Client
 	// RadarValueListItems is the client used to invoke /radar/value_list_items APIs.
-	RadarValueListItems *valuelistitem.Client
+	RadarValueListItems *radarvaluelistitem.Client
+	// RadarValueLists is the client used to invoke /radar/value_lists APIs.
+	RadarValueLists *radarvaluelist.Client
 	// Refunds is the client used to invoke /refunds APIs.
 	Refunds *refund.Client
 	// ReportRuns is the client used to invoke /reporting/report_runs APIs.
-	ReportRuns *reportrun.Client
+	ReportRuns *reportingreportrun.Client
 	// ReportTypes is the client used to invoke /reporting/report_types APIs.
-	ReportTypes *reporttype.Client
-	// Reversals is the client used to invoke /transfers/reversals APIs.
+	ReportTypes *reportingreporttype.Client
+	// Reversals is the client used to invoke /transfers/{id}/reversals APIs.
 	Reversals *reversal.Client
 	// Reviews is the client used to invoke /reviews APIs.
 	Reviews *review.Client
@@ -204,48 +211,47 @@ type API struct {
 	// SetupIntents is the client used to invoke /setup_intents APIs.
 	SetupIntents *setupintent.Client
 	// SigmaScheduledQueryRuns is the client used to invoke /sigma/scheduled_query_runs APIs.
-	SigmaScheduledQueryRuns *scheduledqueryrun.Client
+	SigmaScheduledQueryRuns *sigmascheduledqueryrun.Client
 	// Skus is the client used to invoke /skus APIs.
 	Skus *sku.Client
 	// Sources is the client used to invoke /sources APIs.
 	Sources *source.Client
-	// SourceTransactions is the client used to invoke source transaction related APIs.
+	// SourceTransactions is the client used to invoke source transactions related APIs
 	SourceTransactions *sourcetransaction.Client
+	// SubscriptionItems is the client used to invoke /subscription_items APIs.
+	SubscriptionItems *subitem.Client
 	// Subscriptions is the client used to invoke /subscriptions APIs.
 	Subscriptions *sub.Client
-	// SubscriptionItems is the client used to invoke subscription's items related APIs.
-	SubscriptionItems *subitem.Client
-	// SubscriptionSchedules is the client used to invoke subscription schedules related APIs.
+	// SubscriptionSchedules is the client used to invoke /subscription_schedules APIs.
 	SubscriptionSchedules *subschedule.Client
-	// TaxIDs is the client used to invoke /tax_ids APIs.
-	TaxIDs *taxid.Client
 	// TaxCodes is the client used to invoke /tax_codes APIs.
 	TaxCodes *taxcode.Client
+	// TaxIDs is the client used to invoke /customers/{customer}/tax_ids APIs.
+	TaxIDs *taxid.Client
 	// TaxRates is the client used to invoke /tax_rates APIs.
 	TaxRates *taxrate.Client
-	// TerminalConnectionTokens is the client used to invoke /terminal/connectiontokens related APIs.
+	// TerminalConnectionTokens is the client used to invoke /terminal/connection_tokens APIs.
 	TerminalConnectionTokens *terminalconnectiontoken.Client
-	// TerminalLocations is the client used to invoke /terminal/locations related APIs.
+	// TerminalLocations is the client used to invoke /terminal/locations APIs.
 	TerminalLocations *terminallocation.Client
-	// TerminalReaders is the client used to invoke /terminal/readers related APIs.
+	// TerminalReaders is the client used to invoke /terminal/readers APIs.
 	TerminalReaders *terminalreader.Client
 	// Tokens is the client used to invoke /tokens APIs.
 	Tokens *token.Client
-	// Topups is the client used to invoke /tokens APIs.
+	// Topups is the client used to invoke /topups APIs.
 	Topups *topup.Client
 	// Transfers is the client used to invoke /transfers APIs.
 	Transfers *transfer.Client
-	// UsageRecords is the client used to invoke usage record related APIs.
+	// UsageRecords is the client used to invoke /subscription_items/{subscription_item}/usage_records APIs.
 	UsageRecords *usagerecord.Client
-	// UsageRecordsummaries is the client used to invoke usage record summary related APIs.
+	// UsageRecordSummaries is the client used to invoke /subscription_items/{subscription_item}/usage_record_summaries APIs.
 	UsageRecordSummaries *usagerecordsummary.Client
-	// WebhookEndpoints is the client used to invoke usage record related APIs.
+	// WebhookEndpoints is the client used to invoke /webhook_endpoints APIs.
 	WebhookEndpoints *webhookendpoint.Client
 }
 
-// Init initializes the Stripe client with the appropriate secret key
-// as well as providing the ability to override the backend as needed.
 func (a *API) Init(key string, backends *stripe.Backends) {
+
 	if backends == nil {
 		backends = &stripe.Backends{
 			API:     stripe.GetBackend(stripe.APIBackend),
@@ -255,13 +261,13 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	}
 
 	a.Account = &account.Client{B: backends.API, Key: key}
-	a.ApplePayDomains = &applepaydomain.Client{B: backends.API, Key: key}
 	a.AccountLinks = &accountlink.Client{B: backends.API, Key: key}
+	a.ApplePayDomains = &applepaydomain.Client{B: backends.API, Key: key}
 	a.Balance = &balance.Client{B: backends.API, Key: key}
 	a.BalanceTransaction = &balancetransaction.Client{B: backends.API, Key: key}
 	a.BankAccounts = &bankaccount.Client{B: backends.API, Key: key}
-	a.BillingPortalSessions = &billingportalsession.Client{B: backends.API, Key: key}
 	a.BillingPortalConfigurations = &billingportalconfiguration.Client{B: backends.API, Key: key}
+	a.BillingPortalSessions = &billingportalsession.Client{B: backends.API, Key: key}
 	a.Capabilities = &capability.Client{B: backends.API, Key: key}
 	a.Cards = &card.Client{B: backends.API, Key: key}
 	a.Charges = &charge.Client{B: backends.API, Key: key}
@@ -269,28 +275,28 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.CountrySpec = &countryspec.Client{B: backends.API, Key: key}
 	a.Coupons = &coupon.Client{B: backends.API, Key: key}
 	a.CreditNotes = &creditnote.Client{B: backends.API, Key: key}
-	a.Customers = &customer.Client{B: backends.API, Key: key}
 	a.CustomerBalanceTransactions = &customerbalancetransaction.Client{B: backends.API, Key: key}
+	a.Customers = &customer.Client{B: backends.API, Key: key}
 	a.Discounts = &discount.Client{B: backends.API, Key: key}
 	a.Disputes = &dispute.Client{B: backends.API, Key: key}
 	a.EphemeralKeys = &ephemeralkey.Client{B: backends.API, Key: key}
 	a.Events = &event.Client{B: backends.API, Key: key}
-	a.Fees = &fee.Client{B: backends.API, Key: key}
 	a.FeeRefunds = &feerefund.Client{B: backends.API, Key: key}
-	a.Files = &file.Client{B: backends.Uploads, Key: key}
+	a.Fees = &fee.Client{B: backends.API, Key: key}
 	a.FileLinks = &filelink.Client{B: backends.API, Key: key}
-	a.IdentityVerificationReports = &verificationreport.Client{B: backends.API, Key: key}
-	a.IdentityVerificationSessions = &verificationsession.Client{B: backends.API, Key: key}
-	a.Invoices = &invoice.Client{B: backends.API, Key: key}
+	a.Files = &file.Client{B: backends.Uploads, Key: key}
+	a.IdentityVerificationReports = &identityverificationreport.Client{B: backends.API, Key: key}
+	a.IdentityVerificationSessions = &identityverificationsession.Client{B: backends.API, Key: key}
 	a.InvoiceItems = &invoiceitem.Client{B: backends.API, Key: key}
-	a.IssuingAuthorizations = &authorization.Client{B: backends.API, Key: key}
-	a.IssuingCardholders = &cardholder.Client{B: backends.API, Key: key}
+	a.Invoices = &invoice.Client{B: backends.API, Key: key}
+	a.IssuingAuthorizations = &issuingauthorization.Client{B: backends.API, Key: key}
+	a.IssuingCardholders = &issuingcardholder.Client{B: backends.API, Key: key}
 	a.IssuingCards = &issuingcard.Client{B: backends.API, Key: key}
 	a.IssuingDisputes = &issuingdispute.Client{B: backends.API, Key: key}
-	a.IssuingTransactions = &transaction.Client{B: backends.API, Key: key}
+	a.IssuingTransactions = &issuingtransaction.Client{B: backends.API, Key: key}
 	a.LoginLinks = &loginlink.Client{B: backends.API, Key: key}
 	a.Mandates = &mandate.Client{B: backends.API, Key: key}
-	a.OAuth = &oauth.Client{B: backends.Connect, Key: key}
+	a.OAuth = &oauth.Client{B: backends.API, Key: key}
 	a.OrderReturns = &orderreturn.Client{B: backends.API, Key: key}
 	a.Orders = &order.Client{B: backends.API, Key: key}
 	a.PaymentIntents = &paymentintent.Client{B: backends.API, Key: key}
@@ -303,25 +309,25 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.Products = &product.Client{B: backends.API, Key: key}
 	a.PromotionCodes = &promotioncode.Client{B: backends.API, Key: key}
 	a.Quotes = &quote.Client{B: backends.API, PDFBackend: backends.Uploads, Key: key}
-	a.RadarEarlyFraudWarnings = &earlyfraudwarning.Client{B: backends.API, Key: key}
-	a.RadarValueLists = &valuelist.Client{B: backends.API, Key: key}
-	a.RadarValueListItems = &valuelistitem.Client{B: backends.API, Key: key}
+	a.RadarEarlyFraudWarnings = &radarearlyfraudwarning.Client{B: backends.API, Key: key}
+	a.RadarValueListItems = &radarvaluelistitem.Client{B: backends.API, Key: key}
+	a.RadarValueLists = &radarvaluelist.Client{B: backends.API, Key: key}
 	a.Refunds = &refund.Client{B: backends.API, Key: key}
-	a.ReportRuns = &reportrun.Client{B: backends.API, Key: key}
-	a.ReportTypes = &reporttype.Client{B: backends.API, Key: key}
+	a.ReportRuns = &reportingreportrun.Client{B: backends.API, Key: key}
+	a.ReportTypes = &reportingreporttype.Client{B: backends.API, Key: key}
 	a.Reversals = &reversal.Client{B: backends.API, Key: key}
 	a.Reviews = &review.Client{B: backends.API, Key: key}
 	a.SetupAttempts = &setupattempt.Client{B: backends.API, Key: key}
 	a.SetupIntents = &setupintent.Client{B: backends.API, Key: key}
-	a.SigmaScheduledQueryRuns = &scheduledqueryrun.Client{B: backends.API, Key: key}
+	a.SigmaScheduledQueryRuns = &sigmascheduledqueryrun.Client{B: backends.API, Key: key}
 	a.Skus = &sku.Client{B: backends.API, Key: key}
 	a.Sources = &source.Client{B: backends.API, Key: key}
 	a.SourceTransactions = &sourcetransaction.Client{B: backends.API, Key: key}
-	a.Subscriptions = &sub.Client{B: backends.API, Key: key}
 	a.SubscriptionItems = &subitem.Client{B: backends.API, Key: key}
+	a.Subscriptions = &sub.Client{B: backends.API, Key: key}
 	a.SubscriptionSchedules = &subschedule.Client{B: backends.API, Key: key}
-	a.TaxIDs = &taxid.Client{B: backends.API, Key: key}
 	a.TaxCodes = &taxcode.Client{B: backends.API, Key: key}
+	a.TaxIDs = &taxid.Client{B: backends.API, Key: key}
 	a.TaxRates = &taxrate.Client{B: backends.API, Key: key}
 	a.TerminalConnectionTokens = &terminalconnectiontoken.Client{B: backends.API, Key: key}
 	a.TerminalLocations = &terminallocation.Client{B: backends.API, Key: key}


### PR DESCRIPTION
r? @stripe/api-library-reviewers 
Changes `client/api.go` to be compatible with codegen.

Alphebetization is now consistent, and "namespaced" resources are now consistently given qualified imports.