### PR TITLE
API Updates

### DIFF
--- a/billingportal_configuration.go
+++ b/billingportal_configuration.go
@@ -141,7 +141,7 @@ type BillingPortalConfigurationFeaturesSubscriptionPauseParams struct {
 
 // The list of products that support subscription updates.
 type BillingPortalConfigurationFeaturesSubscriptionUpdateProductParams struct {
-	// The list of prices IDs that a subscription can be updated to.
+	// The list of price IDs for the product that a subscription can be updated to.
 	Prices []*string `form:"prices"`
 	// The product id.
 	Product *string `form:"product"`

--- a/charge.go
+++ b/charge.go
@@ -116,6 +116,16 @@ const (
 	ChargePaymentMethodDetailsTypeWechat            ChargePaymentMethodDetailsType = "wechat"
 )
 
+// The status of the payment is either `succeeded`, `pending`, or `failed`.
+type ChargeStatus string
+
+// List of values that ChargeStatus can take
+const (
+	ChargeStatusFailed    ChargeStatus = "failed"
+	ChargeStatusPending   ChargeStatus = "pending"
+	ChargeStatusSucceeded ChargeStatus = "succeeded"
+)
+
 // Returns a list of charges you've previously created. The charges are returned in sorted order, with the most recent charges appearing first.
 type ChargeListParams struct {
 	ListParams   `form:"*"`
@@ -894,7 +904,7 @@ type Charge struct {
 	// Provides information about the charge that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that's set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
 	StatementDescriptorSuffix string `json:"statement_descriptor_suffix"`
 	// The status of the payment is either `succeeded`, `pending`, or `failed`.
-	Status string `json:"status"`
+	Status ChargeStatus `json:"status"`
 	// ID of the transfer to the `destination` account (only applicable if the charge was created using the `destination` parameter).
 	Transfer *Transfer `json:"transfer"`
 	// An optional dictionary including the account to automatically transfer to as part of a destination charge. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details.

--- a/invoice.go
+++ b/invoice.go
@@ -669,6 +669,8 @@ type Invoice struct {
 	OnBehalfOf *Account `json:"on_behalf_of"`
 	// Whether payment was successfully collected for this invoice. An invoice can be paid (most commonly) with a charge or with credit from the customer's account balance.
 	Paid bool `json:"paid"`
+	// Returns true if the invoice was manually marked paid, returns false if the invoice hasn't been paid yet or was paid on Stripe.
+	PaidOutOfBand bool `json:"paid_out_of_band"`
 	// The PaymentIntent associated with this invoice. The PaymentIntent is generated when the invoice is finalized, and can then be used to pay the invoice. Note that voiding an invoice will cancel the PaymentIntent.
 	PaymentIntent   *PaymentIntent          `json:"payment_intent"`
 	PaymentSettings *InvoicePaymentSettings `json:"payment_settings"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -718,9 +718,9 @@ type PaymentIntentNextActionWechatPayDisplayQRCode struct {
 	// The base64 image data for a pre-generated QR code
 	ImageDataURL string `json:"image_data_url"`
 	// The image_url_png string used to render QR code, can be used as <img src="…" />
-	ImageURLPng string `json:"image_url_png"`
+	ImageURLPNG string `json:"image_url_png"`
 	// The image_url_svg string used to render QR code, can be used as <img src="…" />
-	ImageURLSvg string `json:"image_url_svg"`
+	ImageURLSVG string `json:"image_url_svg"`
 }
 type PaymentIntentNextActionWechatPayRedirectToAndroidApp struct {
 	// app_id is the APP ID registered on WeChat open platform

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -292,6 +292,9 @@ type PaymentIntentPaymentMethodOptionsAlipayParams struct{}
 // If this is a `au_becs_debit` PaymentMethod, this sub-hash contains details about the AU BECS Direct Debit payment method options.
 type PaymentIntentPaymentMethodOptionsAUBECSDebitParams struct{}
 
+// If this is a `bacs_debit` PaymentMethod, this sub-hash contains details about the BACS Debit payment method options.
+type PaymentIntentPaymentMethodOptionsBACSDebitParams struct{}
+
 // If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
 type PaymentIntentPaymentMethodOptionsBancontactParams struct {
 	// Preferred language of the Bancontact authorization page that the customer is redirected to.
@@ -358,8 +361,17 @@ type PaymentIntentPaymentMethodOptionsCardParams struct {
 // If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
 type PaymentIntentPaymentMethodOptionsCardPresentParams struct{}
 
+// If this is a `eps` PaymentMethod, this sub-hash contains details about the EPS payment method options.
+type PaymentIntentPaymentMethodOptionsEPSParams struct{}
+
+// If this is a `fpx` PaymentMethod, this sub-hash contains details about the FPX payment method options.
+type PaymentIntentPaymentMethodOptionsFPXParams struct{}
+
 // If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
 type PaymentIntentPaymentMethodOptionsGiropayParams struct{}
+
+// If this is a `grabpay` PaymentMethod, this sub-hash contains details about the Grabpay payment method options.
+type PaymentIntentPaymentMethodOptionsGrabpayParams struct{}
 
 // If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
 type PaymentIntentPaymentMethodOptionsIdealParams struct{}
@@ -418,6 +430,8 @@ type PaymentIntentPaymentMethodOptionsParams struct {
 	Alipay *PaymentIntentPaymentMethodOptionsAlipayParams `form:"alipay"`
 	// If this is a `au_becs_debit` PaymentMethod, this sub-hash contains details about the AU BECS Direct Debit payment method options.
 	AUBECSDebit *PaymentIntentPaymentMethodOptionsAUBECSDebitParams `form:"au_becs_debit"`
+	// If this is a `bacs_debit` PaymentMethod, this sub-hash contains details about the BACS Debit payment method options.
+	BACSDebit *PaymentIntentPaymentMethodOptionsBACSDebitParams `form:"bacs_debit"`
 	// If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
 	Bancontact *PaymentIntentPaymentMethodOptionsBancontactParams `form:"bancontact"`
 	// If this is a `boleto` PaymentMethod, this sub-hash contains details about the Boleto payment method options.
@@ -426,8 +440,14 @@ type PaymentIntentPaymentMethodOptionsParams struct {
 	Card *PaymentIntentPaymentMethodOptionsCardParams `form:"card"`
 	// If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
 	CardPresent *PaymentIntentPaymentMethodOptionsCardPresentParams `form:"card_present"`
+	// If this is a `eps` PaymentMethod, this sub-hash contains details about the EPS payment method options.
+	EPS *PaymentIntentPaymentMethodOptionsEPSParams `form:"eps"`
+	// If this is a `fpx` PaymentMethod, this sub-hash contains details about the FPX payment method options.
+	FPX *PaymentIntentPaymentMethodOptionsFPXParams `form:"fpx"`
 	// If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
 	Giropay *PaymentIntentPaymentMethodOptionsGiropayParams `form:"giropay"`
+	// If this is a `grabpay` PaymentMethod, this sub-hash contains details about the Grabpay payment method options.
+	Grabpay *PaymentIntentPaymentMethodOptionsGrabpayParams `form:"grabpay"`
 	// If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
 	Ideal *PaymentIntentPaymentMethodOptionsIdealParams `form:"ideal"`
 	// If this is a `interac_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
@@ -697,6 +717,10 @@ type PaymentIntentNextActionWechatPayDisplayQRCode struct {
 	Data string `json:"data"`
 	// The base64 image data for a pre-generated QR code
 	ImageDataURL string `json:"image_data_url"`
+	// The image_url_png string used to render QR code, can be used as <img src="…" />
+	ImageURLPng string `json:"image_url_png"`
+	// The image_url_svg string used to render QR code, can be used as <img src="…" />
+	ImageURLSvg string `json:"image_url_svg"`
 }
 type PaymentIntentNextActionWechatPayRedirectToAndroidApp struct {
 	// app_id is the APP ID registered on WeChat open platform
@@ -756,6 +780,7 @@ type PaymentIntentPaymentMethodOptionsAfterpayClearpay struct {
 }
 type PaymentIntentPaymentMethodOptionsAlipay struct{}
 type PaymentIntentPaymentMethodOptionsAUBECSDebit struct{}
+type PaymentIntentPaymentMethodOptionsBACSDebit struct{}
 type PaymentIntentPaymentMethodOptionsBancontact struct {
 	// Preferred language of the Bancontact authorization page that the customer is redirected to.
 	PreferredLanguage string `json:"preferred_language"`
@@ -807,7 +832,10 @@ type PaymentIntentPaymentMethodOptionsCard struct {
 // PaymentIntentPaymentMethodOptionsCardPresent is the set of Card Present-specific options associated
 // with that payment intent.
 type PaymentIntentPaymentMethodOptionsCardPresent struct{}
+type PaymentIntentPaymentMethodOptionsEPS struct{}
+type PaymentIntentPaymentMethodOptionsFPX struct{}
 type PaymentIntentPaymentMethodOptionsGiropay struct{}
+type PaymentIntentPaymentMethodOptionsGrabpay struct{}
 
 // PaymentIntentPaymentMethodOptionsIdeal is the set of Ideal-specific options associated
 // with that payment intent.
@@ -852,11 +880,15 @@ type PaymentIntentPaymentMethodOptions struct {
 	AfterpayClearpay *PaymentIntentPaymentMethodOptionsAfterpayClearpay `json:"afterpay_clearpay"`
 	Alipay           *PaymentIntentPaymentMethodOptionsAlipay           `json:"alipay"`
 	AUBECSDebit      *PaymentIntentPaymentMethodOptionsAUBECSDebit      `json:"au_becs_debit"`
+	BACSDebit        *PaymentIntentPaymentMethodOptionsBACSDebit        `json:"bacs_debit"`
 	Bancontact       *PaymentIntentPaymentMethodOptionsBancontact       `json:"bancontact"`
 	Boleto           *PaymentIntentPaymentMethodOptionsBoleto           `json:"boleto"`
 	Card             *PaymentIntentPaymentMethodOptionsCard             `json:"card"`
 	CardPresent      *PaymentIntentPaymentMethodOptionsCardPresent      `json:"card_present"`
+	EPS              *PaymentIntentPaymentMethodOptionsEPS              `json:"eps"`
+	FPX              *PaymentIntentPaymentMethodOptionsFPX              `json:"fpx"`
 	Giropay          *PaymentIntentPaymentMethodOptionsGiropay          `json:"giropay"`
+	Grabpay          *PaymentIntentPaymentMethodOptionsGrabpay          `json:"grabpay"`
 	Ideal            *PaymentIntentPaymentMethodOptionsIdeal            `json:"ideal"`
 	InteracPresent   *PaymentIntentPaymentMethodOptionsInteracPresent   `json:"interac_present"`
 	Klarna           *PaymentIntentPaymentMethodOptionsKlarna           `json:"klarna"`

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -284,7 +284,7 @@ type PaymentMethodParams struct {
 // Returns a list of PaymentMethods. For listing a customer's payment methods, you should use [List a Customer's PaymentMethods](https://stripe.com/docs/api/payment_methods/customer_list)
 type PaymentMethodListParams struct {
 	ListParams `form:"*"`
-	// The ID of the customer whose PaymentMethods will be retrieved.
+	// The ID of the customer whose PaymentMethods will be retrieved. If not provided, the response list will be empty.
 	Customer *string `form:"customer"`
 	// A required filter on the list, based on the object `type` field.
 	Type *string `form:"type"`


### PR DESCRIPTION
Codegen for openapi 7734045.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Change type of `ChargeStatus` from `string` to `enum('failed'|'pending'|'succeeded')`
* Add support for `BACSDebit` and `EPS` on `PaymentIntentPaymentMethodOptionsParams`, `PaymentIntentPaymentMethodOptionsParams`, `PaymentIntentConfirmPaymentMethodOptionsParams`, and `PaymentIntentPaymentMethodOptions`
* Add support for `ImageURLPNG` and `ImageURLSVG` on `PaymentIntentNextActionWechatPayDisplayQRCode`

