### PR TITLE
Run goimports on generated test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,6 @@ update-version:
 
 codegen-format:
 	go fmt ./...
+	goimports -w example/generated_examples_test.go
 
 .PHONY: codegen-format update-version


### PR DESCRIPTION
Our generator used to run `goimports` on the generated test suite file separately from calling `make codegen-format`. This is no longer the case, and the past few releases have required manually running goimports on this file. This PR causes `make codegen-format` to run goimports on this file.