### PR TITLE
Use the generated API version

### DIFF
--- a/api_version.go
+++ b/api_version.go
@@ -1,0 +1,16 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+package stripe
+
+const (
+	apiVersion string = "2020-08-27"
+)
+
+//
+// Suppress the unused constant warning
+// The constant is not used for GA releases but is used in betas
+var _ = apiVersion

--- a/api_version.go
+++ b/api_version.go
@@ -9,8 +9,3 @@ package stripe
 const (
 	apiVersion string = "2020-08-27"
 )
-
-//
-// Suppress the unused constant warning
-// The constant is not used for GA releases but is used in betas
-var _ = apiVersion

--- a/stripe.go
+++ b/stripe.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// APIVersion is the currently supported API version
-	APIVersion string = "2020-08-27"
+	APIVersion string = apiVersion
 
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"


### PR DESCRIPTION
Port of https://github.com/stripe/stripe-go/pull/1479 to master.