### PR TITLE
API Updates

### DIFF
--- a/address.go
+++ b/address.go
@@ -28,3 +28,12 @@ type ShippingDetailsParams struct {
 	Phone          *string        `form:"phone"`
 	TrackingNumber *string        `form:"tracking_number"`
 }
+
+// ShippingDetails is the structure containing shipping information.
+type ShippingDetails struct {
+	Address        *Address `json:"address"`
+	Carrier        string   `json:"carrier"`
+	Name           string   `json:"name"`
+	Phone          string   `json:"phone"`
+	TrackingNumber string   `json:"tracking_number"`
+}

--- a/charge.go
+++ b/charge.go
@@ -369,8 +369,8 @@ type ChargePaymentMethodDetailsCard struct {
 	Funding      CardFunding                                 `json:"funding"`
 	Installments *ChargePaymentMethodDetailsCardInstallments `json:"installments"`
 	Last4        string                                      `json:"last4"`
-	Network      PaymentMethodCardNetwork                    `json:"network"`
 	MOTO         bool                                        `json:"moto"`
+	Network      PaymentMethodCardNetwork                    `json:"network"`
 	ThreeDSecure *ChargePaymentMethodDetailsCardThreeDSecure `json:"three_d_secure"`
 	Wallet       *ChargePaymentMethodDetailsCardWallet       `json:"wallet"`
 
@@ -512,6 +512,11 @@ type ChargePaymentMethodDetailsP24 struct {
 	Reference    string `json:"reference"`
 	VerifiedName string `json:"verified_name"`
 }
+type ChargePaymentMethodDetailsSepaCreditTransfer struct {
+	BankName string `json:"bank_name"`
+	Bic      string `json:"bic"`
+	Iban     string `json:"iban"`
+}
 
 // ChargePaymentMethodDetailsSepaDebit represents details about the Sepa Debit PaymentMethod.
 type ChargePaymentMethodDetailsSepaDebit struct {
@@ -551,32 +556,34 @@ type ChargePaymentMethodDetailsWechatPay struct {
 // ChargePaymentMethodDetails represents the details about the PaymentMethod associated with the
 // charge.
 type ChargePaymentMethodDetails struct {
-	AchCreditTransfer *ChargePaymentMethodDetailsAchCreditTransfer `json:"ach_credit_transfer"`
-	AchDebit          *ChargePaymentMethodDetailsAchDebit          `json:"ach_debit"`
-	AcssDebit         *ChargePaymentMethodDetailsAcssDebit         `json:"acss_debit"`
-	AfterpayClearpay  *ChargePaymentMethodDetailsAfterpayClearpay  `json:"afterpay_clearpay"`
-	Alipay            *ChargePaymentMethodDetailsAlipay            `json:"alipay"`
-	AUBECSDebit       *ChargePaymentMethodDetailsAUBECSDebit       `json:"au_becs_debit"`
-	BACSDebit         *ChargePaymentMethodDetailsBACSDebit         `json:"bacs_debit"`
-	Bancontact        *ChargePaymentMethodDetailsBancontact        `json:"bancontact"`
-	Boleto            *ChargePaymentMethodDetailsBoleto            `json:"boleto"`
-	Card              *ChargePaymentMethodDetailsCard              `json:"card"`
-	CardPresent       *ChargePaymentMethodDetailsCardPresent       `json:"card_present"`
-	Eps               *ChargePaymentMethodDetailsEps               `json:"eps"`
-	FPX               *ChargePaymentMethodDetailsFPX               `json:"fpx"`
-	Giropay           *ChargePaymentMethodDetailsGiropay           `json:"giropay"`
-	Grabpay           *ChargePaymentMethodDetailsGrabpay           `json:"grabpay"`
-	Ideal             *ChargePaymentMethodDetailsIdeal             `json:"ideal"`
-	Klarna            *ChargePaymentMethodDetailsKlarna            `json:"klarna"`
-	Multibanco        *ChargePaymentMethodDetailsMultibanco        `json:"multibanco"`
-	OXXO              *ChargePaymentMethodDetailsOXXO              `json:"oxxo"`
-	P24               *ChargePaymentMethodDetailsP24               `json:"p24"`
-	SepaDebit         *ChargePaymentMethodDetailsSepaDebit         `json:"sepa_debit"`
-	Sofort            *ChargePaymentMethodDetailsSofort            `json:"sofort"`
-	StripeAccount     *ChargePaymentMethodDetailsStripeAccount     `json:"stripe_account"`
-	Type              ChargePaymentMethodDetailsType               `json:"type"`
-	Wechat            *ChargePaymentMethodDetailsWechat            `json:"wechat"`
-	WechatPay         *ChargePaymentMethodDetailsWechatPay         `json:"wechat_pay"`
+	AchCreditTransfer  *ChargePaymentMethodDetailsAchCreditTransfer  `json:"ach_credit_transfer"`
+	AchDebit           *ChargePaymentMethodDetailsAchDebit           `json:"ach_debit"`
+	AcssDebit          *ChargePaymentMethodDetailsAcssDebit          `json:"acss_debit"`
+	AfterpayClearpay   *ChargePaymentMethodDetailsAfterpayClearpay   `json:"afterpay_clearpay"`
+	Alipay             *ChargePaymentMethodDetailsAlipay             `json:"alipay"`
+	AUBECSDebit        *ChargePaymentMethodDetailsAUBECSDebit        `json:"au_becs_debit"`
+	BACSDebit          *ChargePaymentMethodDetailsBACSDebit          `json:"bacs_debit"`
+	Bancontact         *ChargePaymentMethodDetailsBancontact         `json:"bancontact"`
+	Boleto             *ChargePaymentMethodDetailsBoleto             `json:"boleto"`
+	Card               *ChargePaymentMethodDetailsCard               `json:"card"`
+	CardPresent        *ChargePaymentMethodDetailsCardPresent        `json:"card_present"`
+	Eps                *ChargePaymentMethodDetailsEps                `json:"eps"`
+	FPX                *ChargePaymentMethodDetailsFPX                `json:"fpx"`
+	Giropay            *ChargePaymentMethodDetailsGiropay            `json:"giropay"`
+	Grabpay            *ChargePaymentMethodDetailsGrabpay            `json:"grabpay"`
+	Ideal              *ChargePaymentMethodDetailsIdeal              `json:"ideal"`
+	InteracPresent     *ChargePaymentMethodDetailsInteracPresent     `json:"interac_present"`
+	Klarna             *ChargePaymentMethodDetailsKlarna             `json:"klarna"`
+	Multibanco         *ChargePaymentMethodDetailsMultibanco         `json:"multibanco"`
+	OXXO               *ChargePaymentMethodDetailsOXXO               `json:"oxxo"`
+	P24                *ChargePaymentMethodDetailsP24                `json:"p24"`
+	SepaCreditTransfer *ChargePaymentMethodDetailsSepaCreditTransfer `json:"sepa_credit_transfer"`
+	SepaDebit          *ChargePaymentMethodDetailsSepaDebit          `json:"sepa_debit"`
+	Sofort             *ChargePaymentMethodDetailsSofort             `json:"sofort"`
+	StripeAccount      *ChargePaymentMethodDetailsStripeAccount      `json:"stripe_account"`
+	Type               ChargePaymentMethodDetailsType                `json:"type"`
+	Wechat             *ChargePaymentMethodDetailsWechat             `json:"wechat"`
+	WechatPay          *ChargePaymentMethodDetailsWechatPay          `json:"wechat_pay"`
 }
 
 // ChargeTransferData represents the information for the transfer_data associated with a charge.
@@ -615,7 +622,9 @@ type Charge struct {
 	Level3                        ChargeLevel3                `json:"level3"`
 	Livemode                      bool                        `json:"livemode"`
 	Metadata                      map[string]string           `json:"metadata"`
+	Object                        string                      `json:"object"`
 	OnBehalfOf                    *Account                    `json:"on_behalf_of"`
+	Order                         *Order                      `json:"order"`
 	Outcome                       *ChargeOutcome              `json:"outcome"`
 	Paid                          bool                        `json:"paid"`
 	PaymentIntent                 *PaymentIntent              `json:"payment_intent"`
@@ -638,36 +647,10 @@ type Charge struct {
 	TransferGroup                 string                      `json:"transfer_group"`
 }
 
-// UnmarshalJSON handles deserialization of a charge.
-// This custom unmarshaling is needed because the resulting
-// property may be an ID or the full struct if it was expanded.
-func (c *Charge) UnmarshalJSON(data []byte) error {
-	if id, ok := ParseID(data); ok {
-		c.ID = id
-		return nil
-	}
-
-	type charge Charge
-	var v charge
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-
-	*c = Charge(v)
-	return nil
-}
-
-// ChargeList is a list of charges as retrieved from a list endpoint.
-type ChargeList struct {
-	APIResource
-	ListMeta
-	Data []*Charge `json:"data"`
-}
-
 // FraudDetails is the structure detailing fraud status.
 type FraudDetails struct {
-	UserReport   ChargeFraudUserReport   `json:"user_report"`
 	StripeReport ChargeFraudStripeReport `json:"stripe_report"`
+	UserReport   ChargeFraudUserReport   `json:"user_report"`
 }
 
 // ChargeOutcomeRule tells you the Radar rule that blocked the charge, if any.
@@ -689,15 +672,6 @@ type ChargeOutcome struct {
 	Type          string             `json:"type"`
 }
 
-// ShippingDetails is the structure containing shipping information.
-type ShippingDetails struct {
-	Address        *Address `json:"address"`
-	Carrier        string   `json:"carrier"`
-	Name           string   `json:"name"`
-	Phone          string   `json:"phone"`
-	TrackingNumber string   `json:"tracking_number"`
-}
-
 // UnmarshalJSON handles deserialization of a ChargeOutcomeRule.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
@@ -714,5 +688,31 @@ func (c *ChargeOutcomeRule) UnmarshalJSON(data []byte) error {
 	}
 
 	*c = ChargeOutcomeRule(v)
+	return nil
+}
+
+// ChargeList is a list of charges as retrieved from a list endpoint.
+type ChargeList struct {
+	APIResource
+	ListMeta
+	Data []*Charge `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a Charge.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (c *Charge) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		c.ID = id
+		return nil
+	}
+
+	type charge Charge
+	var v charge
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*c = Charge(v)
 	return nil
 }

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -16,7 +16,7 @@ type CheckoutSessionCustomerDetailsTaxIDsType string
 const (
 	CheckoutSessionCustomerDetailsTaxIDsTypeAETRN    CheckoutSessionCustomerDetailsTaxIDsType = "ae_trn"
 	CheckoutSessionCustomerDetailsTaxIDsTypeAUABN    CheckoutSessionCustomerDetailsTaxIDsType = "au_abn"
-	CheckoutSessionCustomerDetailsTaxIDsTypeAuArn    CheckoutSessionCustomerDetailsTaxIDsType = "au_arn"
+	CheckoutSessionCustomerDetailsTaxIDsTypeAUARN    CheckoutSessionCustomerDetailsTaxIDsType = "au_arn"
 	CheckoutSessionCustomerDetailsTaxIDsTypeBRCNPJ   CheckoutSessionCustomerDetailsTaxIDsType = "br_cnpj"
 	CheckoutSessionCustomerDetailsTaxIDsTypeBRCPF    CheckoutSessionCustomerDetailsTaxIDsType = "br_cpf"
 	CheckoutSessionCustomerDetailsTaxIDsTypeCABN     CheckoutSessionCustomerDetailsTaxIDsType = "ca_bn"

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -16,6 +16,7 @@ type CheckoutSessionCustomerDetailsTaxIDsType string
 const (
 	CheckoutSessionCustomerDetailsTaxIDsTypeAETRN    CheckoutSessionCustomerDetailsTaxIDsType = "ae_trn"
 	CheckoutSessionCustomerDetailsTaxIDsTypeAUABN    CheckoutSessionCustomerDetailsTaxIDsType = "au_abn"
+	CheckoutSessionCustomerDetailsTaxIDsTypeAuArn    CheckoutSessionCustomerDetailsTaxIDsType = "au_arn"
 	CheckoutSessionCustomerDetailsTaxIDsTypeBRCNPJ   CheckoutSessionCustomerDetailsTaxIDsType = "br_cnpj"
 	CheckoutSessionCustomerDetailsTaxIDsTypeBRCPF    CheckoutSessionCustomerDetailsTaxIDsType = "br_cpf"
 	CheckoutSessionCustomerDetailsTaxIDsTypeCABN     CheckoutSessionCustomerDetailsTaxIDsType = "ca_bn"
@@ -183,6 +184,8 @@ type CheckoutSessionLineItemPriceDataParams struct {
 	UnitAmount        *int64                                             `form:"unit_amount"`
 	UnitAmountDecimal *float64                                           `form:"unit_amount_decimal,high_precision"`
 }
+
+// Settings for automatic tax lookup for this session and resulting payments, invoices, and subscriptions.
 type CheckoutSessionAutomaticTaxParams struct {
 	Enabled *bool `form:"enabled"`
 }

--- a/client/api.go
+++ b/client/api.go
@@ -43,7 +43,6 @@ import (
 	issuingcardholder "github.com/stripe/stripe-go/v72/issuing/cardholder"
 	issuingdispute "github.com/stripe/stripe-go/v72/issuing/dispute"
 	issuingtransaction "github.com/stripe/stripe-go/v72/issuing/transaction"
-	"github.com/stripe/stripe-go/v72/lineitem"
 	"github.com/stripe/stripe-go/v72/loginlink"
 	"github.com/stripe/stripe-go/v72/mandate"
 	"github.com/stripe/stripe-go/v72/oauth"

--- a/quote.go
+++ b/quote.go
@@ -169,7 +169,7 @@ type QuoteListLineItemsParams struct {
 	Quote      *string `form:"-"` // Included in URL
 }
 
-// When retrieving a quote, there is an includable upfront.line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
+// When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
 type QuoteListComputedUpfrontLineItemsParams struct {
 	ListParams `form:"*"`
 	Quote      *string `form:"-"` // Included in URL

--- a/radar/earlyfraudwarning/client.go
+++ b/radar/earlyfraudwarning/client.go
@@ -1,7 +1,10 @@
-// Package earlyfraudwarning provides API functions related to early fraud
-// warnings.
 //
-// For more details, see: https://stripe.com/docs/api/early_fraud_warnings?lang=go
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package earlyfraudwarning provides the /radar/early_fraud_warnings APIs
 package earlyfraudwarning
 
 import (
@@ -11,58 +14,60 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to interact with the /radar/early_fraud_warnings API.
+// Client is used to invoke /radar/early_fraud_warnings APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// Get returns the details of an early fraud warning.
+// Get returns the details of a radar early fraud warning.
 func Get(id string, params *stripe.RadarEarlyFraudWarningParams) (*stripe.RadarEarlyFraudWarning, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of an early fraud warning.
+// Get returns the details of a radar early fraud warning.
 func (c Client) Get(id string, params *stripe.RadarEarlyFraudWarningParams) (*stripe.RadarEarlyFraudWarning, error) {
 	path := stripe.FormatURLPath("/v1/radar/early_fraud_warnings/%s", id)
-	ifr := &stripe.RadarEarlyFraudWarning{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, ifr)
-	return ifr, err
+	earlyfraudwarning := &stripe.RadarEarlyFraudWarning{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, earlyfraudwarning)
+	return earlyfraudwarning, err
 }
 
-// List returns a list of early fraud warnings.
+// List returns a list of radar early fraud warnings.
 func List(params *stripe.RadarEarlyFraudWarningListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of early fraud warnings.
+// List returns a list of radar early fraud warnings.
 func (c Client) List(listParams *stripe.RadarEarlyFraudWarningListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.RadarEarlyFraudWarningList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/radar/early_fraud_warnings", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.RadarEarlyFraudWarningList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/radar/early_fraud_warnings", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Values))
-		for i, v := range list.Values {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Values))
+			for i, v := range list.Values {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
-// Iter is an iterator for early fraud warnings.
+// Iter is an iterator for radar early fraud warnings.
 type Iter struct {
 	*stripe.Iter
 }
 
-// RadarEarlyFraudWarning returns the early fraud warning which the iterator is currently pointing to.
+// RadarEarlyFraudWarning returns the radar early fraud warning which the iterator is currently pointing to.
 func (i *Iter) RadarEarlyFraudWarning() *stripe.RadarEarlyFraudWarning {
 	return i.Current().(*stripe.RadarEarlyFraudWarning)
 }
 
-// RadarEarlyFraudWarningList returns the current list object which the
-// iterator is currently using. List objects will change as new API calls are
-// made to continue pagination.
+// RadarEarlyFraudWarningList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) RadarEarlyFraudWarningList() *stripe.RadarEarlyFraudWarningList {
 	return i.List().(*stripe.RadarEarlyFraudWarningList)
 }

--- a/review.go
+++ b/review.go
@@ -1,11 +1,17 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
 
-// ReviewClosedReason describes the reason why the review is closed.
+// The reason the review was closed, or null if it has not yet been closed. One of `approved`, `refunded`, `refunded_as_fraud`, `disputed`, or `redacted`.
 type ReviewClosedReason string
 
-// List of values that ReviewClosedReason can take.
+// List of values that ReviewClosedReason can take
 const (
 	ReviewClosedReasonApproved        ReviewClosedReason = "approved"
 	ReviewClosedReasonDisputed        ReviewClosedReason = "disputed"
@@ -14,46 +20,49 @@ const (
 	ReviewClosedReasonRefundedAsFraud ReviewClosedReason = "refunded_as_fraud"
 )
 
-// ReviewOpenedReason describes the reason why the review is opened.
+// The reason the review was opened. One of `rule` or `manual`.
 type ReviewOpenedReason string
 
-// List of values that ReviewOpenedReason can take.
+// List of values that ReviewOpenedReason can take
 const (
 	ReviewOpenedReasonManual ReviewOpenedReason = "manual"
 	ReviewOpenedReasonRule   ReviewOpenedReason = "rule"
 )
 
-// ReviewReasonType describes the reason why the review is open or closed.
-type ReviewReasonType string
+// The reason the review is currently open or closed. One of `rule`, `manual`, `approved`, `refunded`, `refunded_as_fraud`, `disputed`, or `redacted`.
+type ReviewReason string
 
-// List of values that ReviewReasonType can take.
+// Deprecated: we preserve this name for backwards-compatibility, prefer `ReviewReason`.
+type ReviewReasonType = ReviewReason
+
+// List of values that ReviewReason can take
 const (
-	ReviewReasonApproved        ReviewReasonType = "approved"
-	ReviewReasonDisputed        ReviewReasonType = "disputed"
-	ReviewReasonManual          ReviewReasonType = "manual"
-	ReviewReasonRefunded        ReviewReasonType = "refunded"
-	ReviewReasonRefundedAsFraud ReviewReasonType = "refunded_as_fraud"
-	ReviewReasonRule            ReviewReasonType = "rule"
+	ReviewReasonApproved        ReviewReason = "approved"
+	ReviewReasonDisputed        ReviewReason = "disputed"
+	ReviewReasonManual          ReviewReason = "manual"
+	ReviewReasonRefunded        ReviewReason = "refunded"
+	ReviewReasonRefundedAsFraud ReviewReason = "refunded_as_fraud"
+	ReviewReasonRule            ReviewReason = "rule"
 )
 
-// ReviewParams is the set of parameters that can be used when approving a review.
-type ReviewParams struct {
-	Params `form:"*"`
-}
-
-// ReviewApproveParams is the set of parameters that can be used when approving a review.
-type ReviewApproveParams struct {
-	Params `form:"*"`
-}
-
-// ReviewListParams is the set of parameters that can be used when listing reviews.
+// Returns a list of Review objects that have open set to true. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 type ReviewListParams struct {
 	ListParams   `form:"*"`
 	Created      *int64            `form:"created"`
 	CreatedRange *RangeQueryParams `form:"created"`
 }
 
-// ReviewIPAddressLocation represents information about the IP associated with a review.
+// Retrieves a Review object.
+type ReviewParams struct {
+	Params `form:"*"`
+}
+
+// Approves a Review object, closing it and removing it from the list of reviews.
+type ReviewApproveParams struct {
+	Params `form:"*"`
+}
+
+// Information related to the location of the payment. Note that this information is an approximation and attempts to locate the nearest population center - it should not be used to determine a specific address.
 type ReviewIPAddressLocation struct {
 	City      string  `json:"city"`
 	Country   string  `json:"country"`
@@ -62,7 +71,7 @@ type ReviewIPAddressLocation struct {
 	Region    string  `json:"region"`
 }
 
-// ReviewSession represents information about the browser session associated with a review.
+// Information related to the browsing session of the user who initiated the payment.
 type ReviewSession struct {
 	Browser  string `json:"browser"`
 	Device   string `json:"device"`
@@ -70,8 +79,10 @@ type ReviewSession struct {
 	Version  string `json:"version"`
 }
 
-// Review is the resource representing a Radar review.
-// For more details see https://stripe.com/docs/api#reviews.
+// Reviews can be used to supplement automated fraud detection with human expertise.
+//
+// Learn more about [Radar](https://stripe.com/radar) and reviewing payments
+// [here](https://stripe.com/docs/radar/reviews).
 type Review struct {
 	APIResource
 	BillingZip        string                   `json:"billing_zip"`
@@ -86,11 +97,11 @@ type Review struct {
 	Open              bool                     `json:"open"`
 	OpenedReason      ReviewOpenedReason       `json:"opened_reason"`
 	PaymentIntent     *PaymentIntent           `json:"payment_intent"`
-	Reason            ReviewReasonType         `json:"reason"`
+	Reason            ReviewReason             `json:"reason"`
 	Session           *ReviewSession           `json:"session"`
 }
 
-// ReviewList is a list of reviews as retrieved from a list endpoint.
+// ReviewList is a list of Reviews as retrieved from a list endpoint.
 type ReviewList struct {
 	APIResource
 	ListMeta

--- a/review/client.go
+++ b/review/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package review provides the /reviews APIs
 package review
 
@@ -14,19 +20,6 @@ type Client struct {
 	Key string
 }
 
-// Approve approves a review.
-func Approve(id string, params *stripe.ReviewApproveParams) (*stripe.Review, error) {
-	return getC().Approve(id, params)
-}
-
-// Approve approves a review.
-func (c Client) Approve(id string, params *stripe.ReviewApproveParams) (*stripe.Review, error) {
-	path := stripe.FormatURLPath("/v1/reviews/%s/approve", id)
-	review := &stripe.Review{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, review)
-	return review, err
-}
-
 // Get returns the details of a review.
 func Get(id string, params *stripe.ReviewParams) (*stripe.Review, error) {
 	return getC().Get(id, params)
@@ -40,6 +33,19 @@ func (c Client) Get(id string, params *stripe.ReviewParams) (*stripe.Review, err
 	return review, err
 }
 
+// Approve is the method for the `POST /v1/reviews/{review}/approve` API.
+func Approve(id string, params *stripe.ReviewApproveParams) (*stripe.Review, error) {
+	return getC().Approve(id, params)
+}
+
+// Approve is the method for the `POST /v1/reviews/{review}/approve` API.
+func (c Client) Approve(id string, params *stripe.ReviewApproveParams) (*stripe.Review, error) {
+	path := stripe.FormatURLPath("/v1/reviews/%s/approve", id)
+	review := &stripe.Review{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, review)
+	return review, err
+}
+
 // List returns a list of reviews.
 func List(params *stripe.ReviewListParams) *Iter {
 	return getC().List(params)
@@ -47,17 +53,19 @@ func List(params *stripe.ReviewListParams) *Iter {
 
 // List returns a list of reviews.
 func (c Client) List(listParams *stripe.ReviewListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.ReviewList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/reviews", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.ReviewList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/reviews", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for reviews.
@@ -70,9 +78,9 @@ func (i *Iter) Review() *stripe.Review {
 	return i.Current().(*stripe.Review)
 }
 
-// ReviewList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// ReviewList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) ReviewList() *stripe.ReviewList {
 	return i.List().(*stripe.ReviewList)
 }

--- a/taxid.go
+++ b/taxid.go
@@ -15,6 +15,7 @@ type TaxIDType string
 const (
 	TaxIDTypeAETRN    TaxIDType = "ae_trn"
 	TaxIDTypeAUABN    TaxIDType = "au_abn"
+	TaxIDTypeAuArn    TaxIDType = "au_arn"
 	TaxIDTypeBRCNPJ   TaxIDType = "br_cnpj"
 	TaxIDTypeBRCPF    TaxIDType = "br_cpf"
 	TaxIDTypeCABN     TaxIDType = "ca_bn"

--- a/taxid.go
+++ b/taxid.go
@@ -15,7 +15,7 @@ type TaxIDType string
 const (
 	TaxIDTypeAETRN    TaxIDType = "ae_trn"
 	TaxIDTypeAUABN    TaxIDType = "au_abn"
-	TaxIDTypeAuArn    TaxIDType = "au_arn"
+	TaxIDTypeAUARN    TaxIDType = "au_arn"
 	TaxIDTypeBRCNPJ   TaxIDType = "br_cnpj"
 	TaxIDTypeBRCPF    TaxIDType = "br_cpf"
 	TaxIDTypeCABN     TaxIDType = "ca_bn"


### PR DESCRIPTION
Codegen for openapi 10ebdb9.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new TaxId type: `au_arn`
* Add support for `InteracPresent` on `ChargePaymentMethodDetails`
* Add support for `SepaCreditTransfer` on `ChargePaymentMethodDetails`
* Codegen related changes:
  * Moved `ShippingDetails` into `address.go`
  * Add support for `Object` and `Order` to `Charge`
  * Renamed `ReviewReasonType` enum to `ReviewReason` but added a type alias to preserve backwards compatibility