### PR TITLE
Make more files codegen-able

### DIFF
--- a/issuing/authorization/client.go
+++ b/issuing/authorization/client.go
@@ -16,32 +16,6 @@ type Client struct {
 	Key string
 }
 
-// Approve approves an issuing authorization.
-func Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
-	return getC().Approve(id, params)
-}
-
-// Approve updates an issuing authorization.
-func (c Client) Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
-	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/approve", id)
-	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
-	return authorization, err
-}
-
-// Decline decline an issuing authorization.
-func Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
-	return getC().Decline(id, params)
-}
-
-// Decline updates an issuing authorization.
-func (c Client) Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
-	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/decline", id)
-	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
-	return authorization, err
-}
-
 // Get returns the details of an issuing authorization.
 func Get(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
 	return getC().Get(id, params)
@@ -63,6 +37,32 @@ func Update(id string, params *stripe.IssuingAuthorizationParams) (*stripe.Issui
 // Update updates an issuing authorization.
 func (c Client) Update(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s", id)
+	authorization := &stripe.IssuingAuthorization{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	return authorization, err
+}
+
+// Approve approves an issuing authorization.
+func Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
+	return getC().Approve(id, params)
+}
+
+// Approve updates an issuing authorization.
+func (c Client) Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
+	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/approve", id)
+	authorization := &stripe.IssuingAuthorization{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	return authorization, err
+}
+
+// Decline decline an issuing authorization.
+func Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
+	return getC().Decline(id, params)
+}
+
+// Decline updates an issuing authorization.
+func (c Client) Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
+	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/decline", id)
 	authorization := &stripe.IssuingAuthorization{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
 	return authorization, err

--- a/issuing/authorization/client.go
+++ b/issuing/authorization/client.go
@@ -1,6 +1,10 @@
-// Package authorization provides API functions related to issuing authorizations.
 //
-// For more details, see: https://stripe.com/docs/api/go#issuing_authorizations
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package authorization provides the /issuing/authorizations APIs
 package authorization
 
 import (
@@ -29,12 +33,12 @@ func (c Client) Get(id string, params *stripe.IssuingAuthorizationParams) (*stri
 	return authorization, err
 }
 
-// Update updates an issuing authorization.
+// Update updates an issuing authorization's properties.
 func Update(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates an issuing authorization.
+// Update updates an issuing authorization's properties.
 func (c Client) Update(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s", id)
 	authorization := &stripe.IssuingAuthorization{}
@@ -42,12 +46,12 @@ func (c Client) Update(id string, params *stripe.IssuingAuthorizationParams) (*s
 	return authorization, err
 }
 
-// Approve approves an issuing authorization.
+// Approve is the method for the `POST /v1/issuing/authorizations/{authorization}/approve` API.
 func Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
 	return getC().Approve(id, params)
 }
 
-// Approve updates an issuing authorization.
+// Approve is the method for the `POST /v1/issuing/authorizations/{authorization}/approve` API.
 func (c Client) Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/approve", id)
 	authorization := &stripe.IssuingAuthorization{}
@@ -55,12 +59,12 @@ func (c Client) Approve(id string, params *stripe.IssuingAuthorizationApprovePar
 	return authorization, err
 }
 
-// Decline decline an issuing authorization.
+// Decline is the method for the `POST /v1/issuing/authorizations/{authorization}/decline` API.
 func Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
 	return getC().Decline(id, params)
 }
 
-// Decline updates an issuing authorization.
+// Decline is the method for the `POST /v1/issuing/authorizations/{authorization}/decline` API.
 func (c Client) Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/decline", id)
 	authorization := &stripe.IssuingAuthorization{}
@@ -75,17 +79,19 @@ func List(params *stripe.IssuingAuthorizationListParams) *Iter {
 
 // List returns a list of issuing authorizations.
 func (c Client) List(listParams *stripe.IssuingAuthorizationListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.IssuingAuthorizationList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/authorizations", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.IssuingAuthorizationList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/authorizations", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for issuing authorizations.
@@ -98,8 +104,8 @@ func (i *Iter) IssuingAuthorization() *stripe.IssuingAuthorization {
 	return i.Current().(*stripe.IssuingAuthorization)
 }
 
-// IssuingAuthorizationList returns the current list object which the iterator
-// is currently using. List objects will change as new API calls are made to
+// IssuingAuthorizationList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
 // continue pagination.
 func (i *Iter) IssuingAuthorizationList() *stripe.IssuingAuthorizationList {
 	return i.List().(*stripe.IssuingAuthorizationList)

--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"

--- a/setupattempt.go
+++ b/setupattempt.go
@@ -1,8 +1,12 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // SetupAttemptPaymentMethodDetailsCardThreeDSecureAuthenticationFlow indicates the type of 3D Secure authentication performed.
 type SetupAttemptPaymentMethodDetailsCardThreeDSecureAuthenticationFlow string
@@ -84,6 +88,9 @@ type SetupAttemptPaymentMethodDetailsCardThreeDSecure struct {
 	ResultReason       SetupAttemptPaymentMethodDetailsCardThreeDSecureResultReason       `json:"result_reason"`
 	Version            string                                                             `json:"version"`
 }
+type SetupAttemptPaymentMethodDetailsACSSDebit struct{}
+type SetupAttemptPaymentMethodDetailsAUBECSDebit struct{}
+type SetupAttemptPaymentMethodDetailsBACSDebit struct{}
 
 // SetupAttemptPaymentMethodDetailsBancontact represents details about the Bancontact PaymentMethod.
 type SetupAttemptPaymentMethodDetailsBancontact struct {
@@ -101,6 +108,9 @@ type SetupAttemptPaymentMethodDetailsBancontact struct {
 type SetupAttemptPaymentMethodDetailsCard struct {
 	ThreeDSecure *SetupAttemptPaymentMethodDetailsCardThreeDSecure `json:"three_d_secure"`
 }
+type SetupAttemptPaymentMethodDetailsCardPresent struct {
+	GeneratedCard *PaymentMethod `json:"generated_card"`
+}
 
 // SetupAttemptPaymentMethodDetailsIdeal represents details about the Bancontact PaymentMethod.
 type SetupAttemptPaymentMethodDetailsIdeal struct {
@@ -111,6 +121,7 @@ type SetupAttemptPaymentMethodDetailsIdeal struct {
 	IbanLast4                 string         `json:"iban_last4"`
 	VerifiedName              string         `json:"verified_name"`
 }
+type SetupAttemptPaymentMethodDetailsSepaDebit struct{}
 
 // SetupAttemptPaymentMethodDetailsSofort represents details about the Bancontact PaymentMethod.
 type SetupAttemptPaymentMethodDetailsSofort struct {
@@ -126,11 +137,16 @@ type SetupAttemptPaymentMethodDetailsSofort struct {
 
 // SetupAttemptPaymentMethodDetails represents the details about the PaymentMethod associated with the setup attempt.
 type SetupAttemptPaymentMethodDetails struct {
-	Bancontact *SetupAttemptPaymentMethodDetailsBancontact `json:"bancontact"`
-	Card       *SetupAttemptPaymentMethodDetailsCard       `json:"card"`
-	Ideal      *SetupAttemptPaymentMethodDetailsIdeal      `json:"ideal"`
-	Sofort     *SetupAttemptPaymentMethodDetailsSofort     `json:"sofort"`
-	Type       SetupAttemptPaymentMethodDetailsType        `json:"type"`
+	ACSSDebit   *SetupAttemptPaymentMethodDetailsACSSDebit   `json:"acss_debit"`
+	AUBECSDebit *SetupAttemptPaymentMethodDetailsAUBECSDebit `json:"au_becs_debit"`
+	BACSDebit   *SetupAttemptPaymentMethodDetailsBACSDebit   `json:"bacs_debit"`
+	Bancontact  *SetupAttemptPaymentMethodDetailsBancontact  `json:"bancontact"`
+	Card        *SetupAttemptPaymentMethodDetailsCard        `json:"card"`
+	CardPresent *SetupAttemptPaymentMethodDetailsCardPresent `json:"card_present"`
+	Ideal       *SetupAttemptPaymentMethodDetailsIdeal       `json:"ideal"`
+	SepaDebit   *SetupAttemptPaymentMethodDetailsSepaDebit   `json:"sepa_debit"`
+	Sofort      *SetupAttemptPaymentMethodDetailsSofort      `json:"sofort"`
+	Type        SetupAttemptPaymentMethodDetailsType         `json:"type"`
 }
 
 // SetupAttempt is the resource representing a Stripe setup attempt.
@@ -146,6 +162,7 @@ type SetupAttempt struct {
 	PaymentMethod        *PaymentMethod                    `json:"payment_method"`
 	PaymentMethodDetails *SetupAttemptPaymentMethodDetails `json:"payment_method_details"`
 	SetupError           *Error                            `json:"setup_error"`
+	SetupIntent          *SetupIntent                      `json:"setup_intent"`
 	Status               SetupAttemptStatus                `json:"status"`
 	Usage                SetupAttemptUsage                 `json:"usage"`
 }
@@ -160,9 +177,9 @@ type SetupAttemptList struct {
 // UnmarshalJSON handles deserialization of a SetupAttempt.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (p *SetupAttempt) UnmarshalJSON(data []byte) error {
+func (s *SetupAttempt) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		p.ID = id
+		s.ID = id
 		return nil
 	}
 
@@ -172,6 +189,6 @@ func (p *SetupAttempt) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*p = SetupAttempt(v)
+	*s = SetupAttempt(v)
 	return nil
 }

--- a/setupintent/client.go
+++ b/setupintent/client.go
@@ -1,6 +1,10 @@
-// Package setupintent provides API functions related to setup intents.
 //
-// For more details, see: https://stripe.com/docs/api/go#setup_intents.
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package setupintent provides the /setup_intents APIs
 package setupintent
 
 import (
@@ -10,74 +14,80 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke APIs related to setup intents.
+// Client is used to invoke /setup_intents APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// New creates a setup intent.
+// New creates a new setup intent.
 func New(params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 	return getC().New(params)
 }
 
-// New creates a setup intent.
+// New creates a new setup intent.
 func (c Client) New(params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
-	intent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodPost, "/v1/setup_intents", c.Key, params, intent)
-	return intent, err
+	setupintent := &stripe.SetupIntent{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/setup_intents",
+		c.Key,
+		params,
+		setupintent,
+	)
+	return setupintent, err
 }
 
-// Get retrieves a setup intent.
+// Get returns the details of a setup intent.
 func Get(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 	return getC().Get(id, params)
 }
 
-// Get retrieves a setup intent.
+// Get returns the details of a setup intent.
 func (c Client) Get(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s", id)
-	intent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, intent)
-	return intent, err
+	setupintent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, setupintent)
+	return setupintent, err
 }
 
-// Update updates a setup intent.
+// Update updates a setup intent's properties.
 func Update(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a setup intent.
+// Update updates a setup intent's properties.
 func (c Client) Update(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s", id)
-	intent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)
-	return intent, err
+	setupintent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, setupintent)
+	return setupintent, err
 }
 
-// Cancel cancels a setup intent.
+// Cancel is the method for the `POST /v1/setup_intents/{intent}/cancel` API.
 func Cancel(id string, params *stripe.SetupIntentCancelParams) (*stripe.SetupIntent, error) {
 	return getC().Cancel(id, params)
 }
 
-// Cancel cancels a setup intent.
+// Cancel is the method for the `POST /v1/setup_intents/{intent}/cancel` API.
 func (c Client) Cancel(id string, params *stripe.SetupIntentCancelParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s/cancel", id)
-	intent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)
-	return intent, err
+	setupintent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, setupintent)
+	return setupintent, err
 }
 
-// Confirm confirms a setup intent.
+// Confirm is the method for the `POST /v1/setup_intents/{intent}/confirm` API.
 func Confirm(id string, params *stripe.SetupIntentConfirmParams) (*stripe.SetupIntent, error) {
 	return getC().Confirm(id, params)
 }
 
-// Confirm confirms a setup intent.
+// Confirm is the method for the `POST /v1/setup_intents/{intent}/confirm` API.
 func (c Client) Confirm(id string, params *stripe.SetupIntentConfirmParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s/confirm", id)
-	intent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, intent)
-	return intent, err
+	setupintent := &stripe.SetupIntent{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, setupintent)
+	return setupintent, err
 }
 
 // List returns a list of setup intents.
@@ -87,17 +97,19 @@ func List(params *stripe.SetupIntentListParams) *Iter {
 
 // List returns a list of setup intents.
 func (c Client) List(listParams *stripe.SetupIntentListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SetupIntentList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/setup_intents", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.SetupIntentList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/setup_intents", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for setup intents.


### PR DESCRIPTION
## Summary
Make the following files codegen-able:
- setupintent
- issuing.authorization
- setupattempt

## Notify
r? @richardm-stripe
cc @dcr

## Changelog
- Add support for `acss_debit`, `au_becs_debit`, `bacs_debit`, and `sepa_debit` on `SetupAttemptPaymentMethodDetails`
- Add support for `setup_intent` on `SetupAttempt`
- Add support for `duplicate` option for `SetupIntentCancellationReason`
- Add support for `challenge_only` option for `SetupIntentPaymentMethodOptionsCardRequestThreeDSecure`
- Add support for `sepa_debit` on `SetupIntentPaymentMethodOptionsParams` and `SetupIntentPaymentMethodOptions`
- Add support for `client_secret` on `SetupIntentParams`