### PR TITLE
Add a support section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 The official [Stripe][stripe] Go client library.
 
+## Support
+
+New features and bug fixes are released on the latest major version of the Stripe Go client library. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
+
 ## Installation
 
 Make sure your project is using Go Modules (it will have a `go.mod` file in its


### PR DESCRIPTION
We have user feedback on the lack of clarity around whether or not we maintain and improve older major versions of the SDK. This PR adds a support section clarifying this