### PR TITLE
Make order-related files codegen-able

### DIFF
--- a/order.go
+++ b/order.go
@@ -1,8 +1,12 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // OrderStatus represents the statuses of an order object.
 type OrderStatus string
@@ -27,21 +31,25 @@ const (
 
 // OrderParams is the set of parameters that can be used when creating an order.
 type OrderParams struct {
-	Params   `form:"*"`
-	Coupon   *string            `form:"coupon"`
-	Currency *string            `form:"currency"`
-	Customer *string            `form:"customer"`
-	Email    *string            `form:"email"`
-	Items    []*OrderItemParams `form:"items"`
-	Shipping *ShippingParams    `form:"shipping"`
+	Params                 `form:"*"`
+	Coupon                 *string            `form:"coupon"`
+	Currency               *string            `form:"currency"`
+	Customer               *string            `form:"customer"`
+	Email                  *string            `form:"email"`
+	Items                  []*OrderItemParams `form:"items"`
+	SelectedShippingMethod *string            `form:"selected_shipping_method"`
+	Shipping               *ShippingParams    `form:"shipping"`
+	Status                 *string            `form:"status"`
 }
 
 // ShippingParams is the set of parameters that can be used for the shipping hash
 // on order creation.
 type ShippingParams struct {
-	Address *AddressParams `form:"address"`
-	Name    *string        `form:"name"`
-	Phone   *string        `form:"phone"`
+	Address        *AddressParams `form:"address"`
+	Carrier        *string        `form:"carrier"`
+	Name           *string        `form:"name"`
+	Phone          *string        `form:"phone"`
+	TrackingNumber *string        `form:"tracking_number"`
 }
 
 // OrderListParams is the set of parameters that can be used when listing orders.
@@ -77,11 +85,11 @@ type OrderPayParams struct {
 	Source         *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 
-// SetSource adds valid sources to a OrderParams object,
+// SetSource adds valid sources to a OrderPayParams object,
 // returning an error for unsupported sources.
-func (op *OrderPayParams) SetSource(sp interface{}) error {
+func (p *OrderPayParams) SetSource(sp interface{}) error {
 	source, err := SourceParamsFor(sp)
-	op.Source = source
+	p.Source = source
 	return err
 }
 
@@ -98,10 +106,10 @@ type OrderItemParams struct {
 // ShippingMethod describes a shipping method as available on an order.
 type ShippingMethod struct {
 	Amount           int64             `json:"amount"`
-	ID               string            `json:"id"`
 	Currency         Currency          `json:"currency"`
 	DeliveryEstimate *DeliveryEstimate `json:"delivery_estimate"`
 	Description      string            `json:"description"`
+	ID               string            `json:"id"`
 }
 
 // DeliveryEstimate represent the properties available for a shipping method's
@@ -141,7 +149,7 @@ type Shipping struct {
 }
 
 // Order is the resource representing a Stripe charge.
-// For more details see https://stripe.com/docs/api#orders.
+// For more details see https://stripe.com/docs/api#orders_legacy.
 type Order struct {
 	APIResource
 	Amount                 int64             `json:"amount"`
@@ -153,10 +161,12 @@ type Order struct {
 	Currency               Currency          `json:"currency"`
 	Customer               Customer          `json:"customer"`
 	Email                  string            `json:"email"`
+	ExternalCouponCode     string            `json:"external_coupon_code"`
 	ID                     string            `json:"id"`
 	Items                  []*OrderItem      `json:"items"`
 	Livemode               bool              `json:"livemode"`
 	Metadata               map[string]string `json:"metadata"`
+	Object                 string            `json:"object"`
 	Returns                *OrderReturnList  `json:"returns"`
 	SelectedShippingMethod *string           `json:"selected_shipping_method"`
 	Shipping               *Shipping         `json:"shipping"`

--- a/order/client.go
+++ b/order/client.go
@@ -1,3 +1,10 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package order provides the /orders APIs
 package order
 
 import (
@@ -20,9 +27,9 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 
 // New creates a new order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
-	p := &stripe.Order{}
-	err := c.B.Call(http.MethodPost, "/v1/orders", c.Key, params, p)
-	return p, err
+	order := &stripe.Order{}
+	err := c.B.Call(http.MethodPost, "/v1/orders", c.Key, params, order)
+	return order, err
 }
 
 // Get returns the details of an order.
@@ -46,35 +53,35 @@ func Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) 
 // Update updates an order's properties.
 func (c Client) Update(id string, params *stripe.OrderUpdateParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/v1/orders/%s", id)
-	o := &stripe.Order{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, o)
-	return o, err
+	order := &stripe.Order{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	return order, err
 }
 
-// Pay pays an order.
+// Pay is the method for the `POST /v1/orders/{id}/pay` API.
 func Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 	return getC().Pay(id, params)
 }
 
-// Pay pays an order.
+// Pay is the method for the `POST /v1/orders/{id}/pay` API.
 func (c Client) Pay(id string, params *stripe.OrderPayParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/v1/orders/%s/pay", id)
-	o := &stripe.Order{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, o)
-	return o, err
+	order := &stripe.Order{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	return order, err
 }
 
-// Return returns all or part of an order.
+// Return is the method for the `POST /v1/orders/{id}/returns` API.
 func Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
 	return getC().Return(id, params)
 }
 
-// Return returns all or part of an order.
+// Return is the method for the `POST /v1/orders/{id}/returns` API.
 func (c Client) Return(id string, params *stripe.OrderReturnParams) (*stripe.OrderReturn, error) {
 	path := stripe.FormatURLPath("/v1/orders/%s/returns", id)
-	ret := &stripe.OrderReturn{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, ret)
-	return ret, err
+	order := &stripe.OrderReturn{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	return order, err
 }
 
 // List returns a list of orders.
@@ -84,17 +91,19 @@ func List(params *stripe.OrderListParams) *Iter {
 
 // List returns a list of orders.
 func (c Client) List(listParams *stripe.OrderListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.OrderList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/orders", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.OrderList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/orders", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for orders.
@@ -107,9 +116,9 @@ func (i *Iter) Order() *stripe.Order {
 	return i.Current().(*stripe.Order)
 }
 
-// OrderList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// OrderList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) OrderList() *stripe.OrderList {
 	return i.List().(*stripe.OrderList)
 }

--- a/orderitem.go
+++ b/orderitem.go
@@ -1,11 +1,17 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
 
-// OrderItemType represents the type of order item
+// The type of line item. One of `sku`, `tax`, `shipping`, or `discount`.
 type OrderItemType string
 
-// List of values that OrderItemType can take.
+// List of values that OrderItemType can take
 const (
 	OrderItemTypeCoupon   OrderItemType = "coupon"
 	OrderItemTypeDiscount OrderItemType = "discount"
@@ -14,7 +20,6 @@ const (
 	OrderItemTypeTax      OrderItemType = "tax"
 )
 
-// OrderItemParentType represents the type of order item parent
 type OrderItemParentType string
 
 // List of values that OrderItemParentType can take.
@@ -33,11 +38,15 @@ type OrderItemParent struct {
 	Type OrderItemParentType `json:"object"`
 }
 
-// OrderItem is the resource representing an order item.
+// A representation of the constituent items of any given order. Can be used to
+// represent [SKUs](https://stripe.com/docs/api#skus), shipping costs, or taxes owed on the order.
+//
+// Related guide: [Orders](https://stripe.com/docs/orders/guide).
 type OrderItem struct {
 	Amount      int64            `json:"amount"`
 	Currency    Currency         `json:"currency"`
 	Description string           `json:"description"`
+	Object      string           `json:"object"`
 	Parent      *OrderItemParent `json:"parent"`
 	Quantity    int64            `json:"quantity"`
 	Type        OrderItemType    `json:"type"`

--- a/orderreturn.go
+++ b/orderreturn.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -27,6 +33,7 @@ type OrderReturn struct {
 	ID       string       `json:"id"`
 	Items    []*OrderItem `json:"items"`
 	Livemode bool         `json:"livemode"`
+	Object   string       `json:"object"`
 	Order    *Order       `json:"order"`
 	Refund   *Refund      `json:"refund"`
 }
@@ -41,9 +48,9 @@ type OrderReturnList struct {
 // UnmarshalJSON handles deserialization of an OrderReturn.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (r *OrderReturn) UnmarshalJSON(data []byte) error {
+func (o *OrderReturn) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		r.ID = id
+		o.ID = id
 		return nil
 	}
 
@@ -53,6 +60,6 @@ func (r *OrderReturn) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*r = OrderReturn(v)
+	*o = OrderReturn(v)
 	return nil
 }

--- a/sku.go
+++ b/sku.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -69,12 +75,14 @@ type SKU struct {
 	Attributes        map[string]string  `json:"attributes"`
 	Created           int64              `json:"created"`
 	Currency          Currency           `json:"currency"`
+	Deleted           bool               `json:"deleted"`
 	Description       string             `json:"description"`
 	ID                string             `json:"id"`
 	Image             string             `json:"image"`
 	Inventory         *Inventory         `json:"inventory"`
 	Livemode          bool               `json:"livemode"`
 	Metadata          map[string]string  `json:"metadata"`
+	Object            string             `json:"object"`
 	PackageDimensions *PackageDimensions `json:"package_dimensions"`
 	Price             int64              `json:"price"`
 	Product           *Product           `json:"product"`
@@ -97,8 +105,8 @@ func (s *SKU) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	type sku SKU
-	var v sku
+	type sKU SKU
+	var v sKU
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Formatting changes and new fields. First commits are rearranging things and last commit has relevant changes.

## Notify
r? @richardm-stripe 
cc @dcr-stripe 

## Changelog
* Add support for `SelectedShippingMethod` and `Status` on `OrderStatus`
* Add support for `Carrier` and `TrackingNumber` on `ShippingParams`
* Add support for `ExternalCouponCode` and `Object` on `Order`
* Add support for `Object` on `OrderItem` and `OrderReturn`
* Add support for `Deleted` and `Object` on `SKU`