### PR TITLE
Handle developer message in preview error responses

### DIFF
--- a/error.go
+++ b/error.go
@@ -232,6 +232,7 @@ type Error struct {
 
 	HTTPStatusCode    int               `json:"status,omitempty"`
 	Msg               string            `json:"message"`
+	DeveloperMsg      string            `json:"developer_message"`
 	Param             string            `json:"param,omitempty"`
 	PaymentIntent     *PaymentIntent    `json:"payment_intent,omitempty"`
 	PaymentMethod     *PaymentMethod    `json:"payment_method,omitempty"`

--- a/error.go
+++ b/error.go
@@ -232,7 +232,7 @@ type Error struct {
 
 	HTTPStatusCode    int               `json:"status,omitempty"`
 	Msg               string            `json:"message"`
-	DeveloperMsg      string            `json:"developer_message"`
+	DeveloperMsg      string            `json:"developer_message,omitempty"`
 	Param             string            `json:"param,omitempty"`
 	PaymentIntent     *PaymentIntent    `json:"payment_intent,omitempty"`
 	PaymentMethod     *PaymentMethod    `json:"payment_method,omitempty"`


### PR DESCRIPTION
The error message can be returned in a developer_message field, add this to the `Error` type. 