### PR TITLE
Remove deprecated events

### DIFF
--- a/climate_supplier.go
+++ b/climate_supplier.go
@@ -14,7 +14,6 @@ const (
 	ClimateSupplierRemovalPathwayBiomassCarbonRemovalAndStorage ClimateSupplierRemovalPathway = "biomass_carbon_removal_and_storage"
 	ClimateSupplierRemovalPathwayDirectAirCapture               ClimateSupplierRemovalPathway = "direct_air_capture"
 	ClimateSupplierRemovalPathwayEnhancedWeathering             ClimateSupplierRemovalPathway = "enhanced_weathering"
-	ClimateSupplierRemovalPathwayVarious                        ClimateSupplierRemovalPathway = "various"
 )
 
 // Lists all available Climate supplier objects.

--- a/event.go
+++ b/event.go
@@ -243,14 +243,6 @@ const (
 	EventTypeTreasuryReceivedCreditFailed                       EventType = "treasury.received_credit.failed"
 	EventTypeTreasuryReceivedCreditSucceeded                    EventType = "treasury.received_credit.succeeded"
 	EventTypeTreasuryReceivedDebitCreated                       EventType = "treasury.received_debit.created"
-	EventTypeInvoiceItemUpdated                                 EventType = "invoiceitem.updated"
-	EventTypeOrderCreated                                       EventType = "order.created"
-	EventTypeRecipientCreated                                   EventType = "recipient.created"
-	EventTypeRecipientDeleted                                   EventType = "recipient.deleted"
-	EventTypeRecipientUpdated                                   EventType = "recipient.updated"
-	EventTypeSKUCreated                                         EventType = "sku.created"
-	EventTypeSKUDeleted                                         EventType = "sku.deleted"
-	EventTypeSKUUpdated                                         EventType = "sku.updated"
 )
 
 // List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in [event object](https://stripe.com/docs/api/events/object) api_version attribute (not according to your current Stripe API version or Stripe-Version header).


### PR DESCRIPTION
Below Event types were removed from the API in the last year

[On Sept 22, 2023](https://docs.stripe.com/changelog#september-22,-2023)

> Remove support for values order.created, recipient.created, recipient.deleted, recipient.updated, sku.created, sku.deleted, and sku.updated from enum Event.type

[On Sept 4th, 2023](https://docs.stripe.com/changelog#september-4,-2023)

> Remove support for value invoiceitem.updated from enum Event.type

And the enum Climate.Supplier.removal_pathway was updated on [Dec 6th , 2023](https://docs.stripe.com/changelog#december-6,-2023)

> Remove support for value various from enum Climate.Supplier.removal_pathway

This PR removes the same from the SDKs

Related Jira: https://jira.corp.stripe.com/browse/DEVSDK-1740



