### PR TITLE
Make paymentsource.go and client codegen-able

### DIFF
--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -156,23 +156,24 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 	} else {
 		outerErr = fmt.Errorf("Invalid bank account params: either Customer or Account need to be set")
 	}
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.BankAccountList{}
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.BankAccountList{}
+			if outerErr != nil {
+				return nil, list, outerErr
+			}
 
-		if outerErr != nil {
-			return nil, list, outerErr
-		}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
-
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for bank accounts.

--- a/card/client.go
+++ b/card/client.go
@@ -156,23 +156,24 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 	} else {
 		outerErr = fmt.Errorf("Invalid card params: either Customer or Account need to be set")
 	}
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CardList{}
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.CardList{}
+			if outerErr != nil {
+				return nil, list, outerErr
+			}
 
-		if outerErr != nil {
-			return nil, list, outerErr
-		}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
-
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
 // Iter is an iterator for cards.

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -1,9 +1,14 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
 package stripe
 
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/stripe/stripe-go/v72/form"
 )
 
@@ -37,16 +42,34 @@ func (p *SourceParams) AppendTo(body *form.Values, keyParts []string) {
 // For more details see https://stripe.com/docs/api#sources
 type CustomerSourceParams struct {
 	Params            `form:"*"`
-	Customer          *string                   `form:"-"` // Goes in the URL
+	Customer          *string                   `form:"-"` // Included in URL
+	AccountHolderName *string                   `form:"account_holder_name"`
+	AccountHolderType *string                   `form:"account_holder_type"`
+	AddressCity       *string                   `form:"address_city"`
+	AddressCountry    *string                   `form:"address_country"`
+	AddressLine1      *string                   `form:"address_line1"`
+	AddressLine2      *string                   `form:"address_line2"`
+	AddressState      *string                   `form:"address_state"`
+	AddressZip        *string                   `form:"address_zip"`
+	ExpMonth          *string                   `form:"exp_month"`
+	ExpYear           *string                   `form:"exp_year"`
+	Name              *string                   `form:"name"`
+	Owner             *PaymentSourceOwnerParams `form:"owner"`
 	Source            *SourceParams             `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+}
+type PaymentSourceOwnerParams struct {
+	Address *AddressParams `form:"address"`
+	Email   *string        `form:"email"`
+	Name    *string        `form:"name"`
+	Phone   *string        `form:"phone"`
 }
 
 // SourceVerifyParams are used to verify a customer source
 // For more details see https://stripe.com/docs/guides/ach-beta
 type SourceVerifyParams struct {
 	Params   `form:"*"`
+	Customer *string   `form:"-"`       // Included in URL
 	Amounts  [2]int64  `form:"amounts"` // Amounts is used when verifying bank accounts
-	Customer *string   `form:"-"`       // Goes in the URL
 	Values   []*string `form:"values"`  // Values is used when verifying sources
 }
 
@@ -54,7 +77,8 @@ type SourceVerifyParams struct {
 // to a Customer.
 type SourceListParams struct {
 	ListParams `form:"*"`
-	Customer   *string `form:"-"` // Handled in URL
+	Customer   *string `form:"-"` // Included in URL
+	Object     *string `form:"object"`
 }
 
 // SetSource adds valid sources to a CustomerSourceParams object,

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -36,9 +36,9 @@ func (p *SourceParams) AppendTo(body *form.Values, keyParts []string) {
 // Customer object's payment sources.
 // For more details see https://stripe.com/docs/api#sources
 type CustomerSourceParams struct {
-	Params   `form:"*"`
-	Customer *string       `form:"-"` // Goes in the URL
-	Source   *SourceParams `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
+	Params            `form:"*"`
+	Customer          *string                   `form:"-"` // Goes in the URL
+	Source            *SourceParams             `form:"*"` // SourceParams has custom encoding so brought to top level with "*"
 }
 
 // SourceVerifyParams are used to verify a customer source
@@ -48,6 +48,13 @@ type SourceVerifyParams struct {
 	Amounts  [2]int64  `form:"amounts"` // Amounts is used when verifying bank accounts
 	Customer *string   `form:"-"`       // Goes in the URL
 	Values   []*string `form:"values"`  // Values is used when verifying sources
+}
+
+// SourceListParams are used to enumerate the payment sources that are attached
+// to a Customer.
+type SourceListParams struct {
+	ListParams `form:"*"`
+	Customer   *string `form:"-"` // Handled in URL
 }
 
 // SetSource adds valid sources to a CustomerSourceParams object,
@@ -100,13 +107,6 @@ type SourceList struct {
 	APIResource
 	ListMeta
 	Data []*PaymentSource `json:"data"`
-}
-
-// SourceListParams are used to enumerate the payment sources that are attached
-// to a Customer.
-type SourceListParams struct {
-	ListParams `form:"*"`
-	Customer   *string `form:"-"` // Handled in URL
 }
 
 // UnmarshalJSON handles deserialization of a PaymentSource.

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -99,6 +99,32 @@ func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.Pay
 	return source, err
 }
 
+// Verify verifies a source which is used for bank accounts.
+func Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
+	return getC().Verify(id, params)
+}
+
+// Verify verifies a source which is used for bank accounts.
+func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
+	if params == nil {
+		return nil, errors.New("params should not be nil")
+	}
+
+	var path string
+	if params.Customer != nil {
+		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s/verify",
+			stripe.StringValue(params.Customer), id)
+	} else if len(params.Values) > 0 {
+		path = stripe.FormatURLPath("/v1/sources/%s/verify", id)
+	} else {
+		return nil, errors.New("Only customer bank accounts or sources can be verified in this manner")
+	}
+
+	source := &stripe.PaymentSource{}
+	err := s.B.Call(http.MethodPost, path, s.Key, params, source)
+	return source, err
+}
+
 // List returns a list of sources.
 func List(params *stripe.SourceListParams) *Iter {
 	return getC().List(params)
@@ -134,32 +160,6 @@ func (s Client) List(listParams *stripe.SourceListParams) *Iter {
 
 		return ret, list, err
 	})}
-}
-
-// Verify verifies a source which is used for bank accounts.
-func Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
-	return getC().Verify(id, params)
-}
-
-// Verify verifies a source which is used for bank accounts.
-func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
-	if params == nil {
-		return nil, errors.New("params should not be nil")
-	}
-
-	var path string
-	if params.Customer != nil {
-		path = stripe.FormatURLPath("/v1/customers/%s/sources/%s/verify",
-			stripe.StringValue(params.Customer), id)
-	} else if len(params.Values) > 0 {
-		path = stripe.FormatURLPath("/v1/sources/%s/verify", id)
-	} else {
-		return nil, errors.New("Only customer bank accounts or sources can be verified in this manner")
-	}
-
-	source := &stripe.PaymentSource{}
-	err := s.B.Call(http.MethodPost, path, s.Key, params, source)
-	return source, err
 }
 
 // Iter is an iterator for sources.

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -1,102 +1,115 @@
-// Package paymentsource provides the /sources APIs
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package paymentsource provides the /customers/{customer}/sources APIs
 package paymentsource
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	stripe "github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/form"
 )
 
-// Client is used to invoke /sources APIs.
+// Client is used to invoke /customers/{customer}/sources APIs.
 type Client struct {
 	B   stripe.Backend
 	Key string
 }
 
-// New creates a new source for a customer.
+// New creates a new payment source.
 func New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	return getC().New(params)
 }
 
-// New creates a new source for a customer.
-func (s Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+// New creates a new payment source.
+func (c Client) New(params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
-
 	if params.Customer == nil {
-		return nil, errors.New("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
 	}
-
-	path := stripe.FormatURLPath("/v1/customers/%s/sources", stripe.StringValue(params.Customer))
-	source := &stripe.PaymentSource{}
-	err := s.B.Call(http.MethodPost, path, s.Key, params, source)
-	return source, err
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/sources",
+		stripe.StringValue(params.Customer),
+	)
+	paymentsource := &stripe.PaymentSource{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentsource)
+	return paymentsource, err
 }
 
-// Get returns the details of a source.
+// Get returns the details of a payment source.
 func Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	return getC().Get(id, params)
 }
 
-// Get returns the details of a source.
-func (s Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+// Get returns the details of a payment source.
+func (c Client) Get(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
-
 	if params.Customer == nil {
-		return nil, errors.New("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
 	}
-
-	path := stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
-	source := &stripe.PaymentSource{}
-	err := s.B.Call(http.MethodGet, path, s.Key, params, source)
-	return source, err
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/sources/%s",
+		stripe.StringValue(params.Customer),
+		id,
+	)
+	paymentsource := &stripe.PaymentSource{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, paymentsource)
+	return paymentsource, err
 }
 
-// Update updates a source's properties.
+// Update updates a payment source's properties.
 func Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	return getC().Update(id, params)
 }
 
-// Update updates a source's properties.
-func (s Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+// Update updates a payment source's properties.
+func (c Client) Update(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
-
 	if params.Customer == nil {
-		return nil, errors.New("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
 	}
-
-	path := stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
-	source := &stripe.PaymentSource{}
-	err := s.B.Call(http.MethodPost, path, s.Key, params, source)
-	return source, err
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/sources/%s",
+		stripe.StringValue(params.Customer),
+		id,
+	)
+	paymentsource := &stripe.PaymentSource{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentsource)
+	return paymentsource, err
 }
 
-// Del removes a source.
+// Del removes a payment source.
 func Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	return getC().Del(id, params)
 }
 
-// Del removes a source.
-func (s Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
+// Del removes a payment source.
+func (c Client) Del(id string, params *stripe.CustomerSourceParams) (*stripe.PaymentSource, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
-
 	if params.Customer == nil {
-		return nil, errors.New("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
 	}
-
-	source := &stripe.PaymentSource{}
-	path := stripe.FormatURLPath("/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
-	err := s.B.Call(http.MethodDelete, path, s.Key, params, source)
-	return source, err
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/sources/%s",
+		stripe.StringValue(params.Customer),
+		id,
+	)
+	paymentsource := &stripe.PaymentSource{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, paymentsource)
+	return paymentsource, err
 }
 
 // Verify verifies a source which is used for bank accounts.
@@ -105,9 +118,9 @@ func Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource
 }
 
 // Verify verifies a source which is used for bank accounts.
-func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
+func (c Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.PaymentSource, error) {
 	if params == nil {
-		return nil, errors.New("params should not be nil")
+		return nil, fmt.Errorf("params should not be nil")
 	}
 
 	var path string
@@ -117,57 +130,58 @@ func (s Client) Verify(id string, params *stripe.SourceVerifyParams) (*stripe.Pa
 	} else if len(params.Values) > 0 {
 		path = stripe.FormatURLPath("/v1/sources/%s/verify", id)
 	} else {
-		return nil, errors.New("Only customer bank accounts or sources can be verified in this manner")
+		return nil, fmt.Errorf("Only customer bank accounts or sources can be verified in this manner")
 	}
 
 	source := &stripe.PaymentSource{}
-	err := s.B.Call(http.MethodPost, path, s.Key, params, source)
+	err := c.B.Call(http.MethodPost, path, c.Key, params, source)
 	return source, err
 }
 
-// List returns a list of sources.
+// List returns a list of payment sources.
 func List(params *stripe.SourceListParams) *Iter {
 	return getC().List(params)
 }
 
-// List returns a list of sources.
-func (s Client) List(listParams *stripe.SourceListParams) *Iter {
+// List returns a list of payment sources.
+func (c Client) List(listParams *stripe.SourceListParams) *Iter {
 	var outerErr error
 	var path string
 
 	if listParams == nil {
-		outerErr = errors.New("params should not be nil")
+		outerErr = fmt.Errorf("params should not be nil")
 	} else if listParams.Customer == nil {
-		outerErr = errors.New("Invalid source params: customer needs to be set")
+		outerErr = fmt.Errorf("Invalid source params: customer needs to be set")
 	} else {
 		path = stripe.FormatURLPath("/v1/customers/%s/sources",
 			stripe.StringValue(listParams.Customer))
 	}
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.SourceList{}
 
-	return &Iter{stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
-		list := &stripe.SourceList{}
+			if outerErr != nil {
+				return nil, list, outerErr
+			}
 
-		if outerErr != nil {
-			return nil, list, outerErr
-		}
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
 
-		err := s.B.CallRaw(http.MethodGet, path, s.Key, b, p, list)
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
 
-		ret := make([]interface{}, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
-
-		return ret, list, err
-	})}
+			return ret, list, err
+		}),
+	}
 }
 
-// Iter is an iterator for sources.
+// Iter is an iterator for payment sources.
 type Iter struct {
 	*stripe.Iter
 }
 
-// PaymentSource returns the source which the iterator is currently pointing to.
+// PaymentSource returns the payment source which the iterator is currently pointing to.
 func (i *Iter) PaymentSource() *stripe.PaymentSource {
 	return i.Current().(*stripe.PaymentSource)
 }


### PR DESCRIPTION
## Summary
Make paymentsource.go and paymentsource/client.go codegen-able. 

Also make some formatting changes for bankaccount/ and card/client.go.

The first commit is rearranging files and the last is the codegen changes.

## Notify
r? @richardm-stripe
cc @dcr-stripe

## Changelog
* Add support for `account_holder_name`, `account_holder_type`, `address_city`, `address_country`, `address_line1`, `address_line2`, `address_state`, `address_zip`, `exp_month`, `exp_year`, `name`, `owner` on `CustomerSourceParams`
* Add support for `PaymentSourceOwnerParams`
* Add support for `Object` on `SourceListParams`