### PR TITLE
Track usage of `raw_request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,10 +458,11 @@ This information is passed along when the library makes calls to the Stripe
 API. Note that while `Name` is always required, `URL` and `Version` are
 optional.
 
-### Request latency telemetry
+### Telemetry
 
-By default, the library sends request latency telemetry to Stripe. These
-numbers help Stripe improve the overall latency of its API for all users.
+By default, the library sends telemetry to Stripe regarding request latency and feature usage. These
+numbers help Stripe improve the overall latency of its API for all users, and
+improve popular features.
 
 You can disable this behavior if you prefer:
 

--- a/params.go
+++ b/params.go
@@ -207,12 +207,20 @@ type Params struct {
 	// account instead of under the account of the owner of the configured
 	// Stripe key.
 	StripeAccount *string `form:"-"` // Passed as header
+
+	usage []string `form:"-"` // Tracked behaviors
 }
 
 // AddExpand on the Params embedded struct is deprecated.
 // Deprecated: please use Expand in the surrounding struct instead.
 func (p *Params) AddExpand(f string) {
 	p.Expand = append(p.Expand, &f)
+}
+
+// InternalSetUsage sets the usage field on the Params struct.
+// Unstable: for internal stripe-go usage only.
+func (p *Params) InternalSetUsage(usage []string) {
+	p.usage = usage
 }
 
 // AddExtra adds a new arbitrary key-value pair to the request data

--- a/stripe.go
+++ b/stripe.go
@@ -108,6 +108,8 @@ type APIResponse struct {
 
 	// StatusCode is a status code as integer. e.g. 200
 	StatusCode int
+
+	duration *time.Duration
 }
 
 // StreamingAPIResponse encapsulates some common features of a response from the
@@ -122,9 +124,10 @@ type StreamingAPIResponse struct {
 	RequestID      string
 	Status         string
 	StatusCode     int
+	duration       *time.Duration
 }
 
-func newAPIResponse(res *http.Response, resBody []byte) *APIResponse {
+func newAPIResponse(res *http.Response, resBody []byte, requestDuration *time.Duration) *APIResponse {
 	return &APIResponse{
 		Header:         res.Header,
 		IdempotencyKey: res.Header.Get("Idempotency-Key"),
@@ -132,10 +135,11 @@ func newAPIResponse(res *http.Response, resBody []byte) *APIResponse {
 		RequestID:      res.Header.Get("Request-Id"),
 		Status:         res.Status,
 		StatusCode:     res.StatusCode,
+		duration:       requestDuration,
 	}
 }
 
-func newStreamingAPIResponse(res *http.Response, body io.ReadCloser) *StreamingAPIResponse {
+func newStreamingAPIResponse(res *http.Response, body io.ReadCloser, requestDuration *time.Duration) *StreamingAPIResponse {
 	return &StreamingAPIResponse{
 		Header:         res.Header,
 		IdempotencyKey: res.Header.Get("Idempotency-Key"),
@@ -143,6 +147,7 @@ func newStreamingAPIResponse(res *http.Response, body io.ReadCloser) *StreamingA
 		RequestID:      res.Header.Get("Request-Id"),
 		Status:         res.Status,
 		StatusCode:     res.StatusCode,
+		duration:       requestDuration,
 	}
 }
 
@@ -279,6 +284,38 @@ type BackendImplementation struct {
 	requestMetricsBuffer chan requestMetrics
 }
 
+type metricsResponseSetter struct {
+	LastResponseSetter
+	backend *BackendImplementation
+	params  *Params
+}
+
+func (s *metricsResponseSetter) SetLastResponse(response *APIResponse) {
+	var usage []string
+	if s.params != nil {
+		usage = s.params.usage
+	}
+	s.backend.maybeEnqueueTelemetryMetrics(response.RequestID, response.duration, usage)
+	s.LastResponseSetter.SetLastResponse(response)
+}
+
+func (s *metricsResponseSetter) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, s.LastResponseSetter)
+}
+
+type streamingLastResponseSetterWrapper struct {
+	StreamingLastResponseSetter
+	f func(*StreamingAPIResponse)
+}
+
+func (l *streamingLastResponseSetterWrapper) SetLastResponse(response *StreamingAPIResponse) {
+	l.f(response)
+	l.StreamingLastResponseSetter.SetLastResponse(response)
+}
+func (l *streamingLastResponseSetterWrapper) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, l.StreamingLastResponseSetter)
+}
+
 func extractParams(params ParamsContainer) (*form.Values, *Params, error) {
 	var formValues *form.Values
 	var commonParams *Params
@@ -350,7 +387,18 @@ func (s *BackendImplementation) CallStreaming(method, path, key string, params P
 		return err
 	}
 
-	if err := s.DoStreaming(req, bodyBuffer, v); err != nil {
+	responseSetter := streamingLastResponseSetterWrapper{
+		v,
+		func(response *StreamingAPIResponse) {
+			var usage []string
+			if commonParams != nil {
+				usage = commonParams.usage
+			}
+			s.maybeEnqueueTelemetryMetrics(response.RequestID, response.duration, usage)
+		},
+	}
+
+	if err := s.DoStreaming(req, bodyBuffer, &responseSetter); err != nil {
 		return err
 	}
 
@@ -430,7 +478,7 @@ func (s *BackendImplementation) RawRequest(method, path, key, content string, pa
 		return s.handleResponseBufferingErrors(res, err)
 	}
 
-	resp, result, err := s.requestWithRetriesAndTelemetry(req, bodyBuffer, handleResponse)
+	resp, result, requestDuration, err := s.requestWithRetriesAndTelemetry(req, bodyBuffer, handleResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +486,7 @@ func (s *BackendImplementation) RawRequest(method, path, key, content string, pa
 	if err != nil {
 		return nil, err
 	}
-	return newAPIResponse(resp, body), nil
+	return newAPIResponse(resp, body, requestDuration), nil
 }
 
 // CallRaw is the implementation for invoking Stripe APIs internally without a backend.
@@ -460,7 +508,13 @@ func (s *BackendImplementation) CallRaw(method, path, key string, form *form.Val
 		return err
 	}
 
-	if err := s.Do(req, bodyBuffer, v); err != nil {
+	responseSetter := metricsResponseSetter{
+		LastResponseSetter: v,
+		backend:            s,
+		params:             params,
+	}
+
+	if err := s.Do(req, bodyBuffer, &responseSetter); err != nil {
 		return err
 	}
 
@@ -540,22 +594,27 @@ func (s *BackendImplementation) maybeSetTelemetryHeader(req *http.Request) {
 	}
 }
 
-func (s *BackendImplementation) maybeEnqueueTelemetryMetrics(res *http.Response, requestDuration time.Duration) {
-	if s.enableTelemetry && res != nil {
-		reqID := res.Header.Get("Request-Id")
-		if len(reqID) > 0 {
-			metrics := requestMetrics{
-				RequestDurationMS: int(requestDuration / time.Millisecond),
-				RequestID:         reqID,
-			}
-
-			// If the metrics buffer is full, discard the new metrics. Otherwise, add
-			// them to the buffer.
-			select {
-			case s.requestMetricsBuffer <- metrics:
-			default:
-			}
-		}
+func (s *BackendImplementation) maybeEnqueueTelemetryMetrics(requestID string, requestDuration *time.Duration, usage []string) {
+	if !s.enableTelemetry || requestID == "" {
+		return
+	}
+	// If there's no duration to report and no usage to report, don't bother
+	if requestDuration == nil && len(usage) == 0 {
+		return
+	}
+	metrics := requestMetrics{
+		RequestID: requestID,
+	}
+	if requestDuration != nil {
+		requestDurationMS := int(*requestDuration / time.Millisecond)
+		metrics.RequestDurationMS = &requestDurationMS
+	}
+	if len(usage) > 0 {
+		metrics.Usage = usage
+	}
+	select {
+	case s.requestMetricsBuffer <- metrics:
+	default:
 	}
 }
 
@@ -613,7 +672,7 @@ func (s *BackendImplementation) requestWithRetriesAndTelemetry(
 	req *http.Request,
 	body *bytes.Buffer,
 	handleResponse func(*http.Response, error) (interface{}, error),
-) (*http.Response, interface{}, error) {
+) (*http.Response, interface{}, *time.Duration, error) {
 	s.LeveledLogger.Infof("Requesting %v %v%v", req.Method, req.URL.Host, req.URL.Path)
 	s.maybeSetTelemetryHeader(req)
 	var resp *http.Response
@@ -649,13 +708,11 @@ func (s *BackendImplementation) requestWithRetriesAndTelemetry(
 		time.Sleep(sleepDuration)
 	}
 
-	s.maybeEnqueueTelemetryMetrics(resp, requestDuration)
-
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return resp, result, nil
+	return resp, result, &requestDuration, nil
 }
 
 func (s *BackendImplementation) logError(statusCode int, err error) {
@@ -719,11 +776,12 @@ func (s *BackendImplementation) DoStreaming(req *http.Request, body *bytes.Buffe
 	handleResponse := func(res *http.Response, err error) (interface{}, error) {
 		return s.handleResponseBufferingErrors(res, err)
 	}
-	resp, result, err := s.requestWithRetriesAndTelemetry(req, body, handleResponse)
+
+	resp, result, requestDuration, err := s.requestWithRetriesAndTelemetry(req, body, handleResponse)
 	if err != nil {
 		return err
 	}
-	v.SetLastResponse(newStreamingAPIResponse(resp, result.(io.ReadCloser)))
+	v.SetLastResponse(newStreamingAPIResponse(resp, result.(io.ReadCloser), requestDuration))
 	return nil
 }
 
@@ -749,14 +807,15 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v Last
 		return resBody, err
 	}
 
-	res, result, err := s.requestWithRetriesAndTelemetry(req, body, handleResponse)
+	res, result, requestDuration, err := s.requestWithRetriesAndTelemetry(req, body, handleResponse)
 	if err != nil {
 		return err
 	}
 	resBody := result.([]byte)
 	s.LeveledLogger.Debugf("Response: %s", string(resBody))
+
 	err = s.UnmarshalJSONVerbose(res.StatusCode, resBody, v)
-	v.SetLastResponse(newAPIResponse(res, resBody))
+	v.SetLastResponse(newAPIResponse(res, resBody, requestDuration))
 	return err
 }
 
@@ -807,7 +866,7 @@ func (s *BackendImplementation) ResponseToError(res *http.Response, resBody []by
 	}
 	raw.Error.Err = typedError
 
-	raw.Error.SetLastResponse(newAPIResponse(res, resBody))
+	raw.Error.SetLastResponse(newAPIResponse(res, resBody, nil))
 
 	return raw.Error
 }
@@ -1344,8 +1403,9 @@ type stripeClientUserAgent struct {
 
 // requestMetrics contains the id and duration of the last request sent
 type requestMetrics struct {
-	RequestDurationMS int    `json:"request_duration_ms"`
-	RequestID         string `json:"request_id"`
+	RequestDurationMS *int     `json:"request_duration_ms"`
+	RequestID         string   `json:"request_id"`
+	Usage             []string `json:"usage"`
 }
 
 // requestTelemetry contains the payload sent in the

--- a/stripe.go
+++ b/stripe.go
@@ -482,6 +482,8 @@ func (s *BackendImplementation) RawRequest(method, path, key, content string, pa
 	if err != nil {
 		return nil, err
 	}
+	requestID := resp.Header.Get("Request-Id")
+	s.maybeEnqueueTelemetryMetrics(requestID, requestDuration, []string{"raw_request"})
 	body, err := ioutil.ReadAll(result.(io.ReadCloser))
 	if err != nil {
 		return nil, err

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -1538,6 +1538,7 @@ func TestRawRequestTelemetry(t *testing.T) {
 	params := &RawParams{Params: Params{}, APIMode: PreviewAPIMode}
 	_, err := backend.RawRequest(http.MethodPost, "/v1/abcs", "sk_test_xyz", `{}`, params)
 	assert.Empty(t, telemetry)
+	assert.NoError(t, err)
 	// Again, for the telemetry.
 	_, err = backend.RawRequest(http.MethodPost, "/v1/abcs", "sk_test_xyz", `{}`, params)
 	assert.NoError(t, err)

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -461,7 +461,7 @@ func TestDo_LastResponsePopulated(t *testing.T) {
 }
 
 // Test that telemetry metrics are not sent by default
-func TestDo_TelemetryDisabled(t *testing.T) {
+func TestCall_TelemetryDisabled(t *testing.T) {
 	type testServerResponse struct {
 		APIResource
 		Message string `json:"message"`
@@ -499,17 +499,8 @@ func TestDo_TelemetryDisabled(t *testing.T) {
 	// _next_ request via the `X-Stripe-Client-Telemetry header`. To test that
 	// metrics aren't being sent, we need to fire off two requests in sequence.
 	for i := 0; i < 2; i++ {
-		request, err := backend.NewRequest(
-			http.MethodGet,
-			"/hello",
-			"sk_test_123",
-			"application/x-www-form-urlencoded",
-			nil,
-		)
-		assert.NoError(t, err)
-
 		var response testServerResponse
-		err = backend.Do(request, nil, &response)
+		err := backend.Call("get", "/hello", "sk_test_xyz", nil, &response)
 
 		assert.NoError(t, err)
 		assert.Equal(t, message, response.Message)
@@ -521,15 +512,10 @@ func TestDo_TelemetryDisabled(t *testing.T) {
 
 // Test that telemetry metrics are sent on subsequent requests when
 // EnableTelemetry = true.
-func TestDo_TelemetryEnabled(t *testing.T) {
+func TestCall_TelemetryEnabled(t *testing.T) {
 	type testServerResponse struct {
 		APIResource
 		Message string `json:"message"`
-	}
-
-	type requestMetrics struct {
-		RequestDurationMS int    `json:"request_duration_ms"`
-		RequestID         string `json:"request_id"`
 	}
 
 	type requestTelemetry struct {
@@ -551,15 +537,19 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 		case 2:
 			assert.True(t, len(telemetryStr) > 0, "telemetryStr should not be empty")
 
-			// the telemetry should properly unmarshal into RequestTelemetry
 			var telemetry requestTelemetry
+			// the telemetry should properly unmarshal into RequestTelemetry
 			err := json.Unmarshal([]byte(telemetryStr), &telemetry)
 			assert.NoError(t, err)
 
 			// the second request should include the metrics for the first request
 			assert.Equal(t, telemetry.LastRequestMetrics.RequestID, "req_1")
-			assert.True(t, telemetry.LastRequestMetrics.RequestDurationMS > 20,
+			assert.True(t, *telemetry.LastRequestMetrics.RequestDurationMS > 20,
 				"request_duration_ms should be > 20ms")
+
+			// The telemetry in the second request should contain the
+			// expected usage
+			assert.Equal(t, telemetry.LastRequestMetrics.Usage, []string{"llama", "bufo"})
 		default:
 			assert.Fail(t, "Should not have reached request %v", requestNum)
 		}
@@ -585,18 +575,17 @@ func TestDo_TelemetryEnabled(t *testing.T) {
 		},
 	).(*BackendImplementation)
 
+	type myCreateParams struct {
+		Params `form:"*"`
+		Foo    string `form:"foo"`
+	}
+	params := &myCreateParams{
+		Foo: "bar",
+	}
+	params.InternalSetUsage([]string{"llama", "bufo"})
 	for i := 0; i < 2; i++ {
-		request, err := backend.NewRequest(
-			http.MethodGet,
-			"/hello",
-			"sk_test_123",
-			"application/x-www-form-urlencoded",
-			nil,
-		)
-		assert.NoError(t, err)
-
 		var response testServerResponse
-		err = backend.Do(request, nil, &response)
+		err := backend.Call("get", "/hello", "sk_test_xyz", params, &response)
 
 		assert.NoError(t, err)
 		assert.Equal(t, message, response.Message)
@@ -648,17 +637,8 @@ func TestDo_TelemetryEnabledNoDataRace(t *testing.T) {
 
 	for i := 0; i < times; i++ {
 		go func() {
-			request, err := backend.NewRequest(
-				http.MethodGet,
-				"/hello",
-				"sk_test_123",
-				"application/x-www-form-urlencoded",
-				nil,
-			)
-			assert.NoError(t, err)
-
 			var response testServerResponse
-			err = backend.Do(request, nil, &response)
+			err := backend.Call("get", "/hello", "sk_test_xyz", nil, &response)
 
 			assert.NoError(t, err)
 			assert.Equal(t, message, response.Message)


### PR DESCRIPTION
## Summary
- Adds infrastructure for reporting `usage` to `X-Stripe-Client-Telemetry`, without breaking changes to the public interface.
- Reports usage for `raw_request` in the beta branch.

## Details

### Release
The first commit [Usage infrastructure](https://github.com/stripe/stripe-go/commit/7527cae42f2f4ed8a0f97300ea83267de7b86cf6) I intend to merge into master in a follow-up, after discussion.

The second commit [Usage for raw_reuest](https://github.com/stripe/stripe-go/commit/4c4da88ee14835faeec4d4dec96c0c61c11155ae) is only applicable to the beta branch. I've opened the PR against beta showing both for a more holistic review.

### Implementation

The tricky part about all this is: we have a struct `BackendImplementation` with public `Do` and `Call` methods (`Call` invokes `Do`). Only the `Do` method has access to `Params` which is where we want to put `usage`, but only the `Call` method has access to `duration`, which also needs to go on the telemetry header. The ideal solution would involve changing the signature of `Do` so that it can shuffle the information back to `Call` in the return value, but that's breaking. To avoid a breaking change, what we instead have to do is pass this information through the `LastResponseSetter`.

`BackendImplementation` although "public" is marked as internal and we say that public use is deprecated since 2018. Things would be much simpler if we [broke it](https://github.com/stripe/stripe-go/compare/beta...richardm-usage-but-breaking?expand=1).

It also turns out, there's not much code sharing in the RawRequest implementation right now, it doesn't go through `backend.Call`, for instance.
