### PR TITLE
Remove `,string` struct tag from ApplicationFeePercent

### DIFF
--- a/subschedule.go
+++ b/subschedule.go
@@ -274,7 +274,7 @@ type SubscriptionScheduleInvoiceSettings struct {
 }
 type SubscriptionScheduleDefaultSettings struct {
 	// A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account during this phase of the schedule.
-	ApplicationFeePercent float64                   `json:"application_fee_percent,string"`
+	ApplicationFeePercent float64                   `json:"application_fee_percent"`
 	AutomaticTax          *SubscriptionAutomaticTax `json:"automatic_tax"`
 	// Possible values are `phase_start` or `automatic`. If `phase_start` then billing cycle anchor of the subscription is set to the start of the phase when entering the phase. If `automatic` then the billing cycle anchor is automatically modified as needed when entering the phase. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
 	BillingCycleAnchor SubscriptionSchedulePhaseBillingCycleAnchor `json:"billing_cycle_anchor"`


### PR DESCRIPTION
With this tag in place it causes unmarshalling error.
Backend return a number, tag expects string and field is a float64