### PR TITLE
Codegen: `sourcetransaction.go` and `sourcetransaction/client.go`

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -218,7 +218,7 @@ type API struct {
 	Skus *sku.Client
 	// Sources is the client used to invoke /sources APIs.
 	Sources *source.Client
-	// SourceTransactions is the client used to invoke source transactions related APIs
+	// SourceTransactions is the client used to invoke sourcetransaction related APIs.
 	SourceTransactions *sourcetransaction.Client
 	// SubscriptionItems is the client used to invoke /subscription_items APIs.
 	SubscriptionItems *subitem.Client

--- a/source/client.go
+++ b/source/client.go
@@ -1,7 +1,14 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package source provides the /sources APIs
 package source
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go/v72"
@@ -20,9 +27,9 @@ func New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
 
 // New creates a new source.
 func (c Client) New(params *stripe.SourceObjectParams) (*stripe.Source, error) {
-	p := &stripe.Source{}
-	err := c.B.Call(http.MethodPost, "/v1/sources", c.Key, params, p)
-	return p, err
+	source := &stripe.Source{}
+	err := c.B.Call(http.MethodPost, "/v1/sources", c.Key, params, source)
+	return source, err
 }
 
 // Get returns the details of a source.
@@ -51,19 +58,23 @@ func (c Client) Update(id string, params *stripe.SourceObjectParams) (*stripe.So
 	return source, err
 }
 
-// Detach detaches the source from a customer.
+// Detach is the method for the `DELETE /v1/customers/{customer}/sources/{id}` API.
 func Detach(id string, params *stripe.SourceObjectDetachParams) (*stripe.Source, error) {
 	return getC().Detach(id, params)
 }
 
-// Detach detaches the source from a customer.
+// Detach is the method for the `DELETE /v1/customers/{customer}/sources/{id}` API.
 func (c Client) Detach(id string, params *stripe.SourceObjectDetachParams) (*stripe.Source, error) {
 	if params.Customer == nil {
-		return nil, errors.New("Invalid source detach params: Customer needs to be set")
+		return nil, fmt.Errorf(
+			"Invalid sourcce detach params: Customer needs to be set",
+		)
 	}
-
-	path := stripe.FormatURLPath("/v1/customers/%s/sources/%s",
-		stripe.StringValue(params.Customer), id)
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/sources/%s",
+		stripe.StringValue(params.Customer),
+		id,
+	)
 	source := &stripe.Source{}
 	err := c.B.Call(http.MethodDelete, path, c.Key, params, source)
 	return source, err

--- a/sourcetransaction.go
+++ b/sourcetransaction.go
@@ -8,13 +8,6 @@ type SourceTransactionListParams struct {
 	Source     *string `form:"-"` // Sent in with the URL
 }
 
-// SourceTransactionList is a list object for SourceTransactions.
-type SourceTransactionList struct {
-	APIResource
-	ListMeta
-	Data []*SourceTransaction `json:"data"`
-}
-
 // SourceTransaction is the resource representing a Stripe source transaction.
 type SourceTransaction struct {
 	Amount       int64    `json:"amount"`
@@ -53,4 +46,11 @@ func (t *SourceTransaction) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// SourceTransactionList is a list object for SourceTransactions.
+type SourceTransactionList struct {
+	APIResource
+	ListMeta
+	Data []*SourceTransaction `json:"data"`
 }

--- a/sourcetransaction.go
+++ b/sourcetransaction.go
@@ -1,3 +1,9 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import "encoding/json"
@@ -5,26 +11,31 @@ import "encoding/json"
 // SourceTransactionListParams is the set of parameters that can be used when listing SourceTransactions.
 type SourceTransactionListParams struct {
 	ListParams `form:"*"`
-	Source     *string `form:"-"` // Sent in with the URL
+	Source     *string `form:"-"` // Included in URL
 }
 
 // SourceTransaction is the resource representing a Stripe source transaction.
 type SourceTransaction struct {
-	Amount       int64    `json:"amount"`
-	Created      int64    `json:"created"`
-	Currency     Currency `json:"currency"`
-	CustomerData string   `json:"customer_data"`
-	ID           string   `json:"id"`
-	Livemode     bool     `json:"livemode"`
-	Source       string   `json:"source"`
-	Type         string   `json:"type"`
-	TypeData     map[string]interface{}
+	Amount   int64    `json:"amount"`
+	Created  int64    `json:"created"`
+	Currency Currency `json:"currency"`
+	ID       string   `json:"id"`
+	Livemode bool     `json:"livemode"`
+	Object   string   `json:"object"`
+	Source   string   `json:"source"`
+	Status   string   `json:"status"`
+	Type     string   `json:"type"`
+
+	// See custom UnmarshalJSON
+	TypeData map[string]interface{}
+
+	// Deprecated
+	CustomerData string `json:"customer_data"`
 }
 
 // UnmarshalJSON handles deserialization of a SourceTransaction. This custom
 // unmarshaling is needed to extract the type specific data (accessible under
-// `TypeData`) but stored in JSON under a hash named after the `type` of the
-// source transaction.
+// `TypeData`) but stored in JSON under a hash named after the `type` of the source transaction.
 func (t *SourceTransaction) UnmarshalJSON(data []byte) error {
 	type sourceTransaction SourceTransaction
 	var v sourceTransaction

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -2,7 +2,7 @@
 package sourcetransaction
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go/v72"
@@ -22,22 +22,19 @@ func List(params *stripe.SourceTransactionListParams) *Iter {
 
 // List returns a list of source transactions.
 func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
-	var outerErr error
-	var path string
-
 	if listParams == nil || listParams.Source == nil {
-		outerErr = errors.New("Invalid source transaction params: Source needs to be set")
-	} else {
-		path = stripe.FormatURLPath("/v1/sources/%s/source_transactions",
-			stripe.StringValue(listParams.Source))
-	}
-
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SourceTransactionList{}
-
-		if outerErr != nil {
-			return nil, list, outerErr
+		return &Iter{
+			Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+				list := &stripe.SourceTransactionList{}
+				return nil, list, fmt.Errorf("Invalid source transaction params: Source needs to be set")
+			}),
 		}
+	}
+	path := stripe.FormatURLPath("/v1/sources/%s/source_transactions",
+		stripe.StringValue(listParams.Source))
+
+	return &Iter{Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+		list := &stripe.SourceTransactionList{}
 
 		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -1,4 +1,10 @@
-// Package sourcetransaction provides the /source/transactions APIs.
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package sourcetransaction provides the TODO APIs
 package sourcetransaction
 
 import (
@@ -30,21 +36,23 @@ func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 			}),
 		}
 	}
-	path := stripe.FormatURLPath("/v1/sources/%s/source_transactions",
-		stripe.StringValue(listParams.Source))
+	path := stripe.FormatURLPath(
+		"/v1/sources/%s/source_transactions",
+		stripe.StringValue(listParams.Source),
+	)
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.SourceTransactionList{}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-	return &Iter{Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SourceTransactionList{}
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
-
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
-
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for source transactions.


### PR DESCRIPTION
## Notify
r? @yejia-stripe 
## Summary
Formats `sourcetransaction.go`, `sourcetransaction/client.go`, and `source/client.go` to be consistent with the code generator.

The most substantive change is in https://github.com/stripe/stripe-go/pull/1388/commits/1a2e463e2fb338ad824c911b341d9b75a5ac6a94 -- this should be a no-op, but is slightly involved.


## Changelog
* Add support for `Object` and `Status` on `SourceTransaction`.