### PR TITLE
Make more files codegen-able

### DIFF
--- a/creditnote.go
+++ b/creditnote.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -57,9 +63,8 @@ type CreditNoteListParams struct {
 // CreditNoteLineItemListParams is the set of parameters that can be used when listing credit note line items.
 type CreditNoteLineItemListParams struct {
 	ListParams `form:"*"`
-
 	// ID is the credit note ID to list line items for.
-	ID *string `form:"-"` // Goes in the URL
+	ID *string `form:"-"` // Included in URL
 }
 
 // CreditNoteLineItemListPreviewParams is the set of parameters that can be used when previewing a credit note's line items
@@ -163,18 +168,18 @@ type CreditNoteList struct {
 // UnmarshalJSON handles deserialization of a CreditNote.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (i *CreditNote) UnmarshalJSON(data []byte) error {
+func (c *CreditNote) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		i.ID = id
+		c.ID = id
 		return nil
 	}
 
-	type note CreditNote
-	var v note
+	type creditNote CreditNote
+	var v creditNote
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*i = CreditNote(v)
+	*c = CreditNote(v)
 	return nil
 }

--- a/creditnote.go
+++ b/creditnote.go
@@ -31,15 +31,6 @@ const (
 	CreditNoteTypePrePayment  CreditNoteType = "pre_payment"
 )
 
-// CreditNoteLineItemType is the list of allowed values for the credit note line item's type.
-type CreditNoteLineItemType string
-
-// List of values that CreditNoteType can take.
-const (
-	CreditNoteLineItemTypeCustomLineItem  CreditNoteLineItemType = "custom_line_item"
-	CreditNoteLineItemTypeInvoiceLineItem CreditNoteLineItemType = "invoice_line_item"
-)
-
 // CreditNoteParams is the set of parameters that can be used when creating or updating a credit note.
 // For more details see https://stripe.com/docs/api/credit_notes/create, https://stripe.com/docs/api/credit_notes/update.
 type CreditNoteParams struct {
@@ -162,43 +153,11 @@ type CreditNote struct {
 	VoidedAt                   int64                       `json:"voided_at"`
 }
 
-// CreditNoteLineItemDiscountAmount represents the amount of discount calculated per discount for this line item.
-type CreditNoteLineItemDiscountAmount struct {
-	Amount   int64     `json:"amount"`
-	Discount *Discount `json:"discount"`
-}
-
-// CreditNoteLineItem is the resource representing a Stripe credit note line item.
-// For more details see https://stripe.com/docs/api/credit_notes/line_item
-type CreditNoteLineItem struct {
-	Amount            int64                               `json:"amount"`
-	Description       string                              `json:"description"`
-	DiscountAmount    int64                               `json:"discount_amount"`
-	DiscountAmounts   []*CreditNoteLineItemDiscountAmount `json:"discount_amounts"`
-	ID                string                              `json:"id"`
-	InvoiceLineItem   string                              `json:"invoice_line_item"`
-	Livemode          bool                                `json:"livemode"`
-	Object            string                              `json:"object"`
-	Quantity          int64                               `json:"quantity"`
-	TaxAmounts        []*CreditNoteTaxAmount              `json:"tax_amounts"`
-	TaxRates          []*TaxRate                          `json:"tax_rates"`
-	Type              CreditNoteLineItemType              `json:"type"`
-	UnitAmount        int64                               `json:"unit_amount"`
-	UnitAmountDecimal float64                             `json:"unit_amount_decimal,string"`
-}
-
 // CreditNoteList is a list of credit notes as retrieved from a list endpoint.
 type CreditNoteList struct {
 	APIResource
 	ListMeta
 	Data []*CreditNote `json:"data"`
-}
-
-// CreditNoteLineItemList is a list of credit note line items as retrieved from a list endpoint.
-type CreditNoteLineItemList struct {
-	APIResource
-	ListMeta
-	Data []*CreditNoteLineItem `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a CreditNote.

--- a/creditnote.go
+++ b/creditnote.go
@@ -93,9 +93,9 @@ type CreditNoteLineParams struct {
 	InvoiceLineItem   *string   `form:"invoice_line_item"`
 	Quantity          *int64    `form:"quantity"`
 	TaxRates          []*string `form:"tax_rates"`
+	Type              *string   `form:"type"`
 	UnitAmount        *int64    `form:"unit_amount"`
 	UnitAmountDecimal *float64  `form:"unit_amount_decimal,high_precision"`
-	Type              *string   `form:"type"`
 }
 
 // CreditNotePreviewParams is the set of parameters that can be used when previewing a credit note.
@@ -142,8 +142,8 @@ type CreditNote struct {
 	CustomerBalanceTransaction *CustomerBalanceTransaction `json:"customer_balance_transaction"`
 	DiscountAmount             int64                       `json:"discount_amount"`
 	DiscountAmounts            []*CreditNoteDiscountAmount `json:"discount_amounts"`
-	Invoice                    *Invoice                    `json:"invoice"`
 	ID                         string                      `json:"id"`
+	Invoice                    *Invoice                    `json:"invoice"`
 	Lines                      *CreditNoteLineItemList     `json:"lines"`
 	Livemode                   bool                        `json:"livemode"`
 	Memo                       string                      `json:"memo"`

--- a/creditnote/client.go
+++ b/creditnote/client.go
@@ -52,6 +52,31 @@ func (c Client) Update(id string, params *stripe.CreditNoteParams) (*stripe.Cred
 	return cn, err
 }
 
+// Preview previews a credit note.
+func Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
+	return getC().Preview(params)
+}
+
+// Preview previews a credit note.
+func (c Client) Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
+	cn := &stripe.CreditNote{}
+	err := c.B.Call(http.MethodGet, "/v1/credit_notes/preview", c.Key, params, cn)
+	return cn, err
+}
+
+// VoidCreditNote voids a credit note.
+func VoidCreditNote(id string, params *stripe.CreditNoteVoidParams) (*stripe.CreditNote, error) {
+	return getC().VoidCreditNote(id, params)
+}
+
+// VoidCreditNote voids a credit note.
+func (c Client) VoidCreditNote(id string, params *stripe.CreditNoteVoidParams) (*stripe.CreditNote, error) {
+	path := stripe.FormatURLPath("/v1/credit_notes/%s/void", id)
+	cn := &stripe.CreditNote{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, cn)
+	return cn, err
+}
+
 // List returns a list of credit notes.
 func List(params *stripe.CreditNoteListParams) *Iter {
 	return getC().List(params)
@@ -70,6 +95,23 @@ func (c Client) List(listParams *stripe.CreditNoteListParams) *Iter {
 
 		return ret, list, err
 	})}
+}
+
+// Iter is an iterator for credit notes.
+type Iter struct {
+	*stripe.Iter
+}
+
+// CreditNote returns the cn which the iterator is currently pointing to.
+func (i *Iter) CreditNote() *stripe.CreditNote {
+	return i.Current().(*stripe.CreditNote)
+}
+
+// CreditNoteList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) CreditNoteList() *stripe.CreditNoteList {
+	return i.List().(*stripe.CreditNoteList)
 }
 
 // ListLines returns a list of credit note line items on a credit note.
@@ -111,48 +153,6 @@ func (c Client) ListPreviewLines(listParams *stripe.CreditNoteLineItemListPrevie
 
 		return ret, list, err
 	})}
-}
-
-// Preview previews a credit note.
-func Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
-	return getC().Preview(params)
-}
-
-// Preview previews a credit note.
-func (c Client) Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
-	cn := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodGet, "/v1/credit_notes/preview", c.Key, params, cn)
-	return cn, err
-}
-
-// VoidCreditNote voids a credit note.
-func VoidCreditNote(id string, params *stripe.CreditNoteVoidParams) (*stripe.CreditNote, error) {
-	return getC().VoidCreditNote(id, params)
-}
-
-// VoidCreditNote voids a credit note.
-func (c Client) VoidCreditNote(id string, params *stripe.CreditNoteVoidParams) (*stripe.CreditNote, error) {
-	path := stripe.FormatURLPath("/v1/credit_notes/%s/void", id)
-	cn := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, cn)
-	return cn, err
-}
-
-// Iter is an iterator for credit notes.
-type Iter struct {
-	*stripe.Iter
-}
-
-// CreditNote returns the cn which the iterator is currently pointing to.
-func (i *Iter) CreditNote() *stripe.CreditNote {
-	return i.Current().(*stripe.CreditNote)
-}
-
-// CreditNoteList returns the current list object which the iterator is
-// currently using. List objects will change as new API calls are made to
-// continue pagination.
-func (i *Iter) CreditNoteList() *stripe.CreditNoteList {
-	return i.List().(*stripe.CreditNoteList)
 }
 
 // LineItemIter is an iterator for credit note line items on a credit note.

--- a/creditnote/client.go
+++ b/creditnote/client.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 // Package creditnote provides the /credit_notes APIs
 package creditnote
 
@@ -8,7 +14,7 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is the client used to invoke /credit_notes APIs.
+// Client is used to invoke /credit_notes APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -21,9 +27,15 @@ func New(params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
 
 // New creates a new credit note.
 func (c Client) New(params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
-	cn := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodPost, "/v1/credit_notes", c.Key, params, cn)
-	return cn, err
+	creditnote := &stripe.CreditNote{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/credit_notes",
+		c.Key,
+		params,
+		creditnote,
+	)
+	return creditnote, err
 }
 
 // Get returns the details of a credit note.
@@ -34,47 +46,53 @@ func Get(id string, params *stripe.CreditNoteParams) (*stripe.CreditNote, error)
 // Get returns the details of a credit note.
 func (c Client) Get(id string, params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
 	path := stripe.FormatURLPath("/v1/credit_notes/%s", id)
-	cn := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, cn)
-	return cn, err
+	creditnote := &stripe.CreditNote{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, creditnote)
+	return creditnote, err
 }
 
-// Update updates a credit note.
+// Update updates a credit note's properties.
 func Update(id string, params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a credit note.
+// Update updates a credit note's properties.
 func (c Client) Update(id string, params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
 	path := stripe.FormatURLPath("/v1/credit_notes/%s", id)
-	cn := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, cn)
-	return cn, err
+	creditnote := &stripe.CreditNote{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, creditnote)
+	return creditnote, err
 }
 
-// Preview previews a credit note.
+// Preview is the method for the `GET /v1/credit_notes/preview` API.
 func Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
 	return getC().Preview(params)
 }
 
-// Preview previews a credit note.
+// Preview is the method for the `GET /v1/credit_notes/preview` API.
 func (c Client) Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
-	cn := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodGet, "/v1/credit_notes/preview", c.Key, params, cn)
-	return cn, err
+	creditnote := &stripe.CreditNote{}
+	err := c.B.Call(
+		http.MethodGet,
+		"/v1/credit_notes/preview",
+		c.Key,
+		params,
+		creditnote,
+	)
+	return creditnote, err
 }
 
-// VoidCreditNote voids a credit note.
+// VoidCreditNote is the method for the `POST /v1/credit_notes/{id}/void` API.
 func VoidCreditNote(id string, params *stripe.CreditNoteVoidParams) (*stripe.CreditNote, error) {
 	return getC().VoidCreditNote(id, params)
 }
 
-// VoidCreditNote voids a credit note.
+// VoidCreditNote is the method for the `POST /v1/credit_notes/{id}/void` API.
 func (c Client) VoidCreditNote(id string, params *stripe.CreditNoteVoidParams) (*stripe.CreditNote, error) {
 	path := stripe.FormatURLPath("/v1/credit_notes/%s/void", id)
-	cn := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, cn)
-	return cn, err
+	creditnote := &stripe.CreditNote{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, creditnote)
+	return creditnote, err
 }
 
 // List returns a list of credit notes.
@@ -84,17 +102,19 @@ func List(params *stripe.CreditNoteListParams) *Iter {
 
 // List returns a list of credit notes.
 func (c Client) List(listParams *stripe.CreditNoteListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CreditNoteList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/credit_notes", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CreditNoteList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/credit_notes", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for credit notes.
@@ -102,7 +122,7 @@ type Iter struct {
 	*stripe.Iter
 }
 
-// CreditNote returns the cn which the iterator is currently pointing to.
+// CreditNote returns the credit note which the iterator is currently pointing to.
 func (i *Iter) CreditNote() *stripe.CreditNote {
 	return i.Current().(*stripe.CreditNote)
 }
@@ -114,48 +134,55 @@ func (i *Iter) CreditNoteList() *stripe.CreditNoteList {
 	return i.List().(*stripe.CreditNoteList)
 }
 
-// ListLines returns a list of credit note line items on a credit note.
+// ListLines is the method for the `GET /v1/credit_notes/{credit_note}/lines` API.
 func ListLines(params *stripe.CreditNoteLineItemListParams) *LineItemIter {
 	return getC().ListLines(params)
 }
 
-// ListLines returns a list of credit note line items on a credit note.
+// ListLines is the method for the `GET /v1/credit_notes/{credit_note}/lines` API.
 func (c Client) ListLines(listParams *stripe.CreditNoteLineItemListParams) *LineItemIter {
-	path := stripe.FormatURLPath("/v1/credit_notes/%s/lines", stripe.StringValue(listParams.ID))
-	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CreditNoteLineItemList{}
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+	path := stripe.FormatURLPath(
+		"/v1/credit_notes/%s/lines",
+		stripe.StringValue(listParams.ID),
+	)
+	return &LineItemIter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CreditNoteLineItemList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
-// ListPreviewLines returns a list of lines on a previewed credit note.
+// ListPreviewLines is the method for the `GET /v1/credit_notes/preview/lines` API.
 func ListPreviewLines(params *stripe.CreditNoteLineItemListPreviewParams) *LineItemIter {
 	return getC().ListPreviewLines(params)
 }
 
-// ListPreviewLines returns a list of lines on a previewed credit note.
+// ListPreviewLines is the method for the `GET /v1/credit_notes/preview/lines` API.
 func (c Client) ListPreviewLines(listParams *stripe.CreditNoteLineItemListPreviewParams) *LineItemIter {
-	return &LineItemIter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CreditNoteLineItemList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/credit_notes/preview/lines", c.Key, b, p, list)
+	return &LineItemIter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CreditNoteLineItemList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/credit_notes/preview/lines", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
-// LineItemIter is an iterator for credit note line items on a credit note.
+// LineItemIter is an iterator for credit note line items.
 type LineItemIter struct {
 	*stripe.Iter
 }

--- a/creditnotelineitem.go
+++ b/creditnotelineitem.go
@@ -1,0 +1,42 @@
+package stripe
+
+// CreditNoteLineItemType is the list of allowed values for the credit note line item's type.
+type CreditNoteLineItemType string
+
+// List of values that CreditNoteType can take.
+const (
+	CreditNoteLineItemTypeCustomLineItem  CreditNoteLineItemType = "custom_line_item"
+	CreditNoteLineItemTypeInvoiceLineItem CreditNoteLineItemType = "invoice_line_item"
+)
+
+// CreditNoteLineItemDiscountAmount represents the amount of discount calculated per discount for this line item.
+type CreditNoteLineItemDiscountAmount struct {
+	Amount   int64     `json:"amount"`
+	Discount *Discount `json:"discount"`
+}
+
+// CreditNoteLineItem is the resource representing a Stripe credit note line item.
+// For more details see https://stripe.com/docs/api/credit_notes/line_item
+type CreditNoteLineItem struct {
+	Amount            int64                               `json:"amount"`
+	Description       string                              `json:"description"`
+	DiscountAmount    int64                               `json:"discount_amount"`
+	DiscountAmounts   []*CreditNoteLineItemDiscountAmount `json:"discount_amounts"`
+	ID                string                              `json:"id"`
+	InvoiceLineItem   string                              `json:"invoice_line_item"`
+	Livemode          bool                                `json:"livemode"`
+	Object            string                              `json:"object"`
+	Quantity          int64                               `json:"quantity"`
+	TaxAmounts        []*CreditNoteTaxAmount              `json:"tax_amounts"`
+	TaxRates          []*TaxRate                          `json:"tax_rates"`
+	Type              CreditNoteLineItemType              `json:"type"`
+	UnitAmount        int64                               `json:"unit_amount"`
+	UnitAmountDecimal float64                             `json:"unit_amount_decimal,string"`
+}
+
+// CreditNoteLineItemList is a list of credit note line items as retrieved from a list endpoint.
+type CreditNoteLineItemList struct {
+	APIResource
+	ListMeta
+	Data []*CreditNoteLineItem `json:"data"`
+}

--- a/creditnotelineitem.go
+++ b/creditnotelineitem.go
@@ -1,15 +1,21 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-// CreditNoteLineItemType is the list of allowed values for the credit note line item's type.
+// The type of the credit note line item, one of `invoice_line_item` or `custom_line_item`. When the type is `invoice_line_item` there is an additional `invoice_line_item` property on the resource the value of which is the id of the credited line item on the invoice.
 type CreditNoteLineItemType string
 
-// List of values that CreditNoteType can take.
+// List of values that CreditNoteLineItemType can take
 const (
 	CreditNoteLineItemTypeCustomLineItem  CreditNoteLineItemType = "custom_line_item"
 	CreditNoteLineItemTypeInvoiceLineItem CreditNoteLineItemType = "invoice_line_item"
 )
 
-// CreditNoteLineItemDiscountAmount represents the amount of discount calculated per discount for this line item.
+// The integer amount in %s representing the discount being credited for this line item.
 type CreditNoteLineItemDiscountAmount struct {
 	Amount   int64     `json:"amount"`
 	Discount *Discount `json:"discount"`
@@ -34,7 +40,7 @@ type CreditNoteLineItem struct {
 	UnitAmountDecimal float64                             `json:"unit_amount_decimal,string"`
 }
 
-// CreditNoteLineItemList is a list of credit note line items as retrieved from a list endpoint.
+// CreditNoteLineItemList is a list of CreditNoteLineItems as retrieved from a list endpoint.
 type CreditNoteLineItemList struct {
 	APIResource
 	ListMeta

--- a/issuing/dispute/client.go
+++ b/issuing/dispute/client.go
@@ -41,19 +41,6 @@ func (c Client) Get(id string, params *stripe.IssuingDisputeParams) (*stripe.Iss
 	return dispute, err
 }
 
-// Submit dismisses a dispute in the customer's favor.
-func Submit(id string, params *stripe.IssuingDisputeSubmitParams) (*stripe.IssuingDispute, error) {
-	return getC().Submit(id, params)
-}
-
-// Submit dismisses a dispute in the customer's favor.
-func (c Client) Submit(id string, params *stripe.IssuingDisputeSubmitParams) (*stripe.IssuingDispute, error) {
-	path := stripe.FormatURLPath("/v1/issuing/disputes/%s/submit", id)
-	dispute := &stripe.IssuingDispute{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
-	return dispute, err
-}
-
 // Update updates an issuing dispute.
 func Update(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 	return getC().Update(id, params)
@@ -62,6 +49,19 @@ func Update(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDisp
 // Update updates an issuing dispute.
 func (c Client) Update(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 	path := stripe.FormatURLPath("/v1/issuing/disputes/%s", id)
+	dispute := &stripe.IssuingDispute{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
+	return dispute, err
+}
+
+// Submit dismisses a dispute in the customer's favor.
+func Submit(id string, params *stripe.IssuingDisputeSubmitParams) (*stripe.IssuingDispute, error) {
+	return getC().Submit(id, params)
+}
+
+// Submit dismisses a dispute in the customer's favor.
+func (c Client) Submit(id string, params *stripe.IssuingDisputeSubmitParams) (*stripe.IssuingDispute, error) {
+	path := stripe.FormatURLPath("/v1/issuing/disputes/%s/submit", id)
 	dispute := &stripe.IssuingDispute{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
 	return dispute, err

--- a/issuing/dispute/client.go
+++ b/issuing/dispute/client.go
@@ -1,6 +1,10 @@
-// Package dispute provides API functions related to issuing disputes.
 //
-// For more details, see: https://stripe.com/docs/api/go#issuing_disputes
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package dispute provides the /issuing/disputes APIs
 package dispute
 
 import (
@@ -24,7 +28,13 @@ func New(params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 // New creates a new issuing dispute.
 func (c Client) New(params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 	dispute := &stripe.IssuingDispute{}
-	err := c.B.Call(http.MethodPost, "/v1/issuing/disputes", c.Key, params, dispute)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/issuing/disputes",
+		c.Key,
+		params,
+		dispute,
+	)
 	return dispute, err
 }
 
@@ -41,12 +51,12 @@ func (c Client) Get(id string, params *stripe.IssuingDisputeParams) (*stripe.Iss
 	return dispute, err
 }
 
-// Update updates an issuing dispute.
+// Update updates an issuing dispute's properties.
 func Update(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates an issuing dispute.
+// Update updates an issuing dispute's properties.
 func (c Client) Update(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 	path := stripe.FormatURLPath("/v1/issuing/disputes/%s", id)
 	dispute := &stripe.IssuingDispute{}
@@ -54,12 +64,12 @@ func (c Client) Update(id string, params *stripe.IssuingDisputeParams) (*stripe.
 	return dispute, err
 }
 
-// Submit dismisses a dispute in the customer's favor.
+// Submit is the method for the `POST /v1/issuing/disputes/{dispute}/submit` API.
 func Submit(id string, params *stripe.IssuingDisputeSubmitParams) (*stripe.IssuingDispute, error) {
 	return getC().Submit(id, params)
 }
 
-// Submit dismisses a dispute in the customer's favor.
+// Submit is the method for the `POST /v1/issuing/disputes/{dispute}/submit` API.
 func (c Client) Submit(id string, params *stripe.IssuingDisputeSubmitParams) (*stripe.IssuingDispute, error) {
 	path := stripe.FormatURLPath("/v1/issuing/disputes/%s/submit", id)
 	dispute := &stripe.IssuingDispute{}
@@ -74,17 +84,19 @@ func List(params *stripe.IssuingDisputeListParams) *Iter {
 
 // List returns a list of issuing disputes.
 func (c Client) List(listParams *stripe.IssuingDisputeListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.IssuingDisputeList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/issuing/disputes", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.IssuingDisputeList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/disputes", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for issuing disputes.

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -155,8 +155,8 @@ type IssuingCardParams struct {
 	Currency          *string                            `form:"currency"`
 	ReplacementFor    *string                            `form:"replacement_for"`
 	ReplacementReason *string                            `form:"replacement_reason"`
-	SpendingControls  *IssuingCardSpendingControlsParams `form:"spending_controls"`
 	Shipping          *IssuingCardShippingParams         `form:"shipping"`
+	SpendingControls  *IssuingCardSpendingControlsParams `form:"spending_controls"`
 	Status            *string                            `form:"status"`
 	Type              *string                            `form:"type"`
 

--- a/issuing_card.go
+++ b/issuing_card.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -159,7 +165,6 @@ type IssuingCardParams struct {
 	SpendingControls  *IssuingCardSpendingControlsParams `form:"spending_controls"`
 	Status            *string                            `form:"status"`
 	Type              *string                            `form:"type"`
-
 	// The following parameter is only supported when updating a card
 	CancellationReason *string `form:"cancellation_reason"`
 }
@@ -206,12 +211,10 @@ type IssuingCardSpendingControls struct {
 	SpendingLimits         []*IssuingCardSpendingControlsSpendingLimit `json:"spending_limits"`
 	SpendingLimitsCurrency Currency                                    `json:"spending_limits_currency"`
 }
-
 type IssuingCardWalletsApplePay struct {
 	Eligible         bool                                       `json:"eligible"`
 	IneligibleReason IssuingCardWalletsApplePayIneligibleReason `json:"ineligible_reason"`
 }
-
 type IssuingCardWalletsGooglePay struct {
 	Eligible         bool                                        `json:"eligible"`
 	IneligibleReason IssuingCardWalletsGooglePayIneligibleReason `json:"ineligible_reason"`

--- a/issuing_dispute.go
+++ b/issuing_dispute.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -143,9 +149,11 @@ type IssuingDisputeEvidenceOtherParams struct {
 type IssuingDisputeEvidenceServiceNotAsDescribedParams struct {
 	AdditionalDocumentation *string `form:"additional_documentation"`
 	CanceledAt              *int64  `form:"canceled_at"`
+	CancellationReason      *string `form:"cancellation_reason"`
 	Explanation             *string `form:"explanation"`
 	ProductDescription      *string `form:"product_description"`
 	ProductType             *string `form:"product_type"`
+	ReceivedAt              *int64  `form:"received_at"`
 }
 
 // IssuingDisputeEvidenceParams is the set of parameters for the evidence on an issuing dispute
@@ -170,6 +178,8 @@ type IssuingDisputeParams struct {
 // IssuingDisputeListParams is the set of parameters that can be used when listing issuing dispute.
 type IssuingDisputeListParams struct {
 	ListParams   `form:"*"`
+	Created      *int64            `form:"created"`
+	CreatedRange *RangeQueryParams `form:"created"`
 	Status       *string           `form:"status"`
 	Transaction  *string           `form:"transaction"`
 }
@@ -240,9 +250,11 @@ type IssuingDisputeEvidenceOther struct {
 type IssuingDisputeEvidenceServiceNotAsDescribed struct {
 	AdditionalDocumentation *File                                                  `json:"additional_documentation"`
 	CanceledAt              int64                                                  `json:"canceled_at"`
+	CancellationReason      string                                                 `json:"cancellation_reason"`
 	Explanation             string                                                 `json:"explanation"`
 	ProductDescription      string                                                 `json:"product_description"`
 	ProductType             IssuingDisputeEvidenceServiceNotAsDescribedProductType `json:"product_type"`
+	ReceivedAt              int64                                                  `json:"received_at"`
 }
 
 // IssuingDisputeEvidence is the resource representing the evidence of an issuing dispute.

--- a/issuing_dispute.go
+++ b/issuing_dispute.go
@@ -92,8 +92,8 @@ type IssuingDisputeEvidenceCanceledParams struct {
 	Explanation                *string `form:"explanation"`
 	ProductDescription         *string `form:"product_description"`
 	ProductType                *string `form:"product_type"`
-	ReturnStatus               *string `form:"return_status"`
 	ReturnedAt                 *int64  `form:"returned_at"`
+	ReturnStatus               *string `form:"return_status"`
 }
 
 // IssuingDisputeEvidenceDuplicateParams is the resource representing the evidence of an issuing dispute with a reason set to duplicate.
@@ -118,8 +118,8 @@ type IssuingDisputeEvidenceMerchandiseNotAsDescribedParams struct {
 	Explanation             *string `form:"explanation"`
 	ReceivedAt              *int64  `form:"received_at"`
 	ReturnDescription       *string `form:"return_description"`
-	ReturnStatus            *string `form:"return_status"`
 	ReturnedAt              *int64  `form:"returned_at"`
+	ReturnStatus            *string `form:"return_status"`
 }
 
 // IssuingDisputeEvidenceNotReceivedParams is the resource representing the evidence of an issuing dispute with a reason set to not received.
@@ -169,9 +169,9 @@ type IssuingDisputeParams struct {
 
 // IssuingDisputeListParams is the set of parameters that can be used when listing issuing dispute.
 type IssuingDisputeListParams struct {
-	ListParams  `form:"*"`
-	Status      *string `form:"status"`
-	Transaction *string `form:"transaction"`
+	ListParams   `form:"*"`
+	Status       *string           `form:"status"`
+	Transaction  *string           `form:"transaction"`
 }
 
 // IssuingDisputeSubmitParams is the set of parameters that can be used when submitting an issuing dispute.
@@ -189,8 +189,8 @@ type IssuingDisputeEvidenceCanceled struct {
 	Explanation                string                                     `json:"explanation"`
 	ProductDescription         string                                     `json:"product_description"`
 	ProductType                IssuingDisputeEvidenceCanceledProductType  `json:"product_type"`
-	ReturnStatus               IssuingDisputeEvidenceCanceledReturnStatus `json:"return_status"`
 	ReturnedAt                 int64                                      `json:"returned_at"`
+	ReturnStatus               IssuingDisputeEvidenceCanceledReturnStatus `json:"return_status"`
 }
 
 // IssuingDisputeEvidenceDuplicate is the resource representing the evidence of an issuing dispute with a reason set to duplicate.
@@ -215,8 +215,8 @@ type IssuingDisputeEvidenceMerchandiseNotAsDescribed struct {
 	Explanation             string                                                      `json:"explanation"`
 	ReceivedAt              int64                                                       `json:"received_at"`
 	ReturnDescription       string                                                      `json:"return_description"`
-	ReturnStatus            IssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus `json:"return_status"`
 	ReturnedAt              int64                                                       `json:"returned_at"`
+	ReturnStatus            IssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus `json:"return_status"`
 }
 
 // IssuingDisputeEvidenceNotReceived is the resource representing the evidence of an issuing dispute with a reason set to not received.

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -306,6 +306,9 @@ type PaymentIntentPaymentMethodOptionsCardParams struct {
 // If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
 type PaymentIntentPaymentMethodOptionsCardPresentParams struct{}
 
+// If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
+type PaymentIntentPaymentMethodOptionsGiropayParams struct{}
+
 // If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
 type PaymentIntentPaymentMethodOptionsIdealParams struct{}
 
@@ -359,6 +362,7 @@ type PaymentIntentPaymentMethodOptionsParams struct {
 	Boleto           *PaymentIntentPaymentMethodOptionsBoletoParams           `form:"boleto"`
 	Card             *PaymentIntentPaymentMethodOptionsCardParams             `form:"card"`
 	CardPresent      *PaymentIntentPaymentMethodOptionsCardPresentParams      `form:"card_present"`
+	Giropay          *PaymentIntentPaymentMethodOptionsGiropayParams          `form:"giropay"`
 	Ideal            *PaymentIntentPaymentMethodOptionsIdealParams            `form:"ideal"`
 	InteracPresent   *PaymentIntentPaymentMethodOptionsInteracPresentParams   `form:"interac_present"`
 	Klarna           *PaymentIntentPaymentMethodOptionsKlarnaParams           `form:"klarna"`
@@ -566,6 +570,7 @@ type PaymentIntentPaymentMethodOptionsCard struct {
 // PaymentIntentPaymentMethodOptionsCardPresent is the set of Card Present-specific options associated
 // with that payment intent.
 type PaymentIntentPaymentMethodOptionsCardPresent struct{}
+type PaymentIntentPaymentMethodOptionsGiropay struct{}
 
 // PaymentIntentPaymentMethodOptionsIdeal is the set of Ideal-specific options associated
 // with that payment intent.
@@ -618,6 +623,7 @@ type PaymentIntentPaymentMethodOptions struct {
 	Boleto           *PaymentIntentPaymentMethodOptionsBoleto           `json:"boleto"`
 	Card             *PaymentIntentPaymentMethodOptionsCard             `json:"card"`
 	CardPresent      *PaymentIntentPaymentMethodOptionsCardPresent      `json:"card_present"`
+	Giropay          *PaymentIntentPaymentMethodOptionsGiropay          `json:"giropay"`
 	Ideal            *PaymentIntentPaymentMethodOptionsIdeal            `json:"ideal"`
 	InteracPresent   *PaymentIntentPaymentMethodOptionsInteracPresent   `json:"interac_present"`
 	Klarna           *PaymentIntentPaymentMethodOptionsKlarna           `json:"klarna"`

--- a/plan.go
+++ b/plan.go
@@ -1,10 +1,15 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import (
 	"encoding/json"
-	"strconv"
-
 	"github.com/stripe/stripe-go/v72/form"
+	"strconv"
 )
 
 // PlanInterval is the list of allowed values for a plan's interval.
@@ -111,16 +116,19 @@ type PlanTierParams struct {
 	FlatAmountDecimal *float64 `form:"flat_amount_decimal,high_precision"`
 	UnitAmount        *int64   `form:"unit_amount"`
 	UnitAmountDecimal *float64 `form:"unit_amount_decimal,high_precision"`
-	UpTo              *int64   `form:"-"` // handled in custom AppendTo
-	UpToInf           *bool    `form:"-"` // handled in custom AppendTo
+	UpTo              *int64   `form:"-"` // See custom AppendTo
+	UpToInf           *bool    `form:"-"` // See custom AppendTo
 }
 
-// AppendTo implements custom up_to serialisation logic for tiers configuration
+// AppendTo implements custom encoding logic for PlanTierParams.
 func (p *PlanTierParams) AppendTo(body *form.Values, keyParts []string) {
 	if BoolValue(p.UpToInf) {
 		body.Add(form.FormatKey(append(keyParts, "up_to")), "inf")
 	} else {
-		body.Add(form.FormatKey(append(keyParts, "up_to")), strconv.FormatInt(Int64Value(p.UpTo), 10))
+		body.Add(
+			form.FormatKey(append(keyParts, "up_to")),
+			strconv.FormatInt(Int64Value(p.UpTo), 10),
+		)
 	}
 }
 
@@ -155,6 +163,7 @@ type Plan struct {
 	Livemode        bool                `json:"livemode"`
 	Metadata        map[string]string   `json:"metadata"`
 	Nickname        string              `json:"nickname"`
+	Object          string              `json:"object"`
 	Product         *Product            `json:"product"`
 	Tiers           []*PlanTier         `json:"tiers"`
 	TiersMode       string              `json:"tiers_mode"`
@@ -188,9 +197,9 @@ type PlanList struct {
 // UnmarshalJSON handles deserialization of a Plan.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (s *Plan) UnmarshalJSON(data []byte) error {
+func (p *Plan) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		s.ID = id
+		p.ID = id
 		return nil
 	}
 
@@ -200,6 +209,6 @@ func (s *Plan) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*s = Plan(v)
+	*p = Plan(v)
 	return nil
 }

--- a/plan.go
+++ b/plan.go
@@ -13,8 +13,8 @@ type PlanInterval string
 // List of values that PlanInterval can take.
 const (
 	PlanIntervalDay   PlanInterval = "day"
-	PlanIntervalWeek  PlanInterval = "week"
 	PlanIntervalMonth PlanInterval = "month"
+	PlanIntervalWeek  PlanInterval = "week"
 	PlanIntervalYear  PlanInterval = "year"
 )
 
@@ -65,39 +65,6 @@ const (
 	PlanAggregateUsageSum              PlanAggregateUsage = "sum"
 )
 
-// Plan is the resource representing a Stripe plan.
-// For more details see https://stripe.com/docs/api#plans.
-type Plan struct {
-	APIResource
-	Active          bool                `json:"active"`
-	AggregateUsage  string              `json:"aggregate_usage"`
-	Amount          int64               `json:"amount"`
-	AmountDecimal   float64             `json:"amount_decimal,string"`
-	BillingScheme   PlanBillingScheme   `json:"billing_scheme"`
-	Created         int64               `json:"created"`
-	Currency        Currency            `json:"currency"`
-	Deleted         bool                `json:"deleted"`
-	ID              string              `json:"id"`
-	Interval        PlanInterval        `json:"interval"`
-	IntervalCount   int64               `json:"interval_count"`
-	Livemode        bool                `json:"livemode"`
-	Metadata        map[string]string   `json:"metadata"`
-	Nickname        string              `json:"nickname"`
-	Product         *Product            `json:"product"`
-	Tiers           []*PlanTier         `json:"tiers"`
-	TiersMode       string              `json:"tiers_mode"`
-	TransformUsage  *PlanTransformUsage `json:"transform_usage"`
-	TrialPeriodDays int64               `json:"trial_period_days"`
-	UsageType       PlanUsageType       `json:"usage_type"`
-}
-
-// PlanList is a list of plans as returned from a list endpoint.
-type PlanList struct {
-	APIResource
-	ListMeta
-	Data []*Plan `json:"data"`
-}
-
 // PlanListParams is the set of parameters that can be used when listing plans.
 // For more details see https://stripe.com/docs/api#list_plans.
 type PlanListParams struct {
@@ -129,21 +96,6 @@ type PlanParams struct {
 	TransformUsage  *PlanTransformUsageParams `form:"transform_usage"`
 	TrialPeriodDays *int64                    `form:"trial_period_days"`
 	UsageType       *string                   `form:"usage_type"`
-}
-
-// PlanTier configures tiered pricing
-type PlanTier struct {
-	FlatAmount        int64   `json:"flat_amount"`
-	FlatAmountDecimal float64 `json:"flat_amount_decimal,string"`
-	UnitAmount        int64   `json:"unit_amount"`
-	UnitAmountDecimal float64 `json:"unit_amount_decimal,string"`
-	UpTo              int64   `json:"up_to"`
-}
-
-// PlanTransformUsage represents the bucket billing configuration.
-type PlanTransformUsage struct {
-	DivideBy int64                   `json:"divide_by"`
-	Round    PlanTransformUsageRound `json:"round"`
 }
 
 // PlanTransformUsageParams represents the bucket billing configuration.
@@ -178,11 +130,59 @@ func (p *PlanTierParams) AppendTo(body *form.Values, keyParts []string) {
 type PlanProductParams struct {
 	Active              *bool             `form:"active"`
 	ID                  *string           `form:"id"`
-	Name                *string           `form:"name"`
 	Metadata            map[string]string `form:"metadata"`
+	Name                *string           `form:"name"`
 	StatementDescriptor *string           `form:"statement_descriptor"`
 	TaxCode             *string           `form:"tax_code"`
 	UnitLabel           *string           `form:"unit_label"`
+}
+
+// Plan is the resource representing a Stripe plan.
+// For more details see https://stripe.com/docs/api#plans.
+type Plan struct {
+	APIResource
+	Active          bool                `json:"active"`
+	AggregateUsage  string              `json:"aggregate_usage"`
+	Amount          int64               `json:"amount"`
+	AmountDecimal   float64             `json:"amount_decimal,string"`
+	BillingScheme   PlanBillingScheme   `json:"billing_scheme"`
+	Created         int64               `json:"created"`
+	Currency        Currency            `json:"currency"`
+	Deleted         bool                `json:"deleted"`
+	ID              string              `json:"id"`
+	Interval        PlanInterval        `json:"interval"`
+	IntervalCount   int64               `json:"interval_count"`
+	Livemode        bool                `json:"livemode"`
+	Metadata        map[string]string   `json:"metadata"`
+	Nickname        string              `json:"nickname"`
+	Product         *Product            `json:"product"`
+	Tiers           []*PlanTier         `json:"tiers"`
+	TiersMode       string              `json:"tiers_mode"`
+	TransformUsage  *PlanTransformUsage `json:"transform_usage"`
+	TrialPeriodDays int64               `json:"trial_period_days"`
+	UsageType       PlanUsageType       `json:"usage_type"`
+}
+
+// PlanTier configures tiered pricing
+type PlanTier struct {
+	FlatAmount        int64   `json:"flat_amount"`
+	FlatAmountDecimal float64 `json:"flat_amount_decimal,string"`
+	UnitAmount        int64   `json:"unit_amount"`
+	UnitAmountDecimal float64 `json:"unit_amount_decimal,string"`
+	UpTo              int64   `json:"up_to"`
+}
+
+// PlanTransformUsage represents the bucket billing configuration.
+type PlanTransformUsage struct {
+	DivideBy int64                   `json:"divide_by"`
+	Round    PlanTransformUsageRound `json:"round"`
+}
+
+// PlanList is a list of plans as returned from a list endpoint.
+type PlanList struct {
+	APIResource
+	ListMeta
+	Data []*Plan `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of a Plan.

--- a/terminal/reader/client.go
+++ b/terminal/reader/client.go
@@ -1,4 +1,10 @@
-// Package reader provides API functions related to terminal readers
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package reader provides the /terminal/readers APIs
 package reader
 
 import (
@@ -22,7 +28,13 @@ func New(params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 // New creates a new terminal reader.
 func (c Client) New(params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, "/v1/terminal/readers", c.Key, params, reader)
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/terminal/readers",
+		c.Key,
+		params,
+		reader,
+	)
 	return reader, err
 }
 
@@ -39,12 +51,12 @@ func (c Client) Get(id string, params *stripe.TerminalReaderGetParams) (*stripe.
 	return reader, err
 }
 
-// Update updates a terminal reader.
+// Update updates a terminal reader's properties.
 func Update(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a terminal reader.
+// Update updates a terminal reader's properties.
 func (c Client) Update(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s", id)
 	reader := &stripe.TerminalReader{}
@@ -52,12 +64,12 @@ func (c Client) Update(id string, params *stripe.TerminalReaderParams) (*stripe.
 	return reader, err
 }
 
-// Del removes a reader.
+// Del removes a terminal reader.
 func Del(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	return getC().Del(id, params)
 }
 
-// Del removes a reader.
+// Del removes a terminal reader.
 func (c Client) Del(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s", id)
 	reader := &stripe.TerminalReader{}
@@ -72,17 +84,19 @@ func List(params *stripe.TerminalReaderListParams) *Iter {
 
 // List returns a list of terminal readers.
 func (c Client) List(listParams *stripe.TerminalReaderListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.TerminalReaderList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/terminal/readers", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.TerminalReaderList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/terminal/readers", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for terminal readers.

--- a/topup/client.go
+++ b/topup/client.go
@@ -13,19 +13,6 @@ type Client struct {
 	Key string
 }
 
-// Cancel cancels a topup.
-func Cancel(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
-	return getC().Cancel(id, params)
-}
-
-// Cancel cancels a topup.
-func (c Client) Cancel(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
-	path := stripe.FormatURLPath("/v1/topups/%s/cancel", id)
-	topup := &stripe.Topup{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, topup)
-	return topup, err
-}
-
 // New creates a new topup.
 func New(params *stripe.TopupParams) (*stripe.Topup, error) {
 	return getC().New(params)
@@ -59,6 +46,19 @@ func Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 // Update updates a topup's properties.
 func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/v1/topups/%s", id)
+	topup := &stripe.Topup{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, topup)
+	return topup, err
+}
+
+// Cancel cancels a topup.
+func Cancel(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
+	return getC().Cancel(id, params)
+}
+
+// Cancel cancels a topup.
+func (c Client) Cancel(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
+	path := stripe.FormatURLPath("/v1/topups/%s/cancel", id)
 	topup := &stripe.Topup{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, topup)
 	return topup, err

--- a/topup/client.go
+++ b/topup/client.go
@@ -1,3 +1,10 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package topup provides the /topups APIs
 package topup
 
 import (
@@ -51,12 +58,12 @@ func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, er
 	return topup, err
 }
 
-// Cancel cancels a topup.
+// Cancel is the method for the `POST /v1/topups/{topup}/cancel` API.
 func Cancel(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	return getC().Cancel(id, params)
 }
 
-// Cancel cancels a topup.
+// Cancel is the method for the `POST /v1/topups/{topup}/cancel` API.
 func (c Client) Cancel(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/v1/topups/%s/cancel", id)
 	topup := &stripe.Topup{}
@@ -71,17 +78,19 @@ func List(params *stripe.TopupListParams) *Iter {
 
 // List returns a list of topups.
 func (c Client) List(listParams *stripe.TopupListParams) *Iter {
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.TopupList{}
-		err := c.B.CallRaw(http.MethodGet, "/v1/topups", c.Key, b, p, list)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.TopupList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/topups", c.Key, b, p, list)
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for topups.
@@ -89,14 +98,14 @@ type Iter struct {
 	*stripe.Iter
 }
 
-// Topup returns the topup item which the iterator is currently pointing to.
+// Topup returns the topup which the iterator is currently pointing to.
 func (i *Iter) Topup() *stripe.Topup {
 	return i.Current().(*stripe.Topup)
 }
 
-// TopupList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// TopupList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) TopupList() *stripe.TopupList {
 	return i.List().(*stripe.TopupList)
 }


### PR DESCRIPTION
## Summary
Make creditnote.go, creditnote/client.go, issuing/dispute/client.go, issuing_card.go, issuing_dispute.go, plan.go, terminal/reader/client.go, and topup/client.go codegen-able., and move `CrediteNoteLineItem` into separate creditnotelineitem.go file.

The first two commits are rearranging files and the last is the codegen changes.

## Notify
r? @richardm-stripe
cc @dcr

## Changelog
* Add support for `CancellationReason` and `ReceivedAt` on `IssuingDisputeEvidenceServiceNotAsDescribed` and `IssuingDisputeEvidenceServiceNotAsDescribedParams`
* Add support for `Created` on `IssuingDisputeListParams`
* Add support for `Object` on `Plan`