### PR TITLE
Fix check_gofmt.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ check-api-clients:
 
 check-gofmt:
 	scripts/check_gofmt.sh
-
 lint:
 	staticcheck
 

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -39,7 +39,7 @@ import (
 	issuing_authorization "github.com/stripe/stripe-go/v76/issuing/authorization"
 	issuing_card "github.com/stripe/stripe-go/v76/issuing/card"
 	issuing_cardholder "github.com/stripe/stripe-go/v76/issuing/cardholder"
-  	issuing_dispute "github.com/stripe/stripe-go/v76/issuing/dispute"
+	issuing_dispute "github.com/stripe/stripe-go/v76/issuing/dispute"
 	issuing_transaction "github.com/stripe/stripe-go/v76/issuing/transaction"
 	loginlink "github.com/stripe/stripe-go/v76/loginlink"
 	mandate "github.com/stripe/stripe-go/v76/mandate"

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -39,7 +39,7 @@ import (
 	issuing_authorization "github.com/stripe/stripe-go/v76/issuing/authorization"
 	issuing_card "github.com/stripe/stripe-go/v76/issuing/card"
 	issuing_cardholder "github.com/stripe/stripe-go/v76/issuing/cardholder"
-	issuing_dispute "github.com/stripe/stripe-go/v76/issuing/dispute"
+  	issuing_dispute "github.com/stripe/stripe-go/v76/issuing/dispute"
 	issuing_transaction "github.com/stripe/stripe-go/v76/issuing/transaction"
 	loginlink "github.com/stripe/stripe-go/v76/loginlink"
 	mandate "github.com/stripe/stripe-go/v76/mandate"

--- a/scripts/check_gofmt.sh
+++ b/scripts/check_gofmt.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-find_files() {
-  find . -not \( \
-      \( \
-        -name 'vendor' \
-      \) -prune \
-    \) -name '*.go'
-}
+# go fmt supports ./... but gofmt does not.
+# but go fmt always runs gofmt with -w, which replaces
+# which we don't desire
+# hence the need for this annoying script
+  
 
-bad_files=$(find_files | xargs gofmt -s -l)
+# go fmt -n prints the command that *would*
+# be run by go fmt ./...
+# so we just mangle that a bit
+bad_files=$(gofmt -l $(go fmt -n ./... | cut -d ' ' -f4-))
 if [[ -n "${bad_files}" ]]; then
-    echo "!!! gofmt -s needs to be run on the following files: "
+    echo "!!! gofmt -w needs to be run on the following files: "
     echo "${bad_files}"
     exit 1
 fi


### PR DESCRIPTION
`check-gofmt` checks for consistency with `gofmt -s` but make codegen-format run `go fmt ./...` which ultimately runs `gofmt` without the `-s` flag.

This PR changes that, plus it simplifies the check_gofmt.sh script.