### PR TITLE
API Updates

### DIFF
--- a/account.go
+++ b/account.go
@@ -60,6 +60,16 @@ const (
 	AccountCapabilityStatusPending  AccountCapabilityStatus = "pending"
 )
 
+// The status of the customer_balance payments capability of the account, or whether the account can directly process customer_balance charges.
+type AccountCapabilitiesBankTransferPayments string
+
+// List of values that AccountCapabilitiesBankTransferPayments can take
+const (
+	AccountCapabilitiesBankTransferPaymentsActive   AccountCapabilitiesBankTransferPayments = "active"
+	AccountCapabilitiesBankTransferPaymentsInactive AccountCapabilitiesBankTransferPayments = "inactive"
+	AccountCapabilitiesBankTransferPaymentsPending  AccountCapabilitiesBankTransferPayments = "pending"
+)
+
 // The status of the konbini payments capability of the account, or whether the account can directly process konbini charges.
 type AccountCapabilitiesKonbiniPayments string
 
@@ -293,6 +303,12 @@ type AccountCapabilitiesBancontactPaymentsParams struct {
 	Requested *bool `form:"requested"`
 }
 
+// The bank_transfer_payments capability.
+type AccountCapabilitiesBankTransferPaymentsParams struct {
+	// Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+	Requested *bool `form:"requested"`
+}
+
 // The boleto_payments capability.
 type AccountCapabilitiesBoletoPaymentsParams struct {
 	// Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
@@ -437,6 +453,8 @@ type AccountCapabilitiesParams struct {
 	BACSDebitPayments *AccountCapabilitiesBACSDebitPaymentsParams `form:"bacs_debit_payments"`
 	// The bancontact_payments capability.
 	BancontactPayments *AccountCapabilitiesBancontactPaymentsParams `form:"bancontact_payments"`
+	// The bank_transfer_payments capability.
+	BankTransferPayments *AccountCapabilitiesBankTransferPaymentsParams `form:"bank_transfer_payments"`
 	// The boleto_payments capability.
 	BoletoPayments *AccountCapabilitiesBoletoPaymentsParams `form:"boleto_payments"`
 	// The card_issuing capability.
@@ -813,6 +831,8 @@ type AccountCapabilities struct {
 	BACSDebitPayments AccountCapabilityStatus `json:"bacs_debit_payments"`
 	// The status of the Bancontact payments capability of the account, or whether the account can directly process Bancontact charges.
 	BancontactPayments AccountCapabilityStatus `json:"bancontact_payments"`
+	// The status of the customer_balance payments capability of the account, or whether the account can directly process customer_balance charges.
+	BankTransferPayments AccountCapabilitiesBankTransferPayments `json:"bank_transfer_payments"`
 	// The status of the boleto payments capability of the account, or whether the account can directly process boleto charges.
 	BoletoPayments AccountCapabilityStatus `json:"boleto_payments"`
 	// The status of the card issuing capability of the account, or whether you can use Issuing to distribute funds on cards

--- a/charge.go
+++ b/charge.go
@@ -161,7 +161,7 @@ const (
 // to an hour behind during outages. Search functionality is not available to merchants in India.
 type ChargeSearchParams struct {
 	SearchParams `form:"*"`
-	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
+	// A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
 	Page *string `form:"page"`
 }
 
@@ -583,6 +583,8 @@ type ChargePaymentMethodDetailsCardPresent struct {
 	AmountAuthorized int64 `json:"amount_authorized"`
 	// Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
 	Brand PaymentMethodCardBrand `json:"brand"`
+	// When using manual capture, a future timestamp after which the charge will be automatically refunded if uncaptured.
+	CaptureBefore int64 `json:"capture_before"`
 	// The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`). In some cases, the cardholder name may not be available depending on how the issuer has configured the card. Cardholder name is typically not available on swipe or contactless payments, such as those made with Apple Pay and Google Pay.
 	CardholderName string `json:"cardholder_name"`
 	// Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -797,9 +797,13 @@ type CheckoutSessionCustomerDetailsTaxIDs struct {
 
 // The customer details including the customer's tax exempt status and the customer's tax IDs. Only present on Sessions in `payment` or `subscription` mode.
 type CheckoutSessionCustomerDetails struct {
+	// The customer's address at the time of checkout. Note: This property is populated only for sessions on or after March 30, 2022.
+	Address *Address `json:"address"`
 	// The email associated with the Customer, if one exists, on the Checkout Session at the time of checkout or at time of session expiry.
 	// Otherwise, if the customer has consented to promotional content, this value is the most recent valid email provided by the customer on the Checkout form.
 	Email string `json:"email"`
+	// The customer's name at the time of checkout. Note: This property is populated only for sessions on or after March 30, 2022.
+	Name string `json:"name"`
 	// The customer's phone number at the time of checkout
 	Phone string `json:"phone"`
 	// The customer's tax exempt status at time of checkout.

--- a/customer.go
+++ b/customer.go
@@ -46,7 +46,7 @@ const (
 // to an hour behind during outages. Search functionality is not available to merchants in India.
 type CustomerSearchParams struct {
 	SearchParams `form:"*"`
-	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
+	// A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
 	Page *string `form:"page"`
 }
 

--- a/invoice.go
+++ b/invoice.go
@@ -74,6 +74,14 @@ const (
 	InvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecureAutomatic InvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
 )
 
+// The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+type InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceFundingType string
+
+// List of values that InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceFundingType can take
+const (
+	InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceFundingTypeBankTransfer InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceFundingType = "bank_transfer"
+)
+
 // Bank account verification method.
 type InvoicePaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod string
 
@@ -97,6 +105,7 @@ const (
 	InvoicePaymentSettingsPaymentMethodTypeBancontact         InvoicePaymentSettingsPaymentMethodType = "bancontact"
 	InvoicePaymentSettingsPaymentMethodTypeBoleto             InvoicePaymentSettingsPaymentMethodType = "boleto"
 	InvoicePaymentSettingsPaymentMethodTypeCard               InvoicePaymentSettingsPaymentMethodType = "card"
+	InvoicePaymentSettingsPaymentMethodTypeCustomerBalance    InvoicePaymentSettingsPaymentMethodType = "customer_balance"
 	InvoicePaymentSettingsPaymentMethodTypeFPX                InvoicePaymentSettingsPaymentMethodType = "fpx"
 	InvoicePaymentSettingsPaymentMethodTypeGiropay            InvoicePaymentSettingsPaymentMethodType = "giropay"
 	InvoicePaymentSettingsPaymentMethodTypeGrabpay            InvoicePaymentSettingsPaymentMethodType = "grabpay"
@@ -129,7 +138,7 @@ const (
 // to an hour behind during outages. Search functionality is not available to merchants in India.
 type InvoiceSearchParams struct {
 	SearchParams `form:"*"`
-	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
+	// A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
 	Page *string `form:"page"`
 }
 
@@ -198,6 +207,20 @@ type InvoicePaymentSettingsPaymentMethodOptionsCardParams struct {
 	RequestThreeDSecure *string `form:"request_three_d_secure"`
 }
 
+// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
+type InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceBankTransferParams struct {
+	// The bank transfer type that can be used for funding. Permitted values include: `us_bank_account`, `eu_bank_account`, `id_bank_account`, `gb_bank_account`, `jp_bank_account`, `mx_bank_account`, `eu_bank_transfer`, `gb_bank_transfer`, `id_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+	Type *string `form:"type"`
+}
+
+// If paying by `customer_balance`, this sub-hash contains details about the Bank transfer payment method options to pass to the invoice's PaymentIntent.
+type InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceParams struct {
+	// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
+	BankTransfer *InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceBankTransferParams `form:"bank_transfer"`
+	// The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+	FundingType *string `form:"funding_type"`
+}
+
 // If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 type InvoicePaymentSettingsPaymentMethodOptionsKonbiniParams struct{}
 
@@ -215,6 +238,8 @@ type InvoicePaymentSettingsPaymentMethodOptionsParams struct {
 	Bancontact *InvoicePaymentSettingsPaymentMethodOptionsBancontactParams `form:"bancontact"`
 	// If paying by `card`, this sub-hash contains details about the Card payment method options to pass to the invoice's PaymentIntent.
 	Card *InvoicePaymentSettingsPaymentMethodOptionsCardParams `form:"card"`
+	// If paying by `customer_balance`, this sub-hash contains details about the Bank transfer payment method options to pass to the invoice's PaymentIntent.
+	CustomerBalance *InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceParams `form:"customer_balance"`
 	// If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 	Konbini *InvoicePaymentSettingsPaymentMethodOptionsKonbiniParams `form:"konbini"`
 	// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
@@ -380,7 +405,7 @@ type InvoiceUpcomingCustomerDetailsParams struct {
 	TaxIDs []*InvoiceUpcomingCustomerDetailsTaxIDParams `form:"tax_ids"`
 }
 
-// The period associated with this invoice item.
+// The period associated with this invoice item. When set to different values, the period will be rendered on the invoice.
 type InvoiceUpcomingInvoiceItemPeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start.
 	End *int64 `form:"end"`
@@ -404,7 +429,7 @@ type InvoiceUpcomingInvoiceItemParams struct {
 	InvoiceItem *string `form:"invoiceitem"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
 	Metadata map[string]string `form:"metadata"`
-	// The period associated with this invoice item.
+	// The period associated with this invoice item. When set to different values, the period will be rendered on the invoice.
 	Period *InvoiceUpcomingInvoiceItemPeriodParams `form:"period"`
 	// The ID of the price object.
 	Price *string `form:"price"`
@@ -515,6 +540,17 @@ type InvoicePaymentSettingsPaymentMethodOptionsCard struct {
 	// We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
 	RequestThreeDSecure InvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure `json:"request_three_d_secure"`
 }
+type InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceBankTransfer struct {
+	// The bank transfer type that can be used for funding. Permitted values include: `us_bank_account`, `eu_bank_account`, `id_bank_account`, `gb_bank_account`, `jp_bank_account`, `mx_bank_account`, `eu_bank_transfer`, `gb_bank_transfer`, `id_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+	Type string `json:"type"`
+}
+
+// If paying by `customer_balance`, this sub-hash contains details about the Bank transfer payment method options to pass to the invoice's PaymentIntent.
+type InvoicePaymentSettingsPaymentMethodOptionsCustomerBalance struct {
+	BankTransfer *InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceBankTransfer `json:"bank_transfer"`
+	// The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+	FundingType InvoicePaymentSettingsPaymentMethodOptionsCustomerBalanceFundingType `json:"funding_type"`
+}
 
 // If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 type InvoicePaymentSettingsPaymentMethodOptionsKonbini struct{}
@@ -533,6 +569,8 @@ type InvoicePaymentSettingsPaymentMethodOptions struct {
 	Bancontact *InvoicePaymentSettingsPaymentMethodOptionsBancontact `json:"bancontact"`
 	// If paying by `card`, this sub-hash contains details about the Card payment method options to pass to the invoice's PaymentIntent.
 	Card *InvoicePaymentSettingsPaymentMethodOptionsCard `json:"card"`
+	// If paying by `customer_balance`, this sub-hash contains details about the Bank transfer payment method options to pass to the invoice's PaymentIntent.
+	CustomerBalance *InvoicePaymentSettingsPaymentMethodOptionsCustomerBalance `json:"customer_balance"`
 	// If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 	Konbini *InvoicePaymentSettingsPaymentMethodOptionsKonbini `json:"konbini"`
 	// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -29,7 +29,7 @@ type InvoiceItemDiscountParams struct {
 	Discount *string `form:"discount"`
 }
 
-// The period associated with this invoice item.
+// The period associated with this invoice item. When set to different values, the period will be rendered on the invoice.
 type InvoiceItemPeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start.
 	End *int64 `form:"end"`
@@ -68,7 +68,7 @@ type InvoiceItemParams struct {
 	Discounts []*InvoiceItemDiscountParams `form:"discounts"`
 	// The ID of an existing invoice to add this invoice item to. When left blank, the invoice item will be added to the next upcoming scheduled invoice. This is useful when adding invoice items in response to an invoice.created webhook. You can only add invoice items to draft invoices and there is a maximum of 250 items per invoice.
 	Invoice *string `form:"invoice"`
-	// The period associated with this invoice item.
+	// The period associated with this invoice item. When set to different values, the period will be rendered on the invoice.
 	Period *InvoiceItemPeriodParams `form:"period"`
 	// The ID of the price object.
 	Price *string `form:"price"`

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -519,7 +519,7 @@ const (
 // to an hour behind during outages. Search functionality is not available to merchants in India.
 type PaymentIntentSearchParams struct {
 	SearchParams `form:"*"`
-	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
+	// A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
 	Page *string `form:"page"`
 }
 
@@ -828,7 +828,10 @@ type PaymentIntentPaymentMethodOptionsCardParams struct {
 }
 
 // If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
-type PaymentIntentPaymentMethodOptionsCardPresentParams struct{}
+type PaymentIntentPaymentMethodOptionsCardPresentParams struct {
+	// Request ability to capture this payment beyond the standard [authorization validity window](https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity)
+	RequestExtendedAuthorization *bool `form:"request_extended_authorization"`
+}
 
 // If this is a `eps` PaymentMethod, this sub-hash contains details about the EPS payment method options.
 type PaymentIntentPaymentMethodOptionsEPSParams struct {
@@ -1603,7 +1606,10 @@ type PaymentIntentPaymentMethodOptionsCard struct {
 
 // PaymentIntentPaymentMethodOptionsCardPresent is the set of Card Present-specific options associated
 // with that payment intent.
-type PaymentIntentPaymentMethodOptionsCardPresent struct{}
+type PaymentIntentPaymentMethodOptionsCardPresent struct {
+	// Request ability to capture this payment beyond the standard [authorization validity window](https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity)
+	RequestExtendedAuthorization bool `json:"request_extended_authorization"`
+}
 type PaymentIntentPaymentMethodOptionsEPS struct {
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
 	//

--- a/price.go
+++ b/price.go
@@ -94,7 +94,7 @@ const (
 // to an hour behind during outages. Search functionality is not available to merchants in India.
 type PriceSearchParams struct {
 	SearchParams `form:"*"`
-	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
+	// A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
 	Page *string `form:"page"`
 }
 

--- a/product.go
+++ b/product.go
@@ -23,7 +23,7 @@ const (
 // to an hour behind during outages. Search functionality is not available to merchants in India.
 type ProductSearchParams struct {
 	SearchParams `form:"*"`
-	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
+	// A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
 	Page *string `form:"page"`
 }
 

--- a/sub.go
+++ b/sub.go
@@ -67,6 +67,14 @@ const (
 	SubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecureAutomatic SubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
 )
 
+// The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+type SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceFundingType string
+
+// List of values that SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceFundingType can take
+const (
+	SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceFundingTypeBankTransfer SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceFundingType = "bank_transfer"
+)
+
 // Bank account verification method.
 type SubscriptionPaymentSettingsPaymentMethodOptionsUSBankAccountVerificationMethod string
 
@@ -90,6 +98,7 @@ const (
 	SubscriptionPaymentSettingsPaymentMethodTypeBancontact         SubscriptionPaymentSettingsPaymentMethodType = "bancontact"
 	SubscriptionPaymentSettingsPaymentMethodTypeBoleto             SubscriptionPaymentSettingsPaymentMethodType = "boleto"
 	SubscriptionPaymentSettingsPaymentMethodTypeCard               SubscriptionPaymentSettingsPaymentMethodType = "card"
+	SubscriptionPaymentSettingsPaymentMethodTypeCustomerBalance    SubscriptionPaymentSettingsPaymentMethodType = "customer_balance"
 	SubscriptionPaymentSettingsPaymentMethodTypeFPX                SubscriptionPaymentSettingsPaymentMethodType = "fpx"
 	SubscriptionPaymentSettingsPaymentMethodTypeGiropay            SubscriptionPaymentSettingsPaymentMethodType = "giropay"
 	SubscriptionPaymentSettingsPaymentMethodTypeGrabpay            SubscriptionPaymentSettingsPaymentMethodType = "grabpay"
@@ -164,7 +173,7 @@ const (
 // to an hour behind during outages. Search functionality is not available to merchants in India.
 type SubscriptionSearchParams struct {
 	SearchParams `form:"*"`
-	// A cursor for pagination across multiple pages of results. Do not include this parameter on the first call. Use the next_page value returned in a response to request subsequent results.
+	// A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
 	Page *string `form:"page"`
 }
 
@@ -280,6 +289,20 @@ type SubscriptionPaymentSettingsPaymentMethodOptionsCardParams struct {
 	RequestThreeDSecure *string `form:"request_three_d_secure"`
 }
 
+// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
+type SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceBankTransferParams struct {
+	// The bank transfer type that can be used for funding. Permitted values include: `us_bank_account`, `eu_bank_account`, `id_bank_account`, `gb_bank_account`, `jp_bank_account`, `mx_bank_account`, `eu_bank_transfer`, `gb_bank_transfer`, `id_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+	Type *string `form:"type"`
+}
+
+// This sub-hash contains details about the Bank transfer payment method options to pass to the invoice's PaymentIntent.
+type SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceParams struct {
+	// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
+	BankTransfer *SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceBankTransferParams `form:"bank_transfer"`
+	// The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+	FundingType *string `form:"funding_type"`
+}
+
 // This sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 type SubscriptionPaymentSettingsPaymentMethodOptionsKonbiniParams struct{}
 
@@ -297,6 +320,8 @@ type SubscriptionPaymentSettingsPaymentMethodOptionsParams struct {
 	Bancontact *SubscriptionPaymentSettingsPaymentMethodOptionsBancontactParams `form:"bancontact"`
 	// This sub-hash contains details about the Card payment method options to pass to the invoice's PaymentIntent.
 	Card *SubscriptionPaymentSettingsPaymentMethodOptionsCardParams `form:"card"`
+	// This sub-hash contains details about the Bank transfer payment method options to pass to the invoice's PaymentIntent.
+	CustomerBalance *SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceParams `form:"customer_balance"`
 	// This sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
 	Konbini *SubscriptionPaymentSettingsPaymentMethodOptionsKonbiniParams `form:"konbini"`
 	// This sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
@@ -496,6 +521,17 @@ type SubscriptionPaymentSettingsPaymentMethodOptionsCard struct {
 	// We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
 	RequestThreeDSecure SubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure `json:"request_three_d_secure"`
 }
+type SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceBankTransfer struct {
+	// The bank transfer type that can be used for funding. Permitted values include: `us_bank_account`, `eu_bank_account`, `id_bank_account`, `gb_bank_account`, `jp_bank_account`, `mx_bank_account`, `eu_bank_transfer`, `gb_bank_transfer`, `id_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+	Type string `json:"type"`
+}
+
+// This sub-hash contains details about the Bank transfer payment method options to pass to invoices created by the subscription.
+type SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalance struct {
+	BankTransfer *SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceBankTransfer `json:"bank_transfer"`
+	// The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+	FundingType SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalanceFundingType `json:"funding_type"`
+}
 
 // This sub-hash contains details about the Konbini payment method options to pass to invoices created by the subscription.
 type SubscriptionPaymentSettingsPaymentMethodOptionsKonbini struct{}
@@ -514,6 +550,8 @@ type SubscriptionPaymentSettingsPaymentMethodOptions struct {
 	Bancontact *SubscriptionPaymentSettingsPaymentMethodOptionsBancontact `json:"bancontact"`
 	// This sub-hash contains details about the Card payment method options to pass to invoices created by the subscription.
 	Card *SubscriptionPaymentSettingsPaymentMethodOptionsCard `json:"card"`
+	// This sub-hash contains details about the Bank transfer payment method options to pass to invoices created by the subscription.
+	CustomerBalance *SubscriptionPaymentSettingsPaymentMethodOptionsCustomerBalance `json:"customer_balance"`
 	// This sub-hash contains details about the Konbini payment method options to pass to invoices created by the subscription.
 	Konbini *SubscriptionPaymentSettingsPaymentMethodOptionsKonbini `json:"konbini"`
 	// This sub-hash contains details about the ACH direct debit payment method options to pass to invoices created by the subscription.

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -79,7 +79,7 @@ type TerminalReaderProcessPaymentIntentProcessConfigParams struct {
 	SkipTipping *bool `form:"skip_tipping"`
 }
 
-// Initiates a payment flow on a Reader
+// Initiates a payment flow on a Reader.
 type TerminalReaderProcessPaymentIntentParams struct {
 	Params `form:"*"`
 	// PaymentIntent ID
@@ -88,7 +88,7 @@ type TerminalReaderProcessPaymentIntentParams struct {
 	ProcessConfig *TerminalReaderProcessPaymentIntentProcessConfigParams `form:"process_config"`
 }
 
-// Initiates a setup intent flow on a Reader
+// Initiates a setup intent flow on a Reader.
 type TerminalReaderProcessSetupIntentParams struct {
 	Params `form:"*"`
 	// Customer Consent Collected
@@ -97,7 +97,7 @@ type TerminalReaderProcessSetupIntentParams struct {
 	SetupIntent *string `form:"setup_intent"`
 }
 
-// Cancels the current reader action
+// Cancels the current reader action.
 type TerminalReaderCancelActionParams struct {
 	Params `form:"*"`
 }
@@ -124,7 +124,7 @@ type TerminalReaderSetReaderDisplayCartParams struct {
 	Total *int64 `form:"total"`
 }
 
-// Sets reader display
+// Sets reader display to show cart details.
 type TerminalReaderSetReaderDisplayParams struct {
 	Params `form:"*"`
 	// Cart

--- a/testhelpersterminal_reader.go
+++ b/testhelpersterminal_reader.go
@@ -12,7 +12,7 @@ type TestHelpersTerminalReaderPresentPaymentMethodCardPresentParams struct {
 	Number *string `form:"number"`
 }
 
-// Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction
+// Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.
 type TestHelpersTerminalReaderPresentPaymentMethodParams struct {
 	Params `form:"*"`
 	// Simulated card present data


### PR DESCRIPTION
Codegen for openapi d412983.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `BankTransferPayments` on `AccountCapabilitiesParams` and `AccountCapabilities`
* Add support for `CaptureBefore` on `ChargePaymentMethodDetailsCardPresent`
* Add support for `Address` and `Name` on `CheckoutSessionCustomerDetails`
* Add support for `CustomerBalance` on `InvoicePaymentSettingsPaymentMethodOptionsParams`, `InvoicePaymentSettingsPaymentMethodOptions`, `SubscriptionPaymentSettingsPaymentMethodOptionsParams`, and `SubscriptionPaymentSettingsPaymentMethodOptions`
* Add support for new value `customer_balance` on enums `InvoicePaymentSettingsPaymentMethodTypes` and `SubscriptionPaymentSettingsPaymentMethodTypes`
* Add support for `RequestExtendedAuthorization` on `PaymentIntentConfirmPaymentMethodOptionsCardPresentParams`, `PaymentIntentPaymentMethodOptionsCardPresentParams`, and `PaymentIntentPaymentMethodOptionsCardPresent`

