### PR TITLE
Make more files codegen-able

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // BalanceSourceType is the list of allowed values for the balance amount's source_type field keys.

--- a/balance.go
+++ b/balance.go
@@ -21,9 +21,9 @@ type BalanceParams struct {
 
 // Amount is a structure wrapping an amount value and its currency.
 type Amount struct {
+	Value       int64                       `json:"amount"`
 	Currency    Currency                    `json:"currency"`
 	SourceTypes map[BalanceSourceType]int64 `json:"source_types"`
-	Value       int64                       `json:"amount"`
 }
 
 // BalanceDetails is the resource representing details about a specific product's balance.

--- a/balance/client.go
+++ b/balance/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package balance provides the /balance APIs
 package balance
 
@@ -7,18 +13,18 @@ import (
 	stripe "github.com/stripe/stripe-go/v72"
 )
 
-// Client is used to invoke /balance and transaction-related APIs.
+// Client is used to invoke /balance APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// Get retrieves an account's balance
+// Get returns the details of a balance.
 func Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 	return getC().Get(params)
 }
 
-// Get retrieves an account's balance
+// Get returns the details of a balance.
 func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 	balance := &stripe.Balance{}
 	err := c.B.Call(http.MethodGet, "/v1/balance", c.Key, params, balance)

--- a/mandate.go
+++ b/mandate.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -78,8 +84,7 @@ type MandateParams struct {
 
 // MandateCustomerAcceptanceOffline represents details about the customer acceptance of an offline
 // mandate.
-type MandateCustomerAcceptanceOffline struct {
-}
+type MandateCustomerAcceptanceOffline struct{}
 
 // MandateCustomerAcceptanceOnline represents details about the customer acceptance of an online
 // mandate.
@@ -97,8 +102,7 @@ type MandateCustomerAcceptance struct {
 }
 
 // MandateMultiUse represents details about a multi-use mandate.
-type MandateMultiUse struct {
-}
+type MandateMultiUse struct{}
 
 // MandatePaymentMethodDetailsACSSDebit represent details about the acss debit associated with this mandate.
 type MandatePaymentMethodDetailsACSSDebit struct {
@@ -123,8 +127,7 @@ type MandatePaymentMethodDetailsBACSDebit struct {
 }
 
 // MandatePaymentMethodDetailsCard represents details about the card associated with this mandate.
-type MandatePaymentMethodDetailsCard struct {
-}
+type MandatePaymentMethodDetailsCard struct{}
 
 // MandatePaymentMethodDetailsSepaDebit represents details about the SEPA debit bank account
 // associated with this mandate.
@@ -168,18 +171,18 @@ type Mandate struct {
 // UnmarshalJSON handles deserialization of a Mandate.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (i *Mandate) UnmarshalJSON(data []byte) error {
+func (m *Mandate) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		i.ID = id
+		m.ID = id
 		return nil
 	}
 
-	type ma Mandate
-	var v ma
+	type mandate Mandate
+	var v mandate
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*i = Mandate(v)
+	*m = Mandate(v)
 	return nil
 }

--- a/mandate.go
+++ b/mandate.go
@@ -2,21 +2,14 @@ package stripe
 
 import "encoding/json"
 
-// List of values that MandateStatus can take.
-const (
-	MandateCustomerAcceptanceTypeOffline MandateCustomerAcceptanceType = "offline"
-	MandateCustomerAcceptanceTypeOnline  MandateCustomerAcceptanceType = "online"
-)
-
 // MandateCustomerAcceptanceType is the list of allowed values for the type of customer acceptance
 // for a given mandate.
 type MandateCustomerAcceptanceType string
 
 // List of values that MandateStatus can take.
 const (
-	MandateStatusActive   MandateStatus = "active"
-	MandateStatusInactive MandateStatus = "inactive"
-	MandateStatusPending  MandateStatus = "pending"
+	MandateCustomerAcceptanceTypeOffline MandateCustomerAcceptanceType = "offline"
+	MandateCustomerAcceptanceTypeOnline  MandateCustomerAcceptanceType = "online"
 )
 
 // List of Stripe products where this mandate can be selected automatically.
@@ -62,14 +55,21 @@ const (
 // MandateStatus is the list of allowed values for the mandate status.
 type MandateStatus string
 
+// List of values that MandateStatus can take.
+const (
+	MandateStatusActive   MandateStatus = "active"
+	MandateStatusInactive MandateStatus = "inactive"
+	MandateStatusPending  MandateStatus = "pending"
+)
+
+// MandateType is the list of allowed values for the mandate type.
+type MandateType string
+
 // List of values that MandateType can take.
 const (
 	MandateTypeMultiUse  MandateType = "multi_use"
 	MandateTypeSingleUse MandateType = "single_use"
 )
-
-// MandateType is the list of allowed values for the mandate type.
-type MandateType string
 
 // MandateParams is the set of parameters that can be used when retrieving a mandate.
 type MandateParams struct {

--- a/radar/valuelist/client.go
+++ b/radar/valuelist/client.go
@@ -1,6 +1,10 @@
-// Package valuelist provides API functions related to value lists.
 //
-// For more details, see: https://stripe.com/docs/api/radar/lists?lang=go
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package valuelist provides the /radar/value_lists APIs
 package valuelist
 
 import (
@@ -16,83 +20,91 @@ type Client struct {
 	Key string
 }
 
-// New creates a new value list.
+// New creates a new radar value list.
 func New(params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	return getC().New(params)
 }
 
-// New creates a new value list.
+// New creates a new radar value list.
 func (c Client) New(params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
-	vl := &stripe.RadarValueList{}
-	err := c.B.Call(http.MethodPost, "/v1/radar/value_lists", c.Key, params, vl)
-	return vl, err
+	valuelist := &stripe.RadarValueList{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/radar/value_lists",
+		c.Key,
+		params,
+		valuelist,
+	)
+	return valuelist, err
 }
 
-// Get returns the details of a value list.
+// Get returns the details of a radar value list.
 func Get(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a value list.
+// Get returns the details of a radar value list.
 func (c Client) Get(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_lists/%s", id)
-	vl := &stripe.RadarValueList{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, vl)
-	return vl, err
+	valuelist := &stripe.RadarValueList{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, valuelist)
+	return valuelist, err
 }
 
-// Update updates a vl's properties.
+// Update updates a radar value list's properties.
 func Update(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a vl's properties.
+// Update updates a radar value list's properties.
 func (c Client) Update(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_lists/%s", id)
-	vl := &stripe.RadarValueList{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, vl)
-	return vl, err
+	valuelist := &stripe.RadarValueList{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, valuelist)
+	return valuelist, err
 }
 
-// Del removes a value list.
+// Del removes a radar value list.
 func Del(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	return getC().Del(id, params)
 }
 
-// Del removes a value list.
+// Del removes a radar value list.
 func (c Client) Del(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_lists/%s", id)
-	vl := &stripe.RadarValueList{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, vl)
-	return vl, err
+	valuelist := &stripe.RadarValueList{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, valuelist)
+	return valuelist, err
 }
 
-// List returns a list of vls.
+// List returns a list of radar value lists.
 func List(params *stripe.RadarValueListListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of vls.
+// List returns a list of radar value lists.
 func (c Client) List(listParams *stripe.RadarValueListListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.RadarValueListList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/radar/value_lists", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.RadarValueListList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/radar/value_lists", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
-// Iter is an iterator for vls.
+// Iter is an iterator for radar value lists.
 type Iter struct {
 	*stripe.Iter
 }
 
-// RadarValueList returns the vl which the iterator is currently pointing to.
+// RadarValueList returns the radar value list which the iterator is currently pointing to.
 func (i *Iter) RadarValueList() *stripe.RadarValueList {
 	return i.Current().(*stripe.RadarValueList)
 }

--- a/reporting/reportrun/client.go
+++ b/reporting/reportrun/client.go
@@ -1,6 +1,10 @@
-// Package reportrun provides API functions related to report runs.
 //
-// For more details, see: https://stripe.com/docs/api/go#reporting_report_run
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package reportrun provides the /reporting/report_runs APIs
 package reportrun
 
 import (
@@ -24,7 +28,13 @@ func New(params *stripe.ReportRunParams) (*stripe.ReportRun, error) {
 // New creates a new report run.
 func (c Client) New(params *stripe.ReportRunParams) (*stripe.ReportRun, error) {
 	reportrun := &stripe.ReportRun{}
-	err := c.B.Call(http.MethodPost, "/v1/reporting/report_runs", c.Key, params, reportrun)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/reporting/report_runs",
+		c.Key,
+		params,
+		reportrun,
+	)
 	return reportrun, err
 }
 
@@ -48,17 +58,19 @@ func List(params *stripe.ReportRunListParams) *Iter {
 
 // List returns a list of report runs.
 func (c Client) List(listParams *stripe.ReportRunListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.ReportRunList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_runs", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.ReportRunList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_runs", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for report runs.

--- a/reporting_reportrun.go
+++ b/reporting_reportrun.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 // ReportRunStatus is the possible values for status on a report run.


### PR DESCRIPTION
## Summary
Make the following files codegen-able:

- mandate.go
- balance.go + balance/client.gi
- reporting_reportrun + reporting/reportrun/client.go
- radar/valuelist/client.go

Formatting, comment, and variable name changes only.

## Notify
r? @richardm-stripe 
cc @dcr