### PR TITLE
Add MsgCode to Error

### DIFF
--- a/error.go
+++ b/error.go
@@ -268,6 +268,7 @@ type Error struct {
 
 	HTTPStatusCode    int               `json:"status,omitempty"`
 	Msg               string            `json:"message"`
+	MsgCode           string            `json:"message_code,omitempty"`
 	Param             string            `json:"param,omitempty"`
 	PaymentIntent     *PaymentIntent    `json:"payment_intent,omitempty"`
 	PaymentMethod     *PaymentMethod    `json:"payment_method,omitempty"`

--- a/error_test.go
+++ b/error_test.go
@@ -19,7 +19,7 @@ func TestErrorResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Request-Id", "req_123")
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, `{"error":{"message":"bar","type":"`+ErrorTypeInvalidRequest+`"}}`)
+		fmt.Fprintln(w, `{"error":{"message":"bar","message_code":"test_message_code","type":"`+ErrorTypeInvalidRequest+`"}}`)
 	}))
 	defer ts.Close()
 
@@ -38,6 +38,7 @@ func TestErrorResponse(t *testing.T) {
 	assert.Equal(t, ErrorTypeInvalidRequest, stripeErr.Type)
 	assert.Equal(t, "req_123", stripeErr.RequestID)
 	assert.Equal(t, 401, stripeErr.HTTPStatusCode)
+	assert.Equal(t, "test_message_code", stripeErr.MsgCode)
 	var invalidRequestErr *InvalidRequestError
 	assert.True(t, errors.As(err, &invalidRequestErr))
 }


### PR DESCRIPTION
### Background Summary

The current `Error` struct does not include a field to store the `message_code`. This requires writing additional code to extract the `message_code` from `RawJSON` when handling specific errors, such as checking if an invoice is already paid.

### Detailed Description

When executing `POST /v1/invoice/:id/pay` on an already paid invoice, the following error is returned:

```json
{
  "error": {
    "message": "foo",
    "message_code": "invoice_already_paid",
    "request_log_url": "https://dashboard.stripe.com/test/logs/foo",
    "type": "invalid_request_error"
  }
}
```

Currently, since the `Error` struct does not have a field that includes `message_code`, it is necessary to write code to extract `message_code` from `RawJSON`.

The example of Before and After of this modification is as follows:

```go
// Before
var stripeErr *stripe.Error
if errors.As(err, &stripeErr) {
    switch stripeErr.Type {
    case stripe.ErrorTypeInvalidRequest:
        if stripeErr.LastResponse != nil {
            var responseBody map[string]interface{}
            jsonErr := json.Unmarshal(stripeErr.LastResponse.RawJSON, &responseBody)
            if jsonErr != nil {
                return jsonErr
            }
            if errorObj, ok := responseBody["error"].(map[string]interface{}); ok {
                messageCode, _ := errorObj["message_code"].(string)
                if messageCode == "invoice_already_paid" {
                    // Process for already paid invoice
                }
            }
        }
    }
}

// After
var stripeErr *stripe.Error
if errors.As(err, &stripeErr) {
    switch stripeErr.Type {
    case stripe.ErrorTypeInvalidRequest:
        if stripeErr.MsgCode == "invoice_already_paid" {
            // Process for already paid invoice
        }
    }
}
```