### PR TITLE
Make bankaccount and card codegen-able

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -44,19 +44,17 @@ const (
 // some unusual logic on creates that necessitates manual handling of all
 // parameters. See AppendToAsSourceOrExternalAccount.
 type BankAccountParams struct {
-	Params `form:"*"`
-
+	Params   `form:"*"`
+	Customer *string `form:"-"`
 	// Account is the identifier of the parent account under which bank
 	// accounts are nested.
-	Account *string `form:"-"`
-
+	Account            *string `form:"-"`
 	AccountHolderName  *string `form:"account_holder_name"`
 	AccountHolderType  *string `form:"account_holder_type"`
-	AccountType        *string `form:"account_type"`
 	AccountNumber      *string `form:"account_number"`
+	AccountType        *string `form:"account_type"`
 	Country            *string `form:"country"`
 	Currency           *string `form:"currency"`
-	Customer           *string `form:"-"`
 	DefaultForCurrency *bool   `form:"default_for_currency"`
 	RoutingNumber      *string `form:"routing_number"`
 

--- a/bankaccount.go
+++ b/bankaccount.go
@@ -1,10 +1,15 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import (
 	"encoding/json"
-	"strconv"
-
 	"github.com/stripe/stripe-go/v72/form"
+	"strconv"
 )
 
 // BankAccountAvailablePayoutMethod is a set of available payout methods for the card.
@@ -45,23 +50,30 @@ const (
 // parameters. See AppendToAsSourceOrExternalAccount.
 type BankAccountParams struct {
 	Params   `form:"*"`
-	Customer *string `form:"-"`
+	Customer *string `form:"-"` // Included in URL
+	// Token is a token referencing an external account like one returned from
+	// Stripe.js.
+	Token *string `form:"-"` // Included in URL
 	// Account is the identifier of the parent account under which bank
 	// accounts are nested.
-	Account            *string `form:"-"`
+	Account            *string `form:"-"` // Included in URL
 	AccountHolderName  *string `form:"account_holder_name"`
 	AccountHolderType  *string `form:"account_holder_type"`
 	AccountNumber      *string `form:"account_number"`
 	AccountType        *string `form:"account_type"`
+	AddressCity        *string `form:"address_city"`
+	AddressCountry     *string `form:"address_country"`
+	AddressLine1       *string `form:"address_line1"`
+	AddressLine2       *string `form:"address_line2"`
+	AddressState       *string `form:"address_state"`
+	AddressZip         *string `form:"address_zip"`
 	Country            *string `form:"country"`
 	Currency           *string `form:"currency"`
 	DefaultForCurrency *bool   `form:"default_for_currency"`
+	ExpMonth           *string `form:"exp_month"`
+	ExpYear            *string `form:"exp_year"`
+	Name               *string `form:"name"`
 	RoutingNumber      *string `form:"routing_number"`
-
-	// Token is a token referencing an external account like one returned from
-	// Stripe.js.
-	Token *string `form:"-"`
-
 	// ID is used when tokenizing a bank account for shared customers
 	ID *string `form:"*"`
 }
@@ -98,7 +110,10 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 		body.Add(sourceType, StringValue(a.Token))
 
 		if a.DefaultForCurrency != nil {
-			body.Add("default_for_currency", strconv.FormatBool(BoolValue(a.DefaultForCurrency)))
+			body.Add(
+				"default_for_currency",
+				strconv.FormatBool(BoolValue(a.DefaultForCurrency)),
+			)
 		}
 	} else {
 		body.Add(sourceType+"[object]", "bank_account")
@@ -130,14 +145,12 @@ func (a *BankAccountParams) AppendToAsSourceOrExternalAccount(body *form.Values)
 // BankAccountListParams is the set of parameters that can be used when listing bank accounts.
 type BankAccountListParams struct {
 	ListParams `form:"*"`
-
 	// The identifier of the parent account under which the bank accounts are
 	// nested. Either Account or Customer should be populated.
-	Account *string `form:"-"`
-
+	Account *string `form:"-"` // Included in URL
 	// The identifier of the parent customer under which the bank accounts are
 	// nested. Either Account or Customer should be populated.
-	Customer *string `form:"-"`
+	Customer *string `form:"-"` // Included in URL
 }
 
 // AppendTo implements custom encoding logic for BankAccountListParams
@@ -153,7 +166,7 @@ type BankAccount struct {
 	Account                *Account                           `json:"account"`
 	AccountHolderName      string                             `json:"account_holder_name"`
 	AccountHolderType      BankAccountAccountHolderType       `json:"account_holder_type"`
-	AccountType            *string                            `form:"account_type"`
+	AccountType            string                             `json:"account_type"`
 	AvailablePayoutMethods []BankAccountAvailablePayoutMethod `json:"available_payout_methods"`
 	BankName               string                             `json:"bank_name"`
 	Country                string                             `json:"country"`

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -1,15 +1,21 @@
-// Package bankaccount provides the /bank_accounts APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package bankaccount provides the bankaccount related APIs
 package bankaccount
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /bank_accounts APIs.
+// Client is used to invoke bankaccount related APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -23,7 +29,7 @@ func New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 // New creates a new bank account.
 func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
@@ -32,7 +38,7 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts", stripe.StringValue(params.Account))
 	} else {
-		return nil, errors.New("Invalid bank account params: either Customer or Account need to be set")
+		return nil, fmt.Errorf("Invalid bank account params: either Customer or Account need to be set")
 	}
 
 	body := &form.Values{}
@@ -45,9 +51,9 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 	// Because bank account creation uses the custom append above, we have to
 	// make an explicit call using a form and CallRaw instead of the standard
 	// Call (which takes a set of parameters).
-	ba := &stripe.BankAccount{}
-	err := c.B.CallRaw(http.MethodPost, path, c.Key, body, &params.Params, ba)
-	return ba, err
+	bankaccount := &stripe.BankAccount{}
+	err := c.B.CallRaw(http.MethodPost, path, c.Key, body, &params.Params, bankaccount)
+	return bankaccount, err
 }
 
 // Get returns the details of a bank account.
@@ -58,7 +64,7 @@ func Get(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 // Get returns the details of a bank account.
 func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
@@ -67,23 +73,23 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	} else if params != nil && params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else {
-		return nil, errors.New("Invalid bank account params: either Customer or Account need to be set")
+		return nil, fmt.Errorf("Invalid bank account params: either Customer or Account need to be set")
 	}
 
-	ba := &stripe.BankAccount{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, ba)
-	return ba, err
+	bankaccount := &stripe.BankAccount{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, bankaccount)
+	return bankaccount, err
 }
 
-// Update updates a bank account.
+// Update updates a bank account's properties.
 func Update(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a bank account.
+// Update updates a bank account's properties.
 func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
@@ -92,12 +98,12 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else {
-		return nil, errors.New("Invalid bank account params: either Customer or Account need to be set")
+		return nil, fmt.Errorf("Invalid bank account params: either Customer or Account need to be set")
 	}
 
-	ba := &stripe.BankAccount{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, ba)
-	return ba, err
+	bankaccount := &stripe.BankAccount{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, bankaccount)
+	return bankaccount, err
 }
 
 // Del removes a bank account.
@@ -108,7 +114,7 @@ func Del(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 // Del removes a bank account.
 func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
@@ -117,12 +123,12 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else {
-		return nil, errors.New("Invalid bank account params: either Customer or Account need to be set")
+		return nil, fmt.Errorf("Invalid bank account params: either Customer or Account need to be set")
 	}
 
-	ba := &stripe.BankAccount{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, ba)
-	return ba, err
+	bankaccount := &stripe.BankAccount{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, bankaccount)
+	return bankaccount, err
 }
 
 // List returns a list of bank accounts.
@@ -140,7 +146,7 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 	// filter `object=bank_account` to make sure that only bank accounts come
 	// back with the response.
 	if listParams == nil {
-		outerErr = errors.New("params should not be nil")
+		outerErr = fmt.Errorf("params should not be nil")
 	} else if listParams.Customer != nil {
 		path = stripe.FormatURLPath("/v1/customers/%s/sources",
 			stripe.StringValue(listParams.Customer))
@@ -148,7 +154,7 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts",
 			stripe.StringValue(listParams.Account))
 	} else {
-		outerErr = errors.New("Invalid bank account params: either Customer or Account need to be set")
+		outerErr = fmt.Errorf("Invalid bank account params: either Customer or Account need to be set")
 	}
 
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {

--- a/card.go
+++ b/card.go
@@ -74,23 +74,23 @@ const cardSource = "source"
 // of all parameters. See AppendToAsCardSourceOrExternalAccount.
 type CardParams struct {
 	Params             `form:"*"`
-	Account            *string `form:"-"`
-	AccountType        *string `form:"account_type"`
-	AddressCity        *string `form:"address_city"`
-	AddressCountry     *string `form:"address_country"`
-	AddressLine1       *string `form:"address_line1"`
-	AddressLine2       *string `form:"address_line2"`
-	AddressState       *string `form:"address_state"`
-	AddressZip         *string `form:"address_zip"`
-	CVC                *string `form:"cvc"`
-	Currency           *string `form:"currency"`
-	Customer           *string `form:"-"`
-	DefaultForCurrency *bool   `form:"default_for_currency"`
-	ExpMonth           *string `form:"exp_month"`
-	ExpYear            *string `form:"exp_year"`
-	Name               *string `form:"name"`
-	Number             *string `form:"number"`
-	Token              *string `form:"-"`
+	Account            *string          `form:"-"`
+	Customer           *string          `form:"-"`
+	Token              *string          `form:"-"`
+	AccountType        *string          `form:"account_type"`
+	AddressCity        *string          `form:"address_city"`
+	AddressCountry     *string          `form:"address_country"`
+	AddressLine1       *string          `form:"address_line1"`
+	AddressLine2       *string          `form:"address_line2"`
+	AddressState       *string          `form:"address_state"`
+	AddressZip         *string          `form:"address_zip"`
+	Currency           *string          `form:"currency"`
+	CVC                *string          `form:"cvc"`
+	DefaultForCurrency *bool            `form:"default_for_currency"`
+	ExpMonth           *string          `form:"exp_month"`
+	ExpYear            *string          `form:"exp_year"`
+	Name               *string          `form:"name"`
+	Number             *string          `form:"number"`
 
 	// ID is used when tokenizing a card for shared customers
 	ID string `form:"*"`
@@ -208,38 +208,33 @@ type Card struct {
 	AddressZipCheck        CardVerification            `json:"address_zip_check"`
 	AvailablePayoutMethods []CardAvailablePayoutMethod `json:"available_payout_methods"`
 	Brand                  CardBrand                   `json:"brand"`
-	CVCCheck               CardVerification            `json:"cvc_check"`
 	Country                string                      `json:"country"`
 	Currency               Currency                    `json:"currency"`
 	Customer               *Customer                   `json:"customer"`
+	CVCCheck               CardVerification            `json:"cvc_check"`
 	DefaultForCurrency     bool                        `json:"default_for_currency"`
 	Deleted                bool                        `json:"deleted"`
-
 	// Description is a succinct summary of the card's information.
 	//
 	// Please note that this field is for internal use only and is not returned
 	// as part of standard API requests.
-	Description string `json:"description"`
-
+	Description  string      `json:"description"`
 	DynamicLast4 string      `json:"dynamic_last4"`
 	ExpMonth     uint8       `json:"exp_month"`
 	ExpYear      uint16      `json:"exp_year"`
 	Fingerprint  string      `json:"fingerprint"`
 	Funding      CardFunding `json:"funding"`
 	ID           string      `json:"id"`
-
 	// IIN is the card's "Issuer Identification Number".
 	//
 	// Please note that this field is for internal use only and is not returned
 	// as part of standard API requests.
 	IIN string `json:"iin"`
-
 	// Issuer is a bank or financial institution that provides the card.
 	//
 	// Please note that this field is for internal use only and is not returned
 	// as part of standard API requests.
-	Issuer string `json:"issuer"`
-
+	Issuer             string                 `json:"issuer"`
 	Last4              string                 `json:"last4"`
 	Metadata           map[string]string      `json:"metadata"`
 	Name               string                 `json:"name"`

--- a/card.go
+++ b/card.go
@@ -147,49 +147,71 @@ func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, ke
 		body.Add(form.FormatKey(append(keyParts, cardSource, "object")), "card")
 		body.Add(form.FormatKey(append(keyParts, cardSource, "number")), StringValue(c.Number))
 	}
-
 	if c.CVC != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "cvc")), StringValue(c.CVC))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "cvc")),
+			StringValue(c.CVC),
+		)
 	}
-
 	if c.Currency != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "currency")), StringValue(c.Currency))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "currency")),
+			StringValue(c.Currency),
+		)
 	}
-
 	if c.ExpMonth != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_month")), StringValue(c.ExpMonth))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "exp_month")),
+			StringValue(c.ExpMonth),
+		)
 	}
-
 	if c.ExpYear != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "exp_year")), StringValue(c.ExpYear))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "exp_year")),
+			StringValue(c.ExpYear),
+		)
 	}
-
 	if c.Name != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "name")), StringValue(c.Name))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "name")),
+			StringValue(c.Name),
+		)
 	}
-
 	if c.AddressCity != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_city")), StringValue(c.AddressCity))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "address_city")),
+			StringValue(c.AddressCity),
+		)
 	}
-
 	if c.AddressCountry != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_country")), StringValue(c.AddressCountry))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "address_country")),
+			StringValue(c.AddressCountry),
+		)
 	}
-
 	if c.AddressLine1 != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line1")), StringValue(c.AddressLine1))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "address_line1")),
+			StringValue(c.AddressLine1),
+		)
 	}
-
 	if c.AddressLine2 != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_line2")), StringValue(c.AddressLine2))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "address_line2")),
+			StringValue(c.AddressLine2),
+		)
 	}
-
 	if c.AddressState != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_state")), StringValue(c.AddressState))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "address_state")),
+			StringValue(c.AddressState),
+		)
 	}
-
 	if c.AddressZip != nil {
-		body.Add(form.FormatKey(append(keyParts, cardSource, "address_zip")), StringValue(c.AddressZip))
+		body.Add(
+			form.FormatKey(append(keyParts, cardSource, "address_zip")),
+			StringValue(c.AddressZip),
+		)
 	}
 }
 

--- a/card.go
+++ b/card.go
@@ -1,10 +1,15 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import (
 	"encoding/json"
-	"strconv"
-
 	"github.com/stripe/stripe-go/v72/form"
+	"strconv"
 )
 
 // CardAvailablePayoutMethod is a set of available payout methods for the card.
@@ -12,8 +17,8 @@ type CardAvailablePayoutMethod string
 
 // List of values that CardAvailablePayoutMethod can take.
 const (
-	CardAvailablePayoutMethodInstant  CardAvailablePayoutMethod = "Instant"
-	CardAvailablePayoutMethodStandard CardAvailablePayoutMethod = "Standard"
+	CardAvailablePayoutMethodInstant  CardAvailablePayoutMethod = "instant"
+	CardAvailablePayoutMethodStandard CardAvailablePayoutMethod = "standard"
 )
 
 // CardBrand is the list of allowed values for the card's brand.
@@ -62,6 +67,13 @@ const (
 	CardVerificationUnchecked   CardVerification = "unchecked"
 )
 
+type CardOwnerParams struct {
+	Address *AddressParams `form:"address"`
+	Email   *string        `form:"email"`
+	Name    *string        `form:"name"`
+	Phone   *string        `form:"phone"`
+}
+
 // cardSource is a string that's used to build card form parameters. It's a
 // constant just to make mistakes less likely.
 const cardSource = "source"
@@ -74,9 +86,11 @@ const cardSource = "source"
 // of all parameters. See AppendToAsCardSourceOrExternalAccount.
 type CardParams struct {
 	Params             `form:"*"`
-	Account            *string          `form:"-"`
-	Customer           *string          `form:"-"`
-	Token              *string          `form:"-"`
+	Account            *string          `form:"-"` // Included in URL
+	Token              *string          `form:"-"` // Included in URL
+	Customer           *string          `form:"-"` // Included in URL
+	AccountHolderName  *string          `form:"account_holder_name"`
+	AccountHolderType  *string          `form:"account_holder_type"`
 	AccountType        *string          `form:"account_type"`
 	AddressCity        *string          `form:"address_city"`
 	AddressCountry     *string          `form:"address_country"`
@@ -91,7 +105,7 @@ type CardParams struct {
 	ExpYear            *string          `form:"exp_year"`
 	Name               *string          `form:"name"`
 	Number             *string          `form:"number"`
-
+	Owner              *CardOwnerParams `form:"owner"`
 	// ID is used when tokenizing a card for shared customers
 	ID string `form:"*"`
 }
@@ -115,7 +129,10 @@ func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, ke
 	form.AppendToPrefixed(body, c.Params, keyParts)
 
 	if c.DefaultForCurrency != nil {
-		body.Add(form.FormatKey(append(keyParts, "default_for_currency")), strconv.FormatBool(BoolValue(c.DefaultForCurrency)))
+		body.Add(
+			form.FormatKey(append(keyParts, "default_for_currency")),
+			strconv.FormatBool(BoolValue(c.DefaultForCurrency)),
+		)
 	}
 
 	if c.Token != nil {
@@ -180,8 +197,8 @@ func (c *CardParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, ke
 // For more details see https://stripe.com/docs/api#list_cards.
 type CardListParams struct {
 	ListParams `form:"*"`
-	Account    *string `form:"-"`
-	Customer   *string `form:"-"`
+	Account    *string `form:"-"` // Included in URL
+	Customer   *string `form:"-"` // Included in URL
 }
 
 // AppendTo implements custom encoding logic for CardListParams
@@ -197,7 +214,7 @@ func (p *CardListParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#cards.
 type Card struct {
 	APIResource
-
+	Account                *Account                    `json:"account"`
 	AddressCity            string                      `json:"address_city"`
 	AddressCountry         string                      `json:"address_country"`
 	AddressLine1           string                      `json:"address_line1"`
@@ -238,6 +255,7 @@ type Card struct {
 	Last4              string                 `json:"last4"`
 	Metadata           map[string]string      `json:"metadata"`
 	Name               string                 `json:"name"`
+	Object             string                 `json:"object"`
 	TokenizationMethod CardTokenizationMethod `json:"tokenization_method"`
 }
 

--- a/card/client.go
+++ b/card/client.go
@@ -1,15 +1,21 @@
-// Package card provides the /cards APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package card provides the card related APIs
 package card
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /cards APIs.
+// Client is used to invoke card related APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
@@ -23,18 +29,16 @@ func New(params *stripe.CardParams) (*stripe.Card, error) {
 // New creates a new card.
 func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
-	if params.Account != nil {
-		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts",
-			stripe.StringValue(params.Account))
-	} else if params.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources",
-			stripe.StringValue(params.Customer))
+	if params.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources", stripe.StringValue(params.Customer))
+	} else if params.Account != nil {
+		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts", stripe.StringValue(params.Account))
 	} else {
-		return nil, errors.New("Invalid card params: either account or customer need to be set")
+		return nil, fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
 
 	body := &form.Values{}
@@ -44,9 +48,9 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	// include some parameters that are undesirable here.
 	params.AppendToAsCardSourceOrExternalAccount(body, nil)
 
-	// Because card creation uses the custom append above, we have to make an
-	// explicit call using a form and CallRaw instead of the standard Call
-	// (which takes a set of parameters).
+	// Because card creation uses the custom append above, we have to
+	// make an explicit call using a form and CallRaw instead of the standard
+	// Call (which takes a set of parameters).
 	card := &stripe.Card{}
 	err := c.B.CallRaw(http.MethodPost, path, c.Key, body, &params.Params, card)
 	return card, err
@@ -60,18 +64,16 @@ func Get(id string, params *stripe.CardParams) (*stripe.Card, error) {
 // Get returns the details of a card.
 func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
-	if params.Account != nil {
-		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s",
-			stripe.StringValue(params.Account), id)
-	} else if params.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s",
-			stripe.StringValue(params.Customer), id)
+	if params != nil && params.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
+	} else if params != nil && params.Account != nil {
+		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else {
-		return nil, errors.New("Invalid card params: either account or customer need to be set")
+		return nil, fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
 
 	card := &stripe.Card{}
@@ -87,18 +89,16 @@ func Update(id string, params *stripe.CardParams) (*stripe.Card, error) {
 // Update updates a card's properties.
 func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
-	if params.Account != nil {
-		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s",
-			stripe.StringValue(params.Account), id)
-	} else if params.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s",
-			stripe.StringValue(params.Customer), id)
+	if params.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
+	} else if params.Account != nil {
+		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else {
-		return nil, errors.New("Invalid card params: either account or customer need to be set")
+		return nil, fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
 
 	card := &stripe.Card{}
@@ -114,16 +114,16 @@ func Del(id string, params *stripe.CardParams) (*stripe.Card, error) {
 // Del removes a card.
 func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
-	if params.Account != nil {
-		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
-	} else if params.Customer != nil {
+	if params.Customer != nil {
 		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
+	} else if params.Account != nil {
+		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else {
-		return nil, errors.New("Invalid card params: either account or customer need to be set")
+		return nil, fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
 
 	card := &stripe.Card{}
@@ -141,19 +141,20 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 	var path string
 	var outerErr error
 
-	// Because the external accounts and sources endpoints can return non-card
-	// objects, CardListParam's `AppendTo` will add the filter `object=card` to
-	// make sure that only cards come back with the response.
+	// There's no cards list URL, so we use one sources or external
+	// accounts. An override on CardListParam's `AppendTo` will add the
+	// filter `object=card` to make sure that only cards come
+	// back with the response.
 	if listParams == nil {
-		outerErr = errors.New("params should not be nil")
-	} else if listParams.Account != nil {
-		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts",
-			stripe.StringValue(listParams.Account))
+		outerErr = fmt.Errorf("params should not be nil")
 	} else if listParams.Customer != nil {
 		path = stripe.FormatURLPath("/v1/customers/%s/sources",
 			stripe.StringValue(listParams.Customer))
+	} else if listParams.Account != nil {
+		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts",
+			stripe.StringValue(listParams.Account))
 	} else {
-		outerErr = errors.New("Invalid card params: either account or customer need to be set")
+		outerErr = fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
 
 	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
@@ -184,9 +185,9 @@ func (i *Iter) Card() *stripe.Card {
 	return i.Current().(*stripe.Card)
 }
 
-// CardList returns the current list object which the iterator is currently
-// using. List objects will change as new API calls are made to continue
-// pagination.
+// CardList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
 func (i *Iter) CardList() *stripe.CardList {
 	return i.List().(*stripe.CardList)
 }

--- a/card/client.go
+++ b/card/client.go
@@ -33,10 +33,10 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	}
 
 	var path string
-	if params.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources", stripe.StringValue(params.Customer))
-	} else if params.Account != nil {
+	if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts", stripe.StringValue(params.Account))
+	} else if params.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources", stripe.StringValue(params.Customer))
 	} else {
 		return nil, fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
@@ -68,10 +68,10 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	}
 
 	var path string
-	if params != nil && params.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
-	} else if params != nil && params.Account != nil {
+	if params != nil && params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
+	} else if params != nil && params.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	} else {
 		return nil, fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
@@ -93,10 +93,10 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 	}
 
 	var path string
-	if params.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
-	} else if params.Account != nil {
+	if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
+	} else if params.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	} else {
 		return nil, fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
@@ -118,10 +118,10 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	}
 
 	var path string
-	if params.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
-	} else if params.Account != nil {
+	if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
+	} else if params.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
 	} else {
 		return nil, fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
@@ -147,12 +147,12 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 	// back with the response.
 	if listParams == nil {
 		outerErr = fmt.Errorf("params should not be nil")
-	} else if listParams.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources",
-			stripe.StringValue(listParams.Customer))
 	} else if listParams.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts",
 			stripe.StringValue(listParams.Account))
+	} else if listParams.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources",
+			stripe.StringValue(listParams.Customer))
 	} else {
 		outerErr = fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -11,6 +11,7 @@ import (
 	billingportal_configuration "github.com/stripe/stripe-go/v72/billingportal/configuration"
 	billingportal_session "github.com/stripe/stripe-go/v72/billingportal/session"
 	capability "github.com/stripe/stripe-go/v72/capability"
+	card "github.com/stripe/stripe-go/v72/card"
 	charge "github.com/stripe/stripe-go/v72/charge"
 	checkout_session "github.com/stripe/stripe-go/v72/checkout/session"
 	countryspec "github.com/stripe/stripe-go/v72/countryspec"
@@ -460,6 +461,31 @@ func TestPaymentMethodAttach(t *testing.T) {
 func TestPaymentMethodDetach(t *testing.T) {
 	params := &stripe.PaymentMethodDetachParams{}
 	result, _ := paymentmethod.Detach("pm_xxxxxxxxxxxxx", params)
+	assert.NotNil(t, result)
+}
+
+func TestCardUpdate(t *testing.T) {
+	params := &stripe.CardParams{}
+	params.AddMetadata("order_id", "6735")
+	result, _ := card.Update("ba_xxxxxxxxxxxxx", params)
+	assert.NotNil(t, result)
+}
+
+func TestCardDelete(t *testing.T) {
+	params := &stripe.CardParams{}
+	result, _ := card.Del("ba_xxxxxxxxxxxxx", params)
+	assert.NotNil(t, result)
+}
+
+func TestCardUpdate2(t *testing.T) {
+	params := &stripe.CardParams{Name: stripe.String("Jenny Rosen")}
+	result, _ := card.Update("card_xxxxxxxxxxxxx", params)
+	assert.NotNil(t, result)
+}
+
+func TestCardDelete2(t *testing.T) {
+	params := &stripe.CardParams{}
+	result, _ := card.Del("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
 }
 

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -11,7 +11,6 @@ import (
 	billingportal_configuration "github.com/stripe/stripe-go/v72/billingportal/configuration"
 	billingportal_session "github.com/stripe/stripe-go/v72/billingportal/session"
 	capability "github.com/stripe/stripe-go/v72/capability"
-	card "github.com/stripe/stripe-go/v72/card"
 	charge "github.com/stripe/stripe-go/v72/charge"
 	checkout_session "github.com/stripe/stripe-go/v72/checkout/session"
 	countryspec "github.com/stripe/stripe-go/v72/countryspec"
@@ -461,31 +460,6 @@ func TestPaymentMethodAttach(t *testing.T) {
 func TestPaymentMethodDetach(t *testing.T) {
 	params := &stripe.PaymentMethodDetachParams{}
 	result, _ := paymentmethod.Detach("pm_xxxxxxxxxxxxx", params)
-	assert.NotNil(t, result)
-}
-
-func TestCardUpdate(t *testing.T) {
-	params := &stripe.CardParams{}
-	params.AddMetadata("order_id", "6735")
-	result, _ := card.Update("ba_xxxxxxxxxxxxx", params)
-	assert.NotNil(t, result)
-}
-
-func TestCardDelete(t *testing.T) {
-	params := &stripe.CardParams{}
-	result, _ := card.Del("ba_xxxxxxxxxxxxx", params)
-	assert.NotNil(t, result)
-}
-
-func TestCardUpdate2(t *testing.T) {
-	params := &stripe.CardParams{Name: stripe.String("Jenny Rosen")}
-	result, _ := card.Update("card_xxxxxxxxxxxxx", params)
-	assert.NotNil(t, result)
-}
-
-func TestCardDelete2(t *testing.T) {
-	params := &stripe.CardParams{}
-	result, _ := card.Del("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
 }
 


### PR DESCRIPTION
## Summary
Make bankaccount.go and card.go and related client.go codegen-able.

The first commit is rearranging files and the last is the codegen changes.

## Notify
r? @dcr-stripe
cc @richardm-stripe 

## Changelog
* Add support for `address_city`, `address_country`, `address_line1`, `address_line2`, `address_state`, `address_zip`, `exp_month`, `exp_year`, and `name` on `BankAccountParams`
* Add support for `account_holder_name`, `account_holder_type`, and `owner` on `CardParams`
* Add support for `account` on `Card`