### PR TITLE
Add unwrap capability to Error

### DIFF
--- a/error.go
+++ b/error.go
@@ -219,6 +219,11 @@ func (e *Error) Error() string {
 	return string(ret)
 }
 
+// Unwrap returns the wrapped typed error.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
 // APIConnectionError is a failure to connect to the Stripe API.
 type APIConnectionError struct {
 	stripeErr *Error

--- a/error_test.go
+++ b/error_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -37,6 +38,8 @@ func TestErrorResponse(t *testing.T) {
 	assert.Equal(t, ErrorTypeInvalidRequest, stripeErr.Type)
 	assert.Equal(t, "req_123", stripeErr.RequestID)
 	assert.Equal(t, 401, stripeErr.HTTPStatusCode)
+	var invalidRequestErr *InvalidRequestError
+	assert.True(t, errors.As(err, &invalidRequestErr))
 }
 
 func TestErrorRedact(t *testing.T) {


### PR DESCRIPTION
Currently, I have to do this to handle different kinds of errors:

```go
if stripeErr := new(stripe.Error); errors.As(err, &stripeErr) {
	switch typedErr := stripeErr.Err.(type) {
	case *stripe.InvalidRequestError:
		return nil, errors.WithStack(herodot.ErrBadRequest.WithReason(typedErr.Error()))
	}
}
```

As the `Error` type literally wraps the typed error, it makes a lot of sense IMO to expose that typed error through `errors.As`:

```go
if reqErr := new(stripe.InvalidRequestError); errors.As(err, &reqErr) {
	return nil, errors.WithStack(herodot.ErrBadRequest.WithReason(reqErr.Error()))
}
```