### PR TITLE
API Updates

### DIFF
--- a/checkout_session.go
+++ b/checkout_session.go
@@ -84,6 +84,16 @@ const (
 	CheckoutSessionConsentPromotionsOptOut CheckoutSessionConsentPromotions = "opt_out"
 )
 
+// If set to `auto`, enables the collection of customer consent for promotional communications. The Checkout
+// Session will determine whether to display an option to opt into promotional communication
+// from the merchant depending on the customer's locale. Only available to US merchants.
+type CheckoutSessionConsentCollectionPromotions string
+
+// List of values that CheckoutSessionConsentCollectionPromotions can take
+const (
+	CheckoutSessionConsentCollectionPromotionsAuto CheckoutSessionConsentCollectionPromotions = "auto"
+)
+
 // CheckoutSessionCustomerDetailsTaxExempt is the list of allowed values for
 // tax_exempt inside customer_details of a checkout session.
 type CheckoutSessionCustomerDetailsTaxExempt string
@@ -431,7 +441,7 @@ type CheckoutSessionConsent struct {
 
 // When set, provides configuration for the Checkout Session to gather active consent from customers.
 type CheckoutSessionConsentCollection struct {
-	Promotions *string `json:"promotions"`
+	Promotions CheckoutSessionConsentCollectionPromotions `json:"promotions"`
 }
 
 // CheckoutSessionCustomerDetailsTaxIDs represent customer's tax IDs at the

--- a/client/api.go
+++ b/client/api.go
@@ -43,6 +43,7 @@ import (
 	issuingcardholder "github.com/stripe/stripe-go/v72/issuing/cardholder"
 	issuingdispute "github.com/stripe/stripe-go/v72/issuing/dispute"
 	issuingtransaction "github.com/stripe/stripe-go/v72/issuing/transaction"
+	"github.com/stripe/stripe-go/v72/lineitem"
 	"github.com/stripe/stripe-go/v72/loginlink"
 	"github.com/stripe/stripe-go/v72/mandate"
 	"github.com/stripe/stripe-go/v72/oauth"

--- a/client/api.go
+++ b/client/api.go
@@ -43,7 +43,6 @@ import (
 	issuingcardholder "github.com/stripe/stripe-go/v72/issuing/cardholder"
 	issuingdispute "github.com/stripe/stripe-go/v72/issuing/dispute"
 	issuingtransaction "github.com/stripe/stripe-go/v72/issuing/transaction"
-	"github.com/stripe/stripe-go/v72/lineitem"
 	"github.com/stripe/stripe-go/v72/loginlink"
 	"github.com/stripe/stripe-go/v72/mandate"
 	"github.com/stripe/stripe-go/v72/oauth"


### PR DESCRIPTION
Codegen for openapi 944e56f.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `AfterExpiration`, `ConsentCollection`, and `ExpiresAt` on `CheckoutSessionParams` and `CheckoutSession`
* Add support for `Consent` and `RecoveredFrom` on `CheckoutSession`

