### PR TITLE
Added missing metadata field on checkout

### DIFF
--- a/checkout/session/client_test.go
+++ b/checkout/session/client_test.go
@@ -30,6 +30,10 @@ func TestCheckoutSessionNew(t *testing.T) {
 				Quantity: stripe.Int64(2),
 			},
 		},
+		Metadata: map[string]string{
+			"attr1": "val1",
+			"attr2": "val2",
+		},
 		PaymentIntentData: &stripe.CheckoutSessionPaymentIntentDataParams{
 			Description: stripe.String("description"),
 			Metadata: map[string]string{

--- a/checkout_session.go
+++ b/checkout_session.go
@@ -696,6 +696,8 @@ type CheckoutSessionParams struct {
 	LineItems []*CheckoutSessionLineItemParams `form:"line_items"`
 	// The IETF language tag of the locale Checkout is displayed in. If blank or `auto`, the browser's locale is used.
 	Locale *string `form:"locale"`
+	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+	Metadata map[string]string `form:"metadata"`
 	// The mode of the Checkout Session. Required when using prices or `setup` mode. Pass `subscription` if the Checkout Session includes at least one recurring item.
 	Mode *string `form:"mode"`
 	// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in `payment` mode.


### PR DESCRIPTION
https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-metadata

Metadata field from create checkout session params is missing. 

Present for the subscription and payment intent data fields, but not the checkout session creation.

Switching over from node (ts) to go and this is a small issue I've encountered. Here is it present on the node type for comparison: 
https://github.com/stripe/stripe-node/blob/babff9b2056af9a810f3c3e3da99e25984ac3242/types/2020-08-27/Checkout/Sessions.d.ts#L1040

