### PR TITLE
Retry for all error codes >= 500

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -929,16 +929,12 @@ func (s *BackendImplementation) shouldRetry(err error, req *http.Request, resp *
 		}
 	}
 
-	// 500 Internal Server Error
+	// Retry on 500, 503, and other internal errors.
 	//
-	// We only bother retrying these for non-POST requests. POSTs end up being
-	// cached by the idempotency layer so there's no purpose in retrying them.
-	if resp.StatusCode >= http.StatusInternalServerError && req.Method != http.MethodPost {
-		return true, ""
-	}
-
-	// 503 Service Unavailable
-	if resp.StatusCode == http.StatusServiceUnavailable {
+	// Note that we expect the stripe-should-retry header to be false
+	// in most cases when a 500 is returned, since our idempotency framework
+	// would typically replay it anyway.
+	if resp.StatusCode >= http.StatusInternalServerError {
 		return true, ""
 	}
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -300,7 +300,7 @@ func TestShouldRetry(t *testing.T) {
 		assert.False(t, shouldRetry)
 	})
 
-	// 500 Internal Server Error -- retry if non-POST
+	// 500 Internal Server Error -- retry
 	t.Run("RetryOn500NonPost", func(t *testing.T) {
 		shouldRetry, _ := c.shouldRetry(
 			nil,
@@ -309,17 +309,6 @@ func TestShouldRetry(t *testing.T) {
 			0,
 		)
 		assert.True(t, shouldRetry)
-	})
-
-	// 500 Internal Server Error -- don't retry POST
-	t.Run("DontRetryOn500Post", func(t *testing.T) {
-		shouldRetry, _ := c.shouldRetry(
-			nil,
-			&http.Request{Method: http.MethodPost},
-			&http.Response{StatusCode: http.StatusInternalServerError},
-			0,
-		)
-		assert.False(t, shouldRetry)
 	})
 
 	// 503 Service Unavailable


### PR DESCRIPTION
This PR udpates the retry behavior in the Go SDK to be the same as rest of our languages in terms of when to retry for errors with code >=500

From @richardm-stripe who lead this investigation previously

> The additional restrictions in stripe-go/stripe-ruby (don't bother retrying POST status=500) is a sensible optimization but the logic also misses some statuses (503/504/502) that possibly could succeed on retry. It's better for cases more granular than `>=500` to be captured in the logic that produces `x-stripe-should-retry` rather than to be hardcoded/maintained across 7+ official server SDKs, Terminal SDKs, direct integrations, etc.

Related Jira: https://jira.corp.stripe.com/browse/DEVSDK-1711

## Changelog
* When no `x-stripe-should-retry` header is set in the response, the library now retries all requests with `status >= 500`, not just non-POST methods.


