### PR TITLE
feat!: Return an error by default when Webhook API version does not match stripe-go API version.

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -39,6 +39,9 @@ const (
 	// APIURL is the URL of the API service backend.
 	APIURL string = "https://api.stripe.com"
 
+	// ClientVersion is the version of the stripe-go library being used.
+	ClientVersion string = clientversion
+
 	// ConnectURL is the URL for OAuth.
 	ConnectURL string = "https://connect.stripe.com"
 

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -63,6 +63,9 @@ func ComputeSignature(t time.Time, payload []byte, secret string) []byte {
 // your signing secret from the Stripe dashboard:
 // https://dashboard.stripe.com/webhooks
 //
+// This will return an error if the event API version does not match the
+// stripe.APIVersion constant.
+//
 func ConstructEvent(payload []byte, header string, secret string) (stripe.Event, error) {
 	return ConstructEventWithTolerance(payload, header, secret, DefaultTolerance)
 }
@@ -76,8 +79,11 @@ func ConstructEvent(payload []byte, header string, secret string) (stripe.Event,
 // your signing secret from the Stripe dashboard:
 // https://dashboard.stripe.com/webhooks
 //
+// This will return an error if the event API version does not match the
+// stripe.APIVersion constant.
+//
 func ConstructEventIgnoringTolerance(payload []byte, header string, secret string) (stripe.Event, error) {
-	return constructEvent(payload, header, secret, 0*time.Second, false)
+	return constructEvent(payload, header, secret, ConstructEventOptions{ignoreTolerance: true})
 }
 
 // ConstructEventWithTolerance initializes an Event object from a JSON webhook payload,
@@ -90,8 +96,31 @@ func ConstructEventIgnoringTolerance(payload []byte, header string, secret strin
 // your signing secret from the Stripe dashboard:
 // https://dashboard.stripe.com/webhooks
 //
+// This will return an error if the event API version does not match the
+// stripe.APIVersion constant.
+//
 func ConstructEventWithTolerance(payload []byte, header string, secret string, tolerance time.Duration) (stripe.Event, error) {
-	return constructEvent(payload, header, secret, tolerance, true)
+	return constructEvent(payload, header, secret, ConstructEventOptions{tolerance: tolerance})
+}
+
+// ConstructEventWithOptions initializes an Event object from a JSON webhook payload,
+// validating the signature in the Stripe-Signature header using the specified signing
+// secret and tolerance window provided by the options, if applicable.
+//
+// See `ConstructEventOptions` for more details on each of the options.
+//
+// Returns an error if the signature doesn't match, or:
+// - if `ignoreTolerance` is false and the timestamp embedded in the event
+//   header is not within the tolerance window (similar to `ConstructEventWithTolerance`)
+// - if `ignoreAPIVersionMismatch` is false and the webhook event API version
+//   does not match the API version of the stripe-go library, as defined in
+//   `stripe.APIVersion`.
+//
+// NOTE: Stripe will only send Webhook signing headers after you have retrieved
+// your signing secret from the Stripe dashboard:
+// https://dashboard.stripe.com/webhooks
+func ConstructEventWithOptions(payload []byte, header string, secret string, options ConstructEventOptions) (stripe.Event, error) {
+	return constructEvent(payload, header, secret, options)
 }
 
 // ValidatePayload validates the payload against the Stripe-Signature header
@@ -133,6 +162,24 @@ func ValidatePayloadWithTolerance(payload []byte, header string, secret string, 
 	return validatePayload(payload, header, secret, tolerance, true)
 }
 
+type ConstructEventOptions struct {
+	// Validates event timestamps using a custom tolerance window. If this is
+	// not set and `ignoreTolerance` is false, will default to
+	// `DefaultTolerance`.
+	tolerance time.Duration
+
+	// If set to true, will ignore the `tolerance` option entirely and will not
+	// check the event signature's timestamp. Defaults to false. When false,
+	// constructing an event will fail with an error if the timestamp is not
+	// within the `tolerance` window.
+	ignoreTolerance bool
+
+	// If set to true, will ignore validating whether an event's API version
+	// matches the stripe-go API version. Defaults to false, returning an error
+	// when there is a mismatch.
+	ignoreAPIVersionMismatch bool
+}
+
 //
 // Private types
 //
@@ -146,15 +193,24 @@ type signedHeader struct {
 // Private functions
 //
 
-func constructEvent(payload []byte, sigHeader string, secret string, tolerance time.Duration, enforceTolerance bool) (stripe.Event, error) {
+func constructEvent(payload []byte, sigHeader string, secret string, options ConstructEventOptions) (stripe.Event, error) {
 	e := stripe.Event{}
 
-	if err := validatePayload(payload, sigHeader, secret, tolerance, enforceTolerance); err != nil {
+	tolerance := options.tolerance
+	if options.tolerance == 0 && !options.ignoreTolerance {
+		tolerance = DefaultTolerance
+	}
+
+	if err := validatePayload(payload, sigHeader, secret, tolerance, !options.ignoreTolerance); err != nil {
 		return e, err
 	}
 
 	if err := json.Unmarshal(payload, &e); err != nil {
 		return e, fmt.Errorf("Failed to parse webhook body json: %s", err.Error())
+	}
+
+	if !options.ignoreAPIVersionMismatch && e.APIVersion != stripe.APIVersion {
+		return e, fmt.Errorf("Received event with API version %s, but stripe-go %s expects API version %s. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this error by using `ConstructEventWithOptions(..., ConstructEventOptions{..., ignoreAPIVersionMismatch: true})`  but be wary that objects may be incorrectly deserialized.", e.APIVersion, stripe.ClientVersion, stripe.APIVersion)
 	}
 
 	return e, nil

--- a/webhook/client_test.go
+++ b/webhook/client_test.go
@@ -3,14 +3,23 @@ package webhook
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/stripe/stripe-go/v72"
 )
 
-var testPayload = []byte(`{
+var testPayload = []byte(fmt.Sprintf(`{
   "id": "evt_test_webhook",
-  "object": "event"
-}`)
+  "object": "event",
+  "api_version": "%s"
+}`, stripe.APIVersion))
+var testPayloadWithAPIVersionMismatch = []byte(`{
+	"id": "evt_test_webhook",
+	"object": "event",
+	"api_version": "2020-01-01"
+  }`)
 var testSecret = "whsec_test_secret"
 
 type SignedPayload struct {
@@ -180,5 +189,63 @@ func TestTokenNew(t *testing.T) {
 	evt, err = ConstructEventIgnoringTolerance(p.payload, p.header, p.secret)
 	if err != nil {
 		t.Errorf("Received %v error when timestamp outside window but no tolerance specified", err)
+	}
+}
+
+func TestConstructEvent_ErrorOnAPIVersionMismatch(t *testing.T) {
+	p := newSignedPayload(func(p *SignedPayload) {
+		p.payload = testPayloadWithAPIVersionMismatch
+	})
+
+	_, err := ConstructEvent(p.payload, p.header, p.secret)
+
+	if err == nil {
+		t.Errorf("Expected error due to API version mismatch.")
+	}
+
+	if !strings.Contains(err.Error(), "Received event with API version") {
+		t.Errorf("Expected API version mismatch error but received %v", err)
+	}
+}
+
+func TestConstructEventWithOptions_IgnoreAPIVersionMismatch(t *testing.T) {
+
+	p := newSignedPayload(func(p *SignedPayload) {
+		p.payload = testPayloadWithAPIVersionMismatch
+	})
+
+	evt, err := ConstructEventWithOptions(p.payload, p.header, p.secret, ConstructEventOptions{ignoreAPIVersionMismatch: true})
+
+	if err != nil {
+		t.Errorf("Expected no error due ignoreAPIVersionMismatch.")
+	}
+
+	if evt.ID != "evt_test_webhook" {
+		t.Errorf("Expected a parsed event matching the test payload, got %v", evt)
+	}
+}
+
+func TestConstructEventWithOptions_UsesDefaultToleranceWhenNoneProvided(t *testing.T) {
+
+	p := newSignedPayload(func(p *SignedPayload) {
+		// Get close to the default tolerance, but give wiggle room to avoid
+		// a flaky test.
+		p.timestamp = time.Now().Add(-DefaultTolerance).Add(1 * time.Second)
+	})
+
+	_, err := ConstructEventWithOptions(p.payload, p.header, p.secret, ConstructEventOptions{})
+
+	if err != nil {
+		t.Errorf("Expected no error due tolerance, but got %v.", err)
+	}
+
+	p = newSignedPayload(func(p *SignedPayload) {
+		p.timestamp = time.Now().Add(-DefaultTolerance).Add(-1 * time.Millisecond)
+	})
+
+	_, err = ConstructEventWithOptions(p.payload, p.header, p.secret, ConstructEventOptions{})
+
+	if err != ErrTooOld {
+		t.Errorf("Expected error due to being too old, but got %v.", err)
 	}
 }


### PR DESCRIPTION
r? @kamil-stripe @yejia-stripe 
cc @stripe/api-libraries

## Changelog
* ⚠️ Updates the Webhook `ConstructEvent`, `ConstructEventIgnoringTolerance` and `ConstructEventWithTolerance` functions to return an error when the webhook event's API version does not match the stripe-go library API version. 
  * This prevents potential errors where the webhook API version does not match the stripe-go API version, thus deserializing in an incorrect state. This is consistent with stripe-java and stripe-dotnet.
  * You can revert to the original behavior by switching to `ConstructEventWithOptions` and setting `ignoreAPIVersionMismatch: false`.
    * If you wish to opt-out and previously used `ConstructEventIgnoringTolerance`, this would now become:
    ```
    ConstructEventWithOptions(payload, header, secret, ConstructEventOptions{ignoreTolerance: true, ignoreAPIVersionMismatch: false})
     ```
    * If you wish to opt-out and previously used `ConstructEventWithTolerance`, this would now become:
    ```
    ConstructEventWithOptions(payload, header, secret, ConstructEventOptions{tolerance: tolerance, ignoreAPIVersionMismatch: false})
     ```