### PR TITLE
API Updates

### DIFF
--- a/application.go
+++ b/application.go
@@ -9,6 +9,7 @@ package stripe
 import "encoding/json"
 
 type Application struct {
+	Deleted bool `json:"deleted"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// The name of the application.

--- a/cashbalance.go
+++ b/cashbalance.go
@@ -19,6 +19,7 @@ const (
 type CashBalanceParams struct {
 	Params   `form:"*"`
 	Settings *CashBalanceSettingsParams `form:"settings"`
+	Customer *string                    `form:"-"` // Included in URL
 }
 type CashBalanceSettingsParams struct {
 	// Method for using the customer balance to pay outstanding

--- a/cashbalance.go
+++ b/cashbalance.go
@@ -1,0 +1,51 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+package stripe
+
+// The configuration for how funds that land in the customer cash balance are reconciled.
+type CashBalanceSettingsReconciliationMode string
+
+// List of values that CashBalanceSettingsReconciliationMode can take
+const (
+	CashBalanceSettingsReconciliationModeAutomatic CashBalanceSettingsReconciliationMode = "automatic"
+	CashBalanceSettingsReconciliationModeManual    CashBalanceSettingsReconciliationMode = "manual"
+)
+
+// Retrieves a customer's cash balance.
+type CashBalanceParams struct {
+	Params   `form:"*"`
+	Settings *CashBalanceSettingsParams `form:"settings"`
+}
+type CashBalanceSettingsParams struct {
+	// Method for using the customer balance to pay outstanding
+	// `customer_balance` PaymentIntents. If set to `automatic`, all available
+	// funds will automatically be used to pay any outstanding PaymentIntent.
+	// If set to `manual`, only customer balance funds from bank transfers
+	// with a reference code matching
+	// `payment_intent.next_action.display_bank_transfer_intructions.reference_code` will
+	// automatically be used to pay the corresponding outstanding
+	// PaymentIntent.
+	ReconciliationMode *string `form:"reconciliation_mode"`
+}
+type CashBalanceSettings struct {
+	// The configuration for how funds that land in the customer cash balance are reconciled.
+	ReconciliationMode CashBalanceSettingsReconciliationMode `json:"reconciliation_mode"`
+}
+
+// A customer's `Cash balance` represents real funds. Customers can add funds to their cash balance by sending a bank transfer. These funds can be used for payment and can eventually be paid out to your bank account.
+type CashBalance struct {
+	APIResource
+	// A hash of all cash balances available to this customer. You cannot delete a customer with any cash balances, even if the balance is 0.
+	Available map[string]int64 `json:"available"`
+	// The ID of the customer whose cash balance this object represents.
+	Customer string `json:"customer"`
+	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+	Livemode bool `json:"livemode"`
+	// String representing the object's type. Objects of the same type share the same value.
+	Object   string               `json:"object"`
+	Settings *CashBalanceSettings `json:"settings"`
+}

--- a/cashbalance/client.go
+++ b/cashbalance/client.go
@@ -1,0 +1,67 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package cashbalance provides the /customers/{customer}/cash_balance APIs
+package cashbalance
+
+import (
+	"fmt"
+	"net/http"
+
+	stripe "github.com/stripe/stripe-go/v72"
+)
+
+// Client is used to invoke /customers/{customer}/cash_balance APIs.
+type Client struct {
+	B   stripe.Backend
+	Key string
+}
+
+// Get returns the details of a cash balance.
+func Get(params *stripe.CashBalanceParams) (*stripe.CashBalance, error) {
+	return getC().Get(params)
+}
+
+// Get returns the details of a cash balance.
+func (c Client) Get(params *stripe.CashBalanceParams) (*stripe.CashBalance, error) {
+	if params == nil || params.Customer == nil {
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Customer must be set",
+		)
+	}
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/cash_balance",
+		stripe.StringValue(params.Customer),
+	)
+	cashbalance := &stripe.CashBalance{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, cashbalance)
+	return cashbalance, err
+}
+
+// Update updates a cash balance's properties.
+func Update(params *stripe.CashBalanceParams) (*stripe.CashBalance, error) {
+	return getC().Update(params)
+}
+
+// Update updates a cash balance's properties.
+func (c Client) Update(params *stripe.CashBalanceParams) (*stripe.CashBalance, error) {
+	if params == nil || params.Customer == nil {
+		return nil, fmt.Errorf(
+			"params cannot be nil, and params.Customer must be set",
+		)
+	}
+	path := stripe.FormatURLPath(
+		"/v1/customers/%s/cash_balance",
+		stripe.StringValue(params.Customer),
+	)
+	cashbalance := &stripe.CashBalance{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, cashbalance)
+	return cashbalance, err
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
+}

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -66,7 +66,7 @@ const (
 	CheckoutSessionCustomerDetailsTaxExemptReverse CheckoutSessionCustomerDetailsTaxExempt = "reverse"
 )
 
-// The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, or `unknown`
+// The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `eu_oss_vat`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, or `unknown`
 type CheckoutSessionCustomerDetailsTaxIDsType string
 
 // List of values that CheckoutSessionCustomerDetailsTaxIDsType can take
@@ -86,6 +86,7 @@ const (
 	CheckoutSessionCustomerDetailsTaxIDsTypeCHVAT    CheckoutSessionCustomerDetailsTaxIDsType = "ch_vat"
 	CheckoutSessionCustomerDetailsTaxIDsTypeCLTIN    CheckoutSessionCustomerDetailsTaxIDsType = "cl_tin"
 	CheckoutSessionCustomerDetailsTaxIDsTypeESCIF    CheckoutSessionCustomerDetailsTaxIDsType = "es_cif"
+	CheckoutSessionCustomerDetailsTaxIDsTypeEUOSSVAT CheckoutSessionCustomerDetailsTaxIDsType = "eu_oss_vat"
 	CheckoutSessionCustomerDetailsTaxIDsTypeEUVAT    CheckoutSessionCustomerDetailsTaxIDsType = "eu_vat"
 	CheckoutSessionCustomerDetailsTaxIDsTypeGBVAT    CheckoutSessionCustomerDetailsTaxIDsType = "gb_vat"
 	CheckoutSessionCustomerDetailsTaxIDsTypeGEVAT    CheckoutSessionCustomerDetailsTaxIDsType = "ge_vat"
@@ -445,6 +446,9 @@ type CheckoutSessionPaymentMethodOptionsACSSDebitParams struct {
 	VerificationMethod *string `form:"verification_method"`
 }
 
+// contains details about the Alipay payment method options.
+type CheckoutSessionPaymentMethodOptionsAlipayParams struct{}
+
 // contains details about the Boleto payment method options.
 type CheckoutSessionPaymentMethodOptionsBoletoParams struct {
 	// The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto invoice will expire on Wednesday at 23:59 America/Sao_Paulo time.
@@ -481,6 +485,8 @@ type CheckoutSessionPaymentMethodOptionsWechatPayParams struct {
 type CheckoutSessionPaymentMethodOptionsParams struct {
 	// contains details about the ACSS Debit payment method options.
 	ACSSDebit *CheckoutSessionPaymentMethodOptionsACSSDebitParams `form:"acss_debit"`
+	// contains details about the Alipay payment method options.
+	Alipay *CheckoutSessionPaymentMethodOptionsAlipayParams `form:"alipay"`
 	// contains details about the Boleto payment method options.
 	Boleto *CheckoutSessionPaymentMethodOptionsBoletoParams `form:"boleto"`
 	// contains details about the Konbini payment method options.
@@ -790,7 +796,7 @@ type CheckoutSessionConsentCollection struct {
 
 // The customer's tax IDs at time of checkout.
 type CheckoutSessionCustomerDetailsTaxIDs struct {
-	// The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, or `unknown`
+	// The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `eu_oss_vat`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, or `unknown`
 	Type CheckoutSessionCustomerDetailsTaxIDsType `json:"type"`
 	// The value of the tax ID.
 	Value string `json:"value"`
@@ -830,6 +836,7 @@ type CheckoutSessionPaymentMethodOptionsACSSDebit struct {
 	// Bank account verification method.
 	VerificationMethod CheckoutSessionPaymentMethodOptionsACSSDebitVerificationMethod `json:"verification_method"`
 }
+type CheckoutSessionPaymentMethodOptionsAlipay struct{}
 type CheckoutSessionPaymentMethodOptionsBoleto struct {
 	// The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will expire on Wednesday at 23:59 America/Sao_Paulo time.
 	ExpiresAfterDays int64 `json:"expires_after_days"`
@@ -850,6 +857,7 @@ type CheckoutSessionPaymentMethodOptionsUSBankAccount struct {
 // Payment-method-specific configuration for the PaymentIntent or SetupIntent of this CheckoutSession.
 type CheckoutSessionPaymentMethodOptions struct {
 	ACSSDebit     *CheckoutSessionPaymentMethodOptionsACSSDebit     `json:"acss_debit"`
+	Alipay        *CheckoutSessionPaymentMethodOptionsAlipay        `json:"alipay"`
 	Boleto        *CheckoutSessionPaymentMethodOptionsBoleto        `json:"boleto"`
 	Konbini       *CheckoutSessionPaymentMethodOptionsKonbini       `json:"konbini"`
 	OXXO          *CheckoutSessionPaymentMethodOptionsOXXO          `json:"oxxo"`

--- a/client/api.go
+++ b/client/api.go
@@ -19,6 +19,7 @@ import (
 	billingportalsession "github.com/stripe/stripe-go/v72/billingportal/session"
 	"github.com/stripe/stripe-go/v72/capability"
 	"github.com/stripe/stripe-go/v72/card"
+	"github.com/stripe/stripe-go/v72/cashbalance"
 	"github.com/stripe/stripe-go/v72/charge"
 	checkoutsession "github.com/stripe/stripe-go/v72/checkout/session"
 	"github.com/stripe/stripe-go/v72/countryspec"
@@ -117,6 +118,8 @@ type API struct {
 	Capabilities *capability.Client
 	// Cards is the client used to invoke card related APIs.
 	Cards *card.Client
+	// CashBalances is the client used to invoke /customers/{customer}/cash_balance APIs.
+	CashBalances *cashbalance.Client
 	// Charges is the client used to invoke /charges APIs.
 	Charges *charge.Client
 	// CheckoutSessions is the client used to invoke /checkout/sessions APIs.
@@ -287,6 +290,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.BillingPortalSessions = &billingportalsession.Client{B: backends.API, Key: key}
 	a.Capabilities = &capability.Client{B: backends.API, Key: key}
 	a.Cards = &card.Client{B: backends.API, Key: key}
+	a.CashBalances = &cashbalance.Client{B: backends.API, Key: key}
 	a.Charges = &charge.Client{B: backends.API, Key: key}
 	a.CheckoutSessions = &checkoutsession.Client{B: backends.API, Key: key}
 	a.CountrySpec = &countryspec.Client{B: backends.API, Key: key}

--- a/customer.go
+++ b/customer.go
@@ -118,7 +118,7 @@ type CustomerTaxParams struct {
 
 // The customer's tax IDs.
 type CustomerTaxIDDataParams struct {
-	// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
+	// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
 	Type *string `form:"type"`
 	// Value of the tax ID.
 	Value *string `form:"value"`
@@ -262,6 +262,8 @@ type Customer struct {
 	Address Address `json:"address"`
 	// Current balance, if any, being stored on the customer. If negative, the customer has credit to apply to their next invoice. If positive, the customer has an amount owed that will be added to their next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account as invoices are finalized.
 	Balance int64 `json:"balance"`
+	// The current funds being held by Stripe on behalf of the customer. These funds can be applied towards payment intents with source "cash_balance".The settings[reconciliation_mode] field describes whether these funds are applied to such payment intents manually or automatically.
+	CashBalance *CashBalance `json:"cash_balance"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
 	Created int64 `json:"created"`
 	// Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) the customer can be charged in for recurring billing purposes.

--- a/invoice.go
+++ b/invoice.go
@@ -385,7 +385,7 @@ type InvoiceUpcomingCustomerDetailsTaxParams struct {
 
 // The customer's tax IDs.
 type InvoiceUpcomingCustomerDetailsTaxIDParams struct {
-	// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
+	// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
 	Type *string `form:"type"`
 	// Value of the tax ID.
 	Value *string `form:"value"`
@@ -512,7 +512,7 @@ type InvoiceCustomField struct {
 
 // The customer's tax IDs. Until the invoice is finalized, this field will contain the same tax IDs as `customer.tax_ids`. Once the invoice is finalized, this field will no longer be updated.
 type InvoiceCustomerTaxID struct {
-	// The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, or `unknown`
+	// The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `eu_oss_vat`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, or `unknown`
 	Type TaxIDType `json:"type"`
 	// The value of the tax ID.
 	Value string `json:"value"`
@@ -679,6 +679,8 @@ type Invoice struct {
 	AmountPaid int64 `json:"amount_paid"`
 	// The amount remaining, in %s, that is due.
 	AmountRemaining int64 `json:"amount_remaining"`
+	// ID of the Connect Application that created the invoice.
+	Application *Application `json:"application"`
 	// The fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account when the invoice is paid.
 	ApplicationFeeAmount int64 `json:"application_fee_amount"`
 	// Number of payment attempts made for this invoice, from the perspective of the payment retry schedule. Any payment attempt counts as the first attempt, and subsequently only automatic retries increment the attempt count. In other words, manual payment attempts after the first attempt do not affect the retry schedule.

--- a/quote.go
+++ b/quote.go
@@ -420,6 +420,8 @@ type Quote struct {
 	AmountSubtotal int64 `json:"amount_subtotal"`
 	// Total after discounts and taxes are applied.
 	AmountTotal int64 `json:"amount_total"`
+	// ID of the Connect Application that created the quote.
+	Application *Application `json:"application"`
 	// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account. Only applicable if there are no line items with recurring prices on the quote.
 	ApplicationFeeAmount int64 `json:"application_fee_amount"`
 	// A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. Only applicable if there are line items with recurring prices on the quote.

--- a/sub.go
+++ b/sub.go
@@ -601,6 +601,8 @@ type SubscriptionTransferData struct {
 // Related guide: [Creating Subscriptions](https://stripe.com/docs/billing/subscriptions/creating).
 type Subscription struct {
 	APIResource
+	// ID of the Connect Application that created the subscription.
+	Application *Application `json:"application"`
 	// A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account.
 	ApplicationFeePercent float64                   `json:"application_fee_percent"`
 	AutomaticTax          *SubscriptionAutomaticTax `json:"automatic_tax"`

--- a/subschedule.go
+++ b/subschedule.go
@@ -354,6 +354,8 @@ type SubscriptionSchedulePhase struct {
 // Related guide: [Subscription Schedules](https://stripe.com/docs/billing/subscriptions/subscription-schedules).
 type SubscriptionSchedule struct {
 	APIResource
+	// ID of the Connect Application that created the schedule.
+	Application *Application `json:"application"`
 	// Time at which the subscription schedule was canceled. Measured in seconds since the Unix epoch.
 	CanceledAt int64 `json:"canceled_at"`
 	// Time at which the subscription schedule was completed. Measured in seconds since the Unix epoch.

--- a/taxid.go
+++ b/taxid.go
@@ -8,7 +8,7 @@ package stripe
 
 import "encoding/json"
 
-// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
 type TaxIDType string
 
 // List of values that TaxIDType can take
@@ -28,6 +28,7 @@ const (
 	TaxIDTypeCHVAT    TaxIDType = "ch_vat"
 	TaxIDTypeCLTIN    TaxIDType = "cl_tin"
 	TaxIDTypeESCIF    TaxIDType = "es_cif"
+	TaxIDTypeEUOSSVAT TaxIDType = "eu_oss_vat"
 	TaxIDTypeEUVAT    TaxIDType = "eu_vat"
 	TaxIDTypeGBVAT    TaxIDType = "gb_vat"
 	TaxIDTypeGEVAT    TaxIDType = "ge_vat"
@@ -76,7 +77,7 @@ const (
 type TaxIDParams struct {
 	Params   `form:"*"`
 	Customer *string `form:"-"` // Included in URL
-	// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
+	// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
 	Type *string `form:"type"`
 	// Value of the tax ID.
 	Value *string `form:"value"`
@@ -117,7 +118,7 @@ type TaxID struct {
 	Livemode bool `json:"livemode"`
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
-	// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+	// Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
 	Type TaxIDType `json:"type"`
 	// Value of the tax ID.
 	Value string `json:"value"`


### PR DESCRIPTION
Codegen for openapi e0e5752.
r? @kamil-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resource `CashBalance`
* Change type of `BillingPortalConfigurationApplication` from `$Application` to `deletable($Application)`
* Add support for `Alipay` on `CheckoutSessionPaymentMethodOptionsParams` and `CheckoutSessionPaymentMethodOptions`
* Add support for new value `eu_oss_vat` on enums `CheckoutSessionCustomerDetailsTaxIdsType`, `InvoiceCustomerTaxIdsType`, and `TaxIdType`
* Add support for `CashBalance` on `Customer`
* Add support for `Application` on `Invoice`, `Quote`, `SubscriptionSchedule`, and `Subscription`

