### PR TITLE
paymentmethod: add Mandate string field to PaymentMethodSepaDebit

### DIFF
--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -409,6 +409,7 @@ type PaymentMethodSepaDebit struct {
 	Fingerprint   string                               `json:"fingerprint"`
 	Last4         string                               `json:"last4"`
 	GeneratedFrom *PaymentMethodSepaDebitGeneratedFrom `json:"generated_from"`
+	Mandate       string                               `json:"mandate"`
 }
 
 // PaymentMethodSofort represents the Sofort-specific properties.

--- a/paymentmethod_test.go
+++ b/paymentmethod_test.go
@@ -1,0 +1,27 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestPaymentMethod_UnmarshalJSON(t *testing.T) {
+	data := map[string]interface{}{
+		"id": "pm_123",
+		"sepa_debit": map[string]interface{}{
+			"mandate": "mandate_123",
+		},
+	}
+
+	bytes, err := json.Marshal(&data)
+	assert.NoError(t, err)
+
+	var paymentMethod PaymentMethod
+	err = json.Unmarshal(bytes, &paymentMethod)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "pm_123", paymentMethod.ID)
+	assert.Equal(t, "mandate_123", paymentMethod.SepaDebit.Mandate)
+}


### PR DESCRIPTION
As Stripe API return `mandate` in JSON payload (at least in PaymentIntent or Charge), field could be present in the struct too.