### PR TITLE
Add test coverage using coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,21 @@ jobs:
          run: make test &&
               make bench &&
               make check-api-clients
+       - name: Coverage
+         run: make coverage
+       - name: Coveralls
+         run: make coveralls
+         env:
+           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           COVERALLS_PARALLEL: true
+           COVERALLS_FLAG_NAME: Go-${{ matrix.go }}
+
+  finish:
+     needs: test
+     runs-on: ubuntu-latest
+     steps:
+       - name: Coveralls finished
+         run: curl "https://coveralls.io/webhook?repo_token=${{ secrets.GITHUB_TOKEN }}&repo_name=${{ github.repository }}" -d "payload[build_num]=${{ github.run_id }}&payload[status]=done"
 
   compile-only:
      runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,17 +55,10 @@ jobs:
          run: make coverage
        - name: Coveralls
          run: make coveralls
+         if: matrix.go == '1.16'
          env:
            COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           COVERALLS_PARALLEL: true
            COVERALLS_FLAG_NAME: Go-${{ matrix.go }}
-
-  finish:
-     needs: test
-     runs-on: ubuntu-latest
-     steps:
-       - name: Coveralls finished
-         run: curl "https://coveralls.io/webhook?repo_token=${{ secrets.GITHUB_TOKEN }}&repo_name=${{ github.repository }}" -d "payload[build_num]=${{ github.run_id }}&payload[status]=done"
 
   compile-only:
      runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,8 @@ jobs:
          run: make test &&
               make bench &&
               make check-api-clients
-       - name: Coverage
-         run: make coverage
        - name: Coveralls
-         run: make coveralls
+         run: make coverage && make coveralls
          if: matrix.go == '1.16'
          env:
            COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ coverage:
 	go run scripts/test_with_stripe_mock/main.go -covermode=count -coverprofile=combined.coverprofile ./...
 
 coveralls:
-	go get github.com/mattn/goveralls@latest && $(HOME)/go/bin/goveralls -service=github -coverprofile=combined.coverprofile
+	go install github.com/mattn/goveralls@latest && $(HOME)/go/bin/goveralls -service=github -coverprofile=combined.coverprofile
 
 clean:
 	find . -name \*.coverprofile -delete

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ vet:
 coverage:
 	go run scripts/test_with_stripe_mock/main.go -covermode=count -coverprofile=combined.coverprofile ./...
 
+coveralls:
+	go get github.com/mattn/goveralls@latest && $(HOME)/go/bin/goveralls -service=github -coverprofile=combined.coverprofile
+
 clean:
 	find . -name \*.coverprofile -delete
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Go Stripe
 [![Go Reference](https://pkg.go.dev/badge/github.com/stripe/stripe-go)](https://pkg.go.dev/github.com/stripe/stripe-go)
 [![Build Status](https://github.com/stripe/stripe-go/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-go/actions/workflows/ci.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-go/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-go?branch=master)
 
 The official [Stripe][stripe] Go client library.
 


### PR DESCRIPTION
### Summary
r? @yejia-stripe 

Add coveralls CI step that is conditionally executed for Go 1.16. Test coverage data will be published to https://coveralls.io/github/stripe/stripe-go and displayed as a badge in the README.

Example: https://coveralls.io/jobs/105039169