### PR TITLE
Bugfix: point files.New back to files.stripe.com

### DIFF
--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -1,4 +1,9 @@
+//
+//
 // File generated from our OpenAPI spec
+//
+//
+
 package example
 
 import (

--- a/file/client.go
+++ b/file/client.go
@@ -41,7 +41,7 @@ func (c Client) New(params *stripe.FileParams) (*stripe.File, error) {
 	}
 
 	file := &stripe.File{}
-	err = c.B.CallMultipart(http.MethodPost, "/v1/files", c.Key, boundary, bodyBuffer, &params.Params, file)
+	err = c.BUploads.CallMultipart(http.MethodPost, "/v1/files", c.Key, boundary, bodyBuffer, &params.Params, file)
 
 	return file, err
 }


### PR DESCRIPTION
Fixes #1734.

This regressed in #1699 (go v75).