### PR TITLE
Adding missing dispute reasons following official documentation (http…

### DIFF
--- a/dispute.go
+++ b/dispute.go
@@ -13,14 +13,20 @@ type DisputeReason string
 
 // List of values that DisputeReason can take.
 const (
-	DisputeReasonCreditNotProcessed   DisputeReason = "credit_not_processed"
-	DisputeReasonDuplicate            DisputeReason = "duplicate"
-	DisputeReasonFraudulent           DisputeReason = "fraudulent"
-	DisputeReasonGeneral              DisputeReason = "general"
-	DisputeReasonProductNotReceived   DisputeReason = "product_not_received"
-	DisputeReasonProductUnacceptable  DisputeReason = "product_unacceptable"
-	DisputeReasonSubscriptionCanceled DisputeReason = "subscription_canceled"
-	DisputeReasonUnrecognized         DisputeReason = "unrecognized"
+	DisputeReasonBankCannotProcess       DisputeReason = "bank_cannot_process"
+	DisputeReasonCheckReturned           DisputeReason = "check_returned"
+	DisputeReasonCreditNotProcessed      DisputeReason = "credit_not_processed"
+	DisputeReasonCustomerInitiated       DisputeReason = "customer_initiated"
+	DisputeReasonDebitNotAuthorized      DisputeReason = "debit_not_authorized"
+	DisputeReasonDuplicate               DisputeReason = "duplicate"
+	DisputeReasonFraudulent              DisputeReason = "fraudulent"
+	DisputeReasonGeneral                 DisputeReason = "general"
+	DisputeReasonIncorrectAccountDetails DisputeReason = "incorrect_account_details"
+	DisputeReasonInsufficientFunds       DisputeReason = "insufficient_funds"
+	DisputeReasonProductNotReceived      DisputeReason = "product_not_received"
+	DisputeReasonProductUnacceptable     DisputeReason = "product_unacceptable"
+	DisputeReasonSubscriptionCanceled    DisputeReason = "subscription_canceled"
+	DisputeReasonUnrecognized            DisputeReason = "unrecognized"
 )
 
 // DisputeStatus is the list of allowed values for a discount's status.


### PR DESCRIPTION
**Story**

Adding missing dispute reasons following official documentation (https://stripe.com/docs/api/disputes/object#dispute_object-reason).

Some values that dispute reason can take were missing:

- bank_cannot_process
- check_returned
- customer_initiated
- debit_not_authorized
- incorrect_account_details
- insufficient_funds

