### PR TITLE
(Beta) [WIP] simplify `stripe.Backend` interface

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.AccountParams) (*stripe.Account, error) {
 // New creates a new account.
 func (c Client) New(params *stripe.AccountParams) (*stripe.Account, error) {
 	account := &stripe.Account{}
-	err := c.B.Call(http.MethodPost, "/v1/accounts", c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/accounts", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -40,7 +46,14 @@ func Get() (*stripe.Account, error) {
 // Get retrieves the authenticating account.
 func (c Client) Get() (*stripe.Account, error) {
 	account := &stripe.Account{}
-	err := c.B.Call(http.MethodGet, "/v1/account", c.Key, nil, account)
+	err := c.B.Call(
+		stripe.StripeRequest{
+			Method: http.MethodGet,
+			Path:   "/v1/account",
+			Key:    c.Key,
+		},
+		account,
+	)
 	return account, err
 }
 
@@ -53,7 +66,13 @@ func GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) GetByID(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/v1/accounts/%s", id)
 	account := &stripe.Account{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -66,7 +85,13 @@ func Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) Update(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/v1/accounts/%s", id)
 	account := &stripe.Account{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -79,7 +104,13 @@ func Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 func (c Client) Del(id string, params *stripe.AccountParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/v1/accounts/%s", id)
 	account := &stripe.Account{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -92,7 +123,13 @@ func Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, err
 func (c Client) Reject(id string, params *stripe.AccountRejectParams) (*stripe.Account, error) {
 	path := stripe.FormatURLPath("/v1/accounts/%s/reject", id)
 	account := &stripe.Account{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -106,7 +143,14 @@ func (c Client) List(listParams *stripe.AccountListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.AccountList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/accounts", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/accounts",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/accountlink/client.go
+++ b/accountlink/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.AccountLinkParams) (*stripe.AccountLink, error) {
 // New creates a new account link.
 func (c Client) New(params *stripe.AccountLinkParams) (*stripe.AccountLink, error) {
 	accountlink := &stripe.AccountLink{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/account_links",
-		c.Key,
-		params,
-		accountlink,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/account_links", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, accountlink)
 	return accountlink, err
 }
 

--- a/accountnotice/client.go
+++ b/accountnotice/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.AccountNoticeParams) (*stripe.AccountNotice, 
 func (c Client) Get(id string, params *stripe.AccountNoticeParams) (*stripe.AccountNotice, error) {
 	path := stripe.FormatURLPath("/v1/account_notices/%s", id)
 	accountnotice := &stripe.AccountNotice{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, accountnotice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, accountnotice)
 	return accountnotice, err
 }
 
@@ -42,7 +48,13 @@ func Update(id string, params *stripe.AccountNoticeParams) (*stripe.AccountNotic
 func (c Client) Update(id string, params *stripe.AccountNoticeParams) (*stripe.AccountNotice, error) {
 	path := stripe.FormatURLPath("/v1/account_notices/%s", id)
 	accountnotice := &stripe.AccountNotice{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, accountnotice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, accountnotice)
 	return accountnotice, err
 }
 
@@ -56,7 +68,14 @@ func (c Client) List(listParams *stripe.AccountNoticeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.AccountNoticeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/account_notices", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/account_notices",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/accountsession/client.go
+++ b/accountsession/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.AccountSessionParams) (*stripe.AccountSession, error) {
 // New creates a new account session.
 func (c Client) New(params *stripe.AccountSessionParams) (*stripe.AccountSession, error) {
 	accountsession := &stripe.AccountSession{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/account_sessions",
-		c.Key,
-		params,
-		accountsession,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/account_sessions", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, accountsession)
 	return accountsession, err
 }
 

--- a/applepaydomain/client.go
+++ b/applepaydomain/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 // New creates a new apple pay domain.
 func (c Client) New(params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	applepaydomain := &stripe.ApplePayDomain{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/apple_pay/domains",
-		c.Key,
-		params,
-		applepaydomain,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/apple_pay/domains", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, applepaydomain)
 	return applepaydomain, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 func (c Client) Get(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	path := stripe.FormatURLPath("/v1/apple_pay/domains/%s", id)
 	applepaydomain := &stripe.ApplePayDomain{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, applepaydomain)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, applepaydomain)
 	return applepaydomain, err
 }
 
@@ -60,7 +66,13 @@ func Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain
 func (c Client) Del(id string, params *stripe.ApplePayDomainParams) (*stripe.ApplePayDomain, error) {
 	path := stripe.FormatURLPath("/v1/apple_pay/domains/%s", id)
 	applepaydomain := &stripe.ApplePayDomain{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, applepaydomain)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, applepaydomain)
 	return applepaydomain, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.ApplePayDomainListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ApplePayDomainList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/apple_pay/domains", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/apple_pay/domains",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/applicationfee/client.go
+++ b/applicationfee/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee
 func (c Client) Get(id string, params *stripe.ApplicationFeeParams) (*stripe.ApplicationFee, error) {
 	path := stripe.FormatURLPath("/v1/application_fees/%s", id)
 	applicationfee := &stripe.ApplicationFee{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, applicationfee)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, applicationfee)
 	return applicationfee, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.ApplicationFeeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ApplicationFeeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/application_fees", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/application_fees",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/apps/secret/client.go
+++ b/apps/secret/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.AppsSecretParams) (*stripe.AppsSecret, error) {
 // New creates a new apps secret.
 func (c Client) New(params *stripe.AppsSecretParams) (*stripe.AppsSecret, error) {
 	secret := &stripe.AppsSecret{}
-	err := c.B.Call(http.MethodPost, "/v1/apps/secrets", c.Key, params, secret)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/apps/secrets", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, secret)
 	return secret, err
 }
 
@@ -40,13 +46,13 @@ func DeleteWhere(params *stripe.AppsSecretDeleteWhereParams) (*stripe.AppsSecret
 // DeleteWhere is the method for the `POST /v1/apps/secrets/delete` API.
 func (c Client) DeleteWhere(params *stripe.AppsSecretDeleteWhereParams) (*stripe.AppsSecret, error) {
 	secret := &stripe.AppsSecret{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/apps/secrets/delete",
-		c.Key,
-		params,
-		secret,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/apps/secrets/delete", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, secret)
 	return secret, err
 }
 
@@ -58,13 +64,13 @@ func Find(params *stripe.AppsSecretFindParams) (*stripe.AppsSecret, error) {
 // Find is the method for the `GET /v1/apps/secrets/find` API.
 func (c Client) Find(params *stripe.AppsSecretFindParams) (*stripe.AppsSecret, error) {
 	secret := &stripe.AppsSecret{}
-	err := c.B.Call(
-		http.MethodGet,
-		"/v1/apps/secrets/find",
-		c.Key,
-		params,
-		secret,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: "/v1/apps/secrets/find", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, secret)
 	return secret, err
 }
 
@@ -78,7 +84,14 @@ func (c Client) List(listParams *stripe.AppsSecretListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.AppsSecretList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/apps/secrets", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/apps/secrets",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/balance/client.go
+++ b/balance/client.go
@@ -27,7 +27,13 @@ func Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 // Get returns the details of a balance.
 func (c Client) Get(params *stripe.BalanceParams) (*stripe.Balance, error) {
 	balance := &stripe.Balance{}
-	err := c.B.Call(http.MethodGet, "/v1/balance", c.Key, params, balance)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: "/v1/balance", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, balance)
 	return balance, err
 }
 

--- a/balancetransaction/client.go
+++ b/balancetransaction/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTra
 func (c Client) Get(id string, params *stripe.BalanceTransactionParams) (*stripe.BalanceTransaction, error) {
 	path := stripe.FormatURLPath("/v1/balance_transactions/%s", id)
 	balancetransaction := &stripe.BalanceTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, balancetransaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, balancetransaction)
 	return balancetransaction, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.BalanceTransactionListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.BalanceTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/balance_transactions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/balance_transactions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -52,7 +52,14 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 	// make an explicit call using a form and CallRaw instead of the standard
 	// Call (which takes a set of parameters).
 	bankaccount := &stripe.BankAccount{}
-	err := c.B.CallRaw(http.MethodPost, path, c.Key, body, &params.Params, bankaccount)
+	err := c.B.Call(stripe.StripeRequest{
+		Method: http.MethodPost,
+		Path:   path,
+		Key:    c.Key,
+		Body:   body,
+		Params: &params.Params,
+	}, bankaccount)
+
 	return bankaccount, err
 }
 
@@ -77,7 +84,16 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	}
 
 	bankaccount := &stripe.BankAccount{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, bankaccount)
+	sr := stripe.StripeRequest{
+		Method: http.MethodGet,
+		Path:   path,
+		Key:    c.Key,
+	}
+	err := sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, bankaccount)
 	return bankaccount, err
 }
 
@@ -102,7 +118,16 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 	}
 
 	bankaccount := &stripe.BankAccount{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, bankaccount)
+	sr := stripe.StripeRequest{
+		Method: http.MethodPost,
+		Path:   path,
+		Key:    c.Key,
+	}
+	err := sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, bankaccount)
 	return bankaccount, err
 }
 
@@ -127,7 +152,16 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 	}
 
 	bankaccount := &stripe.BankAccount{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, bankaccount)
+	sr := stripe.StripeRequest{
+		Method: http.MethodDelete,
+		Path:   path,
+		Key:    c.Key,
+	}
+	err := sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, bankaccount)
 	return bankaccount, err
 }
 
@@ -164,7 +198,14 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 				return nil, list, outerErr
 			}
 
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/billingportal/configuration/client.go
+++ b/billingportal/configuration/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.BillingPortalConfigurationParams) (*stripe.BillingPortal
 // New creates a new billing portal configuration.
 func (c Client) New(params *stripe.BillingPortalConfigurationParams) (*stripe.BillingPortalConfiguration, error) {
 	configuration := &stripe.BillingPortalConfiguration{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/billing_portal/configurations",
-		c.Key,
-		params,
-		configuration,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/billing_portal/configurations", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, configuration)
 	return configuration, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.BillingPortalConfigurationParams) (*stripe.Bi
 func (c Client) Get(id string, params *stripe.BillingPortalConfigurationParams) (*stripe.BillingPortalConfiguration, error) {
 	path := stripe.FormatURLPath("/v1/billing_portal/configurations/%s", id)
 	configuration := &stripe.BillingPortalConfiguration{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, configuration)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, configuration)
 	return configuration, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.BillingPortalConfigurationParams) (*stripe
 func (c Client) Update(id string, params *stripe.BillingPortalConfigurationParams) (*stripe.BillingPortalConfiguration, error) {
 	path := stripe.FormatURLPath("/v1/billing_portal/configurations/%s", id)
 	configuration := &stripe.BillingPortalConfiguration{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, configuration)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, configuration)
 	return configuration, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.BillingPortalConfigurationListParams) *I
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.BillingPortalConfigurationList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/billing_portal/configurations", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/billing_portal/configurations",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/billingportal/session/client.go
+++ b/billingportal/session/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.BillingPortalSessionParams) (*stripe.BillingPortalSessio
 // New creates a new billing portal session.
 func (c Client) New(params *stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error) {
 	session := &stripe.BillingPortalSession{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/billing_portal/sessions",
-		c.Key,
-		params,
-		session,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/billing_portal/sessions", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, session)
 	return session, err
 }
 

--- a/capability/client.go
+++ b/capability/client.go
@@ -39,7 +39,13 @@ func (c Client) Get(id string, params *stripe.CapabilityParams) (*stripe.Capabil
 		id,
 	)
 	capability := &stripe.Capability{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, capability)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, capability)
 	return capability, err
 }
 
@@ -56,7 +62,13 @@ func (c Client) Update(id string, params *stripe.CapabilityParams) (*stripe.Capa
 		id,
 	)
 	capability := &stripe.Capability{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, capability)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, capability)
 	return capability, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.CapabilityListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CapabilityList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/capital/financingoffer/client.go
+++ b/capital/financingoffer/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.CapitalFinancingOfferParams) (*stripe.Capital
 func (c Client) Get(id string, params *stripe.CapitalFinancingOfferParams) (*stripe.CapitalFinancingOffer, error) {
 	path := stripe.FormatURLPath("/v1/capital/financing_offers/%s", id)
 	financingoffer := &stripe.CapitalFinancingOffer{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, financingoffer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financingoffer)
 	return financingoffer, err
 }
 
@@ -45,7 +51,13 @@ func (c Client) MarkDelivered(id string, params *stripe.CapitalFinancingOfferMar
 		id,
 	)
 	financingoffer := &stripe.CapitalFinancingOffer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, financingoffer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financingoffer)
 	return financingoffer, err
 }
 
@@ -59,7 +71,14 @@ func (c Client) List(listParams *stripe.CapitalFinancingOfferListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CapitalFinancingOfferList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/capital/financing_offers", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/capital/financing_offers",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/capital/financingsummary/client.go
+++ b/capital/financingsummary/client.go
@@ -27,13 +27,13 @@ func Get(params *stripe.CapitalFinancingSummaryParams) (*stripe.CapitalFinancing
 // Get returns the details of a capital financing summary.
 func (c Client) Get(params *stripe.CapitalFinancingSummaryParams) (*stripe.CapitalFinancingSummary, error) {
 	financingsummary := &stripe.CapitalFinancingSummary{}
-	err := c.B.Call(
-		http.MethodGet,
-		"/v1/capital/financing_summary",
-		c.Key,
-		params,
-		financingsummary,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: "/v1/capital/financing_summary", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financingsummary)
 	return financingsummary, err
 }
 

--- a/capital/financingtransaction/client.go
+++ b/capital/financingtransaction/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.CapitalFinancingTransactionParams) (*stripe.C
 func (c Client) Get(id string, params *stripe.CapitalFinancingTransactionParams) (*stripe.CapitalFinancingTransaction, error) {
 	path := stripe.FormatURLPath("/v1/capital/financing_transactions/%s", id)
 	financingtransaction := &stripe.CapitalFinancingTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, financingtransaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financingtransaction)
 	return financingtransaction, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.CapitalFinancingTransactionListParams) *
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CapitalFinancingTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/capital/financing_transactions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/capital/financing_transactions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/card/client.go
+++ b/card/client.go
@@ -52,7 +52,14 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 	// make an explicit call using a form and CallRaw instead of the standard
 	// Call (which takes a set of parameters).
 	card := &stripe.Card{}
-	err := c.B.CallRaw(http.MethodPost, path, c.Key, body, &params.Params, card)
+	err := c.B.Call(stripe.StripeRequest{
+		Method: http.MethodPost,
+		Path:   path,
+		Key:    c.Key,
+		Body:   body,
+		Params: &params.Params,
+	}, card)
+
 	return card, err
 }
 
@@ -77,7 +84,16 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, card)
+	sr := stripe.StripeRequest{
+		Method: http.MethodGet,
+		Path:   path,
+		Key:    c.Key,
+	}
+	err := sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -102,7 +118,16 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
+	sr := stripe.StripeRequest{
+		Method: http.MethodPost,
+		Path:   path,
+		Key:    c.Key,
+	}
+	err := sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -127,7 +152,16 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 	}
 
 	card := &stripe.Card{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, card)
+	sr := stripe.StripeRequest{
+		Method: http.MethodDelete,
+		Path:   path,
+		Key:    c.Key,
+	}
+	err := sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -164,7 +198,14 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 				return nil, list, outerErr
 			}
 
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/cashbalance/client.go
+++ b/cashbalance/client.go
@@ -37,7 +37,13 @@ func (c Client) Get(params *stripe.CashBalanceParams) (*stripe.CashBalance, erro
 		stripe.StringValue(params.Customer),
 	)
 	cashbalance := &stripe.CashBalance{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, cashbalance)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, cashbalance)
 	return cashbalance, err
 }
 
@@ -58,7 +64,13 @@ func (c Client) Update(params *stripe.CashBalanceParams) (*stripe.CashBalance, e
 		stripe.StringValue(params.Customer),
 	)
 	cashbalance := &stripe.CashBalance{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, cashbalance)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, cashbalance)
 	return cashbalance, err
 }
 

--- a/charge/client.go
+++ b/charge/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 // New creates a new charge.
 func (c Client) New(params *stripe.ChargeParams) (*stripe.Charge, error) {
 	charge := &stripe.Charge{}
-	err := c.B.Call(http.MethodPost, "/v1/charges", c.Key, params, charge)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/charges", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, charge)
 	return charge, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 func (c Client) Get(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/v1/charges/%s", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, charge)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, charge)
 	return charge, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 func (c Client) Update(id string, params *stripe.ChargeParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/v1/charges/%s", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, charge)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, charge)
 	return charge, err
 }
 
@@ -67,7 +85,13 @@ func Capture(id string, params *stripe.ChargeCaptureParams) (*stripe.Charge, err
 func (c Client) Capture(id string, params *stripe.ChargeCaptureParams) (*stripe.Charge, error) {
 	path := stripe.FormatURLPath("/v1/charges/%s/capture", id)
 	charge := &stripe.Charge{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, charge)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, charge)
 	return charge, err
 }
 
@@ -81,7 +105,14 @@ func (c Client) List(listParams *stripe.ChargeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ChargeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/charges", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/charges",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -120,7 +151,14 @@ func (c Client) Search(params *stripe.ChargeSearchParams) *SearchIter {
 	return &SearchIter{
 		SearchIter: stripe.GetSearchIter(params, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.SearchContainer, error) {
 			list := &stripe.ChargeSearchResult{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/charges/search", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/charges/search",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/checkout/session/client.go
+++ b/checkout/session/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) 
 // New creates a new checkout session.
 func (c Client) New(params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
 	session := &stripe.CheckoutSession{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/checkout/sessions",
-		c.Key,
-		params,
-		session,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/checkout/sessions", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, session)
 	return session, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSessi
 func (c Client) Get(id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
 	path := stripe.FormatURLPath("/v1/checkout/sessions/%s", id)
 	session := &stripe.CheckoutSession{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, session)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, session)
 	return session, err
 }
 
@@ -60,7 +66,13 @@ func Expire(id string, params *stripe.CheckoutSessionExpireParams) (*stripe.Chec
 func (c Client) Expire(id string, params *stripe.CheckoutSessionExpireParams) (*stripe.CheckoutSession, error) {
 	path := stripe.FormatURLPath("/v1/checkout/sessions/%s/expire", id)
 	session := &stripe.CheckoutSession{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, session)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, session)
 	return session, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.CheckoutSessionListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CheckoutSessionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/checkout/sessions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/checkout/sessions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -117,7 +136,14 @@ func (c Client) ListLineItems(listParams *stripe.CheckoutSessionListLineItemsPar
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.LineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/climate/order/client.go
+++ b/climate/order/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.ClimateOrderParams) (*stripe.ClimateOrder, error) {
 // New creates a new climate order.
 func (c Client) New(params *stripe.ClimateOrderParams) (*stripe.ClimateOrder, error) {
 	order := &stripe.ClimateOrder{}
-	err := c.B.Call(http.MethodPost, "/v1/climate/orders", c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/climate/orders", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.ClimateOrderParams) (*stripe.ClimateOrder, er
 func (c Client) Get(id string, params *stripe.ClimateOrderParams) (*stripe.ClimateOrder, error) {
 	path := stripe.FormatURLPath("/v1/climate/orders/%s", id)
 	order := &stripe.ClimateOrder{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.ClimateOrderParams) (*stripe.ClimateOrder,
 func (c Client) Update(id string, params *stripe.ClimateOrderParams) (*stripe.ClimateOrder, error) {
 	path := stripe.FormatURLPath("/v1/climate/orders/%s", id)
 	order := &stripe.ClimateOrder{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -67,7 +85,13 @@ func Cancel(id string, params *stripe.ClimateOrderCancelParams) (*stripe.Climate
 func (c Client) Cancel(id string, params *stripe.ClimateOrderCancelParams) (*stripe.ClimateOrder, error) {
 	path := stripe.FormatURLPath("/v1/climate/orders/%s/cancel", id)
 	order := &stripe.ClimateOrder{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -81,7 +105,14 @@ func (c Client) List(listParams *stripe.ClimateOrderListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ClimateOrderList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/climate/orders", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/climate/orders",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/climate/product/client.go
+++ b/climate/product/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.ClimateProductParams) (*stripe.ClimateProduct
 func (c Client) Get(id string, params *stripe.ClimateProductParams) (*stripe.ClimateProduct, error) {
 	path := stripe.FormatURLPath("/v1/climate/products/%s", id)
 	product := &stripe.ClimateProduct{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, product)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, product)
 	return product, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.ClimateProductListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ClimateProductList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/climate/products", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/climate/products",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/climate/supplier/client.go
+++ b/climate/supplier/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.ClimateSupplierParams) (*stripe.ClimateSuppli
 func (c Client) Get(id string, params *stripe.ClimateSupplierParams) (*stripe.ClimateSupplier, error) {
 	path := stripe.FormatURLPath("/v1/climate/suppliers/%s", id)
 	supplier := &stripe.ClimateSupplier{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, supplier)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, supplier)
 	return supplier, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.ClimateSupplierListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ClimateSupplierList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/climate/suppliers", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/climate/suppliers",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/confirmationtoken/client.go
+++ b/confirmationtoken/client.go
@@ -28,7 +28,13 @@ func Get(id string, params *stripe.ConfirmationTokenParams) (*stripe.Confirmatio
 func (c Client) Get(id string, params *stripe.ConfirmationTokenParams) (*stripe.ConfirmationToken, error) {
 	path := stripe.FormatURLPath("/v1/confirmation_tokens/%s", id)
 	confirmationtoken := &stripe.ConfirmationToken{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, confirmationtoken)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, confirmationtoken)
 	return confirmationtoken, err
 }
 

--- a/countryspec/client.go
+++ b/countryspec/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.CountrySpecParams) (*stripe.CountrySpec, erro
 func (c Client) Get(id string, params *stripe.CountrySpecParams) (*stripe.CountrySpec, error) {
 	path := stripe.FormatURLPath("/v1/country_specs/%s", id)
 	countryspec := &stripe.CountrySpec{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, countryspec)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, countryspec)
 	return countryspec, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.CountrySpecListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CountrySpecList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/country_specs", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/country_specs",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/coupon/client.go
+++ b/coupon/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 // New creates a new coupon.
 func (c Client) New(params *stripe.CouponParams) (*stripe.Coupon, error) {
 	coupon := &stripe.Coupon{}
-	err := c.B.Call(http.MethodPost, "/v1/coupons", c.Key, params, coupon)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/coupons", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, coupon)
 	return coupon, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Get(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/v1/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, coupon)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, coupon)
 	return coupon, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Update(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/v1/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, coupon)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, coupon)
 	return coupon, err
 }
 
@@ -67,7 +85,13 @@ func Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 func (c Client) Del(id string, params *stripe.CouponParams) (*stripe.Coupon, error) {
 	path := stripe.FormatURLPath("/v1/coupons/%s", id)
 	coupon := &stripe.Coupon{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, coupon)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, coupon)
 	return coupon, err
 }
 
@@ -81,7 +105,14 @@ func (c Client) List(listParams *stripe.CouponListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CouponList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/coupons", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/coupons",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/creditnote/client.go
+++ b/creditnote/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
 // New creates a new credit note.
 func (c Client) New(params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
 	creditnote := &stripe.CreditNote{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/credit_notes",
-		c.Key,
-		params,
-		creditnote,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/credit_notes", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditnote)
 	return creditnote, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.CreditNoteParams) (*stripe.CreditNote, error)
 func (c Client) Get(id string, params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
 	path := stripe.FormatURLPath("/v1/credit_notes/%s", id)
 	creditnote := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, creditnote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditnote)
 	return creditnote, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.CreditNoteParams) (*stripe.CreditNote, err
 func (c Client) Update(id string, params *stripe.CreditNoteParams) (*stripe.CreditNote, error) {
 	path := stripe.FormatURLPath("/v1/credit_notes/%s", id)
 	creditnote := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, creditnote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditnote)
 	return creditnote, err
 }
 
@@ -72,13 +84,13 @@ func Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error)
 // Preview is the method for the `GET /v1/credit_notes/preview` API.
 func (c Client) Preview(params *stripe.CreditNotePreviewParams) (*stripe.CreditNote, error) {
 	creditnote := &stripe.CreditNote{}
-	err := c.B.Call(
-		http.MethodGet,
-		"/v1/credit_notes/preview",
-		c.Key,
-		params,
-		creditnote,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: "/v1/credit_notes/preview", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditnote)
 	return creditnote, err
 }
 
@@ -91,7 +103,13 @@ func VoidCreditNote(id string, params *stripe.CreditNoteVoidCreditNoteParams) (*
 func (c Client) VoidCreditNote(id string, params *stripe.CreditNoteVoidCreditNoteParams) (*stripe.CreditNote, error) {
 	path := stripe.FormatURLPath("/v1/credit_notes/%s/void", id)
 	creditnote := &stripe.CreditNote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, creditnote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditnote)
 	return creditnote, err
 }
 
@@ -105,7 +123,14 @@ func (c Client) List(listParams *stripe.CreditNoteListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CreditNoteList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/credit_notes", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/credit_notes",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -148,7 +173,14 @@ func (c Client) ListLines(listParams *stripe.CreditNoteListLinesParams) *LineIte
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CreditNoteLineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -170,7 +202,14 @@ func (c Client) PreviewLines(listParams *stripe.CreditNotePreviewLinesParams) *L
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CreditNoteLineItemList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/credit_notes/preview/lines", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/credit_notes/preview/lines",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/customer/client.go
+++ b/customer/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 // New creates a new customer.
 func (c Client) New(params *stripe.CustomerParams) (*stripe.Customer, error) {
 	customer := &stripe.Customer{}
-	err := c.B.Call(http.MethodPost, "/v1/customers", c.Key, params, customer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/customers", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customer)
 	return customer, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 func (c Client) Get(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/v1/customers/%s", id)
 	customer := &stripe.Customer{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, customer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customer)
 	return customer, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) 
 func (c Client) Update(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/v1/customers/%s", id)
 	customer := &stripe.Customer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, customer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customer)
 	return customer, err
 }
 
@@ -67,7 +85,13 @@ func Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 func (c Client) Del(id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/v1/customers/%s", id)
 	customer := &stripe.Customer{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, customer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customer)
 	return customer, err
 }
 
@@ -80,7 +104,13 @@ func CreateFundingInstructions(id string, params *stripe.CustomerCreateFundingIn
 func (c Client) CreateFundingInstructions(id string, params *stripe.CustomerCreateFundingInstructionsParams) (*stripe.FundingInstructions, error) {
 	path := stripe.FormatURLPath("/v1/customers/%s/funding_instructions", id)
 	fundinginstructions := &stripe.FundingInstructions{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, fundinginstructions)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, fundinginstructions)
 	return fundinginstructions, err
 }
 
@@ -93,7 +123,13 @@ func DeleteDiscount(id string, params *stripe.CustomerDeleteDiscountParams) (*st
 func (c Client) DeleteDiscount(id string, params *stripe.CustomerDeleteDiscountParams) (*stripe.Customer, error) {
 	path := stripe.FormatURLPath("/v1/customers/%s/discount", id)
 	customer := &stripe.Customer{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, customer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customer)
 	return customer, err
 }
 
@@ -110,7 +146,13 @@ func (c Client) RetrievePaymentMethod(id string, params *stripe.CustomerRetrieve
 		id,
 	)
 	paymentmethod := &stripe.PaymentMethod{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, paymentmethod)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethod)
 	return paymentmethod, err
 }
 
@@ -124,7 +166,14 @@ func (c Client) List(listParams *stripe.CustomerListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CustomerList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/customers", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/customers",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -167,7 +216,14 @@ func (c Client) ListPaymentMethods(listParams *stripe.CustomerListPaymentMethods
 	return &PaymentMethodIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PaymentMethodList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -206,7 +262,14 @@ func (c Client) Search(params *stripe.CustomerSearchParams) *SearchIter {
 	return &SearchIter{
 		SearchIter: stripe.GetSearchIter(params, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.SearchContainer, error) {
 			list := &stripe.CustomerSearchResult{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/customers/search", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/customers/search",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/customerbalancetransaction/client.go
+++ b/customerbalancetransaction/client.go
@@ -38,13 +38,13 @@ func (c Client) New(params *stripe.CustomerBalanceTransactionParams) (*stripe.Cu
 		stripe.StringValue(params.Customer),
 	)
 	customerbalancetransaction := &stripe.CustomerBalanceTransaction{}
-	err := c.B.Call(
-		http.MethodPost,
-		path,
-		c.Key,
-		params,
-		customerbalancetransaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customerbalancetransaction)
 	return customerbalancetransaction, err
 }
 
@@ -66,13 +66,13 @@ func (c Client) Get(id string, params *stripe.CustomerBalanceTransactionParams) 
 		id,
 	)
 	customerbalancetransaction := &stripe.CustomerBalanceTransaction{}
-	err := c.B.Call(
-		http.MethodGet,
-		path,
-		c.Key,
-		params,
-		customerbalancetransaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customerbalancetransaction)
 	return customerbalancetransaction, err
 }
 
@@ -89,13 +89,13 @@ func (c Client) Update(id string, params *stripe.CustomerBalanceTransactionParam
 		id,
 	)
 	customerbalancetransaction := &stripe.CustomerBalanceTransaction{}
-	err := c.B.Call(
-		http.MethodPost,
-		path,
-		c.Key,
-		params,
-		customerbalancetransaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customerbalancetransaction)
 	return customerbalancetransaction, err
 }
 
@@ -113,7 +113,14 @@ func (c Client) List(listParams *stripe.CustomerBalanceTransactionListParams) *I
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CustomerBalanceTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/customercashbalancetransaction/client.go
+++ b/customercashbalancetransaction/client.go
@@ -33,13 +33,13 @@ func (c Client) Get(id string, params *stripe.CustomerCashBalanceTransactionPara
 		id,
 	)
 	customercashbalancetransaction := &stripe.CustomerCashBalanceTransaction{}
-	err := c.B.Call(
-		http.MethodGet,
-		path,
-		c.Key,
-		params,
-		customercashbalancetransaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customercashbalancetransaction)
 	return customercashbalancetransaction, err
 }
 
@@ -57,7 +57,14 @@ func (c Client) List(listParams *stripe.CustomerCashBalanceTransactionListParams
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CustomerCashBalanceTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/customersession/client.go
+++ b/customersession/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.CustomerSessionParams) (*stripe.CustomerSession, error) 
 // New creates a new customer session.
 func (c Client) New(params *stripe.CustomerSessionParams) (*stripe.CustomerSession, error) {
 	customersession := &stripe.CustomerSession{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/customer_sessions",
-		c.Key,
-		params,
-		customersession,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/customer_sessions", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customersession)
 	return customersession, err
 }
 

--- a/dispute/client.go
+++ b/dispute/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Get(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/v1/disputes/%s", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, dispute)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, dispute)
 	return dispute, err
 }
 
@@ -42,7 +48,13 @@ func Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Update(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/v1/disputes/%s", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, dispute)
 	return dispute, err
 }
 
@@ -55,7 +67,13 @@ func Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 func (c Client) Close(id string, params *stripe.DisputeParams) (*stripe.Dispute, error) {
 	path := stripe.FormatURLPath("/v1/disputes/%s/close", id)
 	dispute := &stripe.Dispute{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, dispute)
 	return dispute, err
 }
 
@@ -69,7 +87,14 @@ func (c Client) List(listParams *stripe.DisputeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.DisputeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/disputes", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/disputes",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/ephemeralkey/client.go
+++ b/ephemeralkey/client.go
@@ -37,13 +37,13 @@ func (c Client) New(params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 	params.Headers.Add("Stripe-Version", stripe.StringValue(params.StripeVersion))
 
 	ephemeralkey := &stripe.EphemeralKey{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/ephemeral_keys",
-		c.Key,
-		params,
-		ephemeralkey,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/ephemeral_keys", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, ephemeralkey)
 	return ephemeralkey, err
 }
 
@@ -56,7 +56,13 @@ func Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, er
 func (c Client) Del(id string, params *stripe.EphemeralKeyParams) (*stripe.EphemeralKey, error) {
 	path := stripe.FormatURLPath("/v1/ephemeral_keys/%s", id)
 	ephemeralkey := &stripe.EphemeralKey{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, ephemeralkey)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, ephemeralkey)
 	return ephemeralkey, err
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -31,7 +31,11 @@ func TestErrorResponse(t *testing.T) {
 		URL: String(ts.URL),
 	})
 
-	err := backend.Call(http.MethodGet, "/v1/account", "sk_test_badKey", nil, nil)
+	err := backend.Call(StripeRequest{
+		Method: http.MethodGet,
+		Path:   "/v1/account",
+		Key:    "sk_test_badKey",
+	}, nil)
 	assert.Error(t, err)
 
 	stripeErr := err.(*Error)
@@ -58,7 +62,11 @@ func TestPreviewErrorResponse(t *testing.T) {
 		URL: String(ts.URL),
 	})
 
-	err := backend.Call(http.MethodGet, "/v1/charges/ch_123", "sk_test_123", nil, nil)
+	err := backend.Call(StripeRequest{
+		Method: http.MethodGet,
+		Path:   "/v1/charges/ch_123",
+		Key:    "sk_test_123",
+	}, nil)
 	assert.Error(t, err)
 
 	stripeErr := err.(*Error)

--- a/event/client.go
+++ b/event/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.EventParams) (*stripe.Event, error) {
 func (c Client) Get(id string, params *stripe.EventParams) (*stripe.Event, error) {
 	path := stripe.FormatURLPath("/v1/events/%s", id)
 	event := &stripe.Event{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, event)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, event)
 	return event, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.EventListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.EventList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/events", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/events",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/feerefund/client.go
+++ b/feerefund/client.go
@@ -39,7 +39,13 @@ func (c Client) New(params *stripe.FeeRefundParams) (*stripe.FeeRefund, error) {
 		stripe.StringValue(params.ID),
 	)
 	feerefund := &stripe.FeeRefund{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, feerefund)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, feerefund)
 	return feerefund, err
 }
 
@@ -62,7 +68,13 @@ func (c Client) Get(id string, params *stripe.FeeRefundParams) (*stripe.FeeRefun
 		id,
 	)
 	feerefund := &stripe.FeeRefund{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, feerefund)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, feerefund)
 	return feerefund, err
 }
 
@@ -85,7 +97,13 @@ func (c Client) Update(id string, params *stripe.FeeRefundParams) (*stripe.FeeRe
 		id,
 	)
 	feerefund := &stripe.FeeRefund{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, feerefund)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, feerefund)
 	return feerefund, err
 }
 
@@ -103,7 +121,14 @@ func (c Client) List(listParams *stripe.FeeRefundListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.FeeRefundList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/file/client_test.go
+++ b/file/client_test.go
@@ -12,13 +12,11 @@ package file
 //
 
 import (
-	"bytes"
 	"os"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go/v76"
-	"github.com/stripe/stripe-go/v76/form"
 	_ "github.com/stripe/stripe-go/v76/testing"
 )
 
@@ -47,17 +45,14 @@ type testBackend struct {
 	calledMultipart bool
 }
 
-func (b *testBackend) Call(method, path, key string, params stripe.ParamsContainer, v stripe.LastResponseSetter) error {
+func (b *testBackend) Call(req stripe.StripeRequest, v stripe.LastResponseSetter) error {
+	if req.IsMultipart {
+		b.calledMultipart = true
+	}
 	return nil
 }
-func (b *testBackend) CallStreaming(method, path, key string, params stripe.ParamsContainer, v stripe.StreamingLastResponseSetter) error {
-	return nil
-}
-func (b *testBackend) CallRaw(method, path, key string, body *form.Values, params *stripe.Params, v stripe.LastResponseSetter) error {
-	return nil
-}
-func (b *testBackend) CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *stripe.Params, v stripe.LastResponseSetter) error {
-	b.calledMultipart = true
+
+func (b *testBackend) CallStreaming(req stripe.StripeRequest, v stripe.StreamingLastResponseSetter) error {
 	return nil
 }
 func (b *testBackend) SetMaxNetworkRetries(maxNetworkRetries int64) {}

--- a/filelink/client.go
+++ b/filelink/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 // New creates a new file link.
 func (c Client) New(params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 	filelink := &stripe.FileLink{}
-	err := c.B.Call(http.MethodPost, "/v1/file_links", c.Key, params, filelink)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/file_links", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, filelink)
 	return filelink, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 func (c Client) Get(id string, params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 	path := stripe.FormatURLPath("/v1/file_links/%s", id)
 	filelink := &stripe.FileLink{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, filelink)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, filelink)
 	return filelink, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.FileLinkParams) (*stripe.FileLink, error) 
 func (c Client) Update(id string, params *stripe.FileLinkParams) (*stripe.FileLink, error) {
 	path := stripe.FormatURLPath("/v1/file_links/%s", id)
 	filelink := &stripe.FileLink{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, filelink)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, filelink)
 	return filelink, err
 }
 
@@ -68,7 +86,14 @@ func (c Client) List(listParams *stripe.FileLinkListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.FileLinkList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/file_links", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/file_links",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/financialconnections/account/client.go
+++ b/financialconnections/account/client.go
@@ -29,7 +29,13 @@ func GetByID(id string, params *stripe.FinancialConnectionsAccountParams) (*stri
 func (c Client) GetByID(id string, params *stripe.FinancialConnectionsAccountParams) (*stripe.FinancialConnectionsAccount, error) {
 	path := stripe.FormatURLPath("/v1/financial_connections/accounts/%s", id)
 	account := &stripe.FinancialConnectionsAccount{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -45,7 +51,13 @@ func (c Client) Disconnect(id string, params *stripe.FinancialConnectionsAccount
 		id,
 	)
 	account := &stripe.FinancialConnectionsAccount{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -61,7 +73,13 @@ func (c Client) Refresh(id string, params *stripe.FinancialConnectionsAccountRef
 		id,
 	)
 	account := &stripe.FinancialConnectionsAccount{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -77,7 +95,13 @@ func (c Client) Subscribe(id string, params *stripe.FinancialConnectionsAccountS
 		id,
 	)
 	account := &stripe.FinancialConnectionsAccount{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -93,7 +117,13 @@ func (c Client) Unsubscribe(id string, params *stripe.FinancialConnectionsAccoun
 		id,
 	)
 	account := &stripe.FinancialConnectionsAccount{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, account)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, account)
 	return account, err
 }
 
@@ -107,7 +137,14 @@ func (c Client) List(listParams *stripe.FinancialConnectionsAccountListParams) *
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.FinancialConnectionsAccountList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/financial_connections/accounts", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/financial_connections/accounts",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -150,7 +187,14 @@ func (c Client) ListOwners(listParams *stripe.FinancialConnectionsAccountListOwn
 	return &OwnerIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.FinancialConnectionsAccountOwnerList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/financialconnections/accountinferredbalance/client.go
+++ b/financialconnections/accountinferredbalance/client.go
@@ -34,7 +34,14 @@ func (c Client) List(listParams *stripe.FinancialConnectionsAccountInferredBalan
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.FinancialConnectionsAccountInferredBalanceList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/financialconnections/session/client.go
+++ b/financialconnections/session/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.FinancialConnectionsSessionParams) (*stripe.FinancialCon
 // New creates a new financial connections session.
 func (c Client) New(params *stripe.FinancialConnectionsSessionParams) (*stripe.FinancialConnectionsSession, error) {
 	session := &stripe.FinancialConnectionsSession{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/financial_connections/sessions",
-		c.Key,
-		params,
-		session,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/financial_connections/sessions", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, session)
 	return session, err
 }
 
@@ -46,7 +46,13 @@ func Get(id string, params *stripe.FinancialConnectionsSessionParams) (*stripe.F
 func (c Client) Get(id string, params *stripe.FinancialConnectionsSessionParams) (*stripe.FinancialConnectionsSession, error) {
 	path := stripe.FormatURLPath("/v1/financial_connections/sessions/%s", id)
 	session := &stripe.FinancialConnectionsSession{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, session)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, session)
 	return session, err
 }
 

--- a/financialconnections/transaction/client.go
+++ b/financialconnections/transaction/client.go
@@ -30,7 +30,14 @@ func (c Client) List(listParams *stripe.FinancialConnectionsTransactionListParam
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.FinancialConnectionsTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/financial_connections/transactions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/financial_connections/transactions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/giftcards/card/client.go
+++ b/giftcards/card/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.GiftCardsCardParams) (*stripe.GiftCardsCard, error) {
 // New creates a new gift cards card.
 func (c Client) New(params *stripe.GiftCardsCardParams) (*stripe.GiftCardsCard, error) {
 	card := &stripe.GiftCardsCard{}
-	err := c.B.Call(http.MethodPost, "/v1/gift_cards/cards", c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/gift_cards/cards", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.GiftCardsCardParams) (*stripe.GiftCardsCard, 
 func (c Client) Get(id string, params *stripe.GiftCardsCardParams) (*stripe.GiftCardsCard, error) {
 	path := stripe.FormatURLPath("/v1/gift_cards/cards/%s", id)
 	card := &stripe.GiftCardsCard{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.GiftCardsCardParams) (*stripe.GiftCardsCar
 func (c Client) Update(id string, params *stripe.GiftCardsCardParams) (*stripe.GiftCardsCard, error) {
 	path := stripe.FormatURLPath("/v1/gift_cards/cards/%s", id)
 	card := &stripe.GiftCardsCard{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -66,13 +84,13 @@ func Validate(params *stripe.GiftCardsCardValidateParams) (*stripe.GiftCardsCard
 // Validate is the method for the `POST /v1/gift_cards/cards/validate` API.
 func (c Client) Validate(params *stripe.GiftCardsCardValidateParams) (*stripe.GiftCardsCard, error) {
 	card := &stripe.GiftCardsCard{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/gift_cards/cards/validate",
-		c.Key,
-		params,
-		card,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/gift_cards/cards/validate", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -86,7 +104,14 @@ func (c Client) List(listParams *stripe.GiftCardsCardListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.GiftCardsCardList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/gift_cards/cards", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/gift_cards/cards",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/giftcards/transaction/client.go
+++ b/giftcards/transaction/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.GiftCardsTransactionParams) (*stripe.GiftCardsTransactio
 // New creates a new gift cards transaction.
 func (c Client) New(params *stripe.GiftCardsTransactionParams) (*stripe.GiftCardsTransaction, error) {
 	transaction := &stripe.GiftCardsTransaction{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/gift_cards/transactions",
-		c.Key,
-		params,
-		transaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/gift_cards/transactions", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.GiftCardsTransactionParams) (*stripe.GiftCard
 func (c Client) Get(id string, params *stripe.GiftCardsTransactionParams) (*stripe.GiftCardsTransaction, error) {
 	path := stripe.FormatURLPath("/v1/gift_cards/transactions/%s", id)
 	transaction := &stripe.GiftCardsTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.GiftCardsTransactionParams) (*stripe.GiftC
 func (c Client) Update(id string, params *stripe.GiftCardsTransactionParams) (*stripe.GiftCardsTransaction, error) {
 	path := stripe.FormatURLPath("/v1/gift_cards/transactions/%s", id)
 	transaction := &stripe.GiftCardsTransaction{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -73,7 +85,13 @@ func Cancel(id string, params *stripe.GiftCardsTransactionCancelParams) (*stripe
 func (c Client) Cancel(id string, params *stripe.GiftCardsTransactionCancelParams) (*stripe.GiftCardsTransaction, error) {
 	path := stripe.FormatURLPath("/v1/gift_cards/transactions/%s/cancel", id)
 	transaction := &stripe.GiftCardsTransaction{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -86,7 +104,13 @@ func Confirm(id string, params *stripe.GiftCardsTransactionConfirmParams) (*stri
 func (c Client) Confirm(id string, params *stripe.GiftCardsTransactionConfirmParams) (*stripe.GiftCardsTransaction, error) {
 	path := stripe.FormatURLPath("/v1/gift_cards/transactions/%s/confirm", id)
 	transaction := &stripe.GiftCardsTransaction{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -100,7 +124,14 @@ func (c Client) List(listParams *stripe.GiftCardsTransactionListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.GiftCardsTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/gift_cards/transactions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/gift_cards/transactions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/identity/verificationreport/client.go
+++ b/identity/verificationreport/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.IdentityVerificationReportParams) (*stripe.Id
 func (c Client) Get(id string, params *stripe.IdentityVerificationReportParams) (*stripe.IdentityVerificationReport, error) {
 	path := stripe.FormatURLPath("/v1/identity/verification_reports/%s", id)
 	verificationreport := &stripe.IdentityVerificationReport{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, verificationreport)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, verificationreport)
 	return verificationreport, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.IdentityVerificationReportListParams) *I
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IdentityVerificationReportList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/identity/verification_reports", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/identity/verification_reports",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/identity/verificationsession/client.go
+++ b/identity/verificationsession/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.IdentityVerificationSessionParams) (*stripe.IdentityVeri
 // New creates a new identity verification session.
 func (c Client) New(params *stripe.IdentityVerificationSessionParams) (*stripe.IdentityVerificationSession, error) {
 	verificationsession := &stripe.IdentityVerificationSession{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/identity/verification_sessions",
-		c.Key,
-		params,
-		verificationsession,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/identity/verification_sessions", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, verificationsession)
 	return verificationsession, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.IdentityVerificationSessionParams) (*stripe.I
 func (c Client) Get(id string, params *stripe.IdentityVerificationSessionParams) (*stripe.IdentityVerificationSession, error) {
 	path := stripe.FormatURLPath("/v1/identity/verification_sessions/%s", id)
 	verificationsession := &stripe.IdentityVerificationSession{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, verificationsession)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, verificationsession)
 	return verificationsession, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.IdentityVerificationSessionParams) (*strip
 func (c Client) Update(id string, params *stripe.IdentityVerificationSessionParams) (*stripe.IdentityVerificationSession, error) {
 	path := stripe.FormatURLPath("/v1/identity/verification_sessions/%s", id)
 	verificationsession := &stripe.IdentityVerificationSession{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, verificationsession)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, verificationsession)
 	return verificationsession, err
 }
 
@@ -76,7 +88,13 @@ func (c Client) Cancel(id string, params *stripe.IdentityVerificationSessionCanc
 		id,
 	)
 	verificationsession := &stripe.IdentityVerificationSession{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, verificationsession)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, verificationsession)
 	return verificationsession, err
 }
 
@@ -92,7 +110,13 @@ func (c Client) Redact(id string, params *stripe.IdentityVerificationSessionReda
 		id,
 	)
 	verificationsession := &stripe.IdentityVerificationSession{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, verificationsession)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, verificationsession)
 	return verificationsession, err
 }
 
@@ -106,7 +130,14 @@ func (c Client) List(listParams *stripe.IdentityVerificationSessionListParams) *
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IdentityVerificationSessionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/identity/verification_sessions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/identity/verification_sessions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 // New creates a new invoice.
 func (c Client) New(params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodPost, "/v1/invoices", c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/invoices", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 func (c Client) Get(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 func (c Client) Update(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -67,7 +85,13 @@ func Del(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 func (c Client) Del(id string, params *stripe.InvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -80,7 +104,13 @@ func AttachPaymentIntent(id string, params *stripe.InvoiceAttachPaymentIntentPar
 func (c Client) AttachPaymentIntent(id string, params *stripe.InvoiceAttachPaymentIntentParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s/attach_payment_intent", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -93,7 +123,13 @@ func FinalizeInvoice(id string, params *stripe.InvoiceFinalizeInvoiceParams) (*s
 func (c Client) FinalizeInvoice(id string, params *stripe.InvoiceFinalizeInvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s/finalize", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -106,7 +142,13 @@ func MarkUncollectible(id string, params *stripe.InvoiceMarkUncollectibleParams)
 func (c Client) MarkUncollectible(id string, params *stripe.InvoiceMarkUncollectibleParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s/mark_uncollectible", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -119,7 +161,13 @@ func Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 func (c Client) Pay(id string, params *stripe.InvoicePayParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s/pay", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -132,7 +180,13 @@ func SendInvoice(id string, params *stripe.InvoiceSendInvoiceParams) (*stripe.In
 func (c Client) SendInvoice(id string, params *stripe.InvoiceSendInvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s/send", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -144,13 +198,13 @@ func Upcoming(params *stripe.InvoiceUpcomingParams) (*stripe.Invoice, error) {
 // Upcoming is the method for the `GET /v1/invoices/upcoming` API.
 func (c Client) Upcoming(params *stripe.InvoiceUpcomingParams) (*stripe.Invoice, error) {
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(
-		http.MethodGet,
-		"/v1/invoices/upcoming",
-		c.Key,
-		params,
-		invoice,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: "/v1/invoices/upcoming", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -163,7 +217,13 @@ func VoidInvoice(id string, params *stripe.InvoiceVoidInvoiceParams) (*stripe.In
 func (c Client) VoidInvoice(id string, params *stripe.InvoiceVoidInvoiceParams) (*stripe.Invoice, error) {
 	path := stripe.FormatURLPath("/v1/invoices/%s/void", id)
 	invoice := &stripe.Invoice{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoice)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoice)
 	return invoice, err
 }
 
@@ -177,7 +237,14 @@ func (c Client) List(listParams *stripe.InvoiceListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.InvoiceList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/invoices", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/invoices",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -220,7 +287,14 @@ func (c Client) ListLines(listParams *stripe.InvoiceListLinesParams) *LineItemIt
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.InvoiceLineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -242,7 +316,14 @@ func (c Client) UpcomingLines(listParams *stripe.InvoiceUpcomingLinesParams) *Li
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.InvoiceLineItemList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/invoices/upcoming/lines", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/invoices/upcoming/lines",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -281,7 +362,14 @@ func (c Client) Search(params *stripe.InvoiceSearchParams) *SearchIter {
 	return &SearchIter{
 		SearchIter: stripe.GetSearchIter(params, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.SearchContainer, error) {
 			list := &stripe.InvoiceSearchResult{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/invoices/search", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/invoices/search",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/invoiceitem/client.go
+++ b/invoiceitem/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 // New creates a new invoice item.
 func (c Client) New(params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	invoiceitem := &stripe.InvoiceItem{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/invoiceitems",
-		c.Key,
-		params,
-		invoiceitem,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/invoiceitems", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoiceitem)
 	return invoiceitem, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 func (c Client) Get(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/v1/invoiceitems/%s", id)
 	invoiceitem := &stripe.InvoiceItem{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, invoiceitem)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoiceitem)
 	return invoiceitem, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, e
 func (c Client) Update(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/v1/invoiceitems/%s", id)
 	invoiceitem := &stripe.InvoiceItem{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, invoiceitem)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoiceitem)
 	return invoiceitem, err
 }
 
@@ -73,7 +85,13 @@ func Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, erro
 func (c Client) Del(id string, params *stripe.InvoiceItemParams) (*stripe.InvoiceItem, error) {
 	path := stripe.FormatURLPath("/v1/invoiceitems/%s", id)
 	invoiceitem := &stripe.InvoiceItem{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, invoiceitem)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoiceitem)
 	return invoiceitem, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.InvoiceItemListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.InvoiceItemList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/invoiceitems", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/invoiceitems",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/invoicepayment/client.go
+++ b/invoicepayment/client.go
@@ -33,7 +33,13 @@ func (c Client) Get(id string, params *stripe.InvoicePaymentParams) (*stripe.Inv
 		id,
 	)
 	invoicepayment := &stripe.InvoicePayment{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, invoicepayment)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, invoicepayment)
 	return invoicepayment, err
 }
 
@@ -51,7 +57,14 @@ func (c Client) List(listParams *stripe.InvoicePaymentListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.InvoicePaymentList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/authorization/client.go
+++ b/issuing/authorization/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingA
 func (c Client) Get(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s", id)
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, authorization)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 
@@ -42,7 +48,13 @@ func Update(id string, params *stripe.IssuingAuthorizationParams) (*stripe.Issui
 func (c Client) Update(id string, params *stripe.IssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s", id)
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 
@@ -55,7 +67,13 @@ func Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stri
 func (c Client) Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/approve", id)
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 
@@ -68,7 +86,13 @@ func Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stri
 func (c Client) Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/decline", id)
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 
@@ -82,7 +106,14 @@ func (c Client) List(listParams *stripe.IssuingAuthorizationListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingAuthorizationList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/authorizations", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/authorizations",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/card/client.go
+++ b/issuing/card/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.IssuingCardParams) (*stripe.IssuingCard, error) {
 // New creates a new issuing card.
 func (c Client) New(params *stripe.IssuingCardParams) (*stripe.IssuingCard, error) {
 	card := &stripe.IssuingCard{}
-	err := c.B.Call(http.MethodPost, "/v1/issuing/cards", c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/issuing/cards", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.IssuingCardParams) (*stripe.IssuingCard, erro
 func (c Client) Get(id string, params *stripe.IssuingCardParams) (*stripe.IssuingCard, error) {
 	path := stripe.FormatURLPath("/v1/issuing/cards/%s", id)
 	card := &stripe.IssuingCard{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.IssuingCardParams) (*stripe.IssuingCard, e
 func (c Client) Update(id string, params *stripe.IssuingCardParams) (*stripe.IssuingCard, error) {
 	path := stripe.FormatURLPath("/v1/issuing/cards/%s", id)
 	card := &stripe.IssuingCard{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -68,7 +86,14 @@ func (c Client) List(listParams *stripe.IssuingCardListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingCardList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/cards", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/cards",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/cardholder/client.go
+++ b/issuing/cardholder/client.go
@@ -29,13 +29,13 @@ func New(params *stripe.IssuingCardholderParams) (*stripe.IssuingCardholder, err
 // New creates a new issuing cardholder.
 func (c Client) New(params *stripe.IssuingCardholderParams) (*stripe.IssuingCardholder, error) {
 	cardholder := &stripe.IssuingCardholder{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/issuing/cardholders",
-		c.Key,
-		params,
-		cardholder,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/issuing/cardholders", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, cardholder)
 	return cardholder, err
 }
 
@@ -48,7 +48,13 @@ func Get(id string, params *stripe.IssuingCardholderParams) (*stripe.IssuingCard
 func (c Client) Get(id string, params *stripe.IssuingCardholderParams) (*stripe.IssuingCardholder, error) {
 	path := stripe.FormatURLPath("/v1/issuing/cardholders/%s", id)
 	cardholder := &stripe.IssuingCardholder{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, cardholder)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, cardholder)
 	return cardholder, err
 }
 
@@ -61,7 +67,13 @@ func Update(id string, params *stripe.IssuingCardholderParams) (*stripe.IssuingC
 func (c Client) Update(id string, params *stripe.IssuingCardholderParams) (*stripe.IssuingCardholder, error) {
 	path := stripe.FormatURLPath("/v1/issuing/cardholders/%s", id)
 	cardholder := &stripe.IssuingCardholder{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, cardholder)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, cardholder)
 	return cardholder, err
 }
 
@@ -75,7 +87,14 @@ func (c Client) List(listParams *stripe.IssuingCardholderListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingCardholderList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/cardholders", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/cardholders",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/creditunderwritingrecord/client.go
+++ b/issuing/creditunderwritingrecord/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.IssuingCreditUnderwritingRecordParams) (*stri
 func (c Client) Get(id string, params *stripe.IssuingCreditUnderwritingRecordParams) (*stripe.IssuingCreditUnderwritingRecord, error) {
 	path := stripe.FormatURLPath("/v1/issuing/credit_underwriting_records/%s", id)
 	creditunderwritingrecord := &stripe.IssuingCreditUnderwritingRecord{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, creditunderwritingrecord)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditunderwritingrecord)
 	return creditunderwritingrecord, err
 }
 
@@ -45,13 +51,13 @@ func (c Client) Correct(id string, params *stripe.IssuingCreditUnderwritingRecor
 		id,
 	)
 	creditunderwritingrecord := &stripe.IssuingCreditUnderwritingRecord{}
-	err := c.B.Call(
-		http.MethodPost,
-		path,
-		c.Key,
-		params,
-		creditunderwritingrecord,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditunderwritingrecord)
 	return creditunderwritingrecord, err
 }
 
@@ -63,13 +69,13 @@ func CreateFromApplication(params *stripe.IssuingCreditUnderwritingRecordCreateF
 // CreateFromApplication is the method for the `POST /v1/issuing/credit_underwriting_records/create_from_application` API.
 func (c Client) CreateFromApplication(params *stripe.IssuingCreditUnderwritingRecordCreateFromApplicationParams) (*stripe.IssuingCreditUnderwritingRecord, error) {
 	creditunderwritingrecord := &stripe.IssuingCreditUnderwritingRecord{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/issuing/credit_underwriting_records/create_from_application",
-		c.Key,
-		params,
-		creditunderwritingrecord,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/issuing/credit_underwriting_records/create_from_application", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditunderwritingrecord)
 	return creditunderwritingrecord, err
 }
 
@@ -81,13 +87,13 @@ func CreateFromProactiveReview(params *stripe.IssuingCreditUnderwritingRecordCre
 // CreateFromProactiveReview is the method for the `POST /v1/issuing/credit_underwriting_records/create_from_proactive_review` API.
 func (c Client) CreateFromProactiveReview(params *stripe.IssuingCreditUnderwritingRecordCreateFromProactiveReviewParams) (*stripe.IssuingCreditUnderwritingRecord, error) {
 	creditunderwritingrecord := &stripe.IssuingCreditUnderwritingRecord{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/issuing/credit_underwriting_records/create_from_proactive_review",
-		c.Key,
-		params,
-		creditunderwritingrecord,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/issuing/credit_underwriting_records/create_from_proactive_review", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditunderwritingrecord)
 	return creditunderwritingrecord, err
 }
 
@@ -103,13 +109,13 @@ func (c Client) ReportDecision(id string, params *stripe.IssuingCreditUnderwriti
 		id,
 	)
 	creditunderwritingrecord := &stripe.IssuingCreditUnderwritingRecord{}
-	err := c.B.Call(
-		http.MethodPost,
-		path,
-		c.Key,
-		params,
-		creditunderwritingrecord,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditunderwritingrecord)
 	return creditunderwritingrecord, err
 }
 
@@ -123,7 +129,14 @@ func (c Client) List(listParams *stripe.IssuingCreditUnderwritingRecordListParam
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingCreditUnderwritingRecordList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/credit_underwriting_records", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/credit_underwriting_records",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/dispute/client.go
+++ b/issuing/dispute/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 // New creates a new issuing dispute.
 func (c Client) New(params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 	dispute := &stripe.IssuingDispute{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/issuing/disputes",
-		c.Key,
-		params,
-		dispute,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/issuing/disputes", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, dispute)
 	return dispute, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute
 func (c Client) Get(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 	path := stripe.FormatURLPath("/v1/issuing/disputes/%s", id)
 	dispute := &stripe.IssuingDispute{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, dispute)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, dispute)
 	return dispute, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDisp
 func (c Client) Update(id string, params *stripe.IssuingDisputeParams) (*stripe.IssuingDispute, error) {
 	path := stripe.FormatURLPath("/v1/issuing/disputes/%s", id)
 	dispute := &stripe.IssuingDispute{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, dispute)
 	return dispute, err
 }
 
@@ -73,7 +85,13 @@ func Submit(id string, params *stripe.IssuingDisputeSubmitParams) (*stripe.Issui
 func (c Client) Submit(id string, params *stripe.IssuingDisputeSubmitParams) (*stripe.IssuingDispute, error) {
 	path := stripe.FormatURLPath("/v1/issuing/disputes/%s/submit", id)
 	dispute := &stripe.IssuingDispute{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, dispute)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, dispute)
 	return dispute, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.IssuingDisputeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingDisputeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/disputes", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/disputes",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/personalizationdesign/client.go
+++ b/issuing/personalizationdesign/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.IssuingPersonalizationDesignParams) (*stripe.IssuingPers
 // New creates a new issuing personalization design.
 func (c Client) New(params *stripe.IssuingPersonalizationDesignParams) (*stripe.IssuingPersonalizationDesign, error) {
 	personalizationdesign := &stripe.IssuingPersonalizationDesign{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/issuing/personalization_designs",
-		c.Key,
-		params,
-		personalizationdesign,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/issuing/personalization_designs", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, personalizationdesign)
 	return personalizationdesign, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.IssuingPersonalizationDesignParams) (*stripe.
 func (c Client) Get(id string, params *stripe.IssuingPersonalizationDesignParams) (*stripe.IssuingPersonalizationDesign, error) {
 	path := stripe.FormatURLPath("/v1/issuing/personalization_designs/%s", id)
 	personalizationdesign := &stripe.IssuingPersonalizationDesign{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, personalizationdesign)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, personalizationdesign)
 	return personalizationdesign, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.IssuingPersonalizationDesignParams) (*stri
 func (c Client) Update(id string, params *stripe.IssuingPersonalizationDesignParams) (*stripe.IssuingPersonalizationDesign, error) {
 	path := stripe.FormatURLPath("/v1/issuing/personalization_designs/%s", id)
 	personalizationdesign := &stripe.IssuingPersonalizationDesign{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, personalizationdesign)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, personalizationdesign)
 	return personalizationdesign, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.IssuingPersonalizationDesignListParams) 
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingPersonalizationDesignList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/personalization_designs", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/personalization_designs",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/physicalbundle/client.go
+++ b/issuing/physicalbundle/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.IssuingPhysicalBundleParams) (*stripe.Issuing
 func (c Client) Get(id string, params *stripe.IssuingPhysicalBundleParams) (*stripe.IssuingPhysicalBundle, error) {
 	path := stripe.FormatURLPath("/v1/issuing/physical_bundles/%s", id)
 	physicalbundle := &stripe.IssuingPhysicalBundle{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, physicalbundle)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, physicalbundle)
 	return physicalbundle, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.IssuingPhysicalBundleListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingPhysicalBundleList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/physical_bundles", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/physical_bundles",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/token/client.go
+++ b/issuing/token/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.IssuingTokenParams) (*stripe.IssuingToken, er
 func (c Client) Get(id string, params *stripe.IssuingTokenParams) (*stripe.IssuingToken, error) {
 	path := stripe.FormatURLPath("/v1/issuing/tokens/%s", id)
 	token := &stripe.IssuingToken{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, token)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, token)
 	return token, err
 }
 
@@ -42,7 +48,13 @@ func Update(id string, params *stripe.IssuingTokenParams) (*stripe.IssuingToken,
 func (c Client) Update(id string, params *stripe.IssuingTokenParams) (*stripe.IssuingToken, error) {
 	path := stripe.FormatURLPath("/v1/issuing/tokens/%s", id)
 	token := &stripe.IssuingToken{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, token)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, token)
 	return token, err
 }
 
@@ -56,7 +68,14 @@ func (c Client) List(listParams *stripe.IssuingTokenListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingTokenList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/tokens", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/tokens",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/issuing/transaction/client.go
+++ b/issuing/transaction/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.IssuingTransactionParams) (*stripe.IssuingTra
 func (c Client) Get(id string, params *stripe.IssuingTransactionParams) (*stripe.IssuingTransaction, error) {
 	path := stripe.FormatURLPath("/v1/issuing/transactions/%s", id)
 	transaction := &stripe.IssuingTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -42,7 +48,13 @@ func Update(id string, params *stripe.IssuingTransactionParams) (*stripe.Issuing
 func (c Client) Update(id string, params *stripe.IssuingTransactionParams) (*stripe.IssuingTransaction, error) {
 	path := stripe.FormatURLPath("/v1/issuing/transactions/%s", id)
 	transaction := &stripe.IssuingTransaction{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -56,7 +68,14 @@ func (c Client) List(listParams *stripe.IssuingTransactionListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.IssuingTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/issuing/transactions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/issuing/transactions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -35,7 +35,13 @@ func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 		stripe.StringValue(params.Account),
 	)
 	loginlink := &stripe.LoginLink{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, loginlink)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, loginlink)
 	return loginlink, err
 }
 

--- a/mandate/client.go
+++ b/mandate/client.go
@@ -28,7 +28,13 @@ func Get(id string, params *stripe.MandateParams) (*stripe.Mandate, error) {
 func (c Client) Get(id string, params *stripe.MandateParams) (*stripe.Mandate, error) {
 	path := stripe.FormatURLPath("/v1/mandates/%s", id)
 	mandate := &stripe.Mandate{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, mandate)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, mandate)
 	return mandate, err
 }
 

--- a/margin/client.go
+++ b/margin/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.MarginParams) (*stripe.Margin, error) {
 // New creates a new margin.
 func (c Client) New(params *stripe.MarginParams) (*stripe.Margin, error) {
 	margin := &stripe.Margin{}
-	err := c.B.Call(http.MethodPost, "/v1/billing/margins", c.Key, params, margin)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/billing/margins", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, margin)
 	return margin, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.MarginParams) (*stripe.Margin, error) {
 func (c Client) Get(id string, params *stripe.MarginParams) (*stripe.Margin, error) {
 	path := stripe.FormatURLPath("/v1/billing/margins/%s", id)
 	margin := &stripe.Margin{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, margin)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, margin)
 	return margin, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.MarginParams) (*stripe.Margin, error) {
 func (c Client) Update(id string, params *stripe.MarginParams) (*stripe.Margin, error) {
 	path := stripe.FormatURLPath("/v1/billing/margins/%s", id)
 	margin := &stripe.Margin{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, margin)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, margin)
 	return margin, err
 }
 
@@ -68,7 +86,14 @@ func (c Client) List(listParams *stripe.MarginListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.MarginList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/billing/margins", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/billing/margins",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/oauth/client.go
+++ b/oauth/client.go
@@ -49,7 +49,16 @@ func (c Client) New(params *stripe.OAuthTokenParams) (*stripe.OAuthToken, error)
 	}
 
 	oauthToken := &stripe.OAuthToken{}
-	err := c.B.Call(http.MethodPost, "/oauth/token", c.Key, params, oauthToken)
+	sr := stripe.StripeRequest{
+		Method: http.MethodPost,
+		Path:   "/oauth/token",
+		Key:    c.Key,
+	}
+	err := sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, oauthToken)
 
 	return oauthToken, err
 }
@@ -62,11 +71,18 @@ func Del(params *stripe.DeauthorizeParams) (*stripe.Deauthorize, error) {
 // Del deauthorizes a connected account.
 func (c Client) Del(params *stripe.DeauthorizeParams) (*stripe.Deauthorize, error) {
 	deauthorization := &stripe.Deauthorize{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/oauth/deauthorize",
-		c.Key,
-		params,
+
+	sr := stripe.StripeRequest{
+		Method: http.MethodPost,
+		Path:   "/oauth/deauthorize",
+		Key:    c.Key,
+	}
+	err := sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(
+		sr,
 		deauthorization,
 	)
 	return deauthorization, err

--- a/order/client.go
+++ b/order/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.OrderParams) (*stripe.Order, error) {
 // New creates a new order.
 func (c Client) New(params *stripe.OrderParams) (*stripe.Order, error) {
 	order := &stripe.Order{}
-	err := c.B.Call(http.MethodPost, "/v1/orders", c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/orders", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 func (c Client) Get(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/v1/orders/%s", id)
 	order := &stripe.Order{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 func (c Client) Update(id string, params *stripe.OrderParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/v1/orders/%s", id)
 	order := &stripe.Order{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -67,7 +85,13 @@ func Cancel(id string, params *stripe.OrderCancelParams) (*stripe.Order, error) 
 func (c Client) Cancel(id string, params *stripe.OrderCancelParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/v1/orders/%s/cancel", id)
 	order := &stripe.Order{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -80,7 +104,13 @@ func Reopen(id string, params *stripe.OrderReopenParams) (*stripe.Order, error) 
 func (c Client) Reopen(id string, params *stripe.OrderReopenParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/v1/orders/%s/reopen", id)
 	order := &stripe.Order{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -93,7 +123,13 @@ func Submit(id string, params *stripe.OrderSubmitParams) (*stripe.Order, error) 
 func (c Client) Submit(id string, params *stripe.OrderSubmitParams) (*stripe.Order, error) {
 	path := stripe.FormatURLPath("/v1/orders/%s/submit", id)
 	order := &stripe.Order{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, order)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, order)
 	return order, err
 }
 
@@ -107,7 +143,14 @@ func (c Client) List(listParams *stripe.OrderListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.OrderList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/orders", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/orders",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -150,7 +193,14 @@ func (c Client) ListLineItems(listParams *stripe.OrderListLineItemsParams) *Line
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.LineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/paymentintent/client.go
+++ b/paymentintent/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
 // New creates a new payment intent.
 func (c Client) New(params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/payment_intents",
-		c.Key,
-		params,
-		paymentintent,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/payment_intents", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, 
 func (c Client) Get(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
 	path := stripe.FormatURLPath("/v1/payment_intents/%s", id)
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, paymentintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentInten
 func (c Client) Update(id string, params *stripe.PaymentIntentParams) (*stripe.PaymentIntent, error) {
 	path := stripe.FormatURLPath("/v1/payment_intents/%s", id)
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -76,7 +88,13 @@ func (c Client) ApplyCustomerBalance(id string, params *stripe.PaymentIntentAppl
 		id,
 	)
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -89,7 +107,13 @@ func Cancel(id string, params *stripe.PaymentIntentCancelParams) (*stripe.Paymen
 func (c Client) Cancel(id string, params *stripe.PaymentIntentCancelParams) (*stripe.PaymentIntent, error) {
 	path := stripe.FormatURLPath("/v1/payment_intents/%s/cancel", id)
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -102,7 +126,13 @@ func Capture(id string, params *stripe.PaymentIntentCaptureParams) (*stripe.Paym
 func (c Client) Capture(id string, params *stripe.PaymentIntentCaptureParams) (*stripe.PaymentIntent, error) {
 	path := stripe.FormatURLPath("/v1/payment_intents/%s/capture", id)
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -115,7 +145,13 @@ func Confirm(id string, params *stripe.PaymentIntentConfirmParams) (*stripe.Paym
 func (c Client) Confirm(id string, params *stripe.PaymentIntentConfirmParams) (*stripe.PaymentIntent, error) {
 	path := stripe.FormatURLPath("/v1/payment_intents/%s/confirm", id)
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -131,7 +167,13 @@ func (c Client) IncrementAuthorization(id string, params *stripe.PaymentIntentIn
 		id,
 	)
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -147,7 +189,13 @@ func (c Client) VerifyMicrodeposits(id string, params *stripe.PaymentIntentVerif
 		id,
 	)
 	paymentintent := &stripe.PaymentIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentintent)
 	return paymentintent, err
 }
 
@@ -161,7 +209,14 @@ func (c Client) List(listParams *stripe.PaymentIntentListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PaymentIntentList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/payment_intents", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/payment_intents",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -200,7 +255,14 @@ func (c Client) Search(params *stripe.PaymentIntentSearchParams) *SearchIter {
 	return &SearchIter{
 		SearchIter: stripe.GetSearchIter(params, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.SearchContainer, error) {
 			list := &stripe.PaymentIntentSearchResult{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/payment_intents/search", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/payment_intents/search",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/paymentlink/client.go
+++ b/paymentlink/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.PaymentLinkParams) (*stripe.PaymentLink, error) {
 // New creates a new payment link.
 func (c Client) New(params *stripe.PaymentLinkParams) (*stripe.PaymentLink, error) {
 	paymentlink := &stripe.PaymentLink{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/payment_links",
-		c.Key,
-		params,
-		paymentlink,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/payment_links", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentlink)
 	return paymentlink, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.PaymentLinkParams) (*stripe.PaymentLink, erro
 func (c Client) Get(id string, params *stripe.PaymentLinkParams) (*stripe.PaymentLink, error) {
 	path := stripe.FormatURLPath("/v1/payment_links/%s", id)
 	paymentlink := &stripe.PaymentLink{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, paymentlink)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentlink)
 	return paymentlink, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.PaymentLinkParams) (*stripe.PaymentLink, e
 func (c Client) Update(id string, params *stripe.PaymentLinkParams) (*stripe.PaymentLink, error) {
 	path := stripe.FormatURLPath("/v1/payment_links/%s", id)
 	paymentlink := &stripe.PaymentLink{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentlink)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentlink)
 	return paymentlink, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.PaymentLinkListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PaymentLinkList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/payment_links", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/payment_links",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -117,7 +136,14 @@ func (c Client) ListLineItems(listParams *stripe.PaymentLinkListLineItemsParams)
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.LineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/paymentmethod/client.go
+++ b/paymentmethod/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.PaymentMethodParams) (*stripe.PaymentMethod, error) {
 // New creates a new payment method.
 func (c Client) New(params *stripe.PaymentMethodParams) (*stripe.PaymentMethod, error) {
 	paymentmethod := &stripe.PaymentMethod{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/payment_methods",
-		c.Key,
-		params,
-		paymentmethod,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/payment_methods", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethod)
 	return paymentmethod, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.PaymentMethodParams) (*stripe.PaymentMethod, 
 func (c Client) Get(id string, params *stripe.PaymentMethodParams) (*stripe.PaymentMethod, error) {
 	path := stripe.FormatURLPath("/v1/payment_methods/%s", id)
 	paymentmethod := &stripe.PaymentMethod{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, paymentmethod)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethod)
 	return paymentmethod, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.PaymentMethodParams) (*stripe.PaymentMetho
 func (c Client) Update(id string, params *stripe.PaymentMethodParams) (*stripe.PaymentMethod, error) {
 	path := stripe.FormatURLPath("/v1/payment_methods/%s", id)
 	paymentmethod := &stripe.PaymentMethod{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentmethod)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethod)
 	return paymentmethod, err
 }
 
@@ -73,7 +85,13 @@ func Attach(id string, params *stripe.PaymentMethodAttachParams) (*stripe.Paymen
 func (c Client) Attach(id string, params *stripe.PaymentMethodAttachParams) (*stripe.PaymentMethod, error) {
 	path := stripe.FormatURLPath("/v1/payment_methods/%s/attach", id)
 	paymentmethod := &stripe.PaymentMethod{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentmethod)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethod)
 	return paymentmethod, err
 }
 
@@ -86,7 +104,13 @@ func Detach(id string, params *stripe.PaymentMethodDetachParams) (*stripe.Paymen
 func (c Client) Detach(id string, params *stripe.PaymentMethodDetachParams) (*stripe.PaymentMethod, error) {
 	path := stripe.FormatURLPath("/v1/payment_methods/%s/detach", id)
 	paymentmethod := &stripe.PaymentMethod{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentmethod)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethod)
 	return paymentmethod, err
 }
 
@@ -100,7 +124,14 @@ func (c Client) List(listParams *stripe.PaymentMethodListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PaymentMethodList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/payment_methods", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/payment_methods",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/paymentmethodconfiguration/client.go
+++ b/paymentmethodconfiguration/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.PaymentMethodConfigurationParams) (*stripe.PaymentMethod
 // New creates a new payment method configuration.
 func (c Client) New(params *stripe.PaymentMethodConfigurationParams) (*stripe.PaymentMethodConfiguration, error) {
 	paymentmethodconfiguration := &stripe.PaymentMethodConfiguration{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/payment_method_configurations",
-		c.Key,
-		params,
-		paymentmethodconfiguration,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/payment_method_configurations", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethodconfiguration)
 	return paymentmethodconfiguration, err
 }
 
@@ -47,13 +47,13 @@ func Get(id string, params *stripe.PaymentMethodConfigurationParams) (*stripe.Pa
 func (c Client) Get(id string, params *stripe.PaymentMethodConfigurationParams) (*stripe.PaymentMethodConfiguration, error) {
 	path := stripe.FormatURLPath("/v1/payment_method_configurations/%s", id)
 	paymentmethodconfiguration := &stripe.PaymentMethodConfiguration{}
-	err := c.B.Call(
-		http.MethodGet,
-		path,
-		c.Key,
-		params,
-		paymentmethodconfiguration,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethodconfiguration)
 	return paymentmethodconfiguration, err
 }
 
@@ -66,13 +66,13 @@ func Update(id string, params *stripe.PaymentMethodConfigurationParams) (*stripe
 func (c Client) Update(id string, params *stripe.PaymentMethodConfigurationParams) (*stripe.PaymentMethodConfiguration, error) {
 	path := stripe.FormatURLPath("/v1/payment_method_configurations/%s", id)
 	paymentmethodconfiguration := &stripe.PaymentMethodConfiguration{}
-	err := c.B.Call(
-		http.MethodPost,
-		path,
-		c.Key,
-		params,
-		paymentmethodconfiguration,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethodconfiguration)
 	return paymentmethodconfiguration, err
 }
 
@@ -86,7 +86,14 @@ func (c Client) List(listParams *stripe.PaymentMethodConfigurationListParams) *I
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PaymentMethodConfigurationList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/payment_method_configurations", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/payment_method_configurations",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/paymentmethoddomain/client.go
+++ b/paymentmethoddomain/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.PaymentMethodDomainParams) (*stripe.PaymentMethodDomain,
 // New creates a new payment method domain.
 func (c Client) New(params *stripe.PaymentMethodDomainParams) (*stripe.PaymentMethodDomain, error) {
 	paymentmethoddomain := &stripe.PaymentMethodDomain{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/payment_method_domains",
-		c.Key,
-		params,
-		paymentmethoddomain,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/payment_method_domains", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethoddomain)
 	return paymentmethoddomain, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.PaymentMethodDomainParams) (*stripe.PaymentMe
 func (c Client) Get(id string, params *stripe.PaymentMethodDomainParams) (*stripe.PaymentMethodDomain, error) {
 	path := stripe.FormatURLPath("/v1/payment_method_domains/%s", id)
 	paymentmethoddomain := &stripe.PaymentMethodDomain{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, paymentmethoddomain)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethoddomain)
 	return paymentmethoddomain, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.PaymentMethodDomainParams) (*stripe.Paymen
 func (c Client) Update(id string, params *stripe.PaymentMethodDomainParams) (*stripe.PaymentMethodDomain, error) {
 	path := stripe.FormatURLPath("/v1/payment_method_domains/%s", id)
 	paymentmethoddomain := &stripe.PaymentMethodDomain{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentmethoddomain)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethoddomain)
 	return paymentmethoddomain, err
 }
 
@@ -73,7 +85,13 @@ func Validate(id string, params *stripe.PaymentMethodDomainValidateParams) (*str
 func (c Client) Validate(id string, params *stripe.PaymentMethodDomainValidateParams) (*stripe.PaymentMethodDomain, error) {
 	path := stripe.FormatURLPath("/v1/payment_method_domains/%s/validate", id)
 	paymentmethoddomain := &stripe.PaymentMethodDomain{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentmethoddomain)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentmethoddomain)
 	return paymentmethoddomain, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.PaymentMethodDomainListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PaymentMethodDomainList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/payment_method_domains", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/payment_method_domains",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -39,7 +39,13 @@ func (c Client) New(params *stripe.PaymentSourceParams) (*stripe.PaymentSource, 
 		stripe.StringValue(params.Customer),
 	)
 	paymentsource := &stripe.PaymentSource{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentsource)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentsource)
 	return paymentsource, err
 }
 
@@ -62,7 +68,13 @@ func (c Client) Get(id string, params *stripe.PaymentSourceParams) (*stripe.Paym
 		id,
 	)
 	paymentsource := &stripe.PaymentSource{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, paymentsource)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentsource)
 	return paymentsource, err
 }
 
@@ -85,7 +97,13 @@ func (c Client) Update(id string, params *stripe.PaymentSourceParams) (*stripe.P
 		id,
 	)
 	paymentsource := &stripe.PaymentSource{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, paymentsource)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentsource)
 	return paymentsource, err
 }
 
@@ -108,7 +126,13 @@ func (c Client) Del(id string, params *stripe.PaymentSourceParams) (*stripe.Paym
 		id,
 	)
 	paymentsource := &stripe.PaymentSource{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, paymentsource)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, paymentsource)
 	return paymentsource, err
 }
 
@@ -134,7 +158,19 @@ func (c Client) Verify(id string, params *stripe.PaymentSourceVerifyParams) (*st
 	}
 
 	source := &stripe.PaymentSource{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, source)
+	var err error
+
+	sr := stripe.StripeRequest{
+		Method: http.MethodPost,
+		Path:   path,
+		Key:    c.Key,
+	}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.B.Call(sr, source)
 	return source, err
 }
 
@@ -164,7 +200,14 @@ func (c Client) List(listParams *stripe.PaymentSourceListParams) *Iter {
 				return nil, list, outerErr
 			}
 
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/payout/client.go
+++ b/payout/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 // New creates a new payout.
 func (c Client) New(params *stripe.PayoutParams) (*stripe.Payout, error) {
 	payout := &stripe.Payout{}
-	err := c.B.Call(http.MethodPost, "/v1/payouts", c.Key, params, payout)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/payouts", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, payout)
 	return payout, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Get(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/v1/payouts/%s", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, payout)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, payout)
 	return payout, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Update(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/v1/payouts/%s", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, payout)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, payout)
 	return payout, err
 }
 
@@ -67,7 +85,13 @@ func Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 func (c Client) Cancel(id string, params *stripe.PayoutParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/v1/payouts/%s/cancel", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, payout)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, payout)
 	return payout, err
 }
 
@@ -80,7 +104,13 @@ func Reverse(id string, params *stripe.PayoutReverseParams) (*stripe.Payout, err
 func (c Client) Reverse(id string, params *stripe.PayoutReverseParams) (*stripe.Payout, error) {
 	path := stripe.FormatURLPath("/v1/payouts/%s/reverse", id)
 	payout := &stripe.Payout{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, payout)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, payout)
 	return payout, err
 }
 
@@ -94,7 +124,14 @@ func (c Client) List(listParams *stripe.PayoutListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PayoutList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/payouts", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/payouts",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/person/client.go
+++ b/person/client.go
@@ -33,7 +33,13 @@ func (c Client) New(params *stripe.PersonParams) (*stripe.Person, error) {
 		stripe.StringValue(params.Account),
 	)
 	person := &stripe.Person{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, person)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, person)
 	return person, err
 }
 
@@ -55,7 +61,13 @@ func (c Client) Get(id string, params *stripe.PersonParams) (*stripe.Person, err
 		id,
 	)
 	person := &stripe.Person{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, person)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, person)
 	return person, err
 }
 
@@ -72,7 +84,13 @@ func (c Client) Update(id string, params *stripe.PersonParams) (*stripe.Person, 
 		id,
 	)
 	person := &stripe.Person{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, person)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, person)
 	return person, err
 }
 
@@ -89,7 +107,13 @@ func (c Client) Del(id string, params *stripe.PersonParams) (*stripe.Person, err
 		id,
 	)
 	person := &stripe.Person{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, person)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, person)
 	return person, err
 }
 
@@ -107,7 +131,14 @@ func (c Client) List(listParams *stripe.PersonListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PersonList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/plan.go
+++ b/plan.go
@@ -184,6 +184,8 @@ type PlanParams struct {
 	Nickname *string `form:"nickname"`
 	// The product the plan belongs to. This cannot be changed once it has been used in a subscription or subscription schedule.
 	Product *PlanProductParams `form:"product"`
+	// The product the plan belongs to. This cannot be changed once it has been used in a subscription or subscription schedule.
+	ProductID *string `form:"product"`
 	// Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`.
 	Tiers []*PlanTierParams `form:"tiers"`
 	// Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows.

--- a/plan/client.go
+++ b/plan/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.PlanParams) (*stripe.Plan, error) {
 // New creates a new plan.
 func (c Client) New(params *stripe.PlanParams) (*stripe.Plan, error) {
 	plan := &stripe.Plan{}
-	err := c.B.Call(http.MethodPost, "/v1/plans", c.Key, params, plan)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/plans", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, plan)
 	return plan, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Get(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/v1/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, plan)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, plan)
 	return plan, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Update(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/v1/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, plan)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, plan)
 	return plan, err
 }
 
@@ -67,7 +85,13 @@ func Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 func (c Client) Del(id string, params *stripe.PlanParams) (*stripe.Plan, error) {
 	path := stripe.FormatURLPath("/v1/plans/%s", id)
 	plan := &stripe.Plan{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, plan)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, plan)
 	return plan, err
 }
 
@@ -81,7 +105,14 @@ func (c Client) List(listParams *stripe.PlanListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PlanList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/plans", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/plans",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/price/client.go
+++ b/price/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.PriceParams) (*stripe.Price, error) {
 // New creates a new price.
 func (c Client) New(params *stripe.PriceParams) (*stripe.Price, error) {
 	price := &stripe.Price{}
-	err := c.B.Call(http.MethodPost, "/v1/prices", c.Key, params, price)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/prices", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, price)
 	return price, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.PriceParams) (*stripe.Price, error) {
 func (c Client) Get(id string, params *stripe.PriceParams) (*stripe.Price, error) {
 	path := stripe.FormatURLPath("/v1/prices/%s", id)
 	price := &stripe.Price{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, price)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, price)
 	return price, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.PriceParams) (*stripe.Price, error) {
 func (c Client) Update(id string, params *stripe.PriceParams) (*stripe.Price, error) {
 	path := stripe.FormatURLPath("/v1/prices/%s", id)
 	price := &stripe.Price{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, price)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, price)
 	return price, err
 }
 
@@ -68,7 +86,14 @@ func (c Client) List(listParams *stripe.PriceListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PriceList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/prices", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/prices",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -107,7 +132,14 @@ func (c Client) Search(params *stripe.PriceSearchParams) *SearchIter {
 	return &SearchIter{
 		SearchIter: stripe.GetSearchIter(params, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.SearchContainer, error) {
 			list := &stripe.PriceSearchResult{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/prices/search", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/prices/search",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/product/client.go
+++ b/product/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.ProductParams) (*stripe.Product, error) {
 // New creates a new product.
 func (c Client) New(params *stripe.ProductParams) (*stripe.Product, error) {
 	product := &stripe.Product{}
-	err := c.B.Call(http.MethodPost, "/v1/products", c.Key, params, product)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/products", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, product)
 	return product, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Get(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/v1/products/%s", id)
 	product := &stripe.Product{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, product)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, product)
 	return product, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Update(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/v1/products/%s", id)
 	product := &stripe.Product{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, product)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, product)
 	return product, err
 }
 
@@ -67,7 +85,13 @@ func Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 func (c Client) Del(id string, params *stripe.ProductParams) (*stripe.Product, error) {
 	path := stripe.FormatURLPath("/v1/products/%s", id)
 	product := &stripe.Product{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, product)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, product)
 	return product, err
 }
 
@@ -81,7 +105,14 @@ func (c Client) List(listParams *stripe.ProductListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ProductList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/products", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/products",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -120,7 +151,14 @@ func (c Client) Search(params *stripe.ProductSearchParams) *SearchIter {
 	return &SearchIter{
 		SearchIter: stripe.GetSearchIter(params, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.SearchContainer, error) {
 			list := &stripe.ProductSearchResult{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/products/search", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/products/search",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/promotioncode/client.go
+++ b/promotioncode/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.PromotionCodeParams) (*stripe.PromotionCode, error) {
 // New creates a new promotion code.
 func (c Client) New(params *stripe.PromotionCodeParams) (*stripe.PromotionCode, error) {
 	promotioncode := &stripe.PromotionCode{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/promotion_codes",
-		c.Key,
-		params,
-		promotioncode,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/promotion_codes", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, promotioncode)
 	return promotioncode, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.PromotionCodeParams) (*stripe.PromotionCode, 
 func (c Client) Get(id string, params *stripe.PromotionCodeParams) (*stripe.PromotionCode, error) {
 	path := stripe.FormatURLPath("/v1/promotion_codes/%s", id)
 	promotioncode := &stripe.PromotionCode{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, promotioncode)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, promotioncode)
 	return promotioncode, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.PromotionCodeParams) (*stripe.PromotionCod
 func (c Client) Update(id string, params *stripe.PromotionCodeParams) (*stripe.PromotionCode, error) {
 	path := stripe.FormatURLPath("/v1/promotion_codes/%s", id)
 	promotioncode := &stripe.PromotionCode{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, promotioncode)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, promotioncode)
 	return promotioncode, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.PromotionCodeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PromotionCodeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/promotion_codes", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/promotion_codes",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/quote/client.go
+++ b/quote/client.go
@@ -29,7 +29,13 @@ func New(params *stripe.QuoteParams) (*stripe.Quote, error) {
 // New creates a new quote.
 func (c Client) New(params *stripe.QuoteParams) (*stripe.Quote, error) {
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodPost, "/v1/quotes", c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/quotes", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -42,7 +48,13 @@ func Get(id string, params *stripe.QuoteParams) (*stripe.Quote, error) {
 func (c Client) Get(id string, params *stripe.QuoteParams) (*stripe.Quote, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s", id)
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -55,7 +67,13 @@ func Update(id string, params *stripe.QuoteParams) (*stripe.Quote, error) {
 func (c Client) Update(id string, params *stripe.QuoteParams) (*stripe.Quote, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s", id)
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -68,7 +86,13 @@ func Accept(id string, params *stripe.QuoteAcceptParams) (*stripe.Quote, error) 
 func (c Client) Accept(id string, params *stripe.QuoteAcceptParams) (*stripe.Quote, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s/accept", id)
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -81,7 +105,13 @@ func Cancel(id string, params *stripe.QuoteCancelParams) (*stripe.Quote, error) 
 func (c Client) Cancel(id string, params *stripe.QuoteCancelParams) (*stripe.Quote, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s/cancel", id)
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -94,7 +124,13 @@ func FinalizeQuote(id string, params *stripe.QuoteFinalizeQuoteParams) (*stripe.
 func (c Client) FinalizeQuote(id string, params *stripe.QuoteFinalizeQuoteParams) (*stripe.Quote, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s/finalize", id)
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -107,7 +143,13 @@ func MarkDraft(id string, params *stripe.QuoteMarkDraftParams) (*stripe.Quote, e
 func (c Client) MarkDraft(id string, params *stripe.QuoteMarkDraftParams) (*stripe.Quote, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s/mark_draft", id)
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -120,7 +162,13 @@ func MarkStale(id string, params *stripe.QuoteMarkStaleParams) (*stripe.Quote, e
 func (c Client) MarkStale(id string, params *stripe.QuoteMarkStaleParams) (*stripe.Quote, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s/mark_stale", id)
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -133,7 +181,13 @@ func PDF(id string, params *stripe.QuotePDFParams) (*stripe.APIStream, error) {
 func (c Client) PDF(id string, params *stripe.QuotePDFParams) (*stripe.APIStream, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s/pdf", id)
 	stream := &stripe.APIStream{}
-	err := c.BUploads.CallStreaming(http.MethodGet, path, c.Key, params, stream)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.BUploads.CallStreaming(sr, stream)
 	return stream, err
 }
 
@@ -146,7 +200,13 @@ func Reestimate(id string, params *stripe.QuoteReestimateParams) (*stripe.Quote,
 func (c Client) Reestimate(id string, params *stripe.QuoteReestimateParams) (*stripe.Quote, error) {
 	path := stripe.FormatURLPath("/v1/quotes/%s/reestimate", id)
 	quote := &stripe.Quote{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, quote)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quote)
 	return quote, err
 }
 
@@ -160,7 +220,14 @@ func (c Client) List(listParams *stripe.QuoteListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.QuoteList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/quotes", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/quotes",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -203,7 +270,14 @@ func (c Client) ListComputedUpfrontLineItems(listParams *stripe.QuoteListCompute
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.LineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -229,7 +303,14 @@ func (c Client) ListLineItems(listParams *stripe.QuoteListLineItemsParams) *Line
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.LineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -272,7 +353,14 @@ func (c Client) ListLines(listParams *stripe.QuoteListLinesParams) *LineIter {
 	return &LineIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.QuoteLineList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -316,7 +404,14 @@ func (c Client) ListPreviewInvoiceLines(listParams *stripe.QuoteListPreviewInvoi
 	return &InvoiceLineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.InvoiceLineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/quotephase/client.go
+++ b/quotephase/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.QuotePhaseParams) (*stripe.QuotePhase, error)
 func (c Client) Get(id string, params *stripe.QuotePhaseParams) (*stripe.QuotePhase, error) {
 	path := stripe.FormatURLPath("/v1/quote_phases/%s", id)
 	quotephase := &stripe.QuotePhase{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, quotephase)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, quotephase)
 	return quotephase, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.QuotePhaseListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.QuotePhaseList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/quote_phases", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/quote_phases",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -86,7 +99,14 @@ func (c Client) ListLineItems(listParams *stripe.QuotePhaseListLineItemsParams) 
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.LineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/quotepreviewinvoice/client.go
+++ b/quotepreviewinvoice/client.go
@@ -34,7 +34,14 @@ func (c Client) List(listParams *stripe.QuotePreviewInvoiceListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.QuotePreviewInvoiceList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/quotepreviewsubscriptionschedule/client.go
+++ b/quotepreviewsubscriptionschedule/client.go
@@ -34,7 +34,14 @@ func (c Client) List(listParams *stripe.QuotePreviewSubscriptionScheduleListPara
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.QuotePreviewSubscriptionScheduleList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/radar/earlyfraudwarning/client.go
+++ b/radar/earlyfraudwarning/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.RadarEarlyFraudWarningParams) (*stripe.RadarE
 func (c Client) Get(id string, params *stripe.RadarEarlyFraudWarningParams) (*stripe.RadarEarlyFraudWarning, error) {
 	path := stripe.FormatURLPath("/v1/radar/early_fraud_warnings/%s", id)
 	earlyfraudwarning := &stripe.RadarEarlyFraudWarning{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, earlyfraudwarning)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, earlyfraudwarning)
 	return earlyfraudwarning, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.RadarEarlyFraudWarningListParams) *Iter 
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.RadarEarlyFraudWarningList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/radar/early_fraud_warnings", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/radar/early_fraud_warnings",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/radar/valuelist/client.go
+++ b/radar/valuelist/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 // New creates a new radar value list.
 func (c Client) New(params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	valuelist := &stripe.RadarValueList{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/radar/value_lists",
-		c.Key,
-		params,
-		valuelist,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/radar/value_lists", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, valuelist)
 	return valuelist, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList
 func (c Client) Get(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_lists/%s", id)
 	valuelist := &stripe.RadarValueList{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, valuelist)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, valuelist)
 	return valuelist, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueL
 func (c Client) Update(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_lists/%s", id)
 	valuelist := &stripe.RadarValueList{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, valuelist)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, valuelist)
 	return valuelist, err
 }
 
@@ -73,7 +85,13 @@ func Del(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList
 func (c Client) Del(id string, params *stripe.RadarValueListParams) (*stripe.RadarValueList, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_lists/%s", id)
 	valuelist := &stripe.RadarValueList{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, valuelist)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, valuelist)
 	return valuelist, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.RadarValueListListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.RadarValueListList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/radar/value_lists", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/radar/value_lists",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/radar/valuelistitem/client.go
+++ b/radar/valuelistitem/client.go
@@ -29,13 +29,13 @@ func New(params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, e
 // New creates a new radar value list item.
 func (c Client) New(params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
 	valuelistitem := &stripe.RadarValueListItem{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/radar/value_list_items",
-		c.Key,
-		params,
-		valuelistitem,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/radar/value_list_items", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, valuelistitem)
 	return valuelistitem, err
 }
 
@@ -48,7 +48,13 @@ func Get(id string, params *stripe.RadarValueListItemParams) (*stripe.RadarValue
 func (c Client) Get(id string, params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_list_items/%s", id)
 	valuelistitem := &stripe.RadarValueListItem{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, valuelistitem)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, valuelistitem)
 	return valuelistitem, err
 }
 
@@ -61,7 +67,13 @@ func Del(id string, params *stripe.RadarValueListItemParams) (*stripe.RadarValue
 func (c Client) Del(id string, params *stripe.RadarValueListItemParams) (*stripe.RadarValueListItem, error) {
 	path := stripe.FormatURLPath("/v1/radar/value_list_items/%s", id)
 	valuelistitem := &stripe.RadarValueListItem{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, valuelistitem)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, valuelistitem)
 	return valuelistitem, err
 }
 
@@ -75,7 +87,14 @@ func (c Client) List(listParams *stripe.RadarValueListItemListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.RadarValueListItemList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/radar/value_list_items", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/radar/value_list_items",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/refund/client.go
+++ b/refund/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.RefundParams) (*stripe.Refund, error) {
 // New creates a new refund.
 func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	refund := &stripe.Refund{}
-	err := c.B.Call(http.MethodPost, "/v1/refunds", c.Key, params, refund)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/refunds", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, refund)
 	return refund, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 func (c Client) Get(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/v1/refunds/%s", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, refund)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, refund)
 	return refund, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 func (c Client) Update(id string, params *stripe.RefundParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/v1/refunds/%s", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, refund)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, refund)
 	return refund, err
 }
 
@@ -67,7 +85,13 @@ func Cancel(id string, params *stripe.RefundCancelParams) (*stripe.Refund, error
 func (c Client) Cancel(id string, params *stripe.RefundCancelParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/v1/refunds/%s/cancel", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, refund)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, refund)
 	return refund, err
 }
 
@@ -81,7 +105,14 @@ func (c Client) List(listParams *stripe.RefundListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.RefundList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/refunds", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/refunds",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/reporting/reportrun/client.go
+++ b/reporting/reportrun/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.ReportingReportRunParams) (*stripe.ReportingReportRun, e
 // New creates a new reporting report run.
 func (c Client) New(params *stripe.ReportingReportRunParams) (*stripe.ReportingReportRun, error) {
 	reportrun := &stripe.ReportingReportRun{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/reporting/report_runs",
-		c.Key,
-		params,
-		reportrun,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/reporting/report_runs", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reportrun)
 	return reportrun, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.ReportingReportRunParams) (*stripe.ReportingR
 func (c Client) Get(id string, params *stripe.ReportingReportRunParams) (*stripe.ReportingReportRun, error) {
 	path := stripe.FormatURLPath("/v1/reporting/report_runs/%s", id)
 	reportrun := &stripe.ReportingReportRun{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, reportrun)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reportrun)
 	return reportrun, err
 }
 
@@ -61,7 +67,14 @@ func (c Client) List(listParams *stripe.ReportingReportRunListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ReportingReportRunList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_runs", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/reporting/report_runs",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/reporting/reporttype/client.go
+++ b/reporting/reporttype/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.ReportingReportTypeParams) (*stripe.Reporting
 func (c Client) Get(id string, params *stripe.ReportingReportTypeParams) (*stripe.ReportingReportType, error) {
 	path := stripe.FormatURLPath("/v1/reporting/report_types/%s", id)
 	reporttype := &stripe.ReportingReportType{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, reporttype)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reporttype)
 	return reporttype, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.ReportingReportTypeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ReportingReportTypeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_types", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/reporting/report_types",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/review/client.go
+++ b/review/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.ReviewParams) (*stripe.Review, error) {
 func (c Client) Get(id string, params *stripe.ReviewParams) (*stripe.Review, error) {
 	path := stripe.FormatURLPath("/v1/reviews/%s", id)
 	review := &stripe.Review{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, review)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, review)
 	return review, err
 }
 
@@ -42,7 +48,13 @@ func Approve(id string, params *stripe.ReviewApproveParams) (*stripe.Review, err
 func (c Client) Approve(id string, params *stripe.ReviewApproveParams) (*stripe.Review, error) {
 	path := stripe.FormatURLPath("/v1/reviews/%s/approve", id)
 	review := &stripe.Review{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, review)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, review)
 	return review, err
 }
 
@@ -56,7 +68,14 @@ func (c Client) List(listParams *stripe.ReviewListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ReviewList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/reviews", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/reviews",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/search_iter_test.go
+++ b/search_iter_test.go
@@ -169,7 +169,13 @@ func (c Client) Search(params *SearchParams) *TestSearchIter {
 	return &TestSearchIter{
 		SearchIter: GetSearchIter(params, func(p *Params, b *form.Values) ([]interface{}, SearchContainer, error) {
 			list := &TestSearchResult{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/something/search", c.Key, b, p, list)
+			err := c.B.Call(StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/something/search",
+				Key:    c.Key,
+				Body:   b,
+				Params: p,
+			}, list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/setupattempt/client.go
+++ b/setupattempt/client.go
@@ -31,7 +31,14 @@ func (c Client) List(listParams *stripe.SetupAttemptListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.SetupAttemptList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/setup_attempts", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/setup_attempts",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/setupintent/client.go
+++ b/setupintent/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 // New creates a new setup intent.
 func (c Client) New(params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 	setupintent := &stripe.SetupIntent{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/setup_intents",
-		c.Key,
-		params,
-		setupintent,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/setup_intents", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, setupintent)
 	return setupintent, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, erro
 func (c Client) Get(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s", id)
 	setupintent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, setupintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, setupintent)
 	return setupintent, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, e
 func (c Client) Update(id string, params *stripe.SetupIntentParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s", id)
 	setupintent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, setupintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, setupintent)
 	return setupintent, err
 }
 
@@ -73,7 +85,13 @@ func Cancel(id string, params *stripe.SetupIntentCancelParams) (*stripe.SetupInt
 func (c Client) Cancel(id string, params *stripe.SetupIntentCancelParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s/cancel", id)
 	setupintent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, setupintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, setupintent)
 	return setupintent, err
 }
 
@@ -86,7 +104,13 @@ func Confirm(id string, params *stripe.SetupIntentConfirmParams) (*stripe.SetupI
 func (c Client) Confirm(id string, params *stripe.SetupIntentConfirmParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s/confirm", id)
 	setupintent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, setupintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, setupintent)
 	return setupintent, err
 }
 
@@ -99,7 +123,13 @@ func VerifyMicrodeposits(id string, params *stripe.SetupIntentVerifyMicrodeposit
 func (c Client) VerifyMicrodeposits(id string, params *stripe.SetupIntentVerifyMicrodepositsParams) (*stripe.SetupIntent, error) {
 	path := stripe.FormatURLPath("/v1/setup_intents/%s/verify_microdeposits", id)
 	setupintent := &stripe.SetupIntent{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, setupintent)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, setupintent)
 	return setupintent, err
 }
 
@@ -113,7 +143,14 @@ func (c Client) List(listParams *stripe.SetupIntentListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.SetupIntentList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/setup_intents", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/setup_intents",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/shippingrate/client.go
+++ b/shippingrate/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.ShippingRateParams) (*stripe.ShippingRate, error) {
 // New creates a new shipping rate.
 func (c Client) New(params *stripe.ShippingRateParams) (*stripe.ShippingRate, error) {
 	shippingrate := &stripe.ShippingRate{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/shipping_rates",
-		c.Key,
-		params,
-		shippingrate,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/shipping_rates", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, shippingrate)
 	return shippingrate, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.ShippingRateParams) (*stripe.ShippingRate, er
 func (c Client) Get(id string, params *stripe.ShippingRateParams) (*stripe.ShippingRate, error) {
 	path := stripe.FormatURLPath("/v1/shipping_rates/%s", id)
 	shippingrate := &stripe.ShippingRate{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, shippingrate)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, shippingrate)
 	return shippingrate, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.ShippingRateParams) (*stripe.ShippingRate,
 func (c Client) Update(id string, params *stripe.ShippingRateParams) (*stripe.ShippingRate, error) {
 	path := stripe.FormatURLPath("/v1/shipping_rates/%s", id)
 	shippingrate := &stripe.ShippingRate{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, shippingrate)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, shippingrate)
 	return shippingrate, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.ShippingRateListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ShippingRateList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/shipping_rates", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/shipping_rates",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/sigma/scheduledqueryrun/client.go
+++ b/sigma/scheduledqueryrun/client.go
@@ -30,7 +30,13 @@ func Get(id string, params *stripe.SigmaScheduledQueryRunParams) (*stripe.SigmaS
 func (c Client) Get(id string, params *stripe.SigmaScheduledQueryRunParams) (*stripe.SigmaScheduledQueryRun, error) {
 	path := stripe.FormatURLPath("/v1/sigma/scheduled_query_runs/%s", id)
 	scheduledqueryrun := &stripe.SigmaScheduledQueryRun{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, scheduledqueryrun)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, scheduledqueryrun)
 	return scheduledqueryrun, err
 }
 
@@ -44,7 +50,14 @@ func (c Client) List(listParams *stripe.SigmaScheduledQueryRunListParams) *Iter 
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.SigmaScheduledQueryRunList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/sigma/scheduled_query_runs", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/sigma/scheduled_query_runs",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/source/client.go
+++ b/source/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.SourceParams) (*stripe.Source, error) {
 // New creates a new source.
 func (c Client) New(params *stripe.SourceParams) (*stripe.Source, error) {
 	source := &stripe.Source{}
-	err := c.B.Call(http.MethodPost, "/v1/sources", c.Key, params, source)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/sources", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, source)
 	return source, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.SourceParams) (*stripe.Source, error) {
 func (c Client) Get(id string, params *stripe.SourceParams) (*stripe.Source, error) {
 	path := stripe.FormatURLPath("/v1/sources/%s", id)
 	source := &stripe.Source{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, source)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, source)
 	return source, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.SourceParams) (*stripe.Source, error) {
 func (c Client) Update(id string, params *stripe.SourceParams) (*stripe.Source, error) {
 	path := stripe.FormatURLPath("/v1/sources/%s", id)
 	source := &stripe.Source{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, source)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, source)
 	return source, err
 }
 
@@ -76,7 +94,13 @@ func (c Client) Detach(id string, params *stripe.SourceDetachParams) (*stripe.So
 		id,
 	)
 	source := &stripe.Source{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, source)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, source)
 	return source, err
 }
 

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -43,7 +43,14 @@ func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.SourceTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/subscription/client.go
+++ b/subscription/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 // New creates a new subscription.
 func (c Client) New(params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	subscription := &stripe.Subscription{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/subscriptions",
-		c.Key,
-		params,
-		subscription,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/subscriptions", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscription)
 	return subscription, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, er
 func (c Client) Get(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/v1/subscriptions/%s", id)
 	subscription := &stripe.Subscription{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, subscription)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscription)
 	return subscription, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription,
 func (c Client) Update(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/v1/subscriptions/%s", id)
 	subscription := &stripe.Subscription{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, subscription)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscription)
 	return subscription, err
 }
 
@@ -73,7 +85,13 @@ func Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscri
 func (c Client) Cancel(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/v1/subscriptions/%s", id)
 	subscription := &stripe.Subscription{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, subscription)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscription)
 	return subscription, err
 }
 
@@ -86,7 +104,13 @@ func DeleteDiscount(id string, params *stripe.SubscriptionDeleteDiscountParams) 
 func (c Client) DeleteDiscount(id string, params *stripe.SubscriptionDeleteDiscountParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/v1/subscriptions/%s/discount", id)
 	subscription := &stripe.Subscription{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, subscription)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscription)
 	return subscription, err
 }
 
@@ -99,7 +123,13 @@ func Resume(id string, params *stripe.SubscriptionResumeParams) (*stripe.Subscri
 func (c Client) Resume(id string, params *stripe.SubscriptionResumeParams) (*stripe.Subscription, error) {
 	path := stripe.FormatURLPath("/v1/subscriptions/%s/resume", id)
 	subscription := &stripe.Subscription{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, subscription)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscription)
 	return subscription, err
 }
 
@@ -113,7 +143,14 @@ func (c Client) List(listParams *stripe.SubscriptionListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.SubscriptionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/subscriptions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/subscriptions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -152,7 +189,14 @@ func (c Client) Search(params *stripe.SubscriptionSearchParams) *SearchIter {
 	return &SearchIter{
 		SearchIter: stripe.GetSearchIter(params, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.SearchContainer, error) {
 			list := &stripe.SubscriptionSearchResult{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/subscriptions/search", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/subscriptions/search",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/subscriptionitem/client.go
+++ b/subscriptionitem/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error
 // New creates a new subscription item.
 func (c Client) New(params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	subscriptionitem := &stripe.SubscriptionItem{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/subscription_items",
-		c.Key,
-		params,
-		subscriptionitem,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/subscription_items", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionitem)
 	return subscriptionitem, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 func (c Client) Get(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/v1/subscription_items/%s", id)
 	subscriptionitem := &stripe.SubscriptionItem{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, subscriptionitem)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionitem)
 	return subscriptionitem, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscript
 func (c Client) Update(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/v1/subscription_items/%s", id)
 	subscriptionitem := &stripe.SubscriptionItem{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, subscriptionitem)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionitem)
 	return subscriptionitem, err
 }
 
@@ -73,7 +85,13 @@ func Del(id string, params *stripe.SubscriptionItemParams) (*stripe.Subscription
 func (c Client) Del(id string, params *stripe.SubscriptionItemParams) (*stripe.SubscriptionItem, error) {
 	path := stripe.FormatURLPath("/v1/subscription_items/%s", id)
 	subscriptionitem := &stripe.SubscriptionItem{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, subscriptionitem)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionitem)
 	return subscriptionitem, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.SubscriptionItemListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.SubscriptionItemList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/subscription_items", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/subscription_items",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {
@@ -130,7 +155,14 @@ func (c Client) UsageRecordSummaries(listParams *stripe.SubscriptionItemUsageRec
 	return &UsageRecordSummaryIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.UsageRecordSummaryList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/subscriptionschedule/client.go
+++ b/subscriptionschedule/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.SubscriptionScheduleParams) (*stripe.SubscriptionSchedul
 // New creates a new subscription schedule.
 func (c Client) New(params *stripe.SubscriptionScheduleParams) (*stripe.SubscriptionSchedule, error) {
 	subscriptionschedule := &stripe.SubscriptionSchedule{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/subscription_schedules",
-		c.Key,
-		params,
-		subscriptionschedule,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/subscription_schedules", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionschedule)
 	return subscriptionschedule, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.SubscriptionScheduleParams) (*stripe.Subscrip
 func (c Client) Get(id string, params *stripe.SubscriptionScheduleParams) (*stripe.SubscriptionSchedule, error) {
 	path := stripe.FormatURLPath("/v1/subscription_schedules/%s", id)
 	subscriptionschedule := &stripe.SubscriptionSchedule{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, subscriptionschedule)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionschedule)
 	return subscriptionschedule, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.SubscriptionScheduleParams) (*stripe.Subsc
 func (c Client) Update(id string, params *stripe.SubscriptionScheduleParams) (*stripe.SubscriptionSchedule, error) {
 	path := stripe.FormatURLPath("/v1/subscription_schedules/%s", id)
 	subscriptionschedule := &stripe.SubscriptionSchedule{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, subscriptionschedule)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionschedule)
 	return subscriptionschedule, err
 }
 
@@ -73,7 +85,13 @@ func Amend(id string, params *stripe.SubscriptionScheduleAmendParams) (*stripe.S
 func (c Client) Amend(id string, params *stripe.SubscriptionScheduleAmendParams) (*stripe.SubscriptionSchedule, error) {
 	path := stripe.FormatURLPath("/v1/subscription_schedules/%s/amend", id)
 	subscriptionschedule := &stripe.SubscriptionSchedule{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, subscriptionschedule)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionschedule)
 	return subscriptionschedule, err
 }
 
@@ -86,7 +104,13 @@ func Cancel(id string, params *stripe.SubscriptionScheduleCancelParams) (*stripe
 func (c Client) Cancel(id string, params *stripe.SubscriptionScheduleCancelParams) (*stripe.SubscriptionSchedule, error) {
 	path := stripe.FormatURLPath("/v1/subscription_schedules/%s/cancel", id)
 	subscriptionschedule := &stripe.SubscriptionSchedule{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, subscriptionschedule)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionschedule)
 	return subscriptionschedule, err
 }
 
@@ -99,7 +123,13 @@ func Release(id string, params *stripe.SubscriptionScheduleReleaseParams) (*stri
 func (c Client) Release(id string, params *stripe.SubscriptionScheduleReleaseParams) (*stripe.SubscriptionSchedule, error) {
 	path := stripe.FormatURLPath("/v1/subscription_schedules/%s/release", id)
 	subscriptionschedule := &stripe.SubscriptionSchedule{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, subscriptionschedule)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, subscriptionschedule)
 	return subscriptionschedule, err
 }
 
@@ -113,7 +143,14 @@ func (c Client) List(listParams *stripe.SubscriptionScheduleListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.SubscriptionScheduleList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/subscription_schedules", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/subscription_schedules",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/tax/form/client.go
+++ b/tax/form/client.go
@@ -30,7 +30,13 @@ func Get(id string, params *stripe.TaxFormParams) (*stripe.TaxForm, error) {
 func (c Client) Get(id string, params *stripe.TaxFormParams) (*stripe.TaxForm, error) {
 	path := stripe.FormatURLPath("/v1/tax/forms/%s", id)
 	form := &stripe.TaxForm{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, form)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, form)
 	return form, err
 }
 
@@ -43,7 +49,13 @@ func PDF(id string, params *stripe.TaxFormPDFParams) (*stripe.APIStream, error) 
 func (c Client) PDF(id string, params *stripe.TaxFormPDFParams) (*stripe.APIStream, error) {
 	path := stripe.FormatURLPath("/v1/tax/forms/%s/pdf", id)
 	stream := &stripe.APIStream{}
-	err := c.BUploads.CallStreaming(http.MethodGet, path, c.Key, params, stream)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.BUploads.CallStreaming(sr, stream)
 	return stream, err
 }
 
@@ -57,7 +69,14 @@ func (c Client) List(listParams *stripe.TaxFormListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TaxFormList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/tax/forms", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/tax/forms",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/tax/settings/client.go
+++ b/tax/settings/client.go
@@ -27,7 +27,13 @@ func Get(params *stripe.TaxSettingsParams) (*stripe.TaxSettings, error) {
 // Get returns the details of a tax settings.
 func (c Client) Get(params *stripe.TaxSettingsParams) (*stripe.TaxSettings, error) {
 	settings := &stripe.TaxSettings{}
-	err := c.B.Call(http.MethodGet, "/v1/tax/settings", c.Key, params, settings)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: "/v1/tax/settings", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, settings)
 	return settings, err
 }
 
@@ -39,7 +45,13 @@ func Update(params *stripe.TaxSettingsParams) (*stripe.TaxSettings, error) {
 // Update updates a tax settings's properties.
 func (c Client) Update(params *stripe.TaxSettingsParams) (*stripe.TaxSettings, error) {
 	settings := &stripe.TaxSettings{}
-	err := c.B.Call(http.MethodPost, "/v1/tax/settings", c.Key, params, settings)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/tax/settings", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, settings)
 	return settings, err
 }
 

--- a/tax/transaction/client.go
+++ b/tax/transaction/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.TaxTransactionParams) (*stripe.TaxTransaction
 func (c Client) Get(id string, params *stripe.TaxTransactionParams) (*stripe.TaxTransaction, error) {
 	path := stripe.FormatURLPath("/v1/tax/transactions/%s", id)
 	transaction := &stripe.TaxTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -41,13 +47,13 @@ func CreateFromCalculation(params *stripe.TaxTransactionCreateFromCalculationPar
 // CreateFromCalculation is the method for the `POST /v1/tax/transactions/create_from_calculation` API.
 func (c Client) CreateFromCalculation(params *stripe.TaxTransactionCreateFromCalculationParams) (*stripe.TaxTransaction, error) {
 	transaction := &stripe.TaxTransaction{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/tax/transactions/create_from_calculation",
-		c.Key,
-		params,
-		transaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/tax/transactions/create_from_calculation", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -59,13 +65,13 @@ func CreateReversal(params *stripe.TaxTransactionCreateReversalParams) (*stripe.
 // CreateReversal is the method for the `POST /v1/tax/transactions/create_reversal` API.
 func (c Client) CreateReversal(params *stripe.TaxTransactionCreateReversalParams) (*stripe.TaxTransaction, error) {
 	transaction := &stripe.TaxTransaction{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/tax/transactions/create_reversal",
-		c.Key,
-		params,
-		transaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/tax/transactions/create_reversal", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -83,7 +89,14 @@ func (c Client) ListLineItems(listParams *stripe.TaxTransactionListLineItemsPara
 	return &LineItemIter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TaxTransactionLineItemList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/taxcode/client.go
+++ b/taxcode/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.TaxCodeParams) (*stripe.TaxCode, error) {
 func (c Client) Get(id string, params *stripe.TaxCodeParams) (*stripe.TaxCode, error) {
 	path := stripe.FormatURLPath("/v1/tax_codes/%s", id)
 	taxcode := &stripe.TaxCode{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, taxcode)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, taxcode)
 	return taxcode, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.TaxCodeListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TaxCodeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/tax_codes", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/tax_codes",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/taxid/client.go
+++ b/taxid/client.go
@@ -38,7 +38,13 @@ func (c Client) New(params *stripe.TaxIDParams) (*stripe.TaxID, error) {
 		stripe.StringValue(params.Customer),
 	)
 	taxid := &stripe.TaxID{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, taxid)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, taxid)
 	return taxid, err
 }
 
@@ -60,7 +66,13 @@ func (c Client) Get(id string, params *stripe.TaxIDParams) (*stripe.TaxID, error
 		id,
 	)
 	taxid := &stripe.TaxID{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, taxid)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, taxid)
 	return taxid, err
 }
 
@@ -82,7 +94,13 @@ func (c Client) Del(id string, params *stripe.TaxIDParams) (*stripe.TaxID, error
 		id,
 	)
 	taxid := &stripe.TaxID{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, taxid)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, taxid)
 	return taxid, err
 }
 
@@ -100,7 +118,14 @@ func (c Client) List(listParams *stripe.TaxIDListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TaxIDList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/taxrate/client.go
+++ b/taxrate/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 // New creates a new tax rate.
 func (c Client) New(params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 	taxrate := &stripe.TaxRate{}
-	err := c.B.Call(http.MethodPost, "/v1/tax_rates", c.Key, params, taxrate)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/tax_rates", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, taxrate)
 	return taxrate, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 func (c Client) Get(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 	path := stripe.FormatURLPath("/v1/tax_rates/%s", id)
 	taxrate := &stripe.TaxRate{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, taxrate)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, taxrate)
 	return taxrate, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 func (c Client) Update(id string, params *stripe.TaxRateParams) (*stripe.TaxRate, error) {
 	path := stripe.FormatURLPath("/v1/tax_rates/%s", id)
 	taxrate := &stripe.TaxRate{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, taxrate)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, taxrate)
 	return taxrate, err
 }
 
@@ -68,7 +86,14 @@ func (c Client) List(listParams *stripe.TaxRateListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TaxRateList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/tax_rates", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/tax_rates",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/terminal/configuration/client.go
+++ b/terminal/configuration/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TerminalConfigurationParams) (*stripe.TerminalConfigurat
 // New creates a new terminal configuration.
 func (c Client) New(params *stripe.TerminalConfigurationParams) (*stripe.TerminalConfiguration, error) {
 	configuration := &stripe.TerminalConfiguration{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/terminal/configurations",
-		c.Key,
-		params,
-		configuration,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/terminal/configurations", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, configuration)
 	return configuration, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TerminalConfigurationParams) (*stripe.Termina
 func (c Client) Get(id string, params *stripe.TerminalConfigurationParams) (*stripe.TerminalConfiguration, error) {
 	path := stripe.FormatURLPath("/v1/terminal/configurations/%s", id)
 	configuration := &stripe.TerminalConfiguration{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, configuration)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, configuration)
 	return configuration, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.TerminalConfigurationParams) (*stripe.Term
 func (c Client) Update(id string, params *stripe.TerminalConfigurationParams) (*stripe.TerminalConfiguration, error) {
 	path := stripe.FormatURLPath("/v1/terminal/configurations/%s", id)
 	configuration := &stripe.TerminalConfiguration{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, configuration)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, configuration)
 	return configuration, err
 }
 
@@ -73,7 +85,13 @@ func Del(id string, params *stripe.TerminalConfigurationParams) (*stripe.Termina
 func (c Client) Del(id string, params *stripe.TerminalConfigurationParams) (*stripe.TerminalConfiguration, error) {
 	path := stripe.FormatURLPath("/v1/terminal/configurations/%s", id)
 	configuration := &stripe.TerminalConfiguration{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, configuration)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, configuration)
 	return configuration, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.TerminalConfigurationListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TerminalConfigurationList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/terminal/configurations", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/terminal/configurations",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/terminal/connectiontoken/client.go
+++ b/terminal/connectiontoken/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.TerminalConnectionTokenParams) (*stripe.TerminalConnecti
 // New creates a new terminal connection token.
 func (c Client) New(params *stripe.TerminalConnectionTokenParams) (*stripe.TerminalConnectionToken, error) {
 	connectiontoken := &stripe.TerminalConnectionToken{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/terminal/connection_tokens",
-		c.Key,
-		params,
-		connectiontoken,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/terminal/connection_tokens", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, connectiontoken)
 	return connectiontoken, err
 }
 

--- a/terminal/location/client.go
+++ b/terminal/location/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error
 // New creates a new terminal location.
 func (c Client) New(params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	location := &stripe.TerminalLocation{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/terminal/locations",
-		c.Key,
-		params,
-		location,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/terminal/locations", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, location)
 	return location, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLoca
 func (c Client) Get(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	path := stripe.FormatURLPath("/v1/terminal/locations/%s", id)
 	location := &stripe.TerminalLocation{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, location)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, location)
 	return location, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalL
 func (c Client) Update(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	path := stripe.FormatURLPath("/v1/terminal/locations/%s", id)
 	location := &stripe.TerminalLocation{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, location)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, location)
 	return location, err
 }
 
@@ -73,7 +85,13 @@ func Del(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLoca
 func (c Client) Del(id string, params *stripe.TerminalLocationParams) (*stripe.TerminalLocation, error) {
 	path := stripe.FormatURLPath("/v1/terminal/locations/%s", id)
 	location := &stripe.TerminalLocation{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, location)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, location)
 	return location, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.TerminalLocationListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TerminalLocationList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/terminal/locations", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/terminal/locations",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/terminal/reader/client.go
+++ b/terminal/reader/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 // New creates a new terminal reader.
 func (c Client) New(params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/terminal/readers",
-		c.Key,
-		params,
-		reader,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/terminal/readers", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader
 func (c Client) Get(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s", id)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalRea
 func (c Client) Update(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s", id)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -73,7 +85,13 @@ func Del(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader
 func (c Client) Del(id string, params *stripe.TerminalReaderParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s", id)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -86,7 +104,13 @@ func CancelAction(id string, params *stripe.TerminalReaderCancelActionParams) (*
 func (c Client) CancelAction(id string, params *stripe.TerminalReaderCancelActionParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s/cancel_action", id)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -99,7 +123,13 @@ func CollectInputs(id string, params *stripe.TerminalReaderCollectInputsParams) 
 func (c Client) CollectInputs(id string, params *stripe.TerminalReaderCollectInputsParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s/collect_inputs", id)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -115,7 +145,13 @@ func (c Client) CollectPaymentMethod(id string, params *stripe.TerminalReaderCol
 		id,
 	)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -131,7 +167,13 @@ func (c Client) ConfirmPaymentIntent(id string, params *stripe.TerminalReaderCon
 		id,
 	)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -147,7 +189,13 @@ func (c Client) ProcessPaymentIntent(id string, params *stripe.TerminalReaderPro
 		id,
 	)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -163,7 +211,13 @@ func (c Client) ProcessSetupIntent(id string, params *stripe.TerminalReaderProce
 		id,
 	)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -176,7 +230,13 @@ func RefundPayment(id string, params *stripe.TerminalReaderRefundPaymentParams) 
 func (c Client) RefundPayment(id string, params *stripe.TerminalReaderRefundPaymentParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s/refund_payment", id)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -189,7 +249,13 @@ func SetReaderDisplay(id string, params *stripe.TerminalReaderSetReaderDisplayPa
 func (c Client) SetReaderDisplay(id string, params *stripe.TerminalReaderSetReaderDisplayParams) (*stripe.TerminalReader, error) {
 	path := stripe.FormatURLPath("/v1/terminal/readers/%s/set_reader_display", id)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 
@@ -203,7 +269,14 @@ func (c Client) List(listParams *stripe.TerminalReaderListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TerminalReaderList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/terminal/readers", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/terminal/readers",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/testhelpers/customer/client.go
+++ b/testhelpers/customer/client.go
@@ -31,13 +31,13 @@ func (c Client) FundCashBalance(id string, params *stripe.TestHelpersCustomerFun
 		id,
 	)
 	customercashbalancetransaction := &stripe.CustomerCashBalanceTransaction{}
-	err := c.B.Call(
-		http.MethodPost,
-		path,
-		c.Key,
-		params,
-		customercashbalancetransaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, customercashbalancetransaction)
 	return customercashbalancetransaction, err
 }
 

--- a/testhelpers/issuing/authorization/client.go
+++ b/testhelpers/issuing/authorization/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.TestHelpersIssuingAuthorizationParams) (*stripe.IssuingA
 // New creates a new issuing authorization.
 func (c Client) New(params *stripe.TestHelpersIssuingAuthorizationParams) (*stripe.IssuingAuthorization, error) {
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/test_helpers/issuing/authorizations",
-		c.Key,
-		params,
-		authorization,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/test_helpers/issuing/authorizations", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 
@@ -49,7 +49,13 @@ func (c Client) Capture(id string, params *stripe.TestHelpersIssuingAuthorizatio
 		id,
 	)
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 
@@ -65,7 +71,13 @@ func (c Client) Expire(id string, params *stripe.TestHelpersIssuingAuthorization
 		id,
 	)
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 
@@ -81,7 +93,13 @@ func (c Client) Increment(id string, params *stripe.TestHelpersIssuingAuthorizat
 		id,
 	)
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 
@@ -97,7 +115,13 @@ func (c Client) Reverse(id string, params *stripe.TestHelpersIssuingAuthorizatio
 		id,
 	)
 	authorization := &stripe.IssuingAuthorization{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, authorization)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, authorization)
 	return authorization, err
 }
 

--- a/testhelpers/issuing/card/client.go
+++ b/testhelpers/issuing/card/client.go
@@ -31,7 +31,13 @@ func (c Client) DeliverCard(id string, params *stripe.TestHelpersIssuingCardDeli
 		id,
 	)
 	card := &stripe.IssuingCard{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -47,7 +53,13 @@ func (c Client) FailCard(id string, params *stripe.TestHelpersIssuingCardFailCar
 		id,
 	)
 	card := &stripe.IssuingCard{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -63,7 +75,13 @@ func (c Client) ReturnCard(id string, params *stripe.TestHelpersIssuingCardRetur
 		id,
 	)
 	card := &stripe.IssuingCard{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 
@@ -79,7 +97,13 @@ func (c Client) ShipCard(id string, params *stripe.TestHelpersIssuingCardShipCar
 		id,
 	)
 	card := &stripe.IssuingCard{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, card)
 	return card, err
 }
 

--- a/testhelpers/issuing/personalizationdesign/client.go
+++ b/testhelpers/issuing/personalizationdesign/client.go
@@ -31,7 +31,13 @@ func (c Client) Activate(id string, params *stripe.TestHelpersIssuingPersonaliza
 		id,
 	)
 	personalizationdesign := &stripe.IssuingPersonalizationDesign{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, personalizationdesign)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, personalizationdesign)
 	return personalizationdesign, err
 }
 
@@ -47,7 +53,13 @@ func (c Client) Deactivate(id string, params *stripe.TestHelpersIssuingPersonali
 		id,
 	)
 	personalizationdesign := &stripe.IssuingPersonalizationDesign{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, personalizationdesign)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, personalizationdesign)
 	return personalizationdesign, err
 }
 
@@ -63,7 +75,13 @@ func (c Client) Reject(id string, params *stripe.TestHelpersIssuingPersonalizati
 		id,
 	)
 	personalizationdesign := &stripe.IssuingPersonalizationDesign{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, personalizationdesign)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, personalizationdesign)
 	return personalizationdesign, err
 }
 

--- a/testhelpers/issuing/transaction/client.go
+++ b/testhelpers/issuing/transaction/client.go
@@ -27,13 +27,13 @@ func CreateForceCapture(params *stripe.TestHelpersIssuingTransactionCreateForceC
 // CreateForceCapture is the method for the `POST /v1/test_helpers/issuing/transactions/create_force_capture` API.
 func (c Client) CreateForceCapture(params *stripe.TestHelpersIssuingTransactionCreateForceCaptureParams) (*stripe.IssuingTransaction, error) {
 	transaction := &stripe.IssuingTransaction{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/test_helpers/issuing/transactions/create_force_capture",
-		c.Key,
-		params,
-		transaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/test_helpers/issuing/transactions/create_force_capture", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -45,13 +45,13 @@ func CreateUnlinkedRefund(params *stripe.TestHelpersIssuingTransactionCreateUnli
 // CreateUnlinkedRefund is the method for the `POST /v1/test_helpers/issuing/transactions/create_unlinked_refund` API.
 func (c Client) CreateUnlinkedRefund(params *stripe.TestHelpersIssuingTransactionCreateUnlinkedRefundParams) (*stripe.IssuingTransaction, error) {
 	transaction := &stripe.IssuingTransaction{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/test_helpers/issuing/transactions/create_unlinked_refund",
-		c.Key,
-		params,
-		transaction,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/test_helpers/issuing/transactions/create_unlinked_refund", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -67,7 +67,13 @@ func (c Client) Refund(id string, params *stripe.TestHelpersIssuingTransactionRe
 		id,
 	)
 	transaction := &stripe.IssuingTransaction{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 

--- a/testhelpers/refund/client.go
+++ b/testhelpers/refund/client.go
@@ -28,7 +28,13 @@ func Expire(id string, params *stripe.TestHelpersRefundExpireParams) (*stripe.Re
 func (c Client) Expire(id string, params *stripe.TestHelpersRefundExpireParams) (*stripe.Refund, error) {
 	path := stripe.FormatURLPath("/v1/test_helpers/refunds/%s/expire", id)
 	refund := &stripe.Refund{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, refund)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, refund)
 	return refund, err
 }
 

--- a/testhelpers/terminal/reader/client.go
+++ b/testhelpers/terminal/reader/client.go
@@ -31,7 +31,13 @@ func (c Client) PresentPaymentMethod(id string, params *stripe.TestHelpersTermin
 		id,
 	)
 	reader := &stripe.TerminalReader{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, reader)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, reader)
 	return reader, err
 }
 

--- a/testhelpers/testclock/client.go
+++ b/testhelpers/testclock/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestCloc
 // New creates a new test helpers test clock.
 func (c Client) New(params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
 	testclock := &stripe.TestHelpersTestClock{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/test_helpers/test_clocks",
-		c.Key,
-		params,
-		testclock,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/test_helpers/test_clocks", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, testclock)
 	return testclock, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TestHelpersTestClockParams) (*stripe.TestHelp
 func (c Client) Get(id string, params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
 	path := stripe.FormatURLPath("/v1/test_helpers/test_clocks/%s", id)
 	testclock := &stripe.TestHelpersTestClock{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, testclock)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, testclock)
 	return testclock, err
 }
 
@@ -60,7 +66,13 @@ func Del(id string, params *stripe.TestHelpersTestClockParams) (*stripe.TestHelp
 func (c Client) Del(id string, params *stripe.TestHelpersTestClockParams) (*stripe.TestHelpersTestClock, error) {
 	path := stripe.FormatURLPath("/v1/test_helpers/test_clocks/%s", id)
 	testclock := &stripe.TestHelpersTestClock{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, testclock)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, testclock)
 	return testclock, err
 }
 
@@ -73,7 +85,13 @@ func Advance(id string, params *stripe.TestHelpersTestClockAdvanceParams) (*stri
 func (c Client) Advance(id string, params *stripe.TestHelpersTestClockAdvanceParams) (*stripe.TestHelpersTestClock, error) {
 	path := stripe.FormatURLPath("/v1/test_helpers/test_clocks/%s/advance", id)
 	testclock := &stripe.TestHelpersTestClock{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, testclock)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, testclock)
 	return testclock, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.TestHelpersTestClockListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TestHelpersTestClockList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/test_helpers/test_clocks", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/test_helpers/test_clocks",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/testhelpers/treasury/inboundtransfer/client.go
+++ b/testhelpers/treasury/inboundtransfer/client.go
@@ -31,7 +31,13 @@ func (c Client) Fail(id string, params *stripe.TestHelpersTreasuryInboundTransfe
 		id,
 	)
 	inboundtransfer := &stripe.TreasuryInboundTransfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, inboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, inboundtransfer)
 	return inboundtransfer, err
 }
 
@@ -47,7 +53,13 @@ func (c Client) ReturnInboundTransfer(id string, params *stripe.TestHelpersTreas
 		id,
 	)
 	inboundtransfer := &stripe.TreasuryInboundTransfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, inboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, inboundtransfer)
 	return inboundtransfer, err
 }
 
@@ -63,7 +75,13 @@ func (c Client) Succeed(id string, params *stripe.TestHelpersTreasuryInboundTran
 		id,
 	)
 	inboundtransfer := &stripe.TreasuryInboundTransfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, inboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, inboundtransfer)
 	return inboundtransfer, err
 }
 

--- a/testhelpers/treasury/outboundpayment/client.go
+++ b/testhelpers/treasury/outboundpayment/client.go
@@ -31,7 +31,13 @@ func (c Client) Fail(id string, params *stripe.TestHelpersTreasuryOutboundPaymen
 		id,
 	)
 	outboundpayment := &stripe.TreasuryOutboundPayment{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, outboundpayment)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundpayment)
 	return outboundpayment, err
 }
 
@@ -47,7 +53,13 @@ func (c Client) Post(id string, params *stripe.TestHelpersTreasuryOutboundPaymen
 		id,
 	)
 	outboundpayment := &stripe.TreasuryOutboundPayment{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, outboundpayment)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundpayment)
 	return outboundpayment, err
 }
 
@@ -63,7 +75,13 @@ func (c Client) ReturnOutboundPayment(id string, params *stripe.TestHelpersTreas
 		id,
 	)
 	outboundpayment := &stripe.TreasuryOutboundPayment{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, outboundpayment)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundpayment)
 	return outboundpayment, err
 }
 

--- a/testhelpers/treasury/outboundtransfer/client.go
+++ b/testhelpers/treasury/outboundtransfer/client.go
@@ -31,7 +31,13 @@ func (c Client) Fail(id string, params *stripe.TestHelpersTreasuryOutboundTransf
 		id,
 	)
 	outboundtransfer := &stripe.TreasuryOutboundTransfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, outboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundtransfer)
 	return outboundtransfer, err
 }
 
@@ -47,7 +53,13 @@ func (c Client) Post(id string, params *stripe.TestHelpersTreasuryOutboundTransf
 		id,
 	)
 	outboundtransfer := &stripe.TreasuryOutboundTransfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, outboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundtransfer)
 	return outboundtransfer, err
 }
 
@@ -63,7 +75,13 @@ func (c Client) ReturnOutboundTransfer(id string, params *stripe.TestHelpersTrea
 		id,
 	)
 	outboundtransfer := &stripe.TreasuryOutboundTransfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, outboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundtransfer)
 	return outboundtransfer, err
 }
 

--- a/testhelpers/treasury/receivedcredit/client.go
+++ b/testhelpers/treasury/receivedcredit/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.TestHelpersTreasuryReceivedCreditParams) (*stripe.Treasu
 // New creates a new treasury received credit.
 func (c Client) New(params *stripe.TestHelpersTreasuryReceivedCreditParams) (*stripe.TreasuryReceivedCredit, error) {
 	receivedcredit := &stripe.TreasuryReceivedCredit{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/test_helpers/treasury/received_credits",
-		c.Key,
-		params,
-		receivedcredit,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/test_helpers/treasury/received_credits", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, receivedcredit)
 	return receivedcredit, err
 }
 

--- a/testhelpers/treasury/receiveddebit/client.go
+++ b/testhelpers/treasury/receiveddebit/client.go
@@ -27,13 +27,13 @@ func New(params *stripe.TestHelpersTreasuryReceivedDebitParams) (*stripe.Treasur
 // New creates a new treasury received debit.
 func (c Client) New(params *stripe.TestHelpersTreasuryReceivedDebitParams) (*stripe.TreasuryReceivedDebit, error) {
 	receiveddebit := &stripe.TreasuryReceivedDebit{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/test_helpers/treasury/received_debits",
-		c.Key,
-		params,
-		receiveddebit,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/test_helpers/treasury/received_debits", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, receiveddebit)
 	return receiveddebit, err
 }
 

--- a/token/client.go
+++ b/token/client.go
@@ -27,7 +27,13 @@ func New(params *stripe.TokenParams) (*stripe.Token, error) {
 // New creates a new token.
 func (c Client) New(params *stripe.TokenParams) (*stripe.Token, error) {
 	token := &stripe.Token{}
-	err := c.B.Call(http.MethodPost, "/v1/tokens", c.Key, params, token)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/tokens", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, token)
 	return token, err
 }
 
@@ -40,7 +46,13 @@ func Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 func (c Client) Get(id string, params *stripe.TokenParams) (*stripe.Token, error) {
 	path := stripe.FormatURLPath("/v1/tokens/%s", id)
 	token := &stripe.Token{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, token)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, token)
 	return token, err
 }
 

--- a/topup/client.go
+++ b/topup/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.TopupParams) (*stripe.Topup, error) {
 // New creates a new topup.
 func (c Client) New(params *stripe.TopupParams) (*stripe.Topup, error) {
 	topup := &stripe.Topup{}
-	err := c.B.Call(http.MethodPost, "/v1/topups", c.Key, params, topup)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/topups", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, topup)
 	return topup, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 func (c Client) Get(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/v1/topups/%s", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, topup)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, topup)
 	return topup, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 func (c Client) Update(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/v1/topups/%s", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, topup)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, topup)
 	return topup, err
 }
 
@@ -67,7 +85,13 @@ func Cancel(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 func (c Client) Cancel(id string, params *stripe.TopupParams) (*stripe.Topup, error) {
 	path := stripe.FormatURLPath("/v1/topups/%s/cancel", id)
 	topup := &stripe.Topup{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, topup)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, topup)
 	return topup, err
 }
 
@@ -81,7 +105,14 @@ func (c Client) List(listParams *stripe.TopupListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TopupList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/topups", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/topups",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/transfer/client.go
+++ b/transfer/client.go
@@ -28,7 +28,13 @@ func New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 // New creates a new transfer.
 func (c Client) New(params *stripe.TransferParams) (*stripe.Transfer, error) {
 	transfer := &stripe.Transfer{}
-	err := c.B.Call(http.MethodPost, "/v1/transfers", c.Key, params, transfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/transfers", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transfer)
 	return transfer, err
 }
 
@@ -41,7 +47,13 @@ func Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 func (c Client) Get(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	path := stripe.FormatURLPath("/v1/transfers/%s", id)
 	transfer := &stripe.Transfer{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transfer)
 	return transfer, err
 }
 
@@ -54,7 +66,13 @@ func Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) 
 func (c Client) Update(id string, params *stripe.TransferParams) (*stripe.Transfer, error) {
 	path := stripe.FormatURLPath("/v1/transfers/%s", id)
 	transfer := &stripe.Transfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transfer)
 	return transfer, err
 }
 
@@ -68,7 +86,14 @@ func (c Client) List(listParams *stripe.TransferListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TransferList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/transfers", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/transfers",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/transferreversal/client.go
+++ b/transferreversal/client.go
@@ -33,7 +33,13 @@ func (c Client) New(params *stripe.TransferReversalParams) (*stripe.TransferReve
 		stripe.StringValue(params.ID),
 	)
 	transferreversal := &stripe.TransferReversal{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transferreversal)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transferreversal)
 	return transferreversal, err
 }
 
@@ -55,7 +61,13 @@ func (c Client) Get(id string, params *stripe.TransferReversalParams) (*stripe.T
 		id,
 	)
 	transferreversal := &stripe.TransferReversal{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transferreversal)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transferreversal)
 	return transferreversal, err
 }
 
@@ -72,7 +84,13 @@ func (c Client) Update(id string, params *stripe.TransferReversalParams) (*strip
 		id,
 	)
 	transferreversal := &stripe.TransferReversal{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, transferreversal)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transferreversal)
 	return transferreversal, err
 }
 
@@ -90,7 +108,14 @@ func (c Client) List(listParams *stripe.TransferReversalListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TransferReversalList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/creditreversal/client.go
+++ b/treasury/creditreversal/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TreasuryCreditReversalParams) (*stripe.TreasuryCreditRev
 // New creates a new treasury credit reversal.
 func (c Client) New(params *stripe.TreasuryCreditReversalParams) (*stripe.TreasuryCreditReversal, error) {
 	creditreversal := &stripe.TreasuryCreditReversal{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/treasury/credit_reversals",
-		c.Key,
-		params,
-		creditreversal,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/treasury/credit_reversals", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditreversal)
 	return creditreversal, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TreasuryCreditReversalParams) (*stripe.Treasu
 func (c Client) Get(id string, params *stripe.TreasuryCreditReversalParams) (*stripe.TreasuryCreditReversal, error) {
 	path := stripe.FormatURLPath("/v1/treasury/credit_reversals/%s", id)
 	creditreversal := &stripe.TreasuryCreditReversal{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, creditreversal)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, creditreversal)
 	return creditreversal, err
 }
 
@@ -61,7 +67,14 @@ func (c Client) List(listParams *stripe.TreasuryCreditReversalListParams) *Iter 
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryCreditReversalList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/credit_reversals", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/credit_reversals",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/debitreversal/client.go
+++ b/treasury/debitreversal/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TreasuryDebitReversalParams) (*stripe.TreasuryDebitRever
 // New creates a new treasury debit reversal.
 func (c Client) New(params *stripe.TreasuryDebitReversalParams) (*stripe.TreasuryDebitReversal, error) {
 	debitreversal := &stripe.TreasuryDebitReversal{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/treasury/debit_reversals",
-		c.Key,
-		params,
-		debitreversal,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/treasury/debit_reversals", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, debitreversal)
 	return debitreversal, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TreasuryDebitReversalParams) (*stripe.Treasur
 func (c Client) Get(id string, params *stripe.TreasuryDebitReversalParams) (*stripe.TreasuryDebitReversal, error) {
 	path := stripe.FormatURLPath("/v1/treasury/debit_reversals/%s", id)
 	debitreversal := &stripe.TreasuryDebitReversal{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, debitreversal)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, debitreversal)
 	return debitreversal, err
 }
 
@@ -61,7 +67,14 @@ func (c Client) List(listParams *stripe.TreasuryDebitReversalListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryDebitReversalList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/debit_reversals", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/debit_reversals",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/financialaccount/client.go
+++ b/treasury/financialaccount/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TreasuryFinancialAccountParams) (*stripe.TreasuryFinanci
 // New creates a new treasury financial account.
 func (c Client) New(params *stripe.TreasuryFinancialAccountParams) (*stripe.TreasuryFinancialAccount, error) {
 	financialaccount := &stripe.TreasuryFinancialAccount{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/treasury/financial_accounts",
-		c.Key,
-		params,
-		financialaccount,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/treasury/financial_accounts", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financialaccount)
 	return financialaccount, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TreasuryFinancialAccountParams) (*stripe.Trea
 func (c Client) Get(id string, params *stripe.TreasuryFinancialAccountParams) (*stripe.TreasuryFinancialAccount, error) {
 	path := stripe.FormatURLPath("/v1/treasury/financial_accounts/%s", id)
 	financialaccount := &stripe.TreasuryFinancialAccount{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, financialaccount)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financialaccount)
 	return financialaccount, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.TreasuryFinancialAccountParams) (*stripe.T
 func (c Client) Update(id string, params *stripe.TreasuryFinancialAccountParams) (*stripe.TreasuryFinancialAccount, error) {
 	path := stripe.FormatURLPath("/v1/treasury/financial_accounts/%s", id)
 	financialaccount := &stripe.TreasuryFinancialAccount{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, financialaccount)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financialaccount)
 	return financialaccount, err
 }
 
@@ -76,7 +88,13 @@ func (c Client) RetrieveFeatures(id string, params *stripe.TreasuryFinancialAcco
 		id,
 	)
 	financialaccountfeatures := &stripe.TreasuryFinancialAccountFeatures{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, financialaccountfeatures)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financialaccountfeatures)
 	return financialaccountfeatures, err
 }
 
@@ -92,13 +110,13 @@ func (c Client) UpdateFeatures(id string, params *stripe.TreasuryFinancialAccoun
 		id,
 	)
 	financialaccountfeatures := &stripe.TreasuryFinancialAccountFeatures{}
-	err := c.B.Call(
-		http.MethodPost,
-		path,
-		c.Key,
-		params,
-		financialaccountfeatures,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, financialaccountfeatures)
 	return financialaccountfeatures, err
 }
 
@@ -112,7 +130,14 @@ func (c Client) List(listParams *stripe.TreasuryFinancialAccountListParams) *Ite
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryFinancialAccountList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/financial_accounts", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/financial_accounts",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/inboundtransfer/client.go
+++ b/treasury/inboundtransfer/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TreasuryInboundTransferParams) (*stripe.TreasuryInboundT
 // New creates a new treasury inbound transfer.
 func (c Client) New(params *stripe.TreasuryInboundTransferParams) (*stripe.TreasuryInboundTransfer, error) {
 	inboundtransfer := &stripe.TreasuryInboundTransfer{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/treasury/inbound_transfers",
-		c.Key,
-		params,
-		inboundtransfer,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/treasury/inbound_transfers", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, inboundtransfer)
 	return inboundtransfer, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TreasuryInboundTransferParams) (*stripe.Treas
 func (c Client) Get(id string, params *stripe.TreasuryInboundTransferParams) (*stripe.TreasuryInboundTransfer, error) {
 	path := stripe.FormatURLPath("/v1/treasury/inbound_transfers/%s", id)
 	inboundtransfer := &stripe.TreasuryInboundTransfer{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, inboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, inboundtransfer)
 	return inboundtransfer, err
 }
 
@@ -60,7 +66,13 @@ func Cancel(id string, params *stripe.TreasuryInboundTransferCancelParams) (*str
 func (c Client) Cancel(id string, params *stripe.TreasuryInboundTransferCancelParams) (*stripe.TreasuryInboundTransfer, error) {
 	path := stripe.FormatURLPath("/v1/treasury/inbound_transfers/%s/cancel", id)
 	inboundtransfer := &stripe.TreasuryInboundTransfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, inboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, inboundtransfer)
 	return inboundtransfer, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.TreasuryInboundTransferListParams) *Iter
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryInboundTransferList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/inbound_transfers", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/inbound_transfers",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/outboundpayment/client.go
+++ b/treasury/outboundpayment/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TreasuryOutboundPaymentParams) (*stripe.TreasuryOutbound
 // New creates a new treasury outbound payment.
 func (c Client) New(params *stripe.TreasuryOutboundPaymentParams) (*stripe.TreasuryOutboundPayment, error) {
 	outboundpayment := &stripe.TreasuryOutboundPayment{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/treasury/outbound_payments",
-		c.Key,
-		params,
-		outboundpayment,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/treasury/outbound_payments", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundpayment)
 	return outboundpayment, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TreasuryOutboundPaymentParams) (*stripe.Treas
 func (c Client) Get(id string, params *stripe.TreasuryOutboundPaymentParams) (*stripe.TreasuryOutboundPayment, error) {
 	path := stripe.FormatURLPath("/v1/treasury/outbound_payments/%s", id)
 	outboundpayment := &stripe.TreasuryOutboundPayment{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, outboundpayment)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundpayment)
 	return outboundpayment, err
 }
 
@@ -60,7 +66,13 @@ func Cancel(id string, params *stripe.TreasuryOutboundPaymentCancelParams) (*str
 func (c Client) Cancel(id string, params *stripe.TreasuryOutboundPaymentCancelParams) (*stripe.TreasuryOutboundPayment, error) {
 	path := stripe.FormatURLPath("/v1/treasury/outbound_payments/%s/cancel", id)
 	outboundpayment := &stripe.TreasuryOutboundPayment{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, outboundpayment)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundpayment)
 	return outboundpayment, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.TreasuryOutboundPaymentListParams) *Iter
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryOutboundPaymentList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/outbound_payments", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/outbound_payments",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/outboundtransfer/client.go
+++ b/treasury/outboundtransfer/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.TreasuryOutboundTransferParams) (*stripe.TreasuryOutboun
 // New creates a new treasury outbound transfer.
 func (c Client) New(params *stripe.TreasuryOutboundTransferParams) (*stripe.TreasuryOutboundTransfer, error) {
 	outboundtransfer := &stripe.TreasuryOutboundTransfer{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/treasury/outbound_transfers",
-		c.Key,
-		params,
-		outboundtransfer,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/treasury/outbound_transfers", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundtransfer)
 	return outboundtransfer, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.TreasuryOutboundTransferParams) (*stripe.Trea
 func (c Client) Get(id string, params *stripe.TreasuryOutboundTransferParams) (*stripe.TreasuryOutboundTransfer, error) {
 	path := stripe.FormatURLPath("/v1/treasury/outbound_transfers/%s", id)
 	outboundtransfer := &stripe.TreasuryOutboundTransfer{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, outboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundtransfer)
 	return outboundtransfer, err
 }
 
@@ -60,7 +66,13 @@ func Cancel(id string, params *stripe.TreasuryOutboundTransferCancelParams) (*st
 func (c Client) Cancel(id string, params *stripe.TreasuryOutboundTransferCancelParams) (*stripe.TreasuryOutboundTransfer, error) {
 	path := stripe.FormatURLPath("/v1/treasury/outbound_transfers/%s/cancel", id)
 	outboundtransfer := &stripe.TreasuryOutboundTransfer{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, outboundtransfer)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, outboundtransfer)
 	return outboundtransfer, err
 }
 
@@ -74,7 +86,14 @@ func (c Client) List(listParams *stripe.TreasuryOutboundTransferListParams) *Ite
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryOutboundTransferList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/outbound_transfers", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/outbound_transfers",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/receivedcredit/client.go
+++ b/treasury/receivedcredit/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.TreasuryReceivedCreditParams) (*stripe.Treasu
 func (c Client) Get(id string, params *stripe.TreasuryReceivedCreditParams) (*stripe.TreasuryReceivedCredit, error) {
 	path := stripe.FormatURLPath("/v1/treasury/received_credits/%s", id)
 	receivedcredit := &stripe.TreasuryReceivedCredit{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, receivedcredit)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, receivedcredit)
 	return receivedcredit, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.TreasuryReceivedCreditListParams) *Iter 
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryReceivedCreditList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/received_credits", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/received_credits",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/receiveddebit/client.go
+++ b/treasury/receiveddebit/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.TreasuryReceivedDebitParams) (*stripe.Treasur
 func (c Client) Get(id string, params *stripe.TreasuryReceivedDebitParams) (*stripe.TreasuryReceivedDebit, error) {
 	path := stripe.FormatURLPath("/v1/treasury/received_debits/%s", id)
 	receiveddebit := &stripe.TreasuryReceivedDebit{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, receiveddebit)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, receiveddebit)
 	return receiveddebit, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.TreasuryReceivedDebitListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryReceivedDebitList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/received_debits", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/received_debits",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/transaction/client.go
+++ b/treasury/transaction/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.TreasuryTransactionParams) (*stripe.TreasuryT
 func (c Client) Get(id string, params *stripe.TreasuryTransactionParams) (*stripe.TreasuryTransaction, error) {
 	path := stripe.FormatURLPath("/v1/treasury/transactions/%s", id)
 	transaction := &stripe.TreasuryTransaction{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transaction)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transaction)
 	return transaction, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.TreasuryTransactionListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryTransactionList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/transactions", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/transactions",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/treasury/transactionentry/client.go
+++ b/treasury/transactionentry/client.go
@@ -29,7 +29,13 @@ func Get(id string, params *stripe.TreasuryTransactionEntryParams) (*stripe.Trea
 func (c Client) Get(id string, params *stripe.TreasuryTransactionEntryParams) (*stripe.TreasuryTransactionEntry, error) {
 	path := stripe.FormatURLPath("/v1/treasury/transaction_entries/%s", id)
 	transactionentry := &stripe.TreasuryTransactionEntry{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, transactionentry)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, transactionentry)
 	return transactionentry, err
 }
 
@@ -43,7 +49,14 @@ func (c Client) List(listParams *stripe.TreasuryTransactionEntryListParams) *Ite
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.TreasuryTransactionEntryList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/treasury/transaction_entries", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/treasury/transaction_entries",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/usagerecord/client.go
+++ b/usagerecord/client.go
@@ -31,7 +31,13 @@ func (c Client) New(params *stripe.UsageRecordParams) (*stripe.UsageRecord, erro
 		stripe.StringValue(params.SubscriptionItem),
 	)
 	usagerecord := &stripe.UsageRecord{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, usagerecord)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, usagerecord)
 	return usagerecord, err
 }
 

--- a/usagerecordsummary/client.go
+++ b/usagerecordsummary/client.go
@@ -34,7 +34,14 @@ func (c Client) List(listParams *stripe.UsageRecordSummaryListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.UsageRecordSummaryList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   path,
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/webhookendpoint/client.go
+++ b/webhookendpoint/client.go
@@ -28,13 +28,13 @@ func New(params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) 
 // New creates a new webhook endpoint.
 func (c Client) New(params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
 	webhookendpoint := &stripe.WebhookEndpoint{}
-	err := c.B.Call(
-		http.MethodPost,
-		"/v1/webhook_endpoints",
-		c.Key,
-		params,
-		webhookendpoint,
-	)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: "/v1/webhook_endpoints", Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, webhookendpoint)
 	return webhookendpoint, err
 }
 
@@ -47,7 +47,13 @@ func Get(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoi
 func (c Client) Get(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
 	path := stripe.FormatURLPath("/v1/webhook_endpoints/%s", id)
 	webhookendpoint := &stripe.WebhookEndpoint{}
-	err := c.B.Call(http.MethodGet, path, c.Key, params, webhookendpoint)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodGet, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, webhookendpoint)
 	return webhookendpoint, err
 }
 
@@ -60,7 +66,13 @@ func Update(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEnd
 func (c Client) Update(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
 	path := stripe.FormatURLPath("/v1/webhook_endpoints/%s", id)
 	webhookendpoint := &stripe.WebhookEndpoint{}
-	err := c.B.Call(http.MethodPost, path, c.Key, params, webhookendpoint)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodPost, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, webhookendpoint)
 	return webhookendpoint, err
 }
 
@@ -73,7 +85,13 @@ func Del(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoi
 func (c Client) Del(id string, params *stripe.WebhookEndpointParams) (*stripe.WebhookEndpoint, error) {
 	path := stripe.FormatURLPath("/v1/webhook_endpoints/%s", id)
 	webhookendpoint := &stripe.WebhookEndpoint{}
-	err := c.B.Call(http.MethodDelete, path, c.Key, params, webhookendpoint)
+	var err error
+	sr := stripe.StripeRequest{Method: http.MethodDelete, Path: path, Key: c.Key}
+	err = sr.SetParams(params)
+	if err != nil {
+		return nil, err
+	}
+	err = c.B.Call(sr, webhookendpoint)
 	return webhookendpoint, err
 }
 
@@ -87,7 +105,14 @@ func (c Client) List(listParams *stripe.WebhookEndpointListParams) *Iter {
 	return &Iter{
 		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.WebhookEndpointList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/webhook_endpoints", c.Key, b, p, list)
+			err := c.B.Call(stripe.StripeRequest{
+				Method: http.MethodGet,
+				Path:   "/v1/webhook_endpoints",
+				Key:    c.Key,
+				Params: p,
+				Body:   b,
+			},
+				list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {


### PR DESCRIPTION
Along similar lines to https://github.com/stripe/stripe-java/pull/1702 in stripe-java.

## Summary
Introduces `stripe.StripeRequest` struct, and changes `Backend` interface:
```diff
 type Backend interface {
- 	Call(method, path, key string, params ParamsContainer, v LastResponseSetter) error
+  	Call(req StripeRequest, v LastResponseSetter) error
- 	CallStreaming(method, path, key string, params ParamsContainer, v StreamingLastResponseSetter) error
+ 	CallStreaming(req StripeRequest, v StreamingLastResponseSetter) error
- 	CallRaw(method, path, key string, body *form.Values, params *Params, v LastResponseSetter) error
- 	CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *Params, v LastResponseSetter) error
- 	SetMaxNetworkRetries(maxNetworkRetries int64)
 }
```

The new `.Call` is closer to `.CallRaw` because `StripeRequest contains `Body` and `Params` separately, instead of having a `ParamsContainer`. To achieve the equivalent of `b.Call(method, path, key, params, &result)`, you do
```go
sr := StripeRequest{
  Method: method,
  Path: path,
  Key: key,
}
sr.SetParams(params)
b.Call(sr, &result)
```

To achieve the equivalent of `b.CallMultipart(method, path, key, boundary, body, params, &result)` you do
```go
b.CallMultipart(stripe.StripeRequest{
  Method: method,
  Path: path,
  Key: key,
  IsMultipart: true,
  Boundary: boundary,
  StreamingBody: body,
})
```

### Why
This is breaking, but this:
  - will allow us to extend the optional parameters accepted by `.Call` without breaking the interface again, and without smuggling internal things onto `Params`. For instance: `usage` that we are adding to all libraries, or `ApiMode` that is used by `RawRequest` to send preview requests.
  - it decreases the surface area necessary to implement `Backend`, which should make the experience better for future users who need to write an implementation of `Backend` (for mocking in their tests?) -- `Call` is essentially a convenience wrapper for `CallRaw`, but by putting both on the interface, we force users to implement both.

## Follow-ups
I'd like to open up this for discussion early. More changes I am considering/want to make:
* `.Call` should probably take a pointer to `StripeRequest` to avoid making unnecessary requests (will do in this PR shortly)
* Should `StripeRequest` be more constrained? Should everything be public?
  * We could make it into an interface with `GetMethod`, `GetPath`, `GetIsMultipart`, etc. and then have separate `StripeUrlEncodedRequest` and `StripeMultipart` Request structs that implement it. (This doesn't feel right to me but I can't put my finger on why, please discuss if you have thoughts)
  * We could make only `Method`, `Path`, and `Key` public. To set the other properties, you'd have to go through `.SetParams`, `.SetRawParams` or `.SetMultipart(...)` (now I've written this out I think I will pursue)
