### PR TITLE
API Updates

### DIFF
--- a/account.go
+++ b/account.go
@@ -70,6 +70,26 @@ const (
 	AccountCapabilitiesKonbiniPaymentsPending  AccountCapabilitiesKonbiniPayments = "pending"
 )
 
+// The status of the paynow payments capability of the account, or whether the account can directly process paynow charges.
+type AccountCapabilitiesPayNowPayments string
+
+// List of values that AccountCapabilitiesPayNowPayments can take
+const (
+	AccountCapabilitiesPayNowPaymentsActive   AccountCapabilitiesPayNowPayments = "active"
+	AccountCapabilitiesPayNowPaymentsInactive AccountCapabilitiesPayNowPayments = "inactive"
+	AccountCapabilitiesPayNowPaymentsPending  AccountCapabilitiesPayNowPayments = "pending"
+)
+
+// The status of the US bank account ACH payments capability of the account, or whether the account can directly process US bank account charges.
+type AccountCapabilitiesUSBankAccountAchPayments string
+
+// List of values that AccountCapabilitiesUSBankAccountAchPayments can take
+const (
+	AccountCapabilitiesUSBankAccountAchPaymentsActive   AccountCapabilitiesUSBankAccountAchPayments = "active"
+	AccountCapabilitiesUSBankAccountAchPaymentsInactive AccountCapabilitiesUSBankAccountAchPayments = "inactive"
+	AccountCapabilitiesUSBankAccountAchPaymentsPending  AccountCapabilitiesUSBankAccountAchPayments = "pending"
+)
+
 // The category identifying the legal structure of the company or legal entity. See [Business structure](https://stripe.com/docs/connect/identity-verification#business-structure) for more details.
 type AccountCompanyStructure string
 
@@ -363,6 +383,12 @@ type AccountCapabilitiesP24PaymentsParams struct {
 	Requested *bool `form:"requested"`
 }
 
+// The paynow_payments capability.
+type AccountCapabilitiesPayNowPaymentsParams struct {
+	// Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+	Requested *bool `form:"requested"`
+}
+
 // The sepa_debit_payments capability.
 type AccountCapabilitiesSEPADebitPaymentsParams struct {
 	// Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
@@ -389,6 +415,12 @@ type AccountCapabilitiesTaxReportingUS1099MISCParams struct {
 
 // The transfers capability.
 type AccountCapabilitiesTransfersParams struct {
+	// Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+	Requested *bool `form:"requested"`
+}
+
+// The us_bank_account_ach_payments capability.
+type AccountCapabilitiesUSBankAccountAchPaymentsParams struct {
 	// Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
 	Requested *bool `form:"requested"`
 }
@@ -435,6 +467,8 @@ type AccountCapabilitiesParams struct {
 	OXXOPayments *AccountCapabilitiesOXXOPaymentsParams `form:"oxxo_payments"`
 	// The p24_payments capability.
 	P24Payments *AccountCapabilitiesP24PaymentsParams `form:"p24_payments"`
+	// The paynow_payments capability.
+	PayNowPayments *AccountCapabilitiesPayNowPaymentsParams `form:"paynow_payments"`
 	// The sepa_debit_payments capability.
 	SEPADebitPayments *AccountCapabilitiesSEPADebitPaymentsParams `form:"sepa_debit_payments"`
 	// The sofort_payments capability.
@@ -445,6 +479,8 @@ type AccountCapabilitiesParams struct {
 	TaxReportingUS1099MISC *AccountCapabilitiesTaxReportingUS1099MISCParams `form:"tax_reporting_us_1099_misc"`
 	// The transfers capability.
 	Transfers *AccountCapabilitiesTransfersParams `form:"transfers"`
+	// The us_bank_account_ach_payments capability.
+	USBankAccountAchPayments *AccountCapabilitiesUSBankAccountAchPaymentsParams `form:"us_bank_account_ach_payments"`
 }
 
 // The Kana variation of the company's primary address (Japan only).
@@ -807,6 +843,8 @@ type AccountCapabilities struct {
 	OXXOPayments AccountCapabilityStatus `json:"oxxo_payments"`
 	// The status of the P24 payments capability of the account, or whether the account can directly process P24 charges.
 	P24Payments AccountCapabilityStatus `json:"p24_payments"`
+	// The status of the paynow payments capability of the account, or whether the account can directly process paynow charges.
+	PayNowPayments AccountCapabilitiesPayNowPayments `json:"paynow_payments"`
 	// The status of the SEPA Direct Debits payments capability of the account, or whether the account can directly process SEPA Direct Debits charges.
 	SEPADebitPayments AccountCapabilityStatus `json:"sepa_debit_payments"`
 	// The status of the Sofort payments capability of the account, or whether the account can directly process Sofort charges.
@@ -817,6 +855,8 @@ type AccountCapabilities struct {
 	TaxReportingUS1099MISC AccountCapabilityStatus `json:"tax_reporting_us_1099_misc"`
 	// The status of the transfers capability of the account, or whether your platform can transfer funds to the account.
 	Transfers AccountCapabilityStatus `json:"transfers"`
+	// The status of the US bank account ACH payments capability of the account, or whether the account can directly process US bank account charges.
+	USBankAccountAchPayments AccountCapabilitiesUSBankAccountAchPayments `json:"us_bank_account_ach_payments"`
 }
 
 // The Kana variation of the company's primary address (Japan only).
@@ -1080,7 +1120,7 @@ type Account struct {
 	Controller     *AccountController `json:"controller"`
 	// The account's country.
 	Country string `json:"country"`
-	// Time at which the object was created. Measured in seconds since the Unix epoch.
+	// Time at which the account was connected. Measured in seconds since the Unix epoch.
 	Created int64 `json:"created"`
 	// Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts).
 	DefaultCurrency Currency `json:"default_currency"`

--- a/balancetransaction.go
+++ b/balancetransaction.go
@@ -45,18 +45,19 @@ type BalanceTransactionSourceType string
 
 // List of values that BalanceTransactionSourceType can take
 const (
-	BalanceTransactionSourceTypeApplicationFee       BalanceTransactionSourceType = "application_fee"
-	BalanceTransactionSourceTypeCharge               BalanceTransactionSourceType = "charge"
-	BalanceTransactionSourceTypeDispute              BalanceTransactionSourceType = "dispute"
-	BalanceTransactionSourceTypeFeeRefund            BalanceTransactionSourceType = "fee_refund"
-	BalanceTransactionSourceTypeIssuingAuthorization BalanceTransactionSourceType = "issuing.authorization"
-	BalanceTransactionSourceTypeIssuingDispute       BalanceTransactionSourceType = "issuing.dispute"
-	BalanceTransactionSourceTypeIssuingTransaction   BalanceTransactionSourceType = "issuing.transaction"
-	BalanceTransactionSourceTypePayout               BalanceTransactionSourceType = "payout"
-	BalanceTransactionSourceTypeRefund               BalanceTransactionSourceType = "refund"
-	BalanceTransactionSourceTypeReversal             BalanceTransactionSourceType = "reversal"
-	BalanceTransactionSourceTypeTopup                BalanceTransactionSourceType = "topup"
-	BalanceTransactionSourceTypeTransfer             BalanceTransactionSourceType = "transfer"
+	BalanceTransactionSourceTypeApplicationFee            BalanceTransactionSourceType = "application_fee"
+	BalanceTransactionSourceTypeCharge                    BalanceTransactionSourceType = "charge"
+	BalanceTransactionSourceTypeConnectCollectionTransfer BalanceTransactionSourceType = "connect_collection_transfer"
+	BalanceTransactionSourceTypeDispute                   BalanceTransactionSourceType = "dispute"
+	BalanceTransactionSourceTypeFeeRefund                 BalanceTransactionSourceType = "fee_refund"
+	BalanceTransactionSourceTypeIssuingAuthorization      BalanceTransactionSourceType = "issuing.authorization"
+	BalanceTransactionSourceTypeIssuingDispute            BalanceTransactionSourceType = "issuing.dispute"
+	BalanceTransactionSourceTypeIssuingTransaction        BalanceTransactionSourceType = "issuing.transaction"
+	BalanceTransactionSourceTypePayout                    BalanceTransactionSourceType = "payout"
+	BalanceTransactionSourceTypeRefund                    BalanceTransactionSourceType = "refund"
+	BalanceTransactionSourceTypeReversal                  BalanceTransactionSourceType = "reversal"
+	BalanceTransactionSourceTypeTopup                     BalanceTransactionSourceType = "topup"
+	BalanceTransactionSourceTypeTransfer                  BalanceTransactionSourceType = "transfer"
 )
 
 // List of values that BalanceTransactionStatus can take
@@ -187,18 +188,19 @@ type BalanceTransactionSource struct {
 	ID   string                       `json:"id"`
 	Type BalanceTransactionSourceType `json:"object"`
 
-	ApplicationFee       *ApplicationFee       `json:"-"`
-	Charge               *Charge               `json:"-"`
-	Dispute              *Dispute              `json:"-"`
-	FeeRefund            *FeeRefund            `json:"-"`
-	IssuingAuthorization *IssuingAuthorization `json:"-"`
-	IssuingDispute       *IssuingDispute       `json:"-"`
-	IssuingTransaction   *IssuingAuthorization `json:"-"`
-	Payout               *Payout               `json:"-"`
-	Refund               *Refund               `json:"-"`
-	Reversal             *Reversal             `json:"-"`
-	Topup                *Topup                `json:"-"`
-	Transfer             *Transfer             `json:"-"`
+	ApplicationFee            *ApplicationFee            `json:"-"`
+	Charge                    *Charge                    `json:"-"`
+	ConnectCollectionTransfer *ConnectCollectionTransfer `json:"-"`
+	Dispute                   *Dispute                   `json:"-"`
+	FeeRefund                 *FeeRefund                 `json:"-"`
+	IssuingAuthorization      *IssuingAuthorization      `json:"-"`
+	IssuingDispute            *IssuingDispute            `json:"-"`
+	IssuingTransaction        *IssuingAuthorization      `json:"-"`
+	Payout                    *Payout                    `json:"-"`
+	Refund                    *Refund                    `json:"-"`
+	Reversal                  *Reversal                  `json:"-"`
+	Topup                     *Topup                     `json:"-"`
+	Transfer                  *Transfer                  `json:"-"`
 }
 
 // BalanceTransactionList is a list of BalanceTransactions as retrieved from a list endpoint.
@@ -250,6 +252,8 @@ func (b *BalanceTransactionSource) UnmarshalJSON(data []byte) error {
 		err = json.Unmarshal(data, &b.ApplicationFee)
 	case BalanceTransactionSourceTypeCharge:
 		err = json.Unmarshal(data, &b.Charge)
+	case BalanceTransactionSourceTypeConnectCollectionTransfer:
+		err = json.Unmarshal(data, &b.ConnectCollectionTransfer)
 	case BalanceTransactionSourceTypeDispute:
 		err = json.Unmarshal(data, &b.Dispute)
 	case BalanceTransactionSourceTypeFeeRefund:

--- a/charge.go
+++ b/charge.go
@@ -127,6 +127,24 @@ const (
 	ChargePaymentMethodDetailsTypeWechat            ChargePaymentMethodDetailsType = "wechat"
 )
 
+// Account holder type: individual or company.
+type ChargePaymentMethodDetailsUSBankAccountAccountHolderType string
+
+// List of values that ChargePaymentMethodDetailsUSBankAccountAccountHolderType can take
+const (
+	ChargePaymentMethodDetailsUSBankAccountAccountHolderTypeCompany    ChargePaymentMethodDetailsUSBankAccountAccountHolderType = "company"
+	ChargePaymentMethodDetailsUSBankAccountAccountHolderTypeIndividual ChargePaymentMethodDetailsUSBankAccountAccountHolderType = "individual"
+)
+
+// Account type: checkings or savings. Defaults to checking if omitted.
+type ChargePaymentMethodDetailsUSBankAccountAccountType string
+
+// List of values that ChargePaymentMethodDetailsUSBankAccountAccountType can take
+const (
+	ChargePaymentMethodDetailsUSBankAccountAccountTypeChecking ChargePaymentMethodDetailsUSBankAccountAccountType = "checking"
+	ChargePaymentMethodDetailsUSBankAccountAccountTypeSavings  ChargePaymentMethodDetailsUSBankAccountAccountType = "savings"
+)
+
 // The status of the payment is either `succeeded`, `pending`, or `failed`.
 type ChargeStatus string
 
@@ -735,6 +753,10 @@ type ChargePaymentMethodDetailsP24 struct {
 	// Przelewy24 rarely provides this information so the attribute is usually empty.
 	VerifiedName string `json:"verified_name"`
 }
+type ChargePaymentMethodDetailsPayNow struct {
+	// Reference number associated with this PayNow payment
+	Reference string `json:"reference"`
+}
 type ChargePaymentMethodDetailsSepaCreditTransfer struct {
 	// Name of the bank associated with the bank account.
 	BankName string `json:"bank_name"`
@@ -780,6 +802,20 @@ type ChargePaymentMethodDetailsSofort struct {
 	VerifiedName string `json:"verified_name"`
 }
 type ChargePaymentMethodDetailsStripeAccount struct{}
+type ChargePaymentMethodDetailsUSBankAccount struct {
+	// Account holder type: individual or company.
+	AccountHolderType ChargePaymentMethodDetailsUSBankAccountAccountHolderType `json:"account_holder_type"`
+	// Account type: checkings or savings. Defaults to checking if omitted.
+	AccountType ChargePaymentMethodDetailsUSBankAccountAccountType `json:"account_type"`
+	// Name of the bank associated with the bank account.
+	BankName string `json:"bank_name"`
+	// Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+	Fingerprint string `json:"fingerprint"`
+	// Last four digits of the bank account number.
+	Last4 string `json:"last4"`
+	// Routing number of the bank account.
+	RoutingNumber string `json:"routing_number"`
+}
 type ChargePaymentMethodDetailsWechat struct{}
 type ChargePaymentMethodDetailsWechatPay struct {
 	// Uniquely identifies this particular WeChat Pay account. You can use this attribute to check whether two WeChat accounts are the same.
@@ -812,6 +848,7 @@ type ChargePaymentMethodDetails struct {
 	Multibanco         *ChargePaymentMethodDetailsMultibanco         `json:"multibanco"`
 	OXXO               *ChargePaymentMethodDetailsOXXO               `json:"oxxo"`
 	P24                *ChargePaymentMethodDetailsP24                `json:"p24"`
+	PayNow             *ChargePaymentMethodDetailsPayNow             `json:"paynow"`
 	SepaCreditTransfer *ChargePaymentMethodDetailsSepaCreditTransfer `json:"sepa_credit_transfer"`
 	SepaDebit          *ChargePaymentMethodDetailsSepaDebit          `json:"sepa_debit"`
 	Sofort             *ChargePaymentMethodDetailsSofort             `json:"sofort"`
@@ -819,9 +856,10 @@ type ChargePaymentMethodDetails struct {
 	// The type of transaction-specific details of the payment method used in the payment, one of `ach_credit_transfer`, `ach_debit`, `acss_debit`, `alipay`, `au_becs_debit`, `bancontact`, `card`, `card_present`, `eps`, `giropay`, `ideal`, `klarna`, `multibanco`, `p24`, `sepa_debit`, `sofort`, `stripe_account`, or `wechat`.
 	// An additional hash is included on `payment_method_details` with a name matching this value.
 	// It contains information specific to the payment method.
-	Type      ChargePaymentMethodDetailsType       `json:"type"`
-	Wechat    *ChargePaymentMethodDetailsWechat    `json:"wechat"`
-	WechatPay *ChargePaymentMethodDetailsWechatPay `json:"wechat_pay"`
+	Type          ChargePaymentMethodDetailsType           `json:"type"`
+	USBankAccount *ChargePaymentMethodDetailsUSBankAccount `json:"us_bank_account"`
+	Wechat        *ChargePaymentMethodDetailsWechat        `json:"wechat"`
+	WechatPay     *ChargePaymentMethodDetailsWechatPay     `json:"wechat_pay"`
 }
 
 // An optional dictionary including the account to automatically transfer to as part of a destination charge. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details.
@@ -874,6 +912,8 @@ type Charge struct {
 	Dispute *Dispute `json:"dispute"`
 	// Whether the charge has been disputed.
 	Disputed bool `json:"disputed"`
+	// ID of the balance transaction that describes the reversal of the balance on your account due to payment failure.
+	FailureBalanceTransaction *BalanceTransaction `json:"failure_balance_transaction"`
 	// Error code explaining reason for charge failure if available (see [the errors section](https://stripe.com/docs/api#errors) for a list of codes).
 	FailureCode string `json:"failure_code"`
 	// Message to user further explaining reason for charge failure if available.

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -167,6 +167,15 @@ const (
 	CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
 )
 
+// Bank account verification method.
+type CheckoutSessionPaymentMethodOptionsUSBankAccountVerificationMethod string
+
+// List of values that CheckoutSessionPaymentMethodOptionsUSBankAccountVerificationMethod can take
+const (
+	CheckoutSessionPaymentMethodOptionsUSBankAccountVerificationMethodAutomatic CheckoutSessionPaymentMethodOptionsUSBankAccountVerificationMethod = "automatic"
+	CheckoutSessionPaymentMethodOptionsUSBankAccountVerificationMethodInstant   CheckoutSessionPaymentMethodOptionsUSBankAccountVerificationMethod = "instant"
+)
+
 // The payment status of the Checkout Session, one of `paid`, `unpaid`, or `no_payment_required`.
 // You can use this value to decide when to fulfill your customer's order.
 type CheckoutSessionPaymentStatus string
@@ -454,6 +463,12 @@ type CheckoutSessionPaymentMethodOptionsOXXOParams struct {
 	ExpiresAfterDays *int64 `form:"expires_after_days"`
 }
 
+// contains details about the Us Bank Account payment method options.
+type CheckoutSessionPaymentMethodOptionsUSBankAccountParams struct {
+	// Verification method for the intent
+	VerificationMethod *string `form:"verification_method"`
+}
+
 // contains details about the WeChat Pay payment method options.
 type CheckoutSessionPaymentMethodOptionsWechatPayParams struct {
 	// The app ID registered with WeChat Pay. Only required when client is ios or android.
@@ -472,6 +487,8 @@ type CheckoutSessionPaymentMethodOptionsParams struct {
 	Konbini *CheckoutSessionPaymentMethodOptionsKonbiniParams `form:"konbini"`
 	// contains details about the OXXO payment method options.
 	OXXO *CheckoutSessionPaymentMethodOptionsOXXOParams `form:"oxxo"`
+	// contains details about the Us Bank Account payment method options.
+	USBankAccount *CheckoutSessionPaymentMethodOptionsUSBankAccountParams `form:"us_bank_account"`
 	// contains details about the WeChat Pay payment method options.
 	WechatPay *CheckoutSessionPaymentMethodOptionsWechatPayParams `form:"wechat_pay"`
 }
@@ -820,13 +837,18 @@ type CheckoutSessionPaymentMethodOptionsOXXO struct {
 	// The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
 	ExpiresAfterDays int64 `json:"expires_after_days"`
 }
+type CheckoutSessionPaymentMethodOptionsUSBankAccount struct {
+	// Bank account verification method.
+	VerificationMethod CheckoutSessionPaymentMethodOptionsUSBankAccountVerificationMethod `json:"verification_method"`
+}
 
 // Payment-method-specific configuration for the PaymentIntent or SetupIntent of this CheckoutSession.
 type CheckoutSessionPaymentMethodOptions struct {
-	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebit `json:"acss_debit"`
-	Boleto    *CheckoutSessionPaymentMethodOptionsBoleto    `json:"boleto"`
-	Konbini   *CheckoutSessionPaymentMethodOptionsKonbini   `json:"konbini"`
-	OXXO      *CheckoutSessionPaymentMethodOptionsOXXO      `json:"oxxo"`
+	ACSSDebit     *CheckoutSessionPaymentMethodOptionsACSSDebit     `json:"acss_debit"`
+	Boleto        *CheckoutSessionPaymentMethodOptionsBoleto        `json:"boleto"`
+	Konbini       *CheckoutSessionPaymentMethodOptionsKonbini       `json:"konbini"`
+	OXXO          *CheckoutSessionPaymentMethodOptionsOXXO          `json:"oxxo"`
+	USBankAccount *CheckoutSessionPaymentMethodOptionsUSBankAccount `json:"us_bank_account"`
 }
 type CheckoutSessionPhoneNumberCollection struct {
 	// Indicates whether phone number collection is enabled for the session

--- a/connectcollectiontransfer.go
+++ b/connectcollectiontransfer.go
@@ -1,0 +1,43 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+package stripe
+
+import "encoding/json"
+
+type ConnectCollectionTransfer struct {
+	// Amount transferred, in %s.
+	Amount int64 `json:"amount"`
+	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+	Currency Currency `json:"currency"`
+	// ID of the account that funds are being collected for.
+	Destination *Account `json:"destination"`
+	// Unique identifier for the object.
+	ID string `json:"id"`
+	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+	Livemode bool `json:"livemode"`
+	// String representing the object's type. Objects of the same type share the same value.
+	Object string `json:"object"`
+}
+
+// UnmarshalJSON handles deserialization of a ConnectCollectionTransfer.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (c *ConnectCollectionTransfer) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		c.ID = id
+		return nil
+	}
+
+	type connectCollectionTransfer ConnectCollectionTransfer
+	var v connectCollectionTransfer
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*c = ConnectCollectionTransfer(v)
+	return nil
+}

--- a/invoice.go
+++ b/invoice.go
@@ -74,6 +74,16 @@ const (
 	InvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecureAutomatic InvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
 )
 
+// Bank account verification method.
+type InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod string
+
+// List of values that InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod can take
+const (
+	InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethodAutomatic     InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod = "automatic"
+	InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethodInstant       InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod = "instant"
+	InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethodMicrodeposits InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod = "microdeposits"
+)
+
 // The list of payment method types (e.g. card) to provide to the invoice's PaymentIntent. If not set, Stripe attempts to automatically determine the types to use by looking at the invoice's default payment method, the subscription's default payment method, the customer's default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
 type InvoicePaymentSettingsPaymentMethodType string
 
@@ -92,9 +102,11 @@ const (
 	InvoicePaymentSettingsPaymentMethodTypeGrabpay            InvoicePaymentSettingsPaymentMethodType = "grabpay"
 	InvoicePaymentSettingsPaymentMethodTypeIdeal              InvoicePaymentSettingsPaymentMethodType = "ideal"
 	InvoicePaymentSettingsPaymentMethodTypeKonbini            InvoicePaymentSettingsPaymentMethodType = "konbini"
+	InvoicePaymentSettingsPaymentMethodTypePayNow             InvoicePaymentSettingsPaymentMethodType = "paynow"
 	InvoicePaymentSettingsPaymentMethodTypeSepaCreditTransfer InvoicePaymentSettingsPaymentMethodType = "sepa_credit_transfer"
 	InvoicePaymentSettingsPaymentMethodTypeSepaDebit          InvoicePaymentSettingsPaymentMethodType = "sepa_debit"
 	InvoicePaymentSettingsPaymentMethodTypeSofort             InvoicePaymentSettingsPaymentMethodType = "sofort"
+	InvoicePaymentSettingsPaymentMethodTypeUSBankAccount      InvoicePaymentSettingsPaymentMethodType = "us_bank_account"
 	InvoicePaymentSettingsPaymentMethodTypeWechatPay          InvoicePaymentSettingsPaymentMethodType = "wechat_pay"
 )
 
@@ -179,6 +191,12 @@ type InvoicePaymentSettingsPaymentMethodOptionsCardParams struct {
 // If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 type InvoicePaymentSettingsPaymentMethodOptionsKonbiniParams struct{}
 
+// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+type InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountParams struct {
+	// Verification method for the intent
+	VerificationMethod *string `form:"verification_method"`
+}
+
 // Payment-method-specific configuration to provide to the invoice's PaymentIntent.
 type InvoicePaymentSettingsPaymentMethodOptionsParams struct {
 	// If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
@@ -189,6 +207,8 @@ type InvoicePaymentSettingsPaymentMethodOptionsParams struct {
 	Card *InvoicePaymentSettingsPaymentMethodOptionsCardParams `form:"card"`
 	// If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 	Konbini *InvoicePaymentSettingsPaymentMethodOptionsKonbiniParams `form:"konbini"`
+	// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+	USBankAccount *InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountParams `form:"us_bank_account"`
 }
 
 // Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
@@ -489,6 +509,12 @@ type InvoicePaymentSettingsPaymentMethodOptionsCard struct {
 // If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 type InvoicePaymentSettingsPaymentMethodOptionsKonbini struct{}
 
+// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+type InvoicePaymentSettingsPaymentMethodOptionsUSBankAccount struct {
+	// Bank account verification method.
+	VerificationMethod InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod `json:"verification_method"`
+}
+
 // Payment-method-specific configuration to provide to the invoice's PaymentIntent.
 type InvoicePaymentSettingsPaymentMethodOptions struct {
 	// If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
@@ -499,6 +525,8 @@ type InvoicePaymentSettingsPaymentMethodOptions struct {
 	Card *InvoicePaymentSettingsPaymentMethodOptionsCard `json:"card"`
 	// If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 	Konbini *InvoicePaymentSettingsPaymentMethodOptionsKonbini `json:"konbini"`
+	// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+	USBankAccount *InvoicePaymentSettingsPaymentMethodOptionsUSBankAccount `json:"us_bank_account"`
 }
 type InvoicePaymentSettings struct {
 	// Payment-method-specific configuration to provide to the invoice's PaymentIntent.

--- a/mandate.go
+++ b/mandate.go
@@ -124,6 +124,7 @@ type MandatePaymentMethodDetailsSepaDebit struct {
 	// The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively.
 	URL string `json:"url"`
 }
+type MandatePaymentMethodDetailsUSBankAccount struct{}
 type MandatePaymentMethodDetails struct {
 	ACSSDebit   *MandatePaymentMethodDetailsACSSDebit   `json:"acss_debit"`
 	AUBECSDebit *MandatePaymentMethodDetailsAUBECSDebit `json:"au_becs_debit"`
@@ -131,7 +132,8 @@ type MandatePaymentMethodDetails struct {
 	Card        *MandatePaymentMethodDetailsCard        `json:"card"`
 	SepaDebit   *MandatePaymentMethodDetailsSepaDebit   `json:"sepa_debit"`
 	// The type of the payment method associated with this mandate. An additional hash is included on `payment_method_details` with a name matching this value. It contains mandate information specific to the payment method.
-	Type PaymentMethodType `json:"type"`
+	Type          PaymentMethodType                         `json:"type"`
+	USBankAccount *MandatePaymentMethodDetailsUSBankAccount `json:"us_bank_account"`
 }
 type MandateSingleUse struct {
 	// On a single use mandate, the amount of the payment.

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -58,6 +58,15 @@ const (
 	PaymentIntentOffSessionRecurring PaymentIntentOffSession = "recurring"
 )
 
+// The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
+type PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositType string
+
+// List of values that PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositType can take
+const (
+	PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositTypeAmounts        PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositType = "amounts"
+	PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositTypeDescriptorCode PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositType = "descriptor_code"
+)
+
 // Payment schedule for the mandate.
 type PaymentIntentPaymentMethodOptionsACSSDebitMandateOptionsPaymentSchedule string
 
@@ -99,6 +108,14 @@ const (
 	PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethodAutomatic     PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod = "automatic"
 	PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethodInstant       PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod = "instant"
 	PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethodMicrodeposits PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod = "microdeposits"
+)
+
+// Controls when the funds will be captured from the customer's account.
+type PaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod string
+
+// List of values that PaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod can take
+const (
+	PaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethodManual PaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod = "manual"
 )
 
 // Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -179,6 +196,14 @@ const (
 	PaymentIntentPaymentMethodOptionsBoletoSetupFutureUsageNone       PaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage = "none"
 	PaymentIntentPaymentMethodOptionsBoletoSetupFutureUsageOffSession PaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage = "off_session"
 	PaymentIntentPaymentMethodOptionsBoletoSetupFutureUsageOnSession  PaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage = "on_session"
+)
+
+// Controls when the funds will be captured from the customer's account.
+type PaymentIntentPaymentMethodOptionsCardCaptureMethod string
+
+// List of values that PaymentIntentPaymentMethodOptionsCardCaptureMethod can take
+const (
+	PaymentIntentPaymentMethodOptionsCardCaptureMethodManual PaymentIntentPaymentMethodOptionsCardCaptureMethod = "manual"
 )
 
 // For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
@@ -312,6 +337,14 @@ const (
 	PaymentIntentPaymentMethodOptionsIdealSetupFutureUsageOffSession PaymentIntentPaymentMethodOptionsIdealSetupFutureUsage = "off_session"
 )
 
+// Controls when the funds will be captured from the customer's account.
+type PaymentIntentPaymentMethodOptionsKlarnaCaptureMethod string
+
+// List of values that PaymentIntentPaymentMethodOptionsKlarnaCaptureMethod can take
+const (
+	PaymentIntentPaymentMethodOptionsKlarnaCaptureMethodManual PaymentIntentPaymentMethodOptionsKlarnaCaptureMethod = "manual"
+)
+
 // Indicates that you intend to make future payments with this PaymentIntent's payment method.
 //
 // Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
@@ -365,6 +398,18 @@ const (
 // Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
 //
 // When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+type PaymentIntentPaymentMethodOptionsPayNowSetupFutureUsage string
+
+// List of values that PaymentIntentPaymentMethodOptionsPayNowSetupFutureUsage can take
+const (
+	PaymentIntentPaymentMethodOptionsPayNowSetupFutureUsageNone PaymentIntentPaymentMethodOptionsPayNowSetupFutureUsage = "none"
+)
+
+// Indicates that you intend to make future payments with this PaymentIntent's payment method.
+//
+// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+//
+// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
 type PaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage string
 
 // List of values that PaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage can take
@@ -385,6 +430,30 @@ type PaymentIntentPaymentMethodOptionsSofortSetupFutureUsage string
 const (
 	PaymentIntentPaymentMethodOptionsSofortSetupFutureUsageNone       PaymentIntentPaymentMethodOptionsSofortSetupFutureUsage = "none"
 	PaymentIntentPaymentMethodOptionsSofortSetupFutureUsageOffSession PaymentIntentPaymentMethodOptionsSofortSetupFutureUsage = "off_session"
+)
+
+// Indicates that you intend to make future payments with this PaymentIntent's payment method.
+//
+// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+//
+// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+type PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsage string
+
+// List of values that PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsage can take
+const (
+	PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsageNone       PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsage = "none"
+	PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsageOffSession PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsage = "off_session"
+	PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsageOnSession  PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsage = "on_session"
+)
+
+// Bank account verification method.
+type PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethod string
+
+// List of values that PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethod can take
+const (
+	PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethodAutomatic     PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethod = "automatic"
+	PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethodInstant       PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethod = "instant"
+	PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethodMicrodeposits PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethod = "microdeposits"
 )
 
 // The client type that the end customer will pay from
@@ -480,6 +549,21 @@ type PaymentIntentMandateDataParams struct {
 // If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
 type PaymentIntentPaymentMethodDataKonbiniParams struct{}
 
+// If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+type PaymentIntentPaymentMethodDataPayNowParams struct{}
+
+// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+type PaymentIntentPaymentMethodDataUSBankAccountParams struct {
+	// Account holder type: individual or company.
+	AccountHolderType *string `form:"account_holder_type"`
+	// Account number of the bank account.
+	AccountNumber *string `form:"account_number"`
+	// Account type: checkings or savings. Defaults to checking if omitted.
+	AccountType *string `form:"account_type"`
+	// Routing number of the bank account.
+	RoutingNumber *string `form:"routing_number"`
+}
+
 // If provided, this hash will be used to create a PaymentMethod. The new PaymentMethod will appear
 // in the [payment_method](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method)
 // property on the PaymentIntent.
@@ -523,12 +607,16 @@ type PaymentIntentPaymentMethodDataParams struct {
 	OXXO *PaymentMethodOXXOParams `form:"oxxo"`
 	// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
 	P24 *PaymentMethodP24Params `form:"p24"`
+	// If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+	PayNow *PaymentIntentPaymentMethodDataPayNowParams `form:"paynow"`
 	// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
 	SepaDebit *PaymentMethodSepaDebitParams `form:"sepa_debit"`
 	// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
 	Sofort *PaymentMethodSofortParams `form:"sofort"`
 	// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
 	Type *string `form:"type"`
+	// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+	USBankAccount *PaymentIntentPaymentMethodDataUSBankAccountParams `form:"us_bank_account"`
 	// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
 	WechatPay *PaymentMethodWechatPayParams `form:"wechat_pay"`
 }
@@ -565,6 +653,12 @@ type PaymentIntentPaymentMethodOptionsACSSDebitParams struct {
 
 // If this is a `afterpay_clearpay` PaymentMethod, this sub-hash contains details about the Afterpay Clearpay payment method options.
 type PaymentIntentPaymentMethodOptionsAfterpayClearpayParams struct {
+	// Controls when the funds will be captured from the customer's account.
+	//
+	// If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+	//
+	// If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+	CaptureMethod *string `form:"capture_method"`
 	// Order identifier shown to the customer in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about
 	// the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
 	Reference *string `form:"reference"`
@@ -691,6 +785,12 @@ type PaymentIntentPaymentMethodOptionsCardMandateOptionsParams struct {
 
 // Configuration for any card payments attempted on this PaymentIntent.
 type PaymentIntentPaymentMethodOptionsCardParams struct {
+	// Controls when the funds will be captured from the customer's account.
+	//
+	// If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+	//
+	// If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+	CaptureMethod *string `form:"capture_method"`
 	// A single-use `cvc_update` Token that represents a card CVC value. When provided, the CVC value will be verified during the card payment attempt. This parameter can only be provided during confirmation.
 	CVCToken *string `form:"cvc_token"`
 	// Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
@@ -785,6 +885,12 @@ type PaymentIntentPaymentMethodOptionsInteracPresentParams struct{}
 
 // If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
 type PaymentIntentPaymentMethodOptionsKlarnaParams struct {
+	// Controls when the funds will be captured from the customer's account.
+	//
+	// If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+	//
+	// If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+	CaptureMethod *string `form:"capture_method"`
 	// Preferred language of the Klarna authorization page that the customer is redirected to
 	PreferredLocale *string `form:"preferred_locale"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -845,6 +951,18 @@ type PaymentIntentPaymentMethodOptionsP24Params struct {
 	TOSShownAndAccepted *bool `form:"tos_shown_and_accepted"`
 }
 
+// If this is a `paynow` PaymentMethod, this sub-hash contains details about the PayNow payment method options.
+type PaymentIntentPaymentMethodOptionsPayNowParams struct {
+	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
+	//
+	// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+	//
+	// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+	//
+	// If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+	SetupFutureUsage *string `form:"setup_future_usage"`
+}
+
 // Additional fields for Mandate creation
 type PaymentIntentPaymentMethodOptionsSepaDebitMandateOptionsParams struct{}
 
@@ -874,6 +992,20 @@ type PaymentIntentPaymentMethodOptionsSofortParams struct {
 	//
 	// If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
 	SetupFutureUsage *string `form:"setup_future_usage"`
+}
+
+// If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
+type PaymentIntentPaymentMethodOptionsUSBankAccountParams struct {
+	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
+	//
+	// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+	//
+	// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+	//
+	// If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+	SetupFutureUsage *string `form:"setup_future_usage"`
+	// Verification method for the intent
+	VerificationMethod *string `form:"verification_method"`
 }
 
 // If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
@@ -932,10 +1064,14 @@ type PaymentIntentPaymentMethodOptionsParams struct {
 	OXXO *PaymentIntentPaymentMethodOptionsOXXOParams `form:"oxxo"`
 	// If this is a `p24` PaymentMethod, this sub-hash contains details about the Przelewy24 payment method options.
 	P24 *PaymentIntentPaymentMethodOptionsP24Params `form:"p24"`
+	// If this is a `paynow` PaymentMethod, this sub-hash contains details about the PayNow payment method options.
+	PayNow *PaymentIntentPaymentMethodOptionsPayNowParams `form:"paynow"`
 	// If this is a `sepa_debit` PaymentIntent, this sub-hash contains details about the SEPA Debit payment method options.
 	SepaDebit *PaymentIntentPaymentMethodOptionsSepaDebitParams `form:"sepa_debit"`
 	// If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
 	Sofort *PaymentIntentPaymentMethodOptionsSofortParams `form:"sofort"`
+	// If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
+	USBankAccount *PaymentIntentPaymentMethodOptionsUSBankAccountParams `form:"us_bank_account"`
 	// If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
 	WechatPay *PaymentIntentPaymentMethodOptionsWechatPayParams `form:"wechat_pay"`
 }
@@ -1145,6 +1281,8 @@ type PaymentIntentVerifyMicrodepositsParams struct {
 	Params `form:"*"`
 	// Two positive integers, in *cents*, equal to the values of the microdeposits sent to the bank account.
 	Amounts []*int64 `form:"amounts"`
+	// A six-character code starting with SM present in the microdeposit sent to the bank account.
+	DescriptorCode *string `form:"descriptor_code"`
 }
 
 // Settings to configure compatible payment methods from the [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods)
@@ -1235,6 +1373,14 @@ type PaymentIntentNextActionOXXODisplayDetails struct {
 	// OXXO reference number.
 	Number string `json:"number"`
 }
+type PaymentIntentNextActionPayNowDisplayQRCode struct {
+	// The raw data string used to generate QR code, it should be used together with QR code library.
+	Data string `json:"data"`
+	// The image_url_png string used to render QR code
+	ImageURLPNG string `json:"image_url_png"`
+	// The image_url_svg string used to render QR code
+	ImageURLSVG string `json:"image_url_svg"`
+}
 type PaymentIntentNextActionRedirectToURL struct {
 	// If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion.
 	ReturnURL string `json:"return_url"`
@@ -1249,6 +1395,8 @@ type PaymentIntentNextActionVerifyWithMicrodeposits struct {
 	ArrivalDate int64 `json:"arrival_date"`
 	// The URL for the hosted verification page, which allows customers to verify their bank account.
 	HostedVerificationURL string `json:"hosted_verification_url"`
+	// The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
+	MicrodepositType PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositType `json:"microdeposit_type"`
 }
 type PaymentIntentNextActionWechatPayDisplayQRCode struct {
 	// The data being used to generate QR code
@@ -1288,6 +1436,7 @@ type PaymentIntentNextAction struct {
 	CardAwaitNotification *PaymentIntentNextActionCardAwaitNotification `json:"card_await_notification"`
 	KonbiniDisplayDetails *PaymentIntentNextActionKonbiniDisplayDetails `json:"konbini_display_details"`
 	OXXODisplayDetails    *PaymentIntentNextActionOXXODisplayDetails    `json:"oxxo_display_details"`
+	PayNowDisplayQRCode   *PaymentIntentNextActionPayNowDisplayQRCode   `json:"paynow_display_qr_code"`
 	RedirectToURL         *PaymentIntentNextActionRedirectToURL         `json:"redirect_to_url"`
 	// Type of the next action to perform, one of `redirect_to_url`, `use_stripe_sdk`, `alipay_handle_redirect`, `oxxo_display_details`, or `verify_with_microdeposits`.
 	Type PaymentIntentNextActionType `json:"type"`
@@ -1320,6 +1469,8 @@ type PaymentIntentPaymentMethodOptionsACSSDebit struct {
 	VerificationMethod PaymentIntentPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
 }
 type PaymentIntentPaymentMethodOptionsAfterpayClearpay struct {
+	// Controls when the funds will be captured from the customer's account.
+	CaptureMethod PaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod `json:"capture_method"`
 	// Order identifier shown to the customer in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about
 	// the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
 	Reference string `json:"reference"`
@@ -1420,6 +1571,8 @@ type PaymentIntentPaymentMethodOptionsCardMandateOptions struct {
 	SupportedTypes []PaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedType `json:"supported_types"`
 }
 type PaymentIntentPaymentMethodOptionsCard struct {
+	// Controls when the funds will be captured from the customer's account.
+	CaptureMethod PaymentIntentPaymentMethodOptionsCardCaptureMethod `json:"capture_method"`
 	// Installment details for this payment (Mexico only).
 	//
 	// For more information, see the [installments integration guide](https://stripe.com/docs/payments/installments).
@@ -1489,6 +1642,8 @@ type PaymentIntentPaymentMethodOptionsInteracPresent struct{}
 // PaymentIntentPaymentMethodOptionsKlarna is the set of Klarna-specific options associated
 // with that payment intent.
 type PaymentIntentPaymentMethodOptionsKlarna struct {
+	// Controls when the funds will be captured from the customer's account.
+	CaptureMethod PaymentIntentPaymentMethodOptionsKlarnaCaptureMethod `json:"capture_method"`
 	// Preferred locale of the Klarna checkout page that the customer is redirected to.
 	PreferredLocale string `json:"preferred_locale"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -1535,6 +1690,14 @@ type PaymentIntentPaymentMethodOptionsP24 struct {
 	// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
 	SetupFutureUsage PaymentIntentPaymentMethodOptionsP24SetupFutureUsage `json:"setup_future_usage"`
 }
+type PaymentIntentPaymentMethodOptionsPayNow struct {
+	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
+	//
+	// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+	//
+	// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+	SetupFutureUsage PaymentIntentPaymentMethodOptionsPayNowSetupFutureUsage `json:"setup_future_usage"`
+}
 type PaymentIntentPaymentMethodOptionsSepaDebitMandateOptions struct{}
 
 // PaymentIntentPaymentMethodOptionsSepaDebit is the set of SEPA Debit-specific options associated
@@ -1557,6 +1720,16 @@ type PaymentIntentPaymentMethodOptionsSofort struct {
 	//
 	// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
 	SetupFutureUsage PaymentIntentPaymentMethodOptionsSofortSetupFutureUsage `json:"setup_future_usage"`
+}
+type PaymentIntentPaymentMethodOptionsUSBankAccount struct {
+	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
+	//
+	// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+	//
+	// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+	SetupFutureUsage PaymentIntentPaymentMethodOptionsUSBankAccountSetupFutureUsage `json:"setup_future_usage"`
+	// Bank account verification method.
+	VerificationMethod PaymentIntentPaymentMethodOptionsUSBankAccountVerificationMethod `json:"verification_method"`
 }
 type PaymentIntentPaymentMethodOptionsWechatPay struct {
 	// The app ID registered with WeChat Pay. Only required when client is ios or android.
@@ -1592,8 +1765,10 @@ type PaymentIntentPaymentMethodOptions struct {
 	Konbini          *PaymentIntentPaymentMethodOptionsKonbini          `json:"konbini"`
 	OXXO             *PaymentIntentPaymentMethodOptionsOXXO             `json:"oxxo"`
 	P24              *PaymentIntentPaymentMethodOptionsP24              `json:"p24"`
+	PayNow           *PaymentIntentPaymentMethodOptionsPayNow           `json:"paynow"`
 	SepaDebit        *PaymentIntentPaymentMethodOptionsSepaDebit        `json:"sepa_debit"`
 	Sofort           *PaymentIntentPaymentMethodOptionsSofort           `json:"sofort"`
+	USBankAccount    *PaymentIntentPaymentMethodOptionsUSBankAccount    `json:"us_bank_account"`
 	WechatPay        *PaymentIntentPaymentMethodOptionsWechatPay        `json:"wechat_pay"`
 }
 type PaymentIntentProcessingCardCustomerNotification struct {

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -85,9 +85,29 @@ const (
 	PaymentMethodTypeKonbini          PaymentMethodType = "konbini"
 	PaymentMethodTypeOXXO             PaymentMethodType = "oxxo"
 	PaymentMethodTypeP24              PaymentMethodType = "p24"
+	PaymentMethodTypePayNow           PaymentMethodType = "paynow"
 	PaymentMethodTypeSepaDebit        PaymentMethodType = "sepa_debit"
 	PaymentMethodTypeSofort           PaymentMethodType = "sofort"
+	PaymentMethodTypeUSBankAccount    PaymentMethodType = "us_bank_account"
 	PaymentMethodTypeWechatPay        PaymentMethodType = "wechat_pay"
+)
+
+// Account holder type: individual or company.
+type PaymentMethodUSBankAccountAccountHolderType string
+
+// List of values that PaymentMethodUSBankAccountAccountHolderType can take
+const (
+	PaymentMethodUSBankAccountAccountHolderTypeCompany    PaymentMethodUSBankAccountAccountHolderType = "company"
+	PaymentMethodUSBankAccountAccountHolderTypeIndividual PaymentMethodUSBankAccountAccountHolderType = "individual"
+)
+
+// Account type: checkings or savings. Defaults to checking if omitted.
+type PaymentMethodUSBankAccountAccountType string
+
+// List of values that PaymentMethodUSBankAccountAccountType can take
+const (
+	PaymentMethodUSBankAccountAccountTypeChecking PaymentMethodUSBankAccountAccountType = "checking"
+	PaymentMethodUSBankAccountAccountTypeSavings  PaymentMethodUSBankAccountAccountType = "savings"
 )
 
 // If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
@@ -214,6 +234,9 @@ type PaymentMethodP24Params struct {
 	TOSShownAndAccepted *bool   `form:"tos_shown_and_accepted"`
 }
 
+// If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+type PaymentMethodPayNowParams struct{}
+
 // If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
 type PaymentMethodSepaDebitParams struct {
 	// IBAN of the bank account.
@@ -224,6 +247,18 @@ type PaymentMethodSepaDebitParams struct {
 type PaymentMethodSofortParams struct {
 	// Two-letter ISO code representing the country the bank account is located in.
 	Country *string `form:"country"`
+}
+
+// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+type PaymentMethodUSBankAccountParams struct {
+	// Bank account type.
+	AccountHolderType *string `form:"account_holder_type"`
+	// Account number of the bank account.
+	AccountNumber *string `form:"account_number"`
+	// Account type: checkings or savings. Defaults to checking if omitted.
+	AccountType *string `form:"account_type"`
+	// Routing number of the bank account.
+	RoutingNumber *string `form:"routing_number"`
 }
 
 // If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
@@ -272,12 +307,16 @@ type PaymentMethodParams struct {
 	OXXO *PaymentMethodOXXOParams `form:"oxxo"`
 	// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
 	P24 *PaymentMethodP24Params `form:"p24"`
+	// If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+	PayNow *PaymentMethodPayNowParams `form:"paynow"`
 	// This is a legacy parameter that will be removed in the future. It is a hash that does not accept any keys.
 	SepaDebit *PaymentMethodSepaDebitParams `form:"sepa_debit"`
 	// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
 	Sofort *PaymentMethodSofortParams `form:"sofort"`
 	// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
 	Type *string `form:"type"`
+	// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+	USBankAccount *PaymentMethodUSBankAccountParams `form:"us_bank_account"`
 	// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
 	WechatPay *PaymentMethodWechatPayParams `form:"wechat_pay"`
 	// The following parameters are used when cloning a PaymentMethod to the connected account
@@ -499,6 +538,7 @@ type PaymentMethodP24 struct {
 	// The customer's bank, if provided.
 	Bank string `json:"bank"`
 }
+type PaymentMethodPayNow struct{}
 
 // Information about the object that generated this PaymentMethod.
 type PaymentMethodSepaDebitGeneratedFrom struct {
@@ -524,6 +564,20 @@ type PaymentMethodSepaDebit struct {
 type PaymentMethodSofort struct {
 	// Two-letter ISO code representing the country the bank account is located in.
 	Country string `json:"country"`
+}
+type PaymentMethodUSBankAccount struct {
+	// Account holder type: individual or company.
+	AccountHolderType PaymentMethodUSBankAccountAccountHolderType `json:"account_holder_type"`
+	// Account type: checkings or savings. Defaults to checking if omitted.
+	AccountType PaymentMethodUSBankAccountAccountType `json:"account_type"`
+	// The name of the bank.
+	BankName string `json:"bank_name"`
+	// Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+	Fingerprint string `json:"fingerprint"`
+	// Last four digits of the bank account number.
+	Last4 string `json:"last4"`
+	// Routing number of the bank account.
+	RoutingNumber string `json:"routing_number"`
 }
 type PaymentMethodWechatPay struct{}
 
@@ -566,11 +620,13 @@ type PaymentMethod struct {
 	Object    string                  `json:"object"`
 	OXXO      *PaymentMethodOXXO      `json:"oxxo"`
 	P24       *PaymentMethodP24       `json:"p24"`
+	PayNow    *PaymentMethodPayNow    `json:"paynow"`
 	SepaDebit *PaymentMethodSepaDebit `json:"sepa_debit"`
 	Sofort    *PaymentMethodSofort    `json:"sofort"`
 	// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
-	Type      PaymentMethodType       `json:"type"`
-	WechatPay *PaymentMethodWechatPay `json:"wechat_pay"`
+	Type          PaymentMethodType           `json:"type"`
+	USBankAccount *PaymentMethodUSBankAccount `json:"us_bank_account"`
+	WechatPay     *PaymentMethodWechatPay     `json:"wechat_pay"`
 }
 
 // PaymentMethodList is a list of PaymentMethods as retrieved from a list endpoint.

--- a/payout.go
+++ b/payout.go
@@ -21,16 +21,21 @@ type PayoutFailureCode string
 
 // List of values that PayoutFailureCode can take
 const (
-	PayoutFailureCodeAccountClosed         PayoutFailureCode = "account_closed"
-	PayoutFailureCodeAccountFrozen         PayoutFailureCode = "account_frozen"
-	PayoutFailureCodeBankAccountRestricted PayoutFailureCode = "bank_account_restricted"
-	PayoutFailureCodeBankOwnershipChanged  PayoutFailureCode = "bank_ownership_changed"
-	PayoutFailureCodeCouldNotProcess       PayoutFailureCode = "could_not_process"
-	PayoutFailureCodeDebitNotAuthorized    PayoutFailureCode = "debit_not_authorized"
-	PayoutFailureCodeInsufficientFunds     PayoutFailureCode = "insufficient_funds"
-	PayoutFailureCodeInvalidAccountNumber  PayoutFailureCode = "invalid_account_number"
-	PayoutFailureCodeInvalidCurrency       PayoutFailureCode = "invalid_currency"
-	PayoutFailureCodeNoAccount             PayoutFailureCode = "no_account"
+	PayoutFailureCodeAccountClosed                 PayoutFailureCode = "account_closed"
+	PayoutFailureCodeAccountFrozen                 PayoutFailureCode = "account_frozen"
+	PayoutFailureCodeBankAccountRestricted         PayoutFailureCode = "bank_account_restricted"
+	PayoutFailureCodeBankOwnershipChanged          PayoutFailureCode = "bank_ownership_changed"
+	PayoutFailureCodeCouldNotProcess               PayoutFailureCode = "could_not_process"
+	PayoutFailureCodeDebitNotAuthorized            PayoutFailureCode = "debit_not_authorized"
+	PayoutFailureCodeDeclined                      PayoutFailureCode = "declined"
+	PayoutFailureCodeInsufficientFunds             PayoutFailureCode = "insufficient_funds"
+	PayoutFailureCodeInvalidAccountNumber          PayoutFailureCode = "invalid_account_number"
+	PayoutFailureCodeIncorrectAccountHolderName    PayoutFailureCode = "incorrect_account_holder_name"
+	PayoutFailureCodeIncorrectAccountHolderAddress PayoutFailureCode = "incorrect_account_holder_address"
+	PayoutFailureCodeIncorrectAccountHolderTaxID   PayoutFailureCode = "incorrect_account_holder_tax_id"
+	PayoutFailureCodeInvalidCurrency               PayoutFailureCode = "invalid_currency"
+	PayoutFailureCodeNoAccount                     PayoutFailureCode = "no_account"
+	PayoutFailureCodeUnsupportedCard               PayoutFailureCode = "unsupported_card"
 )
 
 // The method used to send this payout, which can be `standard` or `instant`. `instant` is only supported for payouts to debit cards. (See [Instant payouts for marketplaces](https://stripe.com/blog/instant-payouts-for-marketplaces) for more information.)

--- a/setupattempt.go
+++ b/setupattempt.go
@@ -172,6 +172,7 @@ type SetupAttemptPaymentMethodDetailsSofort struct {
 	// (if supported) at the time of authorization or settlement. They cannot be set or mutated.
 	VerifiedName string `json:"verified_name"`
 }
+type SetupAttemptPaymentMethodDetailsUSBankAccount struct{}
 type SetupAttemptPaymentMethodDetails struct {
 	ACSSDebit   *SetupAttemptPaymentMethodDetailsACSSDebit   `json:"acss_debit"`
 	AUBECSDebit *SetupAttemptPaymentMethodDetailsAUBECSDebit `json:"au_becs_debit"`
@@ -184,7 +185,8 @@ type SetupAttemptPaymentMethodDetails struct {
 	SepaDebit   *SetupAttemptPaymentMethodDetailsSepaDebit   `json:"sepa_debit"`
 	Sofort      *SetupAttemptPaymentMethodDetailsSofort      `json:"sofort"`
 	// The type of the payment method used in the SetupIntent (e.g., `card`). An additional hash is included on `payment_method_details` with a name matching this value. It contains confirmation-specific information for the payment method.
-	Type SetupAttemptPaymentMethodDetailsType `json:"type"`
+	Type          SetupAttemptPaymentMethodDetailsType           `json:"type"`
+	USBankAccount *SetupAttemptPaymentMethodDetailsUSBankAccount `json:"us_bank_account"`
 }
 
 // A SetupAttempt describes one attempted confirmation of a SetupIntent,

--- a/setupintent.go
+++ b/setupintent.go
@@ -28,6 +28,15 @@ const (
 	SetupIntentNextActionTypeRedirectToURL SetupIntentNextActionType = "redirect_to_url"
 )
 
+// The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
+type SetupIntentNextActionVerifyWithMicrodepositsMicrodepositType string
+
+// List of values that SetupIntentNextActionVerifyWithMicrodepositsMicrodepositType can take
+const (
+	SetupIntentNextActionVerifyWithMicrodepositsMicrodepositTypeAmounts        SetupIntentNextActionVerifyWithMicrodepositsMicrodepositType = "amounts"
+	SetupIntentNextActionVerifyWithMicrodepositsMicrodepositTypeDescriptorCode SetupIntentNextActionVerifyWithMicrodepositsMicrodepositType = "descriptor_code"
+)
+
 // Currency supported by the bank account
 type SetupIntentPaymentMethodOptionsACSSDebitCurrency string
 
@@ -112,6 +121,16 @@ const (
 	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureAny           SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "any"
 	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureAutomatic     SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
 	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureChallengeOnly SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "challenge_only"
+)
+
+// Bank account verification method.
+type SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethod string
+
+// List of values that SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethod can take
+const (
+	SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethodAutomatic     SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethod = "automatic"
+	SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethodInstant       SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethod = "instant"
+	SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethodMicrodeposits SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethod = "microdeposits"
 )
 
 // [Status](https://stripe.com/docs/payments/intents#intent-statuses) of this SetupIntent, one of `requires_payment_method`, `requires_confirmation`, `requires_action`, `processing`, `canceled`, or `succeeded`.
@@ -238,6 +257,12 @@ type SetupIntentPaymentMethodOptionsSepaDebitParams struct {
 	MandateOptions *SetupIntentPaymentMethodOptionsSepaDebitMandateOptionsParams `form:"mandate_options"`
 }
 
+// If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
+type SetupIntentPaymentMethodOptionsUSBankAccountParams struct {
+	// Verification method for the intent
+	VerificationMethod *string `form:"verification_method"`
+}
+
 // Payment-method-specific configuration for this SetupIntent.
 type SetupIntentPaymentMethodOptionsParams struct {
 	// If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
@@ -246,6 +271,8 @@ type SetupIntentPaymentMethodOptionsParams struct {
 	Card *SetupIntentPaymentMethodOptionsCardParams `form:"card"`
 	// If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the SEPA Debit payment method options.
 	SepaDebit *SetupIntentPaymentMethodOptionsSepaDebitParams `form:"sepa_debit"`
+	// If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
+	USBankAccount *SetupIntentPaymentMethodOptionsUSBankAccountParams `form:"us_bank_account"`
 }
 
 // If this hash is populated, this SetupIntent will generate a single_use Mandate on success.
@@ -344,6 +371,8 @@ type SetupIntentVerifyMicrodepositsParams struct {
 	Params `form:"*"`
 	// Two positive integers, in *cents*, equal to the values of the microdeposits sent to the bank account.
 	Amounts []*int64 `form:"amounts"`
+	// A six-character code starting with SM present in the microdeposit sent to the bank account.
+	DescriptorCode *string `form:"descriptor_code"`
 }
 type SetupIntentNextActionRedirectToURL struct {
 	// If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion.
@@ -359,6 +388,8 @@ type SetupIntentNextActionVerifyWithMicrodeposits struct {
 	ArrivalDate int64 `json:"arrival_date"`
 	// The URL for the hosted verification page, which allows customers to verify their bank account.
 	HostedVerificationURL string `json:"hosted_verification_url"`
+	// The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
+	MicrodepositType SetupIntentNextActionVerifyWithMicrodepositsMicrodepositType `json:"microdeposit_type"`
 }
 
 // If present, this property tells you what actions you need to take in order for your customer to continue payment setup.
@@ -423,12 +454,17 @@ type SetupIntentPaymentMethodOptionsSepaDebitMandateOptions struct{}
 type SetupIntentPaymentMethodOptionsSepaDebit struct {
 	MandateOptions *SetupIntentPaymentMethodOptionsSepaDebitMandateOptions `json:"mandate_options"`
 }
+type SetupIntentPaymentMethodOptionsUSBankAccount struct {
+	// Bank account verification method.
+	VerificationMethod SetupIntentPaymentMethodOptionsUSBankAccountVerificationMethod `json:"verification_method"`
+}
 
 // Payment-method-specific configuration for this SetupIntent.
 type SetupIntentPaymentMethodOptions struct {
-	ACSSDebit *SetupIntentPaymentMethodOptionsACSSDebit `json:"acss_debit"`
-	Card      *SetupIntentPaymentMethodOptionsCard      `json:"card"`
-	SepaDebit *SetupIntentPaymentMethodOptionsSepaDebit `json:"sepa_debit"`
+	ACSSDebit     *SetupIntentPaymentMethodOptionsACSSDebit     `json:"acss_debit"`
+	Card          *SetupIntentPaymentMethodOptionsCard          `json:"card"`
+	SepaDebit     *SetupIntentPaymentMethodOptionsSepaDebit     `json:"sepa_debit"`
+	USBankAccount *SetupIntentPaymentMethodOptionsUSBankAccount `json:"us_bank_account"`
 }
 
 // A SetupIntent guides you through the process of setting up and saving a customer's payment credentials for future payments.

--- a/sub.go
+++ b/sub.go
@@ -67,6 +67,16 @@ const (
 	SubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecureAutomatic SubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
 )
 
+// Bank account verification method.
+type SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod string
+
+// List of values that SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod can take
+const (
+	SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethodAutomatic     SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod = "automatic"
+	SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethodInstant       SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod = "instant"
+	SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethodMicrodeposits SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod = "microdeposits"
+)
+
 // The list of payment method types to provide to every invoice created by the subscription. If not set, Stripe attempts to automatically determine the types to use by looking at the invoice's default payment method, the subscription's default payment method, the customer's default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
 type SubscriptionPaymentSettingsPaymentMethodType string
 
@@ -85,9 +95,11 @@ const (
 	SubscriptionPaymentSettingsPaymentMethodTypeGrabpay            SubscriptionPaymentSettingsPaymentMethodType = "grabpay"
 	SubscriptionPaymentSettingsPaymentMethodTypeIdeal              SubscriptionPaymentSettingsPaymentMethodType = "ideal"
 	SubscriptionPaymentSettingsPaymentMethodTypeKonbini            SubscriptionPaymentSettingsPaymentMethodType = "konbini"
+	SubscriptionPaymentSettingsPaymentMethodTypePayNow             SubscriptionPaymentSettingsPaymentMethodType = "paynow"
 	SubscriptionPaymentSettingsPaymentMethodTypeSepaCreditTransfer SubscriptionPaymentSettingsPaymentMethodType = "sepa_credit_transfer"
 	SubscriptionPaymentSettingsPaymentMethodTypeSepaDebit          SubscriptionPaymentSettingsPaymentMethodType = "sepa_debit"
 	SubscriptionPaymentSettingsPaymentMethodTypeSofort             SubscriptionPaymentSettingsPaymentMethodType = "sofort"
+	SubscriptionPaymentSettingsPaymentMethodTypeUSBankAccount      SubscriptionPaymentSettingsPaymentMethodType = "us_bank_account"
 	SubscriptionPaymentSettingsPaymentMethodTypeWechatPay          SubscriptionPaymentSettingsPaymentMethodType = "wechat_pay"
 )
 
@@ -165,6 +177,8 @@ type SubscriptionListParams struct {
 	Price string `form:"price"`
 	// The status of the subscriptions to retrieve. Passing in a value of `canceled` will return all canceled subscriptions, including those belonging to deleted customers. Pass `ended` to find subscriptions that are canceled and subscriptions that are expired due to [incomplete payment](https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses). Passing in a value of `all` will return subscriptions of all statuses. If no value is supplied, all subscriptions that have not been canceled are returned.
 	Status string `form:"status"`
+	// Filter for subscriptions that are associated with the specified test clock. The response will not include subscriptions with test clocks if this and the customer parameter is not set.
+	TestClock *string `form:"test_clock"`
 }
 
 // A list of prices and quantities that will generate invoice items appended to the first invoice for this subscription. You may pass up to 20 items.
@@ -259,6 +273,12 @@ type SubscriptionPaymentSettingsPaymentMethodOptionsCardParams struct {
 // This sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 type SubscriptionPaymentSettingsPaymentMethodOptionsKonbiniParams struct{}
 
+// This sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+type SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountParams struct {
+	// Verification method for the intent
+	VerificationMethod *string `form:"verification_method"`
+}
+
 // Payment-method-specific configuration to provide to invoices created by the subscription.
 type SubscriptionPaymentSettingsPaymentMethodOptionsParams struct {
 	// This sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
@@ -269,6 +289,8 @@ type SubscriptionPaymentSettingsPaymentMethodOptionsParams struct {
 	Card *SubscriptionPaymentSettingsPaymentMethodOptionsCardParams `form:"card"`
 	// This sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 	Konbini *SubscriptionPaymentSettingsPaymentMethodOptionsKonbiniParams `form:"konbini"`
+	// This sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+	USBankAccount *SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountParams `form:"us_bank_account"`
 }
 
 // Payment settings to pass to invoices created by the subscription.
@@ -468,6 +490,12 @@ type SubscriptionPaymentSettingsPaymentMethodOptionsCard struct {
 // This sub-hash contains details about the Konbini payment method options to pass to invoices created by the subscription.
 type SubscriptionPaymentSettingsPaymentMethodOptionsKonbini struct{}
 
+// This sub-hash contains details about the ACH direct debit payment method options to pass to invoices created by the subscription.
+type SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccount struct {
+	// Bank account verification method.
+	VerificationMethod SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod `json:"verification_method"`
+}
+
 // Payment-method-specific configuration to provide to invoices created by the subscription.
 type SubscriptionPaymentSettingsPaymentMethodOptions struct {
 	// This sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to invoices created by the subscription.
@@ -478,6 +506,8 @@ type SubscriptionPaymentSettingsPaymentMethodOptions struct {
 	Card *SubscriptionPaymentSettingsPaymentMethodOptionsCard `json:"card"`
 	// This sub-hash contains details about the Konbini payment method options to pass to invoices created by the subscription.
 	Konbini *SubscriptionPaymentSettingsPaymentMethodOptionsKonbini `json:"konbini"`
+	// This sub-hash contains details about the ACH direct debit payment method options to pass to invoices created by the subscription.
+	USBankAccount *SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccount `json:"us_bank_account"`
 }
 
 // Payment settings passed on to invoices created by the subscription.


### PR DESCRIPTION
Codegen for openapi dc3ef48.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for PayNow and US Bank Accounts Debits payments
    * **Charge** ([API ref](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details))
        * Add support for `PayNow` and `USBankAccount` on `ChargePaymentMethodDetails`
    * **Mandate** ([API ref](https://stripe.com/docs/api/mandates/object#mandate_object-payment_method_details))
        * Add support for `USBankAccount` on `MandatePaymentMethodDetails`
    * **Payment Intent** ([API ref](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_options))
        * Add support for `PayNow` and `USBankAccount` on `PaymentIntentPaymentMethodOptions`, `PaymentIntentPaymentMethodDataParams`, `PaymentIntentPaymentMethodOptionsParams`, `PaymentIntentConfirmPaymentMethodDataParams`, and `PaymentIntentConfirmPaymentMethodOptionsParams`
        * Add support for `PayNowDisplayQRCode` on `PaymentIntentNextAction`
    * **Setup Intent** ([API ref](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method_options))
        * Add support for `USBankAccount` on `SetupIntentPaymentMethodOptionsParams`, `SetupIntentPaymentMethodOptions`, and `SetupIntentConfirmPaymentMethodOptionsParams`
    * **Setup Attempt** ([API ref](https://stripe.com/docs/api/setup_attempts/object#setup_attempt_object-payment_method_details))
        * Add support for `USBankAccount` on `SetupAttemptPaymentMethodDetails`
    * **Payment Method** ([API ref](https://stripe.com/docs/api/payment_methods/object#payment_method_object-paynow))
        * Add support for `PayNow` and `USBankAccount` on `PaymentMethod` and `PaymentMethodParams`
        * Add support for new values `paynow` and `us_bank_account` on enum `PaymentMethodType`
    * **Checkout Session** ([API ref](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types))
        * Add support for `USBankAccount` on `CheckoutSessionPaymentMethodOptionsParams` and `CheckoutSessionPaymentMethodOptions`
    * **Invoice** ([API ref](https://stripe.com/docs/api/invoices/object#invoice_object-payment_settings-payment_method_types))
        * Add support for `USBankAccount` on `InvoicePaymentSettingsPaymentMethodOptions` and `InvoicePaymentSettingsPaymentMethodOptionsParams`
        * Add support for new values `paynow` and `us_bank_account` on enum `InvoicePaymentSettingsPaymentMethodTypes`
    * **Subscription** ([API ref](https://stripe.com/docs/api/subscriptions/object#subscription_object-payment_settings-payment_method_types))
        * Add support for `USBankAccount` on `SubscriptionPaymentSettingsPaymentMethodOptions` and `SubscriptionPaymentSettingsPaymentMethodOptionsParams`
        * Add support for new values `paynow` and `us_bank_account` on enum `SubscriptionPaymentSettingsPaymentMethodTypes`
    * **Account capabilities** ([API ref](https://stripe.com/docs/api/accounts/object#account_object-capabilities))
      * Add support for `PayNowPayments` and `USBankAccountAchPayments` on `AccountCapabilities` and `AccountCapabilitiesParams`
* Add support for `FailureBalanceTransaction` on `Charge`
* Add support for `TestClock` on `SubscriptionListParams`
* Add support for `CaptureMethod` on `PaymentIntentConfirmPaymentMethodOptionsAfterpayClearpayParams`, `PaymentIntentConfirmPaymentMethodOptionsCardParams`, `PaymentIntentConfirmPaymentMethodOptionsKlarnaParams`, `PaymentIntentPaymentMethodOptionsAfterpayClearpayParams`, `PaymentIntentPaymentMethodOptionsAfterpayClearpay`, `PaymentIntentPaymentMethodOptionsCardParams`, `PaymentIntentPaymentMethodOptionsCard`, `PaymentIntentPaymentMethodOptionsKlarnaParams`, `PaymentIntentPaymentMethodOptionsKlarna`, and `PaymentIntentTypeSpecificPaymentMethodOptionsClient`
* Add additional support for verify microdeposits on Payment Intent and Setup Intent ([API ref](https://stripe.com/docs/api/payment_intents/verify_microdeposits))
    * Add support for `DescriptorCode` on `PaymentIntentVerifyMicrodepositsParams` and `SetupIntentVerifyMicrodepositsParams`
    * Add support for `MicrodepositType` on `PaymentIntentNextActionVerifyWithMicrodeposits` and `SetupIntentNextActionVerifyWithMicrodeposits`
* Add case for `ConnectCollectionTransfer` on `BalanceTransactionSource` `UnmarshalJSON` (fixes #1392)
* Add missing `PayoutFailureCode`s (fixes #1438)