### PR TITLE
Add version to go reference path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Go Stripe
-[![Go Reference](https://pkg.go.dev/badge/github.com/stripe/stripe-go)](https://pkg.go.dev/github.com/stripe/stripe-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/stripe/stripe-go)](https://pkg.go.dev/github.com/stripe/stripe-go/v74)
 [![Build Status](https://github.com/stripe/stripe-go/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-go/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-go/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-go?branch=master)
 


### PR DESCRIPTION
The link to the Go reference docs https://pkg.go.dev/github.com/stripe/stripe-go/ shows v70 by default, instead of the latest version. This fixes the link to be https://pkg.go.dev/github.com/stripe/stripe-go/v74 (verified that running `make update-version` updates this README link with the major version).