### PR TITLE
Change the status on TerminalReader object from string to enum

### DIFF
--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -58,6 +58,15 @@ const (
 	TerminalReaderDeviceTypeVerifoneP400      TerminalReaderDeviceType = "verifone_P400"
 )
 
+// The networking status of the reader.
+type TerminalReaderStatus string
+
+// List of values that TerminalReaderStatus can take
+const (
+	TerminalReaderStatusOffline TerminalReaderStatus = "offline"
+	TerminalReaderStatusOnline  TerminalReaderStatus = "online"
+)
+
 // Deletes a Reader object.
 type TerminalReaderParams struct {
 	Params `form:"*"`
@@ -401,7 +410,7 @@ type TerminalReader struct {
 	// Serial number of the reader.
 	SerialNumber string `json:"serial_number"`
 	// The networking status of the reader.
-	Status string `json:"status"`
+	Status TerminalReaderStatus `json:"status"`
 }
 
 // TerminalReaderList is a list of Readers as retrieved from a list endpoint.


### PR DESCRIPTION
On Jan 31st, 2024 the API for Terminal Reader was changed as below

[Change type of Terminal.Reader.status from string to enum('offline'|'online')](https://docs.stripe.com/changelog#january-31,-2024)

We added overrides to suppress this change to not break users.
This PR removes that override



