### PR TITLE
Point client.API#Oauth to the Connect backend.

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -295,7 +295,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.IssuingTransactions = &issuingtransaction.Client{B: backends.API, Key: key}
 	a.LoginLinks = &loginlink.Client{B: backends.API, Key: key}
 	a.Mandates = &mandate.Client{B: backends.API, Key: key}
-	a.OAuth = &oauth.Client{B: backends.API, Key: key}
+	a.OAuth = &oauth.Client{B: backends.Connect, Key: key}
 	a.OrderReturns = &orderreturn.Client{B: backends.API, Key: key}
 	a.Orders = &order.Client{B: backends.API, Key: key}
 	a.PaymentIntents = &paymentintent.Client{B: backends.API, Key: key}


### PR DESCRIPTION
### Notify

r? @richardm-stripe 

### Summary

Update the OAuth client definition to point to the `Connect` backend. This was accidentally regressed in https://github.com/stripe/stripe-go/pull/1323/.

Unfortunately this failure only occurs when going through `client.API {}`, which we cannot use in the OAuth tests as it introduces a circular dependency.

### Motivation

Fixes https://github.com/stripe/stripe-go/issues/1360