### PR TITLE
Add support for updating the version of the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ update-version:
 	@perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v$(MAJOR_VERSION)|' README.md
 	@perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v$(MAJOR_VERSION)|' go.mod
 	@find . -name '*.go' -exec perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v$(MAJOR_VERSION)|' {} +
+
 codegen-format:
 	go fmt ./...
 
-.PHONY: update-version codegen-format
+.PHONY: codegen-format update-version

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,15 @@ coverage:
 
 clean:
 	find . -name \*.coverprofile -delete
+
+MAJOR_VERSION := $(shell echo $(VERSION) | sed 's/\..*//')
+update-version:
+	@echo "$(VERSION)" > VERSION
+	@perl -pi -e 's|const clientversion = "[.\d\-\w]+"|const clientversion = "$(VERSION)"|' stripe.go
+	@perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v$(MAJOR_VERSION)|' README.md
+	@perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v$(MAJOR_VERSION)|' go.mod
+	@find . -name '*.go' -exec perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v$(MAJOR_VERSION)|' {} +
+codegen-format:
+	go fmt ./...
+
+.PHONY: update-version codegen-format


### PR DESCRIPTION
Encodes the logic for version updating as a Makefile. Simplifies what the generation tools needs to know about the repo.
The plan is to have the same interface across all the repos.

Sample usage:

```
make update-version VERSION=1.2.5
```

Also adds a target that codegen will use to format all our repos:

```
make codegen-format
```