### PR TITLE
Remove shared overrides added for backcompat, change TerminalReaderStatus to enum

### DIFF
--- a/balancetransaction.go
+++ b/balancetransaction.go
@@ -118,10 +118,6 @@ const (
 	BalanceTransactionTypeTransferCancel               BalanceTransactionType = "transfer_cancel"
 	BalanceTransactionTypeTransferFailure              BalanceTransactionType = "transfer_failure"
 	BalanceTransactionTypeTransferRefund               BalanceTransactionType = "transfer_refund"
-	BalanceTransactionTypeObligationInbound            BalanceTransactionType = "obligation_inbound"
-	BalanceTransactionTypeObligationPayout             BalanceTransactionType = "obligation_payout"
-	BalanceTransactionTypeObligationPayoutFailure      BalanceTransactionType = "obligation_payout_failure"
-	BalanceTransactionTypeObligationReversalOutbound   BalanceTransactionType = "obligation_reversal_outbound"
 )
 
 // Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.

--- a/climate_supplier.go
+++ b/climate_supplier.go
@@ -14,7 +14,6 @@ const (
 	ClimateSupplierRemovalPathwayBiomassCarbonRemovalAndStorage ClimateSupplierRemovalPathway = "biomass_carbon_removal_and_storage"
 	ClimateSupplierRemovalPathwayDirectAirCapture               ClimateSupplierRemovalPathway = "direct_air_capture"
 	ClimateSupplierRemovalPathwayEnhancedWeathering             ClimateSupplierRemovalPathway = "enhanced_weathering"
-	ClimateSupplierRemovalPathwayVarious                        ClimateSupplierRemovalPathway = "various"
 )
 
 // Lists all available Climate supplier objects.

--- a/event.go
+++ b/event.go
@@ -243,14 +243,6 @@ const (
 	EventTypeTreasuryReceivedCreditFailed                       EventType = "treasury.received_credit.failed"
 	EventTypeTreasuryReceivedCreditSucceeded                    EventType = "treasury.received_credit.succeeded"
 	EventTypeTreasuryReceivedDebitCreated                       EventType = "treasury.received_debit.created"
-	EventTypeInvoiceItemUpdated                                 EventType = "invoiceitem.updated"
-	EventTypeOrderCreated                                       EventType = "order.created"
-	EventTypeRecipientCreated                                   EventType = "recipient.created"
-	EventTypeRecipientDeleted                                   EventType = "recipient.deleted"
-	EventTypeRecipientUpdated                                   EventType = "recipient.updated"
-	EventTypeSKUCreated                                         EventType = "sku.created"
-	EventTypeSKUDeleted                                         EventType = "sku.deleted"
-	EventTypeSKUUpdated                                         EventType = "sku.updated"
 )
 
 // List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in [event object](https://stripe.com/docs/api/events/object) api_version attribute (not according to your current Stripe API version or Stripe-Version header).

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -1332,8 +1332,6 @@ type PaymentIntentPaymentMethodOptionsCardParams struct {
 type PaymentIntentPaymentMethodOptionsCardPresentParams struct {
 	// Request ability to capture this payment beyond the standard [authorization validity window](https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity)
 	RequestExtendedAuthorization *bool `form:"request_extended_authorization"`
-	// This field was released by mistake and will be removed in the next major version
-	RequestIncrementalAuthorization *string `form:"request_incremental_authorization"`
 	// Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
 	RequestIncrementalAuthorizationSupport *bool `form:"request_incremental_authorization_support"`
 }

--- a/paymentmethodconfiguration.go
+++ b/paymentmethodconfiguration.go
@@ -652,101 +652,6 @@ const (
 	PaymentMethodConfigurationWeChatPayDisplayPreferenceValueOn  PaymentMethodConfigurationWeChatPayDisplayPreferenceValue = "on"
 )
 
-// The account's display preference.
-type PaymentMethodConfigurationIDBankTransferDisplayPreferencePreference string
-
-// List of values that PaymentMethodConfigurationIDBankTransferDisplayPreferencePreference can take
-const (
-	PaymentMethodConfigurationIDBankTransferDisplayPreferencePreferenceNone PaymentMethodConfigurationIDBankTransferDisplayPreferencePreference = "none"
-	PaymentMethodConfigurationIDBankTransferDisplayPreferencePreferenceOff  PaymentMethodConfigurationIDBankTransferDisplayPreferencePreference = "off"
-	PaymentMethodConfigurationIDBankTransferDisplayPreferencePreferenceOn   PaymentMethodConfigurationIDBankTransferDisplayPreferencePreference = "on"
-)
-
-// The effective display preference value.
-type PaymentMethodConfigurationIDBankTransferDisplayPreferenceValue string
-
-// List of values that PaymentMethodConfigurationIDBankTransferDisplayPreferenceValue can take
-const (
-	PaymentMethodConfigurationIDBankTransferDisplayPreferenceValueOff PaymentMethodConfigurationIDBankTransferDisplayPreferenceValue = "off"
-	PaymentMethodConfigurationIDBankTransferDisplayPreferenceValueOn  PaymentMethodConfigurationIDBankTransferDisplayPreferenceValue = "on"
-)
-
-// The account's display preference.
-type PaymentMethodConfigurationMultibancoDisplayPreferencePreference string
-
-// List of values that PaymentMethodConfigurationMultibancoDisplayPreferencePreference can take
-const (
-	PaymentMethodConfigurationMultibancoDisplayPreferencePreferenceNone PaymentMethodConfigurationMultibancoDisplayPreferencePreference = "none"
-	PaymentMethodConfigurationMultibancoDisplayPreferencePreferenceOff  PaymentMethodConfigurationMultibancoDisplayPreferencePreference = "off"
-	PaymentMethodConfigurationMultibancoDisplayPreferencePreferenceOn   PaymentMethodConfigurationMultibancoDisplayPreferencePreference = "on"
-)
-
-// The effective display preference value.
-type PaymentMethodConfigurationMultibancoDisplayPreferenceValue string
-
-// List of values that PaymentMethodConfigurationMultibancoDisplayPreferenceValue can take
-const (
-	PaymentMethodConfigurationMultibancoDisplayPreferenceValueOff PaymentMethodConfigurationMultibancoDisplayPreferenceValue = "off"
-	PaymentMethodConfigurationMultibancoDisplayPreferenceValueOn  PaymentMethodConfigurationMultibancoDisplayPreferenceValue = "on"
-)
-
-// The account's display preference.
-type PaymentMethodConfigurationNetbankingDisplayPreferencePreference string
-
-// List of values that PaymentMethodConfigurationNetbankingDisplayPreferencePreference can take
-const (
-	PaymentMethodConfigurationNetbankingDisplayPreferencePreferenceNone PaymentMethodConfigurationNetbankingDisplayPreferencePreference = "none"
-	PaymentMethodConfigurationNetbankingDisplayPreferencePreferenceOff  PaymentMethodConfigurationNetbankingDisplayPreferencePreference = "off"
-	PaymentMethodConfigurationNetbankingDisplayPreferencePreferenceOn   PaymentMethodConfigurationNetbankingDisplayPreferencePreference = "on"
-)
-
-// The effective display preference value.
-type PaymentMethodConfigurationNetbankingDisplayPreferenceValue string
-
-// List of values that PaymentMethodConfigurationNetbankingDisplayPreferenceValue can take
-const (
-	PaymentMethodConfigurationNetbankingDisplayPreferenceValueOff PaymentMethodConfigurationNetbankingDisplayPreferenceValue = "off"
-	PaymentMethodConfigurationNetbankingDisplayPreferenceValueOn  PaymentMethodConfigurationNetbankingDisplayPreferenceValue = "on"
-)
-
-// The account's display preference.
-type PaymentMethodConfigurationPayByBankDisplayPreferencePreference string
-
-// List of values that PaymentMethodConfigurationPayByBankDisplayPreferencePreference can take
-const (
-	PaymentMethodConfigurationPayByBankDisplayPreferencePreferenceNone PaymentMethodConfigurationPayByBankDisplayPreferencePreference = "none"
-	PaymentMethodConfigurationPayByBankDisplayPreferencePreferenceOff  PaymentMethodConfigurationPayByBankDisplayPreferencePreference = "off"
-	PaymentMethodConfigurationPayByBankDisplayPreferencePreferenceOn   PaymentMethodConfigurationPayByBankDisplayPreferencePreference = "on"
-)
-
-// The effective display preference value.
-type PaymentMethodConfigurationPayByBankDisplayPreferenceValue string
-
-// List of values that PaymentMethodConfigurationPayByBankDisplayPreferenceValue can take
-const (
-	PaymentMethodConfigurationPayByBankDisplayPreferenceValueOff PaymentMethodConfigurationPayByBankDisplayPreferenceValue = "off"
-	PaymentMethodConfigurationPayByBankDisplayPreferenceValueOn  PaymentMethodConfigurationPayByBankDisplayPreferenceValue = "on"
-)
-
-// The account's display preference.
-type PaymentMethodConfigurationUpiDisplayPreferencePreference string
-
-// List of values that PaymentMethodConfigurationUpiDisplayPreferencePreference can take
-const (
-	PaymentMethodConfigurationUpiDisplayPreferencePreferenceNone PaymentMethodConfigurationUpiDisplayPreferencePreference = "none"
-	PaymentMethodConfigurationUpiDisplayPreferencePreferenceOff  PaymentMethodConfigurationUpiDisplayPreferencePreference = "off"
-	PaymentMethodConfigurationUpiDisplayPreferencePreferenceOn   PaymentMethodConfigurationUpiDisplayPreferencePreference = "on"
-)
-
-// The effective display preference value.
-type PaymentMethodConfigurationUpiDisplayPreferenceValue string
-
-// List of values that PaymentMethodConfigurationUpiDisplayPreferenceValue can take
-const (
-	PaymentMethodConfigurationUpiDisplayPreferenceValueOff PaymentMethodConfigurationUpiDisplayPreferenceValue = "off"
-	PaymentMethodConfigurationUpiDisplayPreferenceValueOn  PaymentMethodConfigurationUpiDisplayPreferenceValue = "on"
-)
-
 // List payment method configurations
 type PaymentMethodConfigurationListParams struct {
 	ListParams `form:"*"`
@@ -1711,71 +1616,6 @@ type PaymentMethodConfigurationWeChatPay struct {
 	Available         bool                                                  `json:"available"`
 	DisplayPreference *PaymentMethodConfigurationWeChatPayDisplayPreference `json:"display_preference"`
 }
-type PaymentMethodConfigurationIDBankTransferDisplayPreference struct {
-	// For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-	Overridable bool `json:"overridable"`
-	// The account's display preference.
-	Preference PaymentMethodConfigurationIDBankTransferDisplayPreferencePreference `json:"preference"`
-	// The effective display preference value.
-	Value PaymentMethodConfigurationIDBankTransferDisplayPreferenceValue `json:"value"`
-}
-type PaymentMethodConfigurationIDBankTransfer struct {
-	// Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-	Available         bool                                                       `json:"available"`
-	DisplayPreference *PaymentMethodConfigurationIDBankTransferDisplayPreference `json:"display_preference"`
-}
-type PaymentMethodConfigurationMultibancoDisplayPreference struct {
-	// For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-	Overridable bool `json:"overridable"`
-	// The account's display preference.
-	Preference PaymentMethodConfigurationMultibancoDisplayPreferencePreference `json:"preference"`
-	// The effective display preference value.
-	Value PaymentMethodConfigurationMultibancoDisplayPreferenceValue `json:"value"`
-}
-type PaymentMethodConfigurationMultibanco struct {
-	// Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-	Available         bool                                                   `json:"available"`
-	DisplayPreference *PaymentMethodConfigurationMultibancoDisplayPreference `json:"display_preference"`
-}
-type PaymentMethodConfigurationNetbankingDisplayPreference struct {
-	// For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-	Overridable bool `json:"overridable"`
-	// The account's display preference.
-	Preference PaymentMethodConfigurationNetbankingDisplayPreferencePreference `json:"preference"`
-	// The effective display preference value.
-	Value PaymentMethodConfigurationNetbankingDisplayPreferenceValue `json:"value"`
-}
-type PaymentMethodConfigurationNetbanking struct {
-	// Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-	Available         bool                                                   `json:"available"`
-	DisplayPreference *PaymentMethodConfigurationNetbankingDisplayPreference `json:"display_preference"`
-}
-type PaymentMethodConfigurationPayByBankDisplayPreference struct {
-	// For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-	Overridable bool `json:"overridable"`
-	// The account's display preference.
-	Preference PaymentMethodConfigurationPayByBankDisplayPreferencePreference `json:"preference"`
-	// The effective display preference value.
-	Value PaymentMethodConfigurationPayByBankDisplayPreferenceValue `json:"value"`
-}
-type PaymentMethodConfigurationPayByBank struct {
-	// Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-	Available         bool                                                  `json:"available"`
-	DisplayPreference *PaymentMethodConfigurationPayByBankDisplayPreference `json:"display_preference"`
-}
-type PaymentMethodConfigurationUpiDisplayPreference struct {
-	// For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-	Overridable bool `json:"overridable"`
-	// The account's display preference.
-	Preference PaymentMethodConfigurationUpiDisplayPreferencePreference `json:"preference"`
-	// The effective display preference value.
-	Value PaymentMethodConfigurationUpiDisplayPreferenceValue `json:"value"`
-}
-type PaymentMethodConfigurationUpi struct {
-	// Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-	Available         bool                                            `json:"available"`
-	DisplayPreference *PaymentMethodConfigurationUpiDisplayPreference `json:"display_preference"`
-}
 
 // PaymentMethodConfigurations control which payment methods are displayed to your customers when you don't explicitly specify payment method types. You can have multiple configurations with different sets of payment methods for different scenarios.
 //
@@ -1817,9 +1657,8 @@ type PaymentMethodConfiguration struct {
 	GooglePay       *PaymentMethodConfigurationGooglePay       `json:"google_pay"`
 	Grabpay         *PaymentMethodConfigurationGrabpay         `json:"grabpay"`
 	// Unique identifier for the object.
-	ID             string                                    `json:"id"`
-	IDBankTransfer *PaymentMethodConfigurationIDBankTransfer `json:"id_bank_transfer"`
-	IDEAL          *PaymentMethodConfigurationIDEAL          `json:"ideal"`
+	ID    string                           `json:"id"`
+	IDEAL *PaymentMethodConfigurationIDEAL `json:"ideal"`
 	// The default configuration is used whenever a payment method configuration is not specified.
 	IsDefault bool                               `json:"is_default"`
 	JCB       *PaymentMethodConfigurationJCB     `json:"jcb"`
@@ -1827,25 +1666,21 @@ type PaymentMethodConfiguration struct {
 	Konbini   *PaymentMethodConfigurationKonbini `json:"konbini"`
 	Link      *PaymentMethodConfigurationLink    `json:"link"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
-	Livemode   bool                                  `json:"livemode"`
-	Multibanco *PaymentMethodConfigurationMultibanco `json:"multibanco"`
+	Livemode bool `json:"livemode"`
 	// The configuration's name.
-	Name       string                                `json:"name"`
-	Netbanking *PaymentMethodConfigurationNetbanking `json:"netbanking"`
+	Name string `json:"name"`
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string                          `json:"object"`
 	OXXO   *PaymentMethodConfigurationOXXO `json:"oxxo"`
 	P24    *PaymentMethodConfigurationP24  `json:"p24"`
 	// For child configs, the configuration's parent configuration.
 	Parent        string                                   `json:"parent"`
-	PayByBank     *PaymentMethodConfigurationPayByBank     `json:"pay_by_bank"`
 	PayNow        *PaymentMethodConfigurationPayNow        `json:"paynow"`
 	Paypal        *PaymentMethodConfigurationPaypal        `json:"paypal"`
 	PromptPay     *PaymentMethodConfigurationPromptPay     `json:"promptpay"`
 	RevolutPay    *PaymentMethodConfigurationRevolutPay    `json:"revolut_pay"`
 	SEPADebit     *PaymentMethodConfigurationSEPADebit     `json:"sepa_debit"`
 	Sofort        *PaymentMethodConfigurationSofort        `json:"sofort"`
-	Upi           *PaymentMethodConfigurationUpi           `json:"upi"`
 	USBankAccount *PaymentMethodConfigurationUSBankAccount `json:"us_bank_account"`
 	WeChatPay     *PaymentMethodConfigurationWeChatPay     `json:"wechat_pay"`
 }

--- a/setupintent.go
+++ b/setupintent.go
@@ -160,10 +160,9 @@ type SetupIntentPaymentMethodOptionsCardRequestThreeDSecure string
 
 // List of values that SetupIntentPaymentMethodOptionsCardRequestThreeDSecure can take
 const (
-	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureAny           SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "any"
-	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureAutomatic     SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
-	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureChallenge     SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "challenge"
-	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureChallengeOnly SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "challenge_only"
+	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureAny       SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "any"
+	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureAutomatic SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "automatic"
+	SetupIntentPaymentMethodOptionsCardRequestThreeDSecureChallenge SetupIntentPaymentMethodOptionsCardRequestThreeDSecure = "challenge"
 )
 
 // The list of permissions to request. The `payment_method` permission must be included.

--- a/taxrate.go
+++ b/taxrate.go
@@ -38,7 +38,6 @@ const (
 	TaxRateTaxTypeRST               TaxRateTaxType = "rst"
 	TaxRateTaxTypeSalesTax          TaxRateTaxType = "sales_tax"
 	TaxRateTaxTypeVAT               TaxRateTaxType = "vat"
-	TaxRateTaxTypeServiceTax        TaxRateTaxType = "service_tax"
 )
 
 // Returns a list of your tax rates. Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.

--- a/terminal_reader.go
+++ b/terminal_reader.go
@@ -58,6 +58,15 @@ const (
 	TerminalReaderDeviceTypeVerifoneP400      TerminalReaderDeviceType = "verifone_P400"
 )
 
+// The networking status of the reader.
+type TerminalReaderStatus string
+
+// List of values that TerminalReaderStatus can take
+const (
+	TerminalReaderStatusOffline TerminalReaderStatus = "offline"
+	TerminalReaderStatusOnline  TerminalReaderStatus = "online"
+)
+
 // Deletes a Reader object.
 type TerminalReaderParams struct {
 	Params `form:"*"`
@@ -401,7 +410,7 @@ type TerminalReader struct {
 	// Serial number of the reader.
 	SerialNumber string `json:"serial_number"`
 	// The networking status of the reader.
-	Status string `json:"status"`
+	Status TerminalReaderStatus `json:"status"`
 }
 
 // TerminalReaderList is a list of Readers as retrieved from a list endpoint.


### PR DESCRIPTION
This PR contains the changes generated after removing the following from our code generator
- the shared overrides 
- the Go specific override to change TerminalReaderStatus from string to enum


TODO - Changelog entry