### PR TITLE
API Updates

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -83,6 +83,7 @@ import (
 	terminalconnectiontoken "github.com/stripe/stripe-go/v72/terminal/connectiontoken"
 	terminallocation "github.com/stripe/stripe-go/v72/terminal/location"
 	terminalreader "github.com/stripe/stripe-go/v72/terminal/reader"
+	testhelperstestclock "github.com/stripe/stripe-go/v72/testhelpers/testclock"
 	"github.com/stripe/stripe-go/v72/token"
 	"github.com/stripe/stripe-go/v72/topup"
 	"github.com/stripe/stripe-go/v72/transfer"
@@ -241,6 +242,8 @@ type API struct {
 	TerminalLocations *terminallocation.Client
 	// TerminalReaders is the client used to invoke /terminal/readers APIs.
 	TerminalReaders *terminalreader.Client
+	// TestHelpersTestClocks is the client used to invoke /test_helpers/test_clocks APIs.
+	TestHelpersTestClocks *testhelperstestclock.Client
 	// Tokens is the client used to invoke /tokens APIs.
 	Tokens *token.Client
 	// Topups is the client used to invoke /topups APIs.
@@ -339,6 +342,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.TerminalConnectionTokens = &terminalconnectiontoken.Client{B: backends.API, Key: key}
 	a.TerminalLocations = &terminallocation.Client{B: backends.API, Key: key}
 	a.TerminalReaders = &terminalreader.Client{B: backends.API, Key: key}
+	a.TestHelpersTestClocks = &testhelperstestclock.Client{B: backends.API, Key: key}
 	a.Tokens = &token.Client{B: backends.API, Key: key}
 	a.Topups = &topup.Client{B: backends.API, Key: key}
 	a.Transfers = &transfer.Client{B: backends.API, Key: key}

--- a/customer.go
+++ b/customer.go
@@ -141,7 +141,9 @@ type CustomerParams struct {
 	TaxExempt *string `form:"tax_exempt"`
 	// The customer's tax IDs.
 	TaxIDData []*CustomerTaxIDDataParams `form:"tax_id_data"`
-	Token     *string                    `form:"-"` // This doesn't seem to be used?
+	// ID of the test clock to attach to the customer.
+	TestClock *string `form:"test_clock"`
+	Token     *string `form:"-"` // This doesn't seem to be used?
 }
 
 // Returns a list of PaymentMethods for a given Customer
@@ -250,6 +252,8 @@ type Customer struct {
 	TaxExempt CustomerTaxExempt `json:"tax_exempt"`
 	// The customer's tax IDs.
 	TaxIDs *TaxIDList `json:"tax_ids"`
+	// ID of the test clock this customer belongs to.
+	TestClock *TestHelpersTestClock `json:"test_clock"`
 }
 
 // CustomerList is a list of Customers as retrieved from a list endpoint.

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -53,6 +53,7 @@ import (
 	terminal_connectiontoken "github.com/stripe/stripe-go/v72/terminal/connectiontoken"
 	terminal_location "github.com/stripe/stripe-go/v72/terminal/location"
 	terminal_reader "github.com/stripe/stripe-go/v72/terminal/reader"
+	testhelpers_testclock "github.com/stripe/stripe-go/v72/testhelpers/testclock"
 	_ "github.com/stripe/stripe-go/v72/testing"
 	topup "github.com/stripe/stripe-go/v72/topup"
 	transfer "github.com/stripe/stripe-go/v72/transfer"
@@ -1568,5 +1569,40 @@ func TestPaymentIntentVerifyMicrodeposits(t *testing.T) {
 func TestSetupIntentVerifyMicrodeposits(t *testing.T) {
 	params := &stripe.SetupIntentVerifyMicrodepositsParams{}
 	result, _ := setupintent.VerifyMicrodeposits("seti_xxxxxxxxxxxxx", params)
+	assert.NotNil(t, result)
+}
+
+func TestTestHelpersTestClockCreate(t *testing.T) {
+	params := &stripe.TestHelpersTestClockParams{
+		FrozenTime: stripe.Int64(123),
+		Name:       stripe.String("cogsworth"),
+	}
+	result, _ := testhelpers_testclock.New(params)
+	assert.NotNil(t, result)
+}
+
+func TestTestHelpersTestClockRetrieve(t *testing.T) {
+	params := &stripe.TestHelpersTestClockParams{}
+	result, _ := testhelpers_testclock.Get("clock_xyz", params)
+	assert.NotNil(t, result)
+}
+
+func TestTestHelpersTestClockList(t *testing.T) {
+	params := &stripe.TestHelpersTestClockListParams{}
+	result := testhelpers_testclock.List(params)
+	assert.NotNil(t, result)
+}
+
+func TestTestHelpersTestClockDelete(t *testing.T) {
+	params := &stripe.TestHelpersTestClockParams{}
+	result, _ := testhelpers_testclock.Del("clock_xyz", params)
+	assert.NotNil(t, result)
+}
+
+func TestTestHelpersTestClockAdvance(t *testing.T) {
+	params := &stripe.TestHelpersTestClockAdvanceParams{
+		FrozenTime: stripe.Int64(142),
+	}
+	result, _ := testhelpers_testclock.Advance("clock_xyz", params)
 	assert.NotNil(t, result)
 }

--- a/invoice.go
+++ b/invoice.go
@@ -245,6 +245,8 @@ type InvoiceParams struct {
 	Paid       *bool   `form:"paid"`
 	// Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
 	PaymentSettings *InvoicePaymentSettingsParams `form:"payment_settings"`
+	// How to handle pending invoice items on invoice creation. One of `include`, `include_and_require`, or `exclude`. `include` will include any pending invoice items, and will create an empty draft invoice if no pending invoice items exist. `include_and_require` will include any pending invoice items, if no pending invoice items exist then the request will fail. `exclude` will always create an empty invoice draft regardless if there are pending invoice items or not. Defaults to `include_and_require` if the parameter is omitted.
+	PendingInvoiceItemsBehavior *string `form:"pending_invoice_items_behavior"`
 	// The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields.
 	Schedule *string `form:"schedule"`
 	// Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`.
@@ -712,7 +714,9 @@ type Invoice struct {
 	// Total of all subscriptions, invoice items, and prorations on the invoice before any invoice level discount or tax is applied. Item discounts are already incorporated
 	Subtotal int64 `json:"subtotal"`
 	// The amount of tax on this invoice. This is the sum of all the tax amounts on this invoice.
-	Tax              int64                   `json:"tax"`
+	Tax int64 `json:"tax"`
+	// ID of the test clock this invoice belongs to.
+	TestClock        *TestHelpersTestClock   `json:"test_clock"`
 	ThreasholdReason *InvoiceThresholdReason `json:"threshold_reason"`
 	// Total after discounts and taxes.
 	Total int64 `json:"total"`

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -135,6 +135,8 @@ type InvoiceItem struct {
 	SubscriptionItem string `json:"subscription_item"`
 	// The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the invoice do not apply to this invoice item.
 	TaxRates []*TaxRate `json:"tax_rates"`
+	// ID of the test clock this invoice item belongs to.
+	TestClock *TestHelpersTestClock `json:"test_clock"`
 	// Unit amount (in the `currency` specified) of the invoice item.
 	UnitAmount int64 `json:"unit_amount"`
 	// Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.

--- a/quote.go
+++ b/quote.go
@@ -87,6 +87,8 @@ type QuoteParams struct {
 	OnBehalfOf *string `form:"on_behalf_of"`
 	// When creating a subscription or subscription schedule, the specified configuration data will be used. There must be at least one line item with a recurring price for a subscription or subscription schedule to be created. A subscription schedule is created if `subscription_data[effective_date]` is present and in the future, otherwise a subscription is created.
 	SubscriptionData *QuoteSubscriptionDataParams `form:"subscription_data"`
+	// ID of the test clock to attach to the quote.
+	TestClock *string `form:"test_clock"`
 	// The data with which to automatically create a Transfer for each of the invoices.
 	TransferData *QuoteTransferDataParams `form:"transfer_data"`
 }
@@ -470,7 +472,9 @@ type Quote struct {
 	SubscriptionData *QuoteSubscriptionData `json:"subscription_data"`
 	// The subscription schedule that was created or updated from this quote.
 	SubscriptionSchedule *SubscriptionSchedule `json:"subscription_schedule"`
-	TotalDetails         *QuoteTotalDetails    `json:"total_details"`
+	// ID of the test clock this quote belongs to.
+	TestClock    *TestHelpersTestClock `json:"test_clock"`
+	TotalDetails *QuoteTotalDetails    `json:"total_details"`
 	// The account (if any) the payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the invoices.
 	TransferData *QuoteTransferData `json:"transfer_data"`
 }

--- a/refund.go
+++ b/refund.go
@@ -61,6 +61,25 @@ type RefundParams struct {
 	RefundApplicationFee *bool   `form:"refund_application_fee"`
 	ReverseTransfer      *bool   `form:"reverse_transfer"`
 }
+type RefundNextActionDisplayDetailsEmailSent struct {
+	// The timestamp when the email was sent.
+	EmailSentAt int64 `json:"email_sent_at"`
+	// The recipient's email address.
+	EmailSentTo string `json:"email_sent_to"`
+}
+
+// Contains the refund details.
+type RefundNextActionDisplayDetails struct {
+	EmailSent *RefundNextActionDisplayDetailsEmailSent `json:"email_sent"`
+	// The expiry timestamp.
+	ExpiresAt int64 `json:"expires_at"`
+}
+type RefundNextAction struct {
+	// Contains the refund details.
+	DisplayDetails *RefundNextActionDisplayDetails `json:"display_details"`
+	// Type of the next action to perform.
+	Type string `json:"type"`
+}
 
 // `Refund` objects allow you to refund a charge that has previously been created
 // but not yet refunded. Funds will be refunded to the credit or debit card that
@@ -88,7 +107,8 @@ type Refund struct {
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
-	Metadata map[string]string `json:"metadata"`
+	Metadata   map[string]string `json:"metadata"`
+	NextAction *RefundNextAction `json:"next_action"`
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// ID of the PaymentIntent that was refunded.

--- a/sub.go
+++ b/sub.go
@@ -599,6 +599,8 @@ type Subscription struct {
 	//
 	// If subscription `collection_method=send_invoice` it becomes `past_due` when its invoice is not paid by the due date, and `canceled` or `unpaid` if it is still not paid by an additional deadline after that. Note that when a subscription has a status of `unpaid`, no subsequent invoices will be attempted (invoices will be created, but then immediately automatically closed). After receiving updated payment information from a customer, you may choose to reopen and pay their closed invoices.
 	Status SubscriptionStatus `json:"status"`
+	// ID of the test clock this subscription belongs to.
+	TestClock *TestHelpersTestClock `json:"test_clock"`
 	// The account (if any) the subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
 	TransferData *SubscriptionTransferData `json:"transfer_data"`
 	// If the subscription has a trial, the end of that trial.

--- a/subschedule.go
+++ b/subschedule.go
@@ -385,6 +385,8 @@ type SubscriptionSchedule struct {
 	Status SubscriptionScheduleStatus `json:"status"`
 	// ID of the subscription managed by the subscription schedule.
 	Subscription *Subscription `json:"subscription"`
+	// ID of the test clock this subscription schedule belongs to.
+	TestClock *TestHelpersTestClock `json:"test_clock"`
 }
 
 // SubscriptionScheduleList is a list of SubscriptionSchedules as retrieved from a list endpoint.

--- a/testhelpers/testclock/client.go
+++ b/testhelpers/testclock/client.go
@@ -1,0 +1,121 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package testclock provides the /test_helpers/test_clocks APIs
+package testclock
+
+import (
+	"net/http"
+
+	stripe "github.com/stripe/stripe-go/v72"
+	"github.com/stripe/stripe-go/v72/form"
+)
+
+// Client is used to invoke /test_helpers/test_clocks APIs.
+type Client struct {
+	B   stripe.Backend
+	Key string
+}
+
+// New creates a new test helpers test clock.
+func New(params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
+	return getC().New(params)
+}
+
+// New creates a new test helpers test clock.
+func (c Client) New(params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
+	testclock := &stripe.TestHelpersTestClock{}
+	err := c.B.Call(
+		http.MethodPost,
+		"/v1/test_helpers/test_clocks",
+		c.Key,
+		params,
+		testclock,
+	)
+	return testclock, err
+}
+
+// Get returns the details of a test helpers test clock.
+func Get(id string, params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
+	return getC().Get(id, params)
+}
+
+// Get returns the details of a test helpers test clock.
+func (c Client) Get(id string, params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
+	path := stripe.FormatURLPath("/v1/test_helpers/test_clocks/%s", id)
+	testclock := &stripe.TestHelpersTestClock{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, testclock)
+	return testclock, err
+}
+
+// Del removes a test helpers test clock.
+func Del(id string, params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
+	return getC().Del(id, params)
+}
+
+// Del removes a test helpers test clock.
+func (c Client) Del(id string, params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
+	path := stripe.FormatURLPath("/v1/test_helpers/test_clocks/%s", id)
+	testclock := &stripe.TestHelpersTestClock{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, testclock)
+	return testclock, err
+}
+
+// Advance is the method for the `POST /v1/test_helpers/test_clocks/{test_clock}/advance` API.
+func Advance(id string, params *stripe.TestHelpersTestClockAdvanceParams) (*stripe.TestHelpersTestClock, error) {
+	return getC().Advance(id, params)
+}
+
+// Advance is the method for the `POST /v1/test_helpers/test_clocks/{test_clock}/advance` API.
+func (c Client) Advance(id string, params *stripe.TestHelpersTestClockAdvanceParams) (*stripe.TestHelpersTestClock, error) {
+	path := stripe.FormatURLPath("/v1/test_helpers/test_clocks/%s/advance", id)
+	testclock := &stripe.TestHelpersTestClock{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, testclock)
+	return testclock, err
+}
+
+// List returns a list of test helpers test clocks.
+func List(params *stripe.TestHelpersTestClockListParams) *Iter {
+	return getC().List(params)
+}
+
+// List returns a list of test helpers test clocks.
+func (c Client) List(listParams *stripe.TestHelpersTestClockListParams) *Iter {
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.TestHelpersTestClockList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/test_helpers/test_clocks", c.Key, b, p, list)
+
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
+
+			return ret, list, err
+		}),
+	}
+}
+
+// Iter is an iterator for test helpers test clocks.
+type Iter struct {
+	*stripe.Iter
+}
+
+// TestHelpersTestClock returns the test helpers test clock which the iterator is currently pointing to.
+func (i *Iter) TestHelpersTestClock() *stripe.TestHelpersTestClock {
+	return i.Current().(*stripe.TestHelpersTestClock)
+}
+
+// TestHelpersTestClockList returns the current list object which the iterator is
+// currently using. List objects will change as new API calls are made to
+// continue pagination.
+func (i *Iter) TestHelpersTestClockList() *stripe.TestHelpersTestClockList {
+	return i.List().(*stripe.TestHelpersTestClockList)
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
+}

--- a/testhelpers_testclock.go
+++ b/testhelpers_testclock.go
@@ -1,0 +1,88 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+package stripe
+
+import "encoding/json"
+
+// The status of the Test Clock.
+type TestHelpersTestClockStatus string
+
+// List of values that TestHelpersTestClockStatus can take
+const (
+	TestHelpersTestClockStatusAdvancing       TestHelpersTestClockStatus = "advancing"
+	TestHelpersTestClockStatusInternalFailure TestHelpersTestClockStatus = "internal_failure"
+	TestHelpersTestClockStatusReady           TestHelpersTestClockStatus = "ready"
+)
+
+// Retrieves a test clock.
+type TestHelpersTestClockParams struct {
+	Params `form:"*"`
+	// The initial frozen time for this test clock.
+	FrozenTime *int64 `form:"frozen_time"`
+	// The name for this test clock.
+	Name *string `form:"name"`
+}
+
+// Returns a list of your test clocks.
+type TestHelpersTestClockListParams struct {
+	ListParams `form:"*"`
+}
+
+// Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to Ready.
+type TestHelpersTestClockAdvanceParams struct {
+	Params `form:"*"`
+	// The time to advance the test clock. Must be after the test clock's current frozen time. Cannot be more than two intervals in the future from the shortest subscription in this test clock. If there are no subscriptions in this test clock, it cannot be more than two years in the future.
+	FrozenTime *int64 `form:"frozen_time"`
+}
+
+// A test clock enables deterministic control over objects in testmode. With a test clock, you can create
+// objects at a frozen time in the past or future, and advance to a specific future time to observe webhooks and state changes. After the clock advances,
+// you can either validate the current state of your scenario (and test your assumptions), change the current state of your scenario (and test more complex scenarios), or keep advancing forward in time.
+type TestHelpersTestClock struct {
+	APIResource
+	// Time at which the object was created. Measured in seconds since the Unix epoch.
+	Created int64 `json:"created"`
+	Deleted bool  `json:"deleted"`
+	// Time at which all objects belonging to this clock are frozen.
+	FrozenTime int64 `json:"frozen_time"`
+	// Unique identifier for the object.
+	ID string `json:"id"`
+	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+	Livemode bool `json:"livemode"`
+	// The custom name supplied at creation.
+	Name string `json:"name"`
+	// String representing the object's type. Objects of the same type share the same value.
+	Object string `json:"object"`
+	// The status of the Test Clock.
+	Status TestHelpersTestClockStatus `json:"status"`
+}
+
+// TestHelpersTestClockList is a list of TestClocks as retrieved from a list endpoint.
+type TestHelpersTestClockList struct {
+	APIResource
+	ListMeta
+	Data []*TestHelpersTestClock `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TestHelpersTestClock.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (t *TestHelpersTestClock) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		t.ID = id
+		return nil
+	}
+
+	type testHelpersTestClock TestHelpersTestClock
+	var v testHelpersTestClock
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*t = TestHelpersTestClock(v)
+	return nil
+}


### PR DESCRIPTION
Codegen for openapi 1707cb8.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resource `TestHelpers.TestClock`
* Add support for `TestClock` on `CustomerParams`, `Customer`, `Invoice`, `InvoiceItem`, `QuoteParams`, `Quote`, `Subscription`, and `SubscriptionSchedule`
* Add support for `PendingInvoiceItemsBehavior` on `InvoiceParams`
* Change type of `ProductUrlParams` from `string` to `emptyStringable(string)`
* Add support for `NextAction` on `Refund`

