### PR TITLE
Deprecate Go methods and Params

### DIFF
--- a/confirmationtoken.go
+++ b/confirmationtoken.go
@@ -612,6 +612,7 @@ type ConfirmationTokenPaymentMethodPreviewLink struct {
 	// Account owner's email address.
 	Email string `json:"email"`
 	// [Deprecated] This is a legacy parameter that no longer has any function.
+	// Deprecated:
 	PersistentToken string `json:"persistent_token"`
 }
 type ConfirmationTokenPaymentMethodPreviewMobilepay struct{}

--- a/issuing/authorization/client.go
+++ b/issuing/authorization/client.go
@@ -47,11 +47,13 @@ func (c Client) Update(id string, params *stripe.IssuingAuthorizationParams) (*s
 }
 
 // Approve is the method for the `POST /v1/issuing/authorizations/{authorization}/approve` API.
+// Deprecated:
 func Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
 	return getC().Approve(id, params)
 }
 
 // Approve is the method for the `POST /v1/issuing/authorizations/{authorization}/approve` API.
+// Deprecated:
 func (c Client) Approve(id string, params *stripe.IssuingAuthorizationApproveParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/approve", id)
 	authorization := &stripe.IssuingAuthorization{}
@@ -60,11 +62,13 @@ func (c Client) Approve(id string, params *stripe.IssuingAuthorizationApprovePar
 }
 
 // Decline is the method for the `POST /v1/issuing/authorizations/{authorization}/decline` API.
+// Deprecated:
 func Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
 	return getC().Decline(id, params)
 }
 
 // Decline is the method for the `POST /v1/issuing/authorizations/{authorization}/decline` API.
+// Deprecated:
 func (c Client) Decline(id string, params *stripe.IssuingAuthorizationDeclineParams) (*stripe.IssuingAuthorization, error) {
 	path := stripe.FormatURLPath("/v1/issuing/authorizations/%s/decline", id)
 	authorization := &stripe.IssuingAuthorization{}

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -1563,6 +1563,7 @@ type PaymentIntentPaymentMethodOptionsLinkParams struct {
 	// If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
 	CaptureMethod *string `form:"capture_method"`
 	// [Deprecated] This is a legacy parameter that no longer has any function.
+	// Deprecated:
 	PersistentToken *string `form:"persistent_token"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
 	//
@@ -2930,6 +2931,7 @@ type PaymentIntentPaymentMethodOptionsLink struct {
 	// Controls when the funds will be captured from the customer's account.
 	CaptureMethod PaymentIntentPaymentMethodOptionsLinkCaptureMethod `json:"capture_method"`
 	// [Deprecated] This is a legacy parameter that no longer has any function.
+	// Deprecated:
 	PersistentToken string `json:"persistent_token"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
 	//

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -883,6 +883,7 @@ type PaymentMethodLink struct {
 	// Account owner's email address.
 	Email string `json:"email"`
 	// [Deprecated] This is a legacy parameter that no longer has any function.
+	// Deprecated:
 	PersistentToken string `json:"persistent_token"`
 }
 type PaymentMethodMobilepay struct{}

--- a/setupintent.go
+++ b/setupintent.go
@@ -699,6 +699,7 @@ type SetupIntentPaymentMethodOptionsCardPresentParams struct{}
 // If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
 type SetupIntentPaymentMethodOptionsLinkParams struct {
 	// [Deprecated] This is a legacy parameter that no longer has any function.
+	// Deprecated:
 	PersistentToken *string `form:"persistent_token"`
 }
 
@@ -1323,6 +1324,7 @@ type SetupIntentPaymentMethodOptionsCard struct {
 type SetupIntentPaymentMethodOptionsCardPresent struct{}
 type SetupIntentPaymentMethodOptionsLink struct {
 	// [Deprecated] This is a legacy parameter that no longer has any function.
+	// Deprecated:
 	PersistentToken string `json:"persistent_token"`
 }
 type SetupIntentPaymentMethodOptionsPaypal struct {


### PR DESCRIPTION
This PR adds Go SDK support for automatically marking methods and params as deprecated. 

## Changelog
- Mark as deprecated the `Approve` and `Decline` methods on `issuing/authorization/client.go`.  Instead, [respond directly to the webhook request to approve an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
- Mark as deprecated the `persistent_token` property on `ConfirmationTokenPaymentMethodPreviewLink.persistent_token`, `PaymentIntentPaymentMethodOptionsLink`, `PaymentIntentPaymentMethodOptionsLinkParams`, `PaymentMethodLink`, `SetupIntentPaymentMethodOptionsCard`, `SetupIntentPaymentMethodOptionsLinkParams`. This is a legacy parameter that no longer has any function.