### PR TITLE
Update supported runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,11 @@ jobs:
      strategy:
        matrix:
          go:
+           - "1.19"
+           - "1.18"
+           - "1.17"
            - "1.16"
            - "1.15"
-           - "1.14"
-           - "1.13"
      name: "Test: go v${{ matrix.go }}"
      steps:
        - uses: actions/checkout@v2
@@ -57,41 +58,3 @@ jobs:
          env:
            COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            COVERALLS_FLAG_NAME: Go-${{ matrix.go }}
-
-  compile-only:
-     runs-on: ubuntu-latest
-     strategy:
-       matrix:
-         go:
-           - "1.12"
-           - "1.11"
-     name: "Compile: go v${{ matrix.go }}"
-     steps:
-       - uses: actions/checkout@v2
-       - name: Setup go
-         uses: actions/setup-go@v1
-         with:
-           go-version: ${{ matrix.go }}
-       - name: Compile
-         run: make build
-
-  # go 1.10 is the last version to require the source code
-  # to be located under the GOPATH
-  compile-only-1_10:
-     runs-on: ubuntu-latest
-     name: "Compile: go v1.10"
-     steps:
-       - uses: actions/checkout@v2
-       - name: Setup go
-         uses: actions/setup-go@v1
-         with:
-           go-version: 1.10
-       - name: Compile
-         run: MAJOR_VERSION="v$(awk 'BEGIN {FS="."};{print $1}' < VERSION)" &&
-              DIR="$HOME/go/src/github.com/stripe/stripe-go" &&
-              echo "dir=$DIR;major_version=$MAJOR_VERSION" &&
-              mkdir -p $DIR &&
-              cp -r ./ $DIR/$MAJOR_VERSION &&
-              cd $DIR/$MAJOR_VERSION &&
-              go get -u "golang.org/x/net/http2" &&
-              make build

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 The official [Stripe][stripe] Go client library.
 
+## Requirements
+
+- Go 1.15 or later
+
 ## Installation
 
 Make sure your project is using Go Modules (it will have a `go.mod` file in its


### PR DESCRIPTION
## Summary
Update supported runtime versions for next major release. The changes include:
* Add 1.17, 1.18 and 1.19 to test matrix
* Remove 1.13 and 1.14 from the test matrix
* Remove 1.10, 1.11, 1.12 compile-only tests
* Update README to indicate that we support 1.15 and above 