### PR TITLE
API Updates

### DIFF
--- a/checkout_session.go
+++ b/checkout_session.go
@@ -115,6 +115,15 @@ const (
 	CheckoutSessionModeSubscription CheckoutSessionMode = "subscription"
 )
 
+// List of Stripe products where this mandate can be selected automatically. Returned when the Session is in `setup` mode.
+type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor string
+
+// List of values that CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor can take
+const (
+	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsDefaultForInvoice      CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor = "invoice"
+	CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsDefaultForSubscription CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor = "subscription"
+)
+
 // CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule is the list of allowed values for payment_schedule
 type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
 
@@ -283,10 +292,11 @@ type CheckoutSessionPaymentIntentDataParams struct {
 
 // CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams is the set of parameters allowed for mandate_options for acss debit.
 type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
-	CustomMandateURL    *string `form:"custom_mandate_url"`
-	IntervalDescription *string `form:"interval_description"`
-	PaymentSchedule     *string `form:"payment_schedule"`
-	TransactionType     *string `form:"transaction_type"`
+	CustomMandateURL    *string   `form:"custom_mandate_url"`
+	DefaultFor          []*string `form:"default_for"`
+	IntervalDescription *string   `form:"interval_description"`
+	PaymentSchedule     *string   `form:"payment_schedule"`
+	TransactionType     *string   `form:"transaction_type"`
 }
 
 // CheckoutSessionPaymentMethodOptionsACSSDebitParams is the set of parameters allowed for acss_debit on payment_method_options.
@@ -462,6 +472,7 @@ type CheckoutSessionCustomerDetails struct {
 // CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions represent mandate options for acss debit.
 type CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions struct {
 	CustomMandateURL    string                                                                    `json:"custom_mandate_url"`
+	DefaultFor          []CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor    `json:"default_for"`
 	IntervalDescription string                                                                    `json:"interval_description"`
 	PaymentSchedule     CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule `json:"payment_schedule"`
 	TransactionType     CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`

--- a/invoice.go
+++ b/invoice.go
@@ -38,6 +38,25 @@ const (
 	InvoiceBillingReasonUpcoming              InvoiceBillingReason = "upcoming"
 )
 
+// Transaction type of the mandate.
+type InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType string
+
+// List of values that InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType can take
+const (
+	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypeBusiness InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "business"
+	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypePersonal InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "personal"
+)
+
+// Bank account verification method.
+type InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod string
+
+// List of values that InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod can take
+const (
+	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodAutomatic     InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "automatic"
+	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
+	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodInstant       InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "instant"
+)
+
 // InvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure represents
 // the options for requesting 3D Secure.
 type InvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure string
@@ -55,6 +74,7 @@ type InvoicePaymentSettingsPaymentMethodType string
 const (
 	InvoicePaymentSettingsPaymentMethodTypeAchCreditTransfer  InvoicePaymentSettingsPaymentMethodType = "ach_credit_transfer"
 	InvoicePaymentSettingsPaymentMethodTypeAchDebit           InvoicePaymentSettingsPaymentMethodType = "ach_debit"
+	InvoicePaymentSettingsPaymentMethodTypeACSSDebit          InvoicePaymentSettingsPaymentMethodType = "acss_debit"
 	InvoicePaymentSettingsPaymentMethodTypeAUBECSDebit        InvoicePaymentSettingsPaymentMethodType = "au_becs_debit"
 	InvoicePaymentSettingsPaymentMethodTypeBACSDebit          InvoicePaymentSettingsPaymentMethodType = "bacs_debit"
 	InvoicePaymentSettingsPaymentMethodTypeBancontact         InvoicePaymentSettingsPaymentMethodType = "bancontact"
@@ -159,6 +179,17 @@ type InvoiceDiscountParams struct {
 	Discount *string `form:"discount"`
 }
 
+// Additional fields for Mandate creation
+type InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
+	TransactionType *string `form:"transaction_type"`
+}
+
+// If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
+type InvoicePaymentSettingsPaymentMethodOptionsACSSDebitParams struct {
+	MandateOptions     *InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsParams `form:"mandate_options"`
+	VerificationMethod *string                                                                  `form:"verification_method"`
+}
+
 // InvoicePaymentSettingsPaymentMethodOptionsBancontactParams is the set of parameters allowed for
 // bancontact on payment_method_options on payment_settings on an invoice.
 type InvoicePaymentSettingsPaymentMethodOptionsBancontactParams struct {
@@ -174,6 +205,7 @@ type InvoicePaymentSettingsPaymentMethodOptionsCardParams struct {
 // InvoicePaymentSettingsPaymentMethodOptionsParams is the set of parameters allowed for
 // specific payment methods on an invoice's payment settings.
 type InvoicePaymentSettingsPaymentMethodOptionsParams struct {
+	ACSSDebit  *InvoicePaymentSettingsPaymentMethodOptionsACSSDebitParams  `form:"acss_debit"`
 	Bancontact *InvoicePaymentSettingsPaymentMethodOptionsBancontactParams `form:"bancontact"`
 	Card       *InvoicePaymentSettingsPaymentMethodOptionsCardParams       `form:"card"`
 }
@@ -481,6 +513,16 @@ type InvoiceTransferData struct {
 	Destination *Account `json:"destination"`
 }
 
+type InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions struct {
+	TransactionType InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
+}
+
+// If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
+type InvoicePaymentSettingsPaymentMethodOptionsACSSDebit struct {
+	MandateOptions     *InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
+	VerificationMethod InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
+}
+
 // Period is a structure representing a start and end dates.
 type Period struct {
 	End   int64 `json:"end"`
@@ -508,6 +550,7 @@ type InvoicePaymentSettingsPaymentMethodOptionsCard struct {
 
 // InvoicePaymentSettingsPaymentMethodOptions represents payment-method-specific configuration to provide to the invoice's PaymentIntent.
 type InvoicePaymentSettingsPaymentMethodOptions struct {
+	ACSSDebit  *InvoicePaymentSettingsPaymentMethodOptionsACSSDebit  `json:"acss_debit"`
 	Bancontact *InvoicePaymentSettingsPaymentMethodOptionsBancontact `json:"bancontact"`
 	Card       *InvoicePaymentSettingsPaymentMethodOptionsCard       `json:"card"`
 }

--- a/mandate.go
+++ b/mandate.go
@@ -19,6 +19,15 @@ const (
 	MandateStatusPending  MandateStatus = "pending"
 )
 
+// List of Stripe products where this mandate can be selected automatically.
+type MandatePaymentMethodDetailsACSSDebitDefaultFor string
+
+// List of values that MandatePaymentMethodDetailsACSSDebitDefaultFor can take
+const (
+	MandatePaymentMethodDetailsACSSDebitDefaultForInvoice      MandatePaymentMethodDetailsACSSDebitDefaultFor = "invoice"
+	MandatePaymentMethodDetailsACSSDebitDefaultForSubscription MandatePaymentMethodDetailsACSSDebitDefaultFor = "subscription"
+)
+
 // MandatePaymentMethodDetailsACSSDebitPaymentSchedule is the list of allowed values for an acss debit payment_schedule on payment_method_details
 type MandatePaymentMethodDetailsACSSDebitPaymentSchedule string
 
@@ -93,6 +102,7 @@ type MandateMultiUse struct {
 
 // MandatePaymentMethodDetailsACSSDebit represent details about the acss debit associated with this mandate.
 type MandatePaymentMethodDetailsACSSDebit struct {
+	DefaultFor          []MandatePaymentMethodDetailsACSSDebitDefaultFor    `json:"default_for"`
 	IntervalDescription string                                              `json:"interval_description"`
 	PaymentSchedule     MandatePaymentMethodDetailsACSSDebitPaymentSchedule `json:"payment_schedule"`
 	TransactionType     MandatePaymentMethodDetailsACSSDebitTransactionType `json:"transaction_type"`

--- a/person.go
+++ b/person.go
@@ -114,6 +114,7 @@ type PersonParams struct {
 	FirstName         *string                   `form:"first_name"`
 	FirstNameKana     *string                   `form:"first_name_kana"`
 	FirstNameKanji    *string                   `form:"first_name_kanji"`
+	FullNameAliases   []*string                 `form:"full_name_aliases"`
 	Gender            *string                   `form:"gender"`
 	IDNumber          *string                   `form:"id_number"`
 	LastName          *string                   `form:"last_name"`
@@ -232,6 +233,7 @@ type Person struct {
 	FirstName          string                    `json:"first_name"`
 	FirstNameKana      string                    `json:"first_name_kana"`
 	FirstNameKanji     string                    `json:"first_name_kanji"`
+	FullNameAliases    []string                  `json:"full_name_aliases"`
 	FutureRequirements *PersonFutureRequirements `json:"future_requirements"`
 	Gender             string                    `json:"gender"`
 	ID                 string                    `json:"id"`

--- a/reporting_reporttype.go
+++ b/reporting_reporttype.go
@@ -24,6 +24,7 @@ type ReportType struct {
 	DataAvailableStart int64    `json:"data_available_start"`
 	DefaultColumns     []string `json:"default_columns"`
 	ID                 string   `json:"id"`
+	Livemode           bool     `json:"livemode"`
 	Name               string   `json:"name"`
 	Object             string   `json:"object"`
 	Updated            int64    `json:"updated"`

--- a/setupintent.go
+++ b/setupintent.go
@@ -23,6 +23,15 @@ const (
 	SetupIntentNextActionTypeRedirectToURL SetupIntentNextActionType = "redirect_to_url"
 )
 
+// List of Stripe products where this mandate can be selected automatically.
+type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor string
+
+// List of values that SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor can take
+const (
+	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsDefaultForInvoice      SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor = "invoice"
+	SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsDefaultForSubscription SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor = "subscription"
+)
+
 // SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule is the list of allowed values
 // for payment_schedule on mandate_options.
 type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
@@ -126,10 +135,11 @@ type SetupIntentMandateDataCustomerAcceptanceParams struct {
 // SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams is the set of parameters for
 // mandate_options on acss_debit.
 type SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
-	CustomMandateURL    *string `form:"custom_mandate_url"`
-	IntervalDescription *string `form:"interval_description"`
-	PaymentSchedule     *string `form:"payment_schedule"`
-	TransactionType     *string `form:"transaction_type"`
+	CustomMandateURL    *string   `form:"custom_mandate_url"`
+	DefaultFor          []*string `form:"default_for"`
+	IntervalDescription *string   `form:"interval_description"`
+	PaymentSchedule     *string   `form:"payment_schedule"`
+	TransactionType     *string   `form:"transaction_type"`
 }
 
 // SetupIntentPaymentMethodOptionsACSSDebitParams is the set of parameters for acss debit on
@@ -222,6 +232,7 @@ type SetupIntentNextAction struct {
 // acss debit associated with a setup intent.
 type SetupIntentPaymentMethodOptionsACSSDebitMandateOptions struct {
 	CustomMandateURL    string                                                                `json:"custom_mandate_url"`
+	DefaultFor          []SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsDefaultFor    `json:"default_for"`
 	IntervalDescription string                                                                `json:"interval_description"`
 	PaymentSchedule     SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule `json:"payment_schedule"`
 	TransactionType     SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`

--- a/sub.go
+++ b/sub.go
@@ -40,6 +40,25 @@ const (
 	SubscriptionPauseCollectionBehaviorVoid              SubscriptionPauseCollectionBehavior = "void"
 )
 
+// Transaction type of the mandate.
+type SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType string
+
+// List of values that SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType can take
+const (
+	SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypeBusiness SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "business"
+	SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionTypePersonal SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType = "personal"
+)
+
+// Bank account verification method.
+type SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod string
+
+// List of values that SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod can take
+const (
+	SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodAutomatic     SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "automatic"
+	SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodInstant       SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "instant"
+	SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
+)
+
 // We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
 type SubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure string
 
@@ -56,6 +75,7 @@ type SubscriptionPaymentSettingsPaymentMethodType string
 const (
 	SubscriptionPaymentSettingsPaymentMethodTypeAchCreditTransfer  SubscriptionPaymentSettingsPaymentMethodType = "ach_credit_transfer"
 	SubscriptionPaymentSettingsPaymentMethodTypeAchDebit           SubscriptionPaymentSettingsPaymentMethodType = "ach_debit"
+	SubscriptionPaymentSettingsPaymentMethodTypeACSSDebit          SubscriptionPaymentSettingsPaymentMethodType = "acss_debit"
 	SubscriptionPaymentSettingsPaymentMethodTypeAUBECSDebit        SubscriptionPaymentSettingsPaymentMethodType = "au_becs_debit"
 	SubscriptionPaymentSettingsPaymentMethodTypeBACSDebit          SubscriptionPaymentSettingsPaymentMethodType = "bacs_debit"
 	SubscriptionPaymentSettingsPaymentMethodTypeBancontact         SubscriptionPaymentSettingsPaymentMethodType = "bancontact"
@@ -118,6 +138,17 @@ type SubscriptionPauseCollectionParams struct {
 	ResumesAt *int64  `form:"resumes_at"`
 }
 
+// Additional fields for Mandate creation
+type SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsParams struct {
+	TransactionType *string `form:"transaction_type"`
+}
+
+// This sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
+type SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitParams struct {
+	MandateOptions     *SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsParams `form:"mandate_options"`
+	VerificationMethod *string                                                                       `form:"verification_method"`
+}
+
 // This sub-hash contains details about the Bancontact payment method options to pass to the invoice's PaymentIntent.
 type SubscriptionPaymentSettingsPaymentMethodOptionsBancontactParams struct {
 	PreferredLanguage *string `form:"preferred_language"`
@@ -130,6 +161,7 @@ type SubscriptionPaymentSettingsPaymentMethodOptionsCardParams struct {
 
 // Payment-method-specific configuration to provide to invoices created by the subscription.
 type SubscriptionPaymentSettingsPaymentMethodOptionsParams struct {
+	ACSSDebit  *SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitParams  `form:"acss_debit"`
 	Bancontact *SubscriptionPaymentSettingsPaymentMethodOptionsBancontactParams `form:"bancontact"`
 	Card       *SubscriptionPaymentSettingsPaymentMethodOptionsCardParams       `form:"card"`
 }
@@ -267,6 +299,16 @@ type SubscriptionPauseCollection struct {
 	ResumesAt int64                               `json:"resumes_at"`
 }
 
+type SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions struct {
+	TransactionType SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
+}
+
+// This sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to invoices created by the subscription.
+type SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebit struct {
+	MandateOptions     *SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
+	VerificationMethod SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
+}
+
 // This sub-hash contains details about the Bancontact payment method options to pass to invoices created by the subscription.
 type SubscriptionPaymentSettingsPaymentMethodOptionsBancontact struct {
 	PreferredLanguage string `json:"preferred_language"`
@@ -279,6 +321,7 @@ type SubscriptionPaymentSettingsPaymentMethodOptionsCard struct {
 
 // Payment-method-specific configuration to provide to invoices created by the subscription.
 type SubscriptionPaymentSettingsPaymentMethodOptions struct {
+	ACSSDebit  *SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebit  `json:"acss_debit"`
 	Bancontact *SubscriptionPaymentSettingsPaymentMethodOptionsBancontact `json:"bancontact"`
 	Card       *SubscriptionPaymentSettingsPaymentMethodOptionsCard       `json:"card"`
 }


### PR DESCRIPTION
Codegen for openapi 151a466.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `Livemode` on `ReportingReportType`.
* Add support for `DefaultFor` on `CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptionsParams`, `CheckoutSessionPaymentMethodOptionsACSSDebitMandateOptions`, `MandatePaymentMethodDetailsACSSDebit`, `SetupIntentPaymentMethodOptionsACSSDebitMandateOptionsParams`, and `SetupIntentPaymentMethodOptionsACSSDebitMandateOptions`.
* Add support for `ACSSDebit` on `InvoicePaymentSettingsPaymentMethodOptionsParams`, `InvoicePaymentSettingsPaymentMethodOptionsParams`, `InvoicePaymentSettingsPaymentMethodOptions`, `SubscriptionPaymentSettingsPaymentMethodOptionsParams`, `SubscriptionPaymentSettingsPaymentMethodOptionsParams`, and `SubscriptionPaymentSettingsPaymentMethodOptions`.
* Add support for new value `acss_debit` on enums `InvoicePaymentSettingsPaymentMethodType` and `SubscriptionPaymentSettingsPaymentMethodType`.
* Add support for `FullNameAliases` on `PersonParams` and `Person`.

