### PR TITLE
Add suppressed balancetransaction types

### DIFF
--- a/balancetransaction.go
+++ b/balancetransaction.go
@@ -54,7 +54,10 @@ const (
 	BalanceTransactionSourceTypeIssuingDispute            BalanceTransactionSourceType = "issuing.dispute"
 	BalanceTransactionSourceTypeIssuingTransaction        BalanceTransactionSourceType = "issuing.transaction"
 	BalanceTransactionSourceTypePayout                    BalanceTransactionSourceType = "payout"
+	BalanceTransactionSourceTypePlatformTaxFee            BalanceTransactionSourceType = "platform_tax_fee"
 	BalanceTransactionSourceTypeRefund                    BalanceTransactionSourceType = "refund"
+	BalanceTransactionSourceTypeReserveTransaction        BalanceTransactionSourceType = "reserve_transaction"
+	BalanceTransactionSourceTypeTaxDeductedAtSource       BalanceTransactionSourceType = "tax_deducted_at_source"
 	BalanceTransactionSourceTypeTopup                     BalanceTransactionSourceType = "topup"
 	BalanceTransactionSourceTypeTransfer                  BalanceTransactionSourceType = "transfer"
 	BalanceTransactionSourceTypeTransferReversal          BalanceTransactionSourceType = "transfer_reversal"
@@ -204,7 +207,10 @@ type BalanceTransactionSource struct {
 	IssuingDispute            *IssuingDispute            `json:"-"`
 	IssuingTransaction        *IssuingTransaction        `json:"-"`
 	Payout                    *Payout                    `json:"-"`
+	PlatformTaxFee            *PlatformTaxFee            `json:"-"`
 	Refund                    *Refund                    `json:"-"`
+	ReserveTransaction        *ReserveTransaction        `json:"-"`
+	TaxDeductedAtSource       *TaxDeductedAtSource       `json:"-"`
 	Topup                     *Topup                     `json:"-"`
 	Transfer                  *Transfer                  `json:"-"`
 	TransferReversal          *TransferReversal          `json:"-"`
@@ -273,8 +279,14 @@ func (b *BalanceTransactionSource) UnmarshalJSON(data []byte) error {
 		err = json.Unmarshal(data, &b.IssuingTransaction)
 	case BalanceTransactionSourceTypePayout:
 		err = json.Unmarshal(data, &b.Payout)
+	case BalanceTransactionSourceTypePlatformTaxFee:
+		err = json.Unmarshal(data, &b.PlatformTaxFee)
 	case BalanceTransactionSourceTypeRefund:
 		err = json.Unmarshal(data, &b.Refund)
+	case BalanceTransactionSourceTypeReserveTransaction:
+		err = json.Unmarshal(data, &b.ReserveTransaction)
+	case BalanceTransactionSourceTypeTaxDeductedAtSource:
+		err = json.Unmarshal(data, &b.TaxDeductedAtSource)
 	case BalanceTransactionSourceTypeTopup:
 		err = json.Unmarshal(data, &b.Topup)
 	case BalanceTransactionSourceTypeTransfer:

--- a/platformtaxfee.go
+++ b/platformtaxfee.go
@@ -1,0 +1,41 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+package stripe
+
+import "encoding/json"
+
+type PlatformTaxFee struct {
+	// The Connected account that incurred this charge.
+	Account string `json:"account"`
+	// Unique identifier for the object.
+	ID string `json:"id"`
+	// String representing the object's type. Objects of the same type share the same value.
+	Object string `json:"object"`
+	// The payment object that caused this tax to be inflicted.
+	SourceTransaction string `json:"source_transaction"`
+	// The type of tax (VAT).
+	Type string `json:"type"`
+}
+
+// UnmarshalJSON handles deserialization of a PlatformTaxFee.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (p *PlatformTaxFee) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		p.ID = id
+		return nil
+	}
+
+	type platformTaxFee PlatformTaxFee
+	var v platformTaxFee
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*p = PlatformTaxFee(v)
+	return nil
+}

--- a/reservetransaction.go
+++ b/reservetransaction.go
@@ -1,0 +1,40 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+package stripe
+
+import "encoding/json"
+
+type ReserveTransaction struct {
+	Amount int64 `json:"amount"`
+	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+	Currency Currency `json:"currency"`
+	// An arbitrary string attached to the object. Often useful for displaying to users.
+	Description string `json:"description"`
+	// Unique identifier for the object.
+	ID string `json:"id"`
+	// String representing the object's type. Objects of the same type share the same value.
+	Object string `json:"object"`
+}
+
+// UnmarshalJSON handles deserialization of a ReserveTransaction.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (r *ReserveTransaction) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		r.ID = id
+		return nil
+	}
+
+	type reserveTransaction ReserveTransaction
+	var v reserveTransaction
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*r = ReserveTransaction(v)
+	return nil
+}

--- a/taxdeductedatsource.go
+++ b/taxdeductedatsource.go
@@ -1,0 +1,41 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+package stripe
+
+import "encoding/json"
+
+type TaxDeductedAtSource struct {
+	// Unique identifier for the object.
+	ID string `json:"id"`
+	// String representing the object's type. Objects of the same type share the same value.
+	Object string `json:"object"`
+	// The end of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period.
+	PeriodEnd int64 `json:"period_end"`
+	// The start of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period.
+	PeriodStart int64 `json:"period_start"`
+	// The TAN that was supplied to Stripe when TDS was assessed
+	TaxDeductionAccountNumber string `json:"tax_deduction_account_number"`
+}
+
+// UnmarshalJSON handles deserialization of a TaxDeductedAtSource.
+// This custom unmarshaling is needed because the resulting
+// property may be an id or the full struct if it was expanded.
+func (t *TaxDeductedAtSource) UnmarshalJSON(data []byte) error {
+	if id, ok := ParseID(data); ok {
+		t.ID = id
+		return nil
+	}
+
+	type taxDeductedAtSource TaxDeductedAtSource
+	var v taxDeductedAtSource
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*t = TaxDeductedAtSource(v)
+	return nil
+}


### PR DESCRIPTION
## Summary
These types are rarely used but exist in other Stripe libraries. We have changed our generator to correctly include them.