### PR TITLE
Add support for passing expansions in SearchParams.

### DIFF
--- a/search_params.go
+++ b/search_params.go
@@ -46,9 +46,10 @@ type SearchParams struct {
 	// key or query the state of the API.
 	Context context.Context `form:"-"`
 
-	Query string  `form:"query"`
-	Limit *int64  `form:"limit"`
-	Page  *string `form:"page"`
+	Query  string    `form:"query"`
+	Limit  *int64    `form:"limit"`
+	Page   *string   `form:"page"`
+	Expand []*string `form:"expand"`
 
 	// Single specifies whether this is a single page iterator. By default,
 	// listing through an iterator will automatically grab additional pages as
@@ -61,6 +62,11 @@ type SearchParams struct {
 	// account instead of under the account of the owner of the configured
 	// Stripe key.
 	StripeAccount *string `form:"-"` // Passed as header
+}
+
+// AddExpand appends a new field to expand.
+func (p *SearchParams) AddExpand(f string) {
+	p.Expand = append(p.Expand, &f)
 }
 
 // GetSearchParams returns a SearchParams struct (itself). It exists because any

--- a/search_params_test.go
+++ b/search_params_test.go
@@ -1,0 +1,80 @@
+package stripe_test
+
+import (
+	"context"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v72"
+	"github.com/stripe/stripe-go/v72/form"
+	. "github.com/stripe/stripe-go/v72/testing"
+)
+
+type testSearchParams struct {
+	stripe.SearchParams `form:"*"`
+	Page                *string `form:"page"`
+}
+
+func TestSearchParams_Nested(t *testing.T) {
+	params := &testSearchParams{
+		Page: stripe.String("page_value"),
+		SearchParams: stripe.SearchParams{
+			Query: "query_value",
+		},
+	}
+
+	body := &form.Values{}
+	form.AppendTo(body, params)
+
+	assert.Equal(t, valuesFromArray([][2]string{
+		{"query", "query_value"},
+		{"page", "page_value"},
+	}), body)
+}
+
+func TestSearchParams_Expand(t *testing.T) {
+	testCases := []struct {
+		InitialBody  [][2]string
+		Expand       []string
+		ExpectedBody [][2]string
+	}{
+		{
+			InitialBody:  [][2]string{{"foo", "bar"}},
+			Expand:       []string{},
+			ExpectedBody: [][2]string{{"foo", "bar"}},
+		},
+		{
+			InitialBody:  [][2]string{{"foo", "bar"}, {"foo", "baz"}},
+			Expand:       []string{"data", "data.foo"},
+			ExpectedBody: [][2]string{{"foo", "bar"}, {"foo", "baz"}, {"expand[0]", "data"}, {"expand[1]", "data.foo"}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		p := stripe.SearchParams{}
+
+		for _, exp := range testCase.Expand {
+			p.AddExpand(exp)
+		}
+
+		body := valuesFromArray(testCase.InitialBody)
+		form.AppendTo(body, p)
+		assert.Equal(t, valuesFromArray(testCase.ExpectedBody), body)
+	}
+}
+
+func TestSearchParams_SetStripeAccount(t *testing.T) {
+	p := &stripe.SearchParams{}
+	p.SetStripeAccount(TestMerchantID)
+	assert.Equal(t, TestMerchantID, *p.StripeAccount)
+}
+
+func TestSearchParams_ToParams(t *testing.T) {
+	SearchParams := &stripe.SearchParams{
+		Context: context.Background(),
+	}
+	SearchParams.SetStripeAccount(TestMerchantID)
+	params := SearchParams.ToParams()
+	assert.Equal(t, SearchParams.Context, params.Context)
+	assert.Equal(t, *SearchParams.StripeAccount, *params.StripeAccount)
+}


### PR DESCRIPTION
r? @yejia-stripe 
cc @pakrym-stripe 

## Summary

Adds support for settting `expand` parameters in `SearchParams`. This is necessary for expanding `total_count`.

Implementation is essentially the same as list parameters.

## Test Plan

Added tests similar to `ListParams`.