### PR TITLE
API Updates

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -155,7 +155,10 @@ const (
 	ChargeStatusSucceeded ChargeStatus = "succeeded"
 )
 
-// Search for charges you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+// Search for charges you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+// Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+// conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+// to an hour behind during outages. Search functionality is not available to merchants in India.
 type ChargeSearchParams struct {
 	SearchParams `form:"*"`
 	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -288,7 +288,7 @@ type CheckoutSessionLineItemPriceDataProductDataParams struct {
 	Images []*string `form:"images"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
 	Metadata map[string]string `form:"metadata"`
-	// The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+	// The product's name, meant to be displayable to the customer.
 	Name *string `form:"name"`
 	// A [tax code](https://stripe.com/docs/tax/tax-codes) ID.
 	TaxCode *string `form:"tax_code"`

--- a/client/api.go
+++ b/client/api.go
@@ -83,6 +83,7 @@ import (
 	terminalconnectiontoken "github.com/stripe/stripe-go/v72/terminal/connectiontoken"
 	terminallocation "github.com/stripe/stripe-go/v72/terminal/location"
 	terminalreader "github.com/stripe/stripe-go/v72/terminal/reader"
+	testhelpersterminalreader "github.com/stripe/stripe-go/v72/testhelpers/terminal/reader"
 	testhelperstestclock "github.com/stripe/stripe-go/v72/testhelpers/testclock"
 	"github.com/stripe/stripe-go/v72/token"
 	"github.com/stripe/stripe-go/v72/topup"
@@ -242,6 +243,8 @@ type API struct {
 	TerminalLocations *terminallocation.Client
 	// TerminalReaders is the client used to invoke /terminal/readers APIs.
 	TerminalReaders *terminalreader.Client
+	// TestHelpersTerminalReaders is the client used to invoke /terminal/readers APIs.
+	TestHelpersTerminalReaders *testhelpersterminalreader.Client
 	// TestHelpersTestClocks is the client used to invoke /test_helpers/test_clocks APIs.
 	TestHelpersTestClocks *testhelperstestclock.Client
 	// Tokens is the client used to invoke /tokens APIs.
@@ -342,6 +345,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.TerminalConnectionTokens = &terminalconnectiontoken.Client{B: backends.API, Key: key}
 	a.TerminalLocations = &terminallocation.Client{B: backends.API, Key: key}
 	a.TerminalReaders = &terminalreader.Client{B: backends.API, Key: key}
+	a.TestHelpersTerminalReaders = &testhelpersterminalreader.Client{B: backends.API, Key: key}
 	a.TestHelpersTestClocks = &testhelperstestclock.Client{B: backends.API, Key: key}
 	a.Tokens = &token.Client{B: backends.API, Key: key}
 	a.Topups = &topup.Client{B: backends.API, Key: key}

--- a/customer.go
+++ b/customer.go
@@ -40,7 +40,10 @@ const (
 	CustomerTaxExemptReverse CustomerTaxExempt = "reverse"
 )
 
-// Search for customers you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+// Search for customers you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+// Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+// conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+// to an hour behind during outages. Search functionality is not available to merchants in India.
 type CustomerSearchParams struct {
 	SearchParams `form:"*"`
 	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.

--- a/invoice.go
+++ b/invoice.go
@@ -123,7 +123,10 @@ const (
 	InvoiceStatusVoid          InvoiceStatus = "void"
 )
 
-// Search for invoices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+// Search for invoices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+// Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+// conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+// to an hour behind during outages. Search functionality is not available to merchants in India.
 type InvoiceSearchParams struct {
 	SearchParams `form:"*"`
 	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -513,7 +513,10 @@ const (
 	PaymentIntentStatusSucceeded             PaymentIntentStatus = "succeeded"
 )
 
-// Search for PaymentIntents you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+// Search for PaymentIntents you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+// Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+// conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+// to an hour behind during outages. Search functionality is not available to merchants in India.
 type PaymentIntentSearchParams struct {
 	SearchParams `form:"*"`
 	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.

--- a/plan.go
+++ b/plan.go
@@ -91,7 +91,7 @@ type PlanProductParams struct {
 	ID *string `form:"id"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
 	Metadata map[string]string `form:"metadata"`
-	// The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+	// The product's name, meant to be displayable to the customer.
 	Name *string `form:"name"`
 	// An arbitrary string to be displayed on your customer's credit card or bank statement. While most banks display this information consistently, some may display it incorrectly or not at all.
 	//

--- a/price.go
+++ b/price.go
@@ -88,7 +88,10 @@ const (
 	PriceTypeRecurring PriceType = "recurring"
 )
 
-// Search for prices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+// Search for prices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+// Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+// conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+// to an hour behind during outages. Search functionality is not available to merchants in India.
 type PriceSearchParams struct {
 	SearchParams `form:"*"`
 	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
@@ -132,7 +135,7 @@ type PriceProductDataParams struct {
 	ID *string `form:"id"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
 	Metadata map[string]string `form:"metadata"`
-	// The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+	// The product's name, meant to be displayable to the customer.
 	Name *string `form:"name"`
 	// An arbitrary string to be displayed on your customer's credit card or bank statement. While most banks display this information consistently, some may display it incorrectly or not at all.
 	//

--- a/product.go
+++ b/product.go
@@ -17,7 +17,10 @@ const (
 	ProductTypeService ProductType = "service"
 )
 
-// Search for products you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+// Search for products you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+// Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+// conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+// to an hour behind during outages. Search functionality is not available to merchants in India.
 type ProductSearchParams struct {
 	SearchParams `form:"*"`
 	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
@@ -53,7 +56,7 @@ type ProductParams struct {
 	ID *string `form:"id"`
 	// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
 	Images []*string `form:"images"`
-	// The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+	// The product's name, meant to be displayable to the customer.
 	Name *string `form:"name"`
 	// The dimensions of this product for shipping purposes.
 	PackageDimensions *PackageDimensionsParams `form:"package_dimensions"`
@@ -136,7 +139,7 @@ type Product struct {
 	Livemode bool `json:"livemode"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
 	Metadata map[string]string `json:"metadata"`
-	// The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+	// The product's name, meant to be displayable to the customer.
 	Name string `json:"name"`
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`

--- a/sub.go
+++ b/sub.go
@@ -158,7 +158,10 @@ const (
 	SubscriptionStatusUnpaid            SubscriptionStatus = "unpaid"
 )
 
-// Search for subscriptions you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+// Search for subscriptions you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+// Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+// conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+// to an hour behind during outages. Search functionality is not available to merchants in India.
 type SubscriptionSearchParams struct {
 	SearchParams `form:"*"`
 	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.

--- a/terminal/reader/client.go
+++ b/terminal/reader/client.go
@@ -77,6 +77,64 @@ func (c Client) Del(id string, params *stripe.TerminalReaderParams) (*stripe.Ter
 	return reader, err
 }
 
+// CancelAction is the method for the `POST /v1/terminal/readers/{reader}/cancel_action` API.
+func CancelAction(id string, params *stripe.TerminalReaderCancelActionParams) (*stripe.TerminalReader, error) {
+	return getC().CancelAction(id, params)
+}
+
+// CancelAction is the method for the `POST /v1/terminal/readers/{reader}/cancel_action` API.
+func (c Client) CancelAction(id string, params *stripe.TerminalReaderCancelActionParams) (*stripe.TerminalReader, error) {
+	path := stripe.FormatURLPath("/v1/terminal/readers/%s/cancel_action", id)
+	reader := &stripe.TerminalReader{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	return reader, err
+}
+
+// ProcessPaymentIntent is the method for the `POST /v1/terminal/readers/{reader}/process_payment_intent` API.
+func ProcessPaymentIntent(id string, params *stripe.TerminalReaderProcessPaymentIntentParams) (*stripe.TerminalReader, error) {
+	return getC().ProcessPaymentIntent(id, params)
+}
+
+// ProcessPaymentIntent is the method for the `POST /v1/terminal/readers/{reader}/process_payment_intent` API.
+func (c Client) ProcessPaymentIntent(id string, params *stripe.TerminalReaderProcessPaymentIntentParams) (*stripe.TerminalReader, error) {
+	path := stripe.FormatURLPath(
+		"/v1/terminal/readers/%s/process_payment_intent",
+		id,
+	)
+	reader := &stripe.TerminalReader{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	return reader, err
+}
+
+// ProcessSetupIntent is the method for the `POST /v1/terminal/readers/{reader}/process_setup_intent` API.
+func ProcessSetupIntent(id string, params *stripe.TerminalReaderProcessSetupIntentParams) (*stripe.TerminalReader, error) {
+	return getC().ProcessSetupIntent(id, params)
+}
+
+// ProcessSetupIntent is the method for the `POST /v1/terminal/readers/{reader}/process_setup_intent` API.
+func (c Client) ProcessSetupIntent(id string, params *stripe.TerminalReaderProcessSetupIntentParams) (*stripe.TerminalReader, error) {
+	path := stripe.FormatURLPath(
+		"/v1/terminal/readers/%s/process_setup_intent",
+		id,
+	)
+	reader := &stripe.TerminalReader{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	return reader, err
+}
+
+// SetReaderDisplay is the method for the `POST /v1/terminal/readers/{reader}/set_reader_display` API.
+func SetReaderDisplay(id string, params *stripe.TerminalReaderSetReaderDisplayParams) (*stripe.TerminalReader, error) {
+	return getC().SetReaderDisplay(id, params)
+}
+
+// SetReaderDisplay is the method for the `POST /v1/terminal/readers/{reader}/set_reader_display` API.
+func (c Client) SetReaderDisplay(id string, params *stripe.TerminalReaderSetReaderDisplayParams) (*stripe.TerminalReader, error) {
+	path := stripe.FormatURLPath("/v1/terminal/readers/%s/set_reader_display", id)
+	reader := &stripe.TerminalReader{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	return reader, err
+}
+
 // List returns a list of terminal readers.
 func List(params *stripe.TerminalReaderListParams) *Iter {
 	return getC().List(params)

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -6,6 +6,34 @@
 
 package stripe
 
+// Type of information to be displayed by the reader.
+type TerminalReaderActionSetReaderDisplayType string
+
+// List of values that TerminalReaderActionSetReaderDisplayType can take
+const (
+	TerminalReaderActionSetReaderDisplayTypeCart TerminalReaderActionSetReaderDisplayType = "cart"
+)
+
+// Status of the action performed by the reader.
+type TerminalReaderActionStatus string
+
+// List of values that TerminalReaderActionStatus can take
+const (
+	TerminalReaderActionStatusFailed     TerminalReaderActionStatus = "failed"
+	TerminalReaderActionStatusInProgress TerminalReaderActionStatus = "in_progress"
+	TerminalReaderActionStatusSucceeded  TerminalReaderActionStatus = "succeeded"
+)
+
+// Type of action performed by the reader.
+type TerminalReaderActionType string
+
+// List of values that TerminalReaderActionType can take
+const (
+	TerminalReaderActionTypeProcessPaymentIntent TerminalReaderActionType = "process_payment_intent"
+	TerminalReaderActionTypeProcessSetupIntent   TerminalReaderActionType = "process_setup_intent"
+	TerminalReaderActionTypeSetReaderDisplay     TerminalReaderActionType = "set_reader_display"
+)
+
 // Type of reader, one of `bbpos_wisepad3`, `stripe_m2`, `bbpos_chipper2x`, `bbpos_wisepos_e`, or `verifone_P400`.
 type TerminalReaderDeviceType string
 
@@ -45,12 +73,135 @@ type TerminalReaderListParams struct {
 	Status *string `form:"status"`
 }
 
+// Configuration overrides
+type TerminalReaderProcessPaymentIntentProcessConfigParams struct {
+	// Override showing a tipping selection screen on this transaction.
+	SkipTipping *bool `form:"skip_tipping"`
+}
+
+// Initiates a payment flow on a Reader
+type TerminalReaderProcessPaymentIntentParams struct {
+	Params `form:"*"`
+	// PaymentIntent ID
+	PaymentIntent *string `form:"payment_intent"`
+	// Configuration overrides
+	ProcessConfig *TerminalReaderProcessPaymentIntentProcessConfigParams `form:"process_config"`
+}
+
+// Initiates a setup intent flow on a Reader
+type TerminalReaderProcessSetupIntentParams struct {
+	Params `form:"*"`
+	// Customer Consent Collected
+	CustomerConsentCollected *bool `form:"customer_consent_collected"`
+	// SetupIntent ID
+	SetupIntent *string `form:"setup_intent"`
+}
+
+// Cancels the current reader action
+type TerminalReaderCancelActionParams struct {
+	Params `form:"*"`
+}
+
+// Array of line items that were purchased.
+type TerminalReaderSetReaderDisplayCartLineItemParams struct {
+	// The price of the item in cents.
+	Amount *int64 `form:"amount"`
+	// The description or name of the item.
+	Description *string `form:"description"`
+	// The quantity of the line item being purchased.
+	Quantity *int64 `form:"quantity"`
+}
+
+// Cart
+type TerminalReaderSetReaderDisplayCartParams struct {
+	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+	Currency *string `form:"currency"`
+	// Array of line items that were purchased.
+	LineItems []*TerminalReaderSetReaderDisplayCartLineItemParams `form:"line_items"`
+	// The amount of tax in cents.
+	Tax *int64 `form:"tax"`
+	// Total balance of cart due in cents.
+	Total *int64 `form:"total"`
+}
+
+// Sets reader display
+type TerminalReaderSetReaderDisplayParams struct {
+	Params `form:"*"`
+	// Cart
+	Cart *TerminalReaderSetReaderDisplayCartParams `form:"cart"`
+	// Type
+	Type *string `form:"type"`
+}
+
+// Represents a reader action to process a payment intent
+type TerminalReaderActionProcessPaymentIntent struct {
+	// Most recent PaymentIntent processed by the reader.
+	PaymentIntent *PaymentIntent `json:"payment_intent"`
+}
+
+// Represents a reader action to process a setup intent
+type TerminalReaderActionProcessSetupIntent struct {
+	GeneratedCard string `json:"generated_card"`
+	// Most recent SetupIntent processed by the reader.
+	SetupIntent *SetupIntent `json:"setup_intent"`
+}
+
+// List of line items in the cart.
+type TerminalReaderActionSetReaderDisplayCartLineItem struct {
+	// The amount of the line item. A positive integer in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+	Amount int64 `json:"amount"`
+	// Description of the line item.
+	Description string `json:"description"`
+	// The quantity of the line item.
+	Quantity int64 `json:"quantity"`
+}
+
+// Cart object to be displayed by the reader.
+type TerminalReaderActionSetReaderDisplayCart struct {
+	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+	Currency Currency `json:"currency"`
+	// List of line items in the cart.
+	LineItems []*TerminalReaderActionSetReaderDisplayCartLineItem `json:"line_items"`
+	// Tax amount for the entire cart. A positive integer in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+	Tax int64 `json:"tax"`
+	// Total amount for the entire cart, including tax. A positive integer in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+	Total int64 `json:"total"`
+}
+
+// Represents a reader action to set the reader display
+type TerminalReaderActionSetReaderDisplay struct {
+	// Cart object to be displayed by the reader.
+	Cart *TerminalReaderActionSetReaderDisplayCart `json:"cart"`
+	// Type of information to be displayed by the reader.
+	Type TerminalReaderActionSetReaderDisplayType `json:"type"`
+}
+
+// The most recent action performed by the reader.
+type TerminalReaderAction struct {
+	// Failure code, only set if status is `failed`.
+	FailureCode string `json:"failure_code"`
+	// Detailed failure message, only set if status is `failed`.
+	FailureMessage string `json:"failure_message"`
+	// Represents a reader action to process a payment intent
+	ProcessPaymentIntent *TerminalReaderActionProcessPaymentIntent `json:"process_payment_intent"`
+	// Represents a reader action to process a setup intent
+	ProcessSetupIntent *TerminalReaderActionProcessSetupIntent `json:"process_setup_intent"`
+	// Represents a reader action to set the reader display
+	SetReaderDisplay *TerminalReaderActionSetReaderDisplay `json:"set_reader_display"`
+	// Status of the action performed by the reader.
+	Status TerminalReaderActionStatus `json:"status"`
+	// Type of action performed by the reader.
+	Type TerminalReaderActionType `json:"type"`
+}
+
 // A Reader represents a physical device for accepting payment details.
 //
 // Related guide: [Connecting to a Reader](https://stripe.com/docs/terminal/payments/connect-reader).
 type TerminalReader struct {
 	APIResource
-	Deleted bool `json:"deleted"`
+	// The most recent action performed by the reader.
+	Action  *TerminalReaderAction `json:"action"`
+	Deleted bool                  `json:"deleted"`
 	// The current software version of the reader.
 	DeviceSwVersion string `json:"device_sw_version"`
 	// Type of reader, one of `bbpos_wisepad3`, `stripe_m2`, `bbpos_chipper2x`, `bbpos_wisepos_e`, or `verifone_P400`.

--- a/testhelpers/terminal/reader/client.go
+++ b/testhelpers/terminal/reader/client.go
@@ -1,0 +1,40 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package reader provides the /terminal/readers APIs
+package reader
+
+import (
+	"net/http"
+
+	stripe "github.com/stripe/stripe-go/v72"
+)
+
+// Client is used to invoke /terminal/readers APIs.
+type Client struct {
+	B   stripe.Backend
+	Key string
+}
+
+// PresentPaymentMethod is the method for the `POST /v1/test_helpers/terminal/readers/{reader}/present_payment_method` API.
+func PresentPaymentMethod(id string, params *stripe.TestHelpersTerminalReaderPresentPaymentMethodParams) (*stripe.TerminalReader, error) {
+	return getC().PresentPaymentMethod(id, params)
+}
+
+// PresentPaymentMethod is the method for the `POST /v1/test_helpers/terminal/readers/{reader}/present_payment_method` API.
+func (c Client) PresentPaymentMethod(id string, params *stripe.TestHelpersTerminalReaderPresentPaymentMethodParams) (*stripe.TerminalReader, error) {
+	path := stripe.FormatURLPath(
+		"/v1/test_helpers/terminal/readers/%s/present_payment_method",
+		id,
+	)
+	reader := &stripe.TerminalReader{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	return reader, err
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
+}

--- a/testhelpers/terminal/reader/client_test.go
+++ b/testhelpers/terminal/reader/client_test.go
@@ -1,0 +1,18 @@
+package reader
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v72"
+	_ "github.com/stripe/stripe-go/v72/testing"
+)
+
+func TestTerminalReaderUpdate(t *testing.T) {
+	reader, err := PresentPaymentMethod("rdr_123", &stripe.TestHelpersTerminalReaderPresentPaymentMethodParams{
+		Type: stripe.String("card_present"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, reader)
+	assert.Equal(t, "terminal.reader", reader.Object)
+}

--- a/testhelpersterminal_reader.go
+++ b/testhelpersterminal_reader.go
@@ -1,0 +1,22 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+package stripe
+
+// Simulated card present data
+type TestHelpersTerminalReaderPresentPaymentMethodCardPresentParams struct {
+	// Card Number
+	Number *string `form:"number"`
+}
+
+// Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction
+type TestHelpersTerminalReaderPresentPaymentMethodParams struct {
+	Params `form:"*"`
+	// Simulated card present data
+	CardPresent *TestHelpersTerminalReaderPresentPaymentMethodCardPresentParams `form:"card_present"`
+	// Simulated payment type
+	Type *string `form:"type"`
+}


### PR DESCRIPTION
Codegen for openapi 1700e20.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `CancelAction`, `ProcessPaymentIntent`, `ProcessSetupIntent`, and `SetReaderDisplay` methods on resource `Terminal.Reader`
* Add support for `Action` on `TerminalReader`

