### PR TITLE
Use pinned version of tools in Makefile and ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: lint
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.4.7 &&
-          go install golang.org/x/tools/cmd/goimports@v.0.24.0 &&
+          go install golang.org/x/tools/cmd/goimports@v0.24.0 &&
           $HOME/go/bin/staticcheck &&
           make vet &&
           make check-gofmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: lint
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.4.7 &&
-          go install golang.org/x/tools/cmd/goimports@latest &&
+          go install golang.org/x/tools/cmd/goimports@v.0.24.0 &&
           $HOME/go/bin/staticcheck &&
           make vet &&
           make check-gofmt

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ update-version:
 
 codegen-format: normalize-imports
 	scripts/gofmt.sh
-	go install golang.org/x/tools/cmd/goimports@latest && goimports -w example/generated_examples_test.go
+	go install golang.org/x/tools/cmd/goimports@v0.24.0 && goimports -w example/generated_examples_test.go
 
 CURRENT_MAJOR_VERSION := $(shell cat VERSION | sed 's/\..*//')
 normalize-imports:	


### PR DESCRIPTION
Context:
go tools new release requires a later version of go than what we support.  Use of @latest in the Makefile and ci.yml file causes us to always fetch the latest which will cause CI builds to fail.

Changes:
changed Makefile codegen format to install tools v0.24.0 (which is the last version before the breaking change) instead of latest
changed ci.yml in linter step to use v0.24.0 instead of latest

