### PR TITLE
Allow setting APIVersion

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -30,9 +30,6 @@ import (
 //
 
 const (
-	// APIVersion is the currently supported API version
-	APIVersion string = apiVersion
-
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"
 
@@ -79,6 +76,9 @@ var EnableTelemetry = true
 
 // Key is the Stripe API key used globally in the binding.
 var Key string
+
+// APIVersion is the currently supported API version
+var APIVersion string = apiVersion
 
 //
 // Public types

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -47,6 +47,31 @@ func TestBearerAuth(t *testing.T) {
 	assert.Equal(t, "Bearer "+key, req.Header.Get("Authorization"))
 }
 
+func TestApiVersion(t *testing.T) {
+	c := GetBackend(APIBackend).(*BackendImplementation)
+	key := "apiKey"
+
+	req, err := c.NewRequest("", "", key, "", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, APIVersion, req.Header.Get("Stripe-Version"))
+}
+
+func TestCanSetApiVersion(t *testing.T) {
+	oldVersion := APIVersion
+	APIVersion = "12-23-2022; feature_in_beta=v3"
+
+	c := GetBackend(APIBackend).(*BackendImplementation)
+	key := "apiKey"
+
+	req, err := c.NewRequest("", "", key, "", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "12-23-2022; feature_in_beta=v3", req.Header.Get("Stripe-Version"))
+
+	APIVersion = oldVersion
+}
+
 func TestContext(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	p := &Params{Context: context.Background()}


### PR DESCRIPTION
Allows APIVersion value to be modified. Trims beta headers before using them in WebHook event version check.

r? @dcr-stripe