### PR TITLE
Make sub.go and event.go codegen-able

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import (
@@ -28,10 +34,12 @@ type EventListParams struct {
 type Event struct {
 	APIResource
 	Account         string        `json:"account"`
+	APIVersion      string        `json:"api_version"`
 	Created         int64         `json:"created"`
 	Data            *EventData    `json:"data"`
 	ID              string        `json:"id"`
 	Livemode        bool          `json:"livemode"`
+	Object          string        `json:"object"`
 	PendingWebhooks int64         `json:"pending_webhooks"`
 	Request         *EventRequest `json:"request"`
 	Type            string        `json:"type"`

--- a/event.go
+++ b/event.go
@@ -6,6 +6,23 @@ import (
 	"strconv"
 )
 
+// EventParams is the set of parameters that can be used when retrieving events.
+// For more details see https://stripe.com/docs/api#retrieve_events.
+type EventParams struct {
+	Params `form:"*"`
+}
+
+// EventListParams is the set of parameters that can be used when listing events.
+// For more details see https://stripe.com/docs/api#list_events.
+type EventListParams struct {
+	ListParams      `form:"*"`
+	Created         *int64            `form:"created"`
+	CreatedRange    *RangeQueryParams `form:"created"`
+	DeliverySuccess *bool             `form:"delivery_success"`
+	Type            *string           `form:"type"`
+	Types           []*string         `form:"types"`
+}
+
 // Event is the resource representing a Stripe event.
 // For more details see https://stripe.com/docs/api#events.
 type Event struct {
@@ -42,28 +59,11 @@ type EventData struct {
 	Raw                json.RawMessage        `json:"object"`
 }
 
-// EventParams is the set of parameters that can be used when retrieving events.
-// For more details see https://stripe.com/docs/api#retrieve_events.
-type EventParams struct {
-	Params `form:"*"`
-}
-
 // EventList is a list of events as retrieved from a list endpoint.
 type EventList struct {
 	APIResource
 	ListMeta
 	Data []*Event `json:"data"`
-}
-
-// EventListParams is the set of parameters that can be used when listing events.
-// For more details see https://stripe.com/docs/api#list_events.
-type EventListParams struct {
-	ListParams      `form:"*"`
-	Created         *int64            `form:"created"`
-	CreatedRange    *RangeQueryParams `form:"created"`
-	DeliverySuccess *bool             `form:"delivery_success"`
-	Type            *string           `form:"type"`
-	Types           []*string         `form:"types"`
 }
 
 // GetObjectValue returns the value from the e.Data.Object bag based on the keys hierarchy.

--- a/sub.go
+++ b/sub.go
@@ -1,8 +1,13 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import (
 	"encoding/json"
-
 	"github.com/stripe/stripe-go/v72/form"
 )
 
@@ -225,23 +230,20 @@ type SubscriptionParams struct {
 	TrialPeriodDays             *int64                                        `form:"trial_period_days"`
 }
 
-// AppendTo implements custom encoding logic for SubscriptionParams so that the special
-// "now" value for billing_cycle_anchor and trial_end can be implemented
-// (they're otherwise timestamps rather than strings).
-func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
-	if BoolValue(p.BillingCycleAnchorNow) {
+// AppendTo implements custom encoding logic for SubscriptionParams.
+func (s *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
+	if BoolValue(s.BillingCycleAnchorNow) {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "now")
 	}
-
-	if BoolValue(p.BillingCycleAnchorUnchanged) {
+	if BoolValue(s.BillingCycleAnchorUnchanged) {
 		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "unchanged")
 	}
-
-	if BoolValue(p.TrialEndNow) {
+	if BoolValue(s.TrialEndNow) {
 		body.Add(form.FormatKey(append(keyParts, "trial_end")), "now")
 	}
 }
 
+// Automatic tax settings for this subscription.
 type SubscriptionAutomaticTaxParams struct {
 	Enabled *bool `form:"enabled"`
 }
@@ -269,6 +271,7 @@ type SubscriptionItemsParams struct {
 	ClearUsage        *bool                                    `form:"clear_usage"`
 	Deleted           *bool                                    `form:"deleted"`
 	ID                *string                                  `form:"id"`
+	Metadata          map[string]string                        `form:"metadata"`
 	Plan              *string                                  `form:"plan"`
 	Price             *string                                  `form:"price"`
 	PriceData         *SubscriptionItemPriceDataParams         `form:"price_data"`
@@ -298,7 +301,6 @@ type SubscriptionPauseCollection struct {
 	Behavior  SubscriptionPauseCollectionBehavior `json:"behavior"`
 	ResumesAt int64                               `json:"resumes_at"`
 }
-
 type SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions struct {
 	TransactionType SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
 }
@@ -398,7 +400,6 @@ type Subscription struct {
 	TrialEnd                      int64                                  `json:"trial_end"`
 	TrialStart                    int64                                  `json:"trial_start"`
 }
-
 type SubscriptionAutomaticTax struct {
 	Enabled bool `json:"enabled"`
 }

--- a/sub.go
+++ b/sub.go
@@ -218,11 +218,28 @@ type SubscriptionParams struct {
 	ProrationBehavior           *string                                       `form:"proration_behavior"`
 	ProrationDate               *int64                                        `form:"proration_date"`
 	Quantity                    *int64                                        `form:"quantity"`
-	TrialEnd                    *int64                                        `form:"trial_end"`
 	TransferData                *SubscriptionTransferDataParams               `form:"transfer_data"`
+	TrialEnd                    *int64                                        `form:"trial_end"`
 	TrialEndNow                 *bool                                         `form:"-"` // See custom AppendTo
 	TrialFromPlan               *bool                                         `form:"trial_from_plan"`
 	TrialPeriodDays             *int64                                        `form:"trial_period_days"`
+}
+
+// AppendTo implements custom encoding logic for SubscriptionParams so that the special
+// "now" value for billing_cycle_anchor and trial_end can be implemented
+// (they're otherwise timestamps rather than strings).
+func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
+	if BoolValue(p.BillingCycleAnchorNow) {
+		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "now")
+	}
+
+	if BoolValue(p.BillingCycleAnchorUnchanged) {
+		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "unchanged")
+	}
+
+	if BoolValue(p.TrialEndNow) {
+		body.Add(form.FormatKey(append(keyParts, "trial_end")), "now")
+	}
 }
 
 type SubscriptionAutomaticTaxParams struct {
@@ -242,23 +259,6 @@ type SubscriptionCancelParams struct {
 	Params     `form:"*"`
 	InvoiceNow *bool `form:"invoice_now"`
 	Prorate    *bool `form:"prorate"`
-}
-
-// AppendTo implements custom encoding logic for SubscriptionParams so that the special
-// "now" value for billing_cycle_anchor and trial_end can be implemented
-// (they're otherwise timestamps rather than strings).
-func (p *SubscriptionParams) AppendTo(body *form.Values, keyParts []string) {
-	if BoolValue(p.BillingCycleAnchorNow) {
-		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "now")
-	}
-
-	if BoolValue(p.BillingCycleAnchorUnchanged) {
-		body.Add(form.FormatKey(append(keyParts, "billing_cycle_anchor")), "unchanged")
-	}
-
-	if BoolValue(p.TrialEndNow) {
-		body.Add(form.FormatKey(append(keyParts, "trial_end")), "now")
-	}
 }
 
 // SubscriptionItemsParams is the set of parameters that can be used when creating or updating a subscription item on a subscription


### PR DESCRIPTION
## Summary
Make sub.go and event.go codegen-able.

The first commit is rearranging files and the [last is the codegen changes](https://github.com/stripe/stripe-go/commit/a509a9ede361152d9f9b3cbb753b2dc15fc0c1cf).

## Notify
r? @richardm-stripe
cc @dcr

## Changelog
* Add support for `APIVersion` and `Object` on `Event`
* Add support for `Metadata` on `SubscriptionItemsParams`