### PR TITLE
Make person.go and invoice.go codegen-able

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -1,13 +1,19 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import (
 	"encoding/json"
-
 	"github.com/stripe/stripe-go/v72/form"
 )
 
 type InvoiceAutomaticTaxStatus string
 
+// List of values that InvoiceAutomaticTaxStatus can take
 const (
 	InvoiceAutomaticTaxStatusComplete               InvoiceAutomaticTaxStatus = "complete"
 	InvoiceAutomaticTaxStatusFailed                 InvoiceAutomaticTaxStatus = "failed"
@@ -19,6 +25,7 @@ type InvoiceBillingReason string
 
 // List of values that InvoiceBillingReason can take.
 const (
+	InvoiceBillingReasonAutomaticPendingInvoiceItemInvoice InvoiceBillingReason = "automatic_pending_invoice_item_invoice"
 	InvoiceBillingReasonManual                             InvoiceBillingReason = "manual"
 	InvoiceBillingReasonQuoteAccept                        InvoiceBillingReason = "quote_accept"
 	InvoiceBillingReasonSubscription                       InvoiceBillingReason = "subscription"
@@ -85,6 +92,7 @@ type InvoiceStatus string
 
 // List of values that InvoiceStatus can take.
 const (
+	InvoiceStatusDeleted       InvoiceStatus = "deleted"
 	InvoiceStatusDraft         InvoiceStatus = "draft"
 	InvoiceStatusOpen          InvoiceStatus = "open"
 	InvoiceStatusPaid          InvoiceStatus = "paid"
@@ -105,21 +113,25 @@ type InvoiceUpcomingAutomaticTaxParams struct {
 	Enabled *bool `form:"enabled"`
 }
 
+// The customer's shipping information. Appears on invoices emailed to this customer.
 type InvoiceUpcomingCustomerDetailsShippingParams struct {
 	Address *AddressParams `form:"address"`
 	Name    *string        `form:"name"`
 	Phone   *string        `form:"phone"`
 }
 
+// Tax details about the customer.
 type InvoiceUpcomingCustomerDetailsTaxParams struct {
 	IPAddress *string `form:"ip_address"`
 }
 
+// The customer's tax IDs.
 type InvoiceUpcomingCustomerDetailsTaxIDParams struct {
 	Type  *string `form:"type"`
 	Value *string `form:"value"`
 }
 
+// Details about the customer you want to invoice or overrides for an existing customer.
 type InvoiceUpcomingCustomerDetailsParams struct {
 	Address   *AddressParams                                `form:"address"`
 	Shipping  *InvoiceUpcomingCustomerDetailsShippingParams `form:"shipping"`
@@ -144,6 +156,7 @@ type InvoiceUpcomingInvoiceItemParams struct {
 	Discountable      *bool                                   `form:"discountable"`
 	Discounts         []*InvoiceItemDiscountParams            `form:"discounts"`
 	InvoiceItem       *string                                 `form:"invoiceitem"`
+	Metadata          map[string]string                       `form:"metadata"`
 	Period            *InvoiceUpcomingInvoiceItemPeriodParams `form:"period"`
 	Price             *string                                 `form:"price"`
 	PriceData         *InvoiceItemPriceDataParams             `form:"price_data"`
@@ -154,6 +167,7 @@ type InvoiceUpcomingInvoiceItemParams struct {
 	UnitAmountDecimal *float64                                `form:"unit_amount_decimal,high_precision"`
 }
 
+// Settings for automatic tax lookup for this invoice.
 type InvoiceAutomaticTaxParams struct {
 	Enabled *bool `form:"enabled"`
 }
@@ -235,12 +249,11 @@ type InvoiceParams struct {
 	OnBehalfOf           *string                       `form:"on_behalf_of"`
 	Paid                 *bool                         `form:"paid"`
 	PaymentSettings      *InvoicePaymentSettingsParams `form:"payment_settings"`
+	Schedule             *string                       `form:"schedule"`
 	StatementDescriptor  *string                       `form:"statement_descriptor"`
 	Subscription         *string                       `form:"subscription"`
 	TransferData         *InvoiceTransferDataParams    `form:"transfer_data"`
-
 	// These are all for exclusive use by GetNext.
-
 	Coupon                                  *string                               `form:"coupon"`
 	CustomerDetails                         *InvoiceUpcomingCustomerDetailsParams `form:"customer_details"`
 	InvoiceItems                            []*InvoiceUpcomingInvoiceItemParams   `form:"invoice_items"`
@@ -262,19 +275,15 @@ type InvoiceParams struct {
 	SubscriptionTrialFromPlan               *bool                                 `form:"subscription_trial_from_plan"`
 }
 
-// AppendTo implements custom encoding logic for InvoiceParams so that the special
-// "now" value for subscription_billing_cycle_anchor can be implemented
-// (they're otherwise timestamps rather than strings).
-func (p *InvoiceParams) AppendTo(body *form.Values, keyParts []string) {
-	if BoolValue(p.SubscriptionBillingCycleAnchorNow) {
+// AppendTo implements custom encoding logic for InvoiceParams.
+func (i *InvoiceParams) AppendTo(body *form.Values, keyParts []string) {
+	if BoolValue(i.SubscriptionBillingCycleAnchorNow) {
 		body.Add(form.FormatKey(append(keyParts, "subscription_billing_cycle_anchor")), "now")
 	}
-
-	if BoolValue(p.SubscriptionBillingCycleAnchorUnchanged) {
+	if BoolValue(i.SubscriptionBillingCycleAnchorUnchanged) {
 		body.Add(form.FormatKey(append(keyParts, "subscription_billing_cycle_anchor")), "unchanged")
 	}
-
-	if BoolValue(p.SubscriptionTrialEndNow) {
+	if BoolValue(i.SubscriptionTrialEndNow) {
 		body.Add(form.FormatKey(append(keyParts, "subscription_trial_end")), "now")
 	}
 }
@@ -298,7 +307,7 @@ type InvoiceListParams struct {
 type InvoiceLineListParams struct {
 	ListParams `form:"*"`
 	// ID is the invoice ID to list invoice lines for.
-	ID           *string `form:"-"` // Goes in the URL
+	ID           *string `form:"-"` // Included in URL
 	Customer     *string `form:"customer"`
 	Subscription *string `form:"subscription"`
 }
@@ -411,7 +420,6 @@ type Invoice struct {
 	TransferData                 *InvoiceTransferData     `json:"transfer_data"`
 	WebhooksDeliveredAt          int64                    `json:"webhooks_delivered_at"`
 }
-
 type InvoiceAutomaticTax struct {
 	Enabled bool                      `json:"enabled"`
 	Status  InvoiceAutomaticTaxStatus `json:"status"`
@@ -460,7 +468,6 @@ type InvoiceTransferData struct {
 	Amount      int64    `json:"amount"`
 	Destination *Account `json:"destination"`
 }
-
 type InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions struct {
 	TransactionType InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptionsTransactionType `json:"transaction_type"`
 }

--- a/invoice.go
+++ b/invoice.go
@@ -28,14 +28,14 @@ type InvoiceBillingReason string
 
 // List of values that InvoiceBillingReason can take.
 const (
-	InvoiceBillingReasonManual                InvoiceBillingReason = "manual"
-	InvoiceBillingReasonQuoteAccept           InvoiceBillingReason = "quote_accept"
-	InvoiceBillingReasonSubscription          InvoiceBillingReason = "subscription"
-	InvoiceBillingReasonSubscriptionCreate    InvoiceBillingReason = "subscription_create"
-	InvoiceBillingReasonSubscriptionCycle     InvoiceBillingReason = "subscription_cycle"
-	InvoiceBillingReasonSubscriptionThreshold InvoiceBillingReason = "subscription_threshold"
-	InvoiceBillingReasonSubscriptionUpdate    InvoiceBillingReason = "subscription_update"
-	InvoiceBillingReasonUpcoming              InvoiceBillingReason = "upcoming"
+	InvoiceBillingReasonManual                             InvoiceBillingReason = "manual"
+	InvoiceBillingReasonQuoteAccept                        InvoiceBillingReason = "quote_accept"
+	InvoiceBillingReasonSubscription                       InvoiceBillingReason = "subscription"
+	InvoiceBillingReasonSubscriptionCreate                 InvoiceBillingReason = "subscription_create"
+	InvoiceBillingReasonSubscriptionCycle                  InvoiceBillingReason = "subscription_cycle"
+	InvoiceBillingReasonSubscriptionThreshold              InvoiceBillingReason = "subscription_threshold"
+	InvoiceBillingReasonSubscriptionUpdate                 InvoiceBillingReason = "subscription_update"
+	InvoiceBillingReasonUpcoming                           InvoiceBillingReason = "upcoming"
 )
 
 // Transaction type of the mandate.
@@ -227,8 +227,8 @@ type InvoiceTransferDataParams struct {
 type InvoiceParams struct {
 	Params               `form:"*"`
 	AccountTaxIDs        []*string                     `form:"account_tax_ids"`
-	AutoAdvance          *bool                         `form:"auto_advance"`
 	ApplicationFeeAmount *int64                        `form:"application_fee_amount"`
+	AutoAdvance          *bool                         `form:"auto_advance"`
 	AutomaticTax         *InvoiceAutomaticTaxParams    `form:"automatic_tax"`
 	CollectionMethod     *string                       `form:"collection_method"`
 	CustomFields         []*InvoiceCustomFieldParams   `form:"custom_fields"`
@@ -369,7 +369,6 @@ type Invoice struct {
 	CollectionMethod             *InvoiceCollectionMethod `json:"collection_method"`
 	Created                      int64                    `json:"created"`
 	Currency                     Currency                 `json:"currency"`
-	CustomFields                 []*InvoiceCustomField    `json:"custom_fields"`
 	Customer                     *Customer                `json:"customer"`
 	CustomerAddress              *Address                 `json:"customer_address"`
 	CustomerEmail                string                   `json:"customer_email"`
@@ -378,6 +377,7 @@ type Invoice struct {
 	CustomerShipping             *CustomerShippingDetails `json:"customer_shipping"`
 	CustomerTaxExempt            CustomerTaxExempt        `json:"customer_tax_exempt"`
 	CustomerTaxIDs               []*InvoiceCustomerTaxID  `json:"customer_tax_ids"`
+	CustomFields                 []*InvoiceCustomField    `json:"custom_fields"`
 	DefaultPaymentMethod         *PaymentMethod           `json:"default_payment_method"`
 	DefaultSource                *PaymentSource           `json:"default_source"`
 	DefaultTaxRates              []*TaxRate               `json:"default_tax_rates"`

--- a/invoice.go
+++ b/invoice.go
@@ -44,8 +44,8 @@ type InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod strin
 // List of values that InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod can take
 const (
 	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodAutomatic     InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "automatic"
-	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
 	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodInstant       InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "instant"
+	InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
 )
 
 // InvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure represents
@@ -284,9 +284,9 @@ func (p *InvoiceParams) AppendTo(body *form.Values, keyParts []string) {
 type InvoiceListParams struct {
 	ListParams       `form:"*"`
 	CollectionMethod *string           `form:"collection_method"`
-	Customer         *string           `form:"customer"`
 	Created          *int64            `form:"created"`
 	CreatedRange     *RangeQueryParams `form:"created"`
+	Customer         *string           `form:"customer"`
 	DueDate          *int64            `form:"due_date"`
 	DueDateRange     *RangeQueryParams `form:"due_date"`
 	Status           *string           `form:"status"`
@@ -297,12 +297,9 @@ type InvoiceListParams struct {
 // For more details see https://stripe.com/docs/api#invoice_lines.
 type InvoiceLineListParams struct {
 	ListParams `form:"*"`
-
-	Customer *string `form:"customer"`
-
 	// ID is the invoice ID to list invoice lines for.
-	ID *string `form:"-"` // Goes in the URL
-
+	ID           *string `form:"-"` // Goes in the URL
+	Customer     *string `form:"customer"`
 	Subscription *string `form:"subscription"`
 }
 
@@ -458,13 +455,6 @@ type InvoiceThresholdReasonItemReason struct {
 	UsageGTE    int64    `json:"usage_gte"`
 }
 
-// InvoiceList is a list of invoices as retrieved from a list endpoint.
-type InvoiceList struct {
-	APIResource
-	ListMeta
-	Data []*Invoice `json:"data"`
-}
-
 // InvoiceTransferData represents the information for the transfer_data associated with an invoice.
 type InvoiceTransferData struct {
 	Amount      int64    `json:"amount"`
@@ -512,6 +502,13 @@ type InvoiceStatusTransitions struct {
 	MarkedUncollectibleAt int64 `json:"marked_uncollectible_at"`
 	PaidAt                int64 `json:"paid_at"`
 	VoidedAt              int64 `json:"voided_at"`
+}
+
+// InvoiceList is a list of invoices as retrieved from a list endpoint.
+type InvoiceList struct {
+	APIResource
+	ListMeta
+	Data []*Invoice `json:"data"`
 }
 
 // UnmarshalJSON handles deserialization of an Invoice.

--- a/invoice.go
+++ b/invoice.go
@@ -6,15 +6,6 @@ import (
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// InvoiceLineType is the list of allowed values for the invoice line's type.
-type InvoiceLineType string
-
-// List of values that InvoiceLineType can take.
-const (
-	InvoiceLineTypeInvoiceItem  InvoiceLineType = "invoiceitem"
-	InvoiceLineTypeSubscription InvoiceLineType = "subscription"
-)
-
 type InvoiceAutomaticTaxStatus string
 
 const (
@@ -231,8 +222,8 @@ type InvoiceParams struct {
 	AutoAdvance          *bool                         `form:"auto_advance"`
 	AutomaticTax         *InvoiceAutomaticTaxParams    `form:"automatic_tax"`
 	CollectionMethod     *string                       `form:"collection_method"`
-	CustomFields         []*InvoiceCustomFieldParams   `form:"custom_fields"`
 	Customer             *string                       `form:"customer"`
+	CustomFields         []*InvoiceCustomFieldParams   `form:"custom_fields"`
 	DaysUntilDue         *int64                        `form:"days_until_due"`
 	DefaultPaymentMethod *string                       `form:"default_payment_method"`
 	DefaultSource        *string                       `form:"default_source"`
@@ -474,39 +465,6 @@ type InvoiceList struct {
 	Data []*Invoice `json:"data"`
 }
 
-// InvoiceLineDiscountAmount represents the amount of discount calculated per discount for this line item.
-type InvoiceLineDiscountAmount struct {
-	Amount   int64     `json:"amount"`
-	Discount *Discount `json:"discount"`
-}
-
-// InvoiceLine is the resource representing a Stripe invoice line item.
-// For more details see https://stripe.com/docs/api#invoice_line_item_object.
-type InvoiceLine struct {
-	Amount           int64                        `json:"amount"`
-	Currency         Currency                     `json:"currency"`
-	Description      string                       `json:"description"`
-	Discountable     bool                         `json:"discountable"`
-	Discounts        []*Discount                  `json:"discounts"`
-	DiscountAmounts  []*InvoiceLineDiscountAmount `json:"discount_amounts"`
-	ID               string                       `json:"id"`
-	InvoiceItem      string                       `json:"invoice_item"`
-	Livemode         bool                         `json:"livemode"`
-	Metadata         map[string]string            `json:"metadata"`
-	Object           string                       `json:"object"`
-	Period           *Period                      `json:"period"`
-	Plan             *Plan                        `json:"plan"`
-	Price            *Price                       `json:"price"`
-	Proration        bool                         `json:"proration"`
-	Quantity         int64                        `json:"quantity"`
-	Subscription     string                       `json:"subscription"`
-	SubscriptionItem string                       `json:"subscription_item"`
-	TaxAmounts       []*InvoiceTaxAmount          `json:"tax_amounts"`
-	TaxRates         []*TaxRate                   `json:"tax_rates"`
-	Type             InvoiceLineType              `json:"type"`
-	UnifiedProration bool                         `json:"unified_proration"`
-}
-
 // InvoiceTransferData represents the information for the transfer_data associated with an invoice.
 type InvoiceTransferData struct {
 	Amount      int64    `json:"amount"`
@@ -521,19 +479,6 @@ type InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions struct {
 type InvoicePaymentSettingsPaymentMethodOptionsACSSDebit struct {
 	MandateOptions     *InvoicePaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions    `json:"mandate_options"`
 	VerificationMethod InvoicePaymentSettingsPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
-}
-
-// Period is a structure representing a start and end dates.
-type Period struct {
-	End   int64 `json:"end"`
-	Start int64 `json:"start"`
-}
-
-// InvoiceLineList is a list object for invoice line items.
-type InvoiceLineList struct {
-	APIResource
-	ListMeta
-	Data []*InvoiceLine `json:"data"`
 }
 
 // InvoicePaymentSettingsPaymentMethodOptionsBancontact contains details about the Bancontact

--- a/invoicelineitem.go
+++ b/invoicelineitem.go
@@ -1,22 +1,25 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
-// InvoiceLineType is the list of allowed values for the invoice line's type.
+// A string identifying the type of the source of this line item, either an `invoiceitem` or a `subscription`.
 type InvoiceLineType string
 
-// List of values that InvoiceLineType can take.
+// List of values that InvoiceLineType can take
 const (
 	InvoiceLineTypeInvoiceItem  InvoiceLineType = "invoiceitem"
 	InvoiceLineTypeSubscription InvoiceLineType = "subscription"
 )
 
-// InvoiceLineDiscountAmount represents the amount of discount calculated per discount for this line item.
+// The amount of discount calculated per discount for this line item.
 type InvoiceLineDiscountAmount struct {
 	Amount   int64     `json:"amount"`
 	Discount *Discount `json:"discount"`
 }
-
-// InvoiceLine is the resource representing a Stripe invoice line item.
-// For more details see https://stripe.com/docs/api#invoice_line_item_object.
 type InvoiceLine struct {
 	Amount           int64                        `json:"amount"`
 	Currency         Currency                     `json:"currency"`
@@ -48,7 +51,7 @@ type Period struct {
 	Start int64 `json:"start"`
 }
 
-// InvoiceLineList is a list object for invoice line items.
+// InvoiceLineList is a list of InvoiceLineItems as retrieved from a list endpoint.
 type InvoiceLineList struct {
 	APIResource
 	ListMeta

--- a/invoicelineitem.go
+++ b/invoicelineitem.go
@@ -22,8 +22,8 @@ type InvoiceLine struct {
 	Currency         Currency                     `json:"currency"`
 	Description      string                       `json:"description"`
 	Discountable     bool                         `json:"discountable"`
-	Discounts        []*Discount                  `json:"discounts"`
 	DiscountAmounts  []*InvoiceLineDiscountAmount `json:"discount_amounts"`
+	Discounts        []*Discount                  `json:"discounts"`
 	ID               string                       `json:"id"`
 	InvoiceItem      string                       `json:"invoice_item"`
 	Livemode         bool                         `json:"livemode"`

--- a/invoicelineitem.go
+++ b/invoicelineitem.go
@@ -1,0 +1,56 @@
+package stripe
+
+// InvoiceLineType is the list of allowed values for the invoice line's type.
+type InvoiceLineType string
+
+// List of values that InvoiceLineType can take.
+const (
+	InvoiceLineTypeInvoiceItem  InvoiceLineType = "invoiceitem"
+	InvoiceLineTypeSubscription InvoiceLineType = "subscription"
+)
+
+// InvoiceLineDiscountAmount represents the amount of discount calculated per discount for this line item.
+type InvoiceLineDiscountAmount struct {
+	Amount   int64     `json:"amount"`
+	Discount *Discount `json:"discount"`
+}
+
+// InvoiceLine is the resource representing a Stripe invoice line item.
+// For more details see https://stripe.com/docs/api#invoice_line_item_object.
+type InvoiceLine struct {
+	Amount           int64                        `json:"amount"`
+	Currency         Currency                     `json:"currency"`
+	Description      string                       `json:"description"`
+	Discountable     bool                         `json:"discountable"`
+	Discounts        []*Discount                  `json:"discounts"`
+	DiscountAmounts  []*InvoiceLineDiscountAmount `json:"discount_amounts"`
+	ID               string                       `json:"id"`
+	InvoiceItem      string                       `json:"invoice_item"`
+	Livemode         bool                         `json:"livemode"`
+	Metadata         map[string]string            `json:"metadata"`
+	Object           string                       `json:"object"`
+	Period           *Period                      `json:"period"`
+	Plan             *Plan                        `json:"plan"`
+	Price            *Price                       `json:"price"`
+	Proration        bool                         `json:"proration"`
+	Quantity         int64                        `json:"quantity"`
+	Subscription     string                       `json:"subscription"`
+	SubscriptionItem string                       `json:"subscription_item"`
+	TaxAmounts       []*InvoiceTaxAmount          `json:"tax_amounts"`
+	TaxRates         []*TaxRate                   `json:"tax_rates"`
+	Type             InvoiceLineType              `json:"type"`
+	UnifiedProration bool                         `json:"unified_proration"`
+}
+
+// Period is a structure representing a start and end dates.
+type Period struct {
+	End   int64 `json:"end"`
+	Start int64 `json:"start"`
+}
+
+// InvoiceLineList is a list object for invoice line items.
+type InvoiceLineList struct {
+	APIResource
+	ListMeta
+	Data []*InvoiceLine `json:"data"`
+}

--- a/person.go
+++ b/person.go
@@ -146,21 +146,11 @@ type PersonListParams struct {
 	Relationship *RelationshipListParams `form:"relationship"`
 }
 
-// PersonVerificationDocument represents the documents associated with a Person.
-type PersonVerificationDocument struct {
-	Back        *File                           `json:"back"`
-	Details     string                          `json:"details"`
-	DetailsCode VerificationDocumentDetailsCode `json:"details_code"`
-	Front       *File                           `json:"front"`
-}
-
-// PersonVerification is the structure for a person's verification details.
-type PersonVerification struct {
-	AdditionalDocument *PersonVerificationDocument   `json:"additional_document"`
-	Details            string                        `json:"details"`
-	DetailsCode        PersonVerificationDetailsCode `json:"details_code"`
-	Document           *PersonVerificationDocument   `json:"document"`
-	Status             IdentityVerificationStatus    `json:"status"`
+// DOB represents a Person's date of birth.
+type DOB struct {
+	Day   int64 `json:"day"`
+	Month int64 `json:"month"`
+	Year  int64 `json:"year"`
 }
 
 // Fields that are due and can be satisfied by providing the corresponding alternative fields instead.
@@ -186,19 +176,6 @@ type PersonFutureRequirements struct {
 	PendingVerification []string                               `json:"pending_verification"`
 }
 
-// Fields that are due and can be satisfied by providing the corresponding alternative fields instead.
-type PersonRequirementsAlternative struct {
-	AlternativeFieldsDue []string `json:"alternative_fields_due"`
-	OriginalFieldsDue    []string `json:"original_fields_due"`
-}
-
-// DOB represents a Person's date of birth.
-type DOB struct {
-	Day   int64 `json:"day"`
-	Month int64 `json:"month"`
-	Year  int64 `json:"year"`
-}
-
 // Relationship represents how the Person relates to the business.
 type Relationship struct {
 	Director         bool    `json:"director"`
@@ -209,6 +186,12 @@ type Relationship struct {
 	Title            string  `json:"title"`
 }
 
+// Fields that are due and can be satisfied by providing the corresponding alternative fields instead.
+type PersonRequirementsAlternative struct {
+	AlternativeFieldsDue []string `json:"alternative_fields_due"`
+	OriginalFieldsDue    []string `json:"original_fields_due"`
+}
+
 // Requirements represents what's missing to verify a Person.
 type Requirements struct {
 	Alternatives        []*PersonRequirementsAlternative `json:"alternatives"`
@@ -217,6 +200,23 @@ type Requirements struct {
 	EventuallyDue       []string                         `json:"eventually_due"`
 	PastDue             []string                         `json:"past_due"`
 	PendingVerification []string                         `json:"pending_verification"`
+}
+
+// PersonVerificationDocument represents the documents associated with a Person.
+type PersonVerificationDocument struct {
+	Back        *File                           `json:"back"`
+	Details     string                          `json:"details"`
+	DetailsCode VerificationDocumentDetailsCode `json:"details_code"`
+	Front       *File                           `json:"front"`
+}
+
+// PersonVerification is the structure for a person's verification details.
+type PersonVerification struct {
+	AdditionalDocument *PersonVerificationDocument   `json:"additional_document"`
+	Details            string                        `json:"details"`
+	DetailsCode        PersonVerificationDetailsCode `json:"details_code"`
+	Document           *PersonVerificationDocument   `json:"document"`
+	Status             IdentityVerificationStatus    `json:"status"`
 }
 
 // Person is the resource representing a Stripe person.
@@ -242,8 +242,8 @@ type Person struct {
 	LastNameKana       string                    `json:"last_name_kana"`
 	LastNameKanji      string                    `json:"last_name_kanji"`
 	MaidenName         string                    `json:"maiden_name"`
-	Nationality        string                    `json:"nationality"`
 	Metadata           map[string]string         `json:"metadata"`
+	Nationality        string                    `json:"nationality"`
 	Object             string                    `json:"object"`
 	Phone              string                    `json:"phone"`
 	PoliticalExposure  PersonPoliticalExposure   `json:"political_exposure"`

--- a/person.go
+++ b/person.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -61,15 +67,22 @@ type DOBParams struct {
 	Year  *int64 `form:"year"`
 }
 
+// One or more documents that demonstrate proof that this person is authorized to represent the company.
 type DocumentsCompanyAuthorizationParams struct {
 	Files []*string `form:"files"`
 }
+
+// One or more documents showing the person's passport page with photo and personal data.
 type DocumentsPassportParams struct {
 	Files []*string `form:"files"`
 }
+
+// One or more documents showing the person's visa required for living in the country where they are residing.
 type DocumentsVisaParams struct {
 	Files []*string `form:"files"`
 }
+
+// Documents that may be submitted to satisfy various informational requests.
 type DocumentsParams struct {
 	CompanyAuthorization *DocumentsCompanyAuthorizationParams `form:"company_authorization"`
 	Passport             *DocumentsPassportParams             `form:"passport"`
@@ -227,6 +240,7 @@ type Person struct {
 	Address            *AccountAddress           `json:"address"`
 	AddressKana        *AccountAddress           `json:"address_kana"`
 	AddressKanji       *AccountAddress           `json:"address_kanji"`
+	Created            int64                     `json:"created"`
 	Deleted            bool                      `json:"deleted"`
 	DOB                *DOB                      `json:"dob"`
 	Email              string                    `json:"email"`
@@ -263,9 +277,9 @@ type PersonList struct {
 // UnmarshalJSON handles deserialization of a Person.
 // This custom unmarshaling is needed because the resulting
 // property may be an id or the full struct if it was expanded.
-func (c *Person) UnmarshalJSON(data []byte) error {
+func (p *Person) UnmarshalJSON(data []byte) error {
 	if id, ok := ParseID(data); ok {
-		c.ID = id
+		p.ID = id
 		return nil
 	}
 
@@ -275,6 +289,6 @@ func (c *Person) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*c = Person(v)
+	*p = Person(v)
 	return nil
 }


### PR DESCRIPTION
## Summary
Make person.go and invoice.go codegen-able, and move InvoiceLine into its own file (invoicelineitem.go)

The first commits are rearranging files moving InvoiceLine(Item) into its own file and the [last is the codegen changes](https://github.com/stripe/stripe-go/commit/97f420d983ec2e3980bf3575393f3962a55fa1ff).

## Notify
r? @richardm-stripe
cc @dcr

## Changelog
* Add support for `'automatic_pending_invoice_item_invoice'` option for `InvoiceBillingReason`
* Add support for `'deleted'` option for `InvoiceStatus`
* Add support for `metadata` on `InvoiceUpcomingCustomerDetailsParams`
* Add support for `schedule` on `InvoiceParams`
* Add support for `created` on `Person`