### PR TITLE
add support for RawRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Go Stripe
+
 [![Go Reference](https://pkg.go.dev/badge/github.com/stripe/stripe-go)](https://pkg.go.dev/github.com/stripe/stripe-go/v79)
 [![Build Status](https://github.com/stripe/stripe-go/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-go/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-go/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-go?branch=master)
@@ -14,13 +15,13 @@ The official [Stripe][stripe] Go client library.
 Make sure your project is using Go Modules (it will have a `go.mod` file in its
 root if it already is):
 
-``` sh
+```sh
 go mod init
 ```
 
 Then, reference stripe-go in a Go program with `import`:
 
-``` go
+```go
 import (
 	"github.com/stripe/stripe-go/v79"
 	"github.com/stripe/stripe-go/v79/customer"
@@ -256,7 +257,7 @@ if err := i.Err(); err != nil {
 Use `LastResponse` on any `APIResource` to look at the API response that
 generated the current object:
 
-``` go
+```go
 c, err := coupon.New(...)
 requestID := coupon.LastResponse.RequestID
 ```
@@ -264,7 +265,7 @@ requestID := coupon.LastResponse.RequestID
 Similarly, for `List` operations, the last response is available on the list
 object attached to the iterator:
 
-``` go
+```go
 it := coupon.List(...)
 for it.Next() {
     // Last response *NOT* on the individual iterator object
@@ -354,7 +355,7 @@ full resource struct, but unless expansion is requested, only the `ID` field of
 that struct is populated. Expansion is requested by calling `AddExpand` on
 parameter structs. For example:
 
-``` go
+```go
 //
 // *Without* expansion
 //
@@ -373,11 +374,12 @@ c, _ = charge.Get("ch_123", p)
 c.Customer.ID    // ID is still available
 c.Customer.Name  // Name is now also available (if it had a value)
 ```
+
 ### How to use undocumented parameters and properties
 
 stripe-go is a typed library and it supports all public properties or parameters.
 
-Stripe sometimes launches private beta features which introduce new properties or parameters that are not immediately public. These will not have typed accessors in the stripe-go library but can still be used. 
+Stripe sometimes launches private beta features which introduce new properties or parameters that are not immediately public. These will not have typed accessors in the stripe-go library but can still be used.
 
 #### Parameters
 
@@ -412,13 +414,15 @@ secret_parameter, ok := rawData["secret_parameter"].(map[string]interface{})
 if ok {
 	primary := secret_parameter["primary"].(string)
 	secondary := secret_parameter["secondary"].(string)
-} 
+}
 ```
 
 ### Webhook signing
+
 Stripe can optionally sign the webhook events it sends to your endpoint, allowing you to validate that they were not sent by a third-party. You can read more about it [here](https://stripe.com/docs/webhooks/signatures).
 
 #### Testing Webhook signing
+
 You can use `stripe.webhook.GenerateTestSignedPayload` to mock webhook events that come from Stripe:
 
 ```go
@@ -477,10 +481,13 @@ config := &stripe.BackendConfig{
 To mock a Stripe client for a unit tests using [GoMock](https://github.com/golang/mock):
 
 1. Generate a `Backend` type mock.
+
 ```
 mockgen -destination=mocks/backend.go -package=mocks github.com/stripe/stripe-go/v79 Backend
 ```
+
 2. Use the `Backend` mock to initialize and call methods on the client.
+
 ```go
 
 import (
@@ -531,17 +538,64 @@ go get -u github.com/stripe/stripe-go/v79@v77.1.0-beta.1
 ```
 
 > **Note**
-> There can be breaking changes between beta versions. 
+> There can be breaking changes between beta versions.
 
 We highly recommend keeping an eye on when the beta feature you are interested in goes from beta to stable so that you can move from using a beta version of the SDK to the stable version.
 
 If your beta feature requires a `Stripe-Version` header to be sent, set the `stripe.APIVersion` field using the `stripe.AddBetaVersion` function to set it:
 
 > **Note**
-> The `APIVersion` can only be set in beta versions of the library. 
+> The `APIVersion` can only be set in beta versions of the library.
 
 ```go
 stripe.AddBetaVersion("feature_beta", "v3")
+```
+
+### Raw Request
+
+If you would like to send a request to an API that is:
+
+- not yet supported in stripe-go (like any `/v2/...` endpoints), or
+- undocumented (like a private beta), or
+- public, but you prefer to bypass the method definitions in the library and specify your request details directly
+
+You can use the `RawRequest` method on the `stripe` backend.
+
+```go
+import "github.com/stripe/stripe-go/v79"
+
+func make_raw_request() error {
+	//
+	stripe.Key = "sk_test_123"
+
+	body_struct := map[string]interface{}{
+		"event_name": "my_event_name",
+		"payload": map[string]string{
+			"value":              "123",
+			"stripe_customer_id": "cus_1234",
+		},
+	}
+	body, err := json.Marshal(body_struct)
+	if err != nil {
+		return err
+	}
+
+	params := stripe.RawParams{
+		APIMode: stripe.PreviewAPIMode, // required for V2 APIs
+	}
+	resp, err := stripe.RawRequest("POST", "/v2/billing/meter_events", string(body), &params)
+	if err != nil {
+		return err
+	}
+
+	var deserializedResponse map[string]interface{}
+	err = json.Unmarshal(resp.RawJSON, &deserializedResponse)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
 ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -572,7 +572,6 @@ import (
 )
 
 func make_raw_request() error {
-	//
 	stripe.Key = "sk_test_123"
 
 	payload := map[string]interface{}{

--- a/api_version.go
+++ b/api_version.go
@@ -7,5 +7,5 @@
 package stripe
 
 const (
-	apiVersion string = "2024-06-20"
+	apiVersion string = "2024-09-30.acacia"
 )

--- a/params.go
+++ b/params.go
@@ -268,8 +268,7 @@ type ParamsContainer interface {
 
 type RawParams struct {
 	Params        `form:"*"`
-	APIMode       APIMode `form:"-"`
-	StripeContext string  `form:"-"`
+	StripeContext string `form:"-"`
 }
 
 // RangeQueryParams are a set of generic request parameters that are used on

--- a/params.go
+++ b/params.go
@@ -172,6 +172,11 @@ type ListParamsContainer interface {
 	GetListParams() *ListParams
 }
 
+type APIMode string
+
+var V1APIMode APIMode = "v1"
+var V2APIMode APIMode = "v2"
+
 // Params is the structure that contains the common properties
 // of any *Params structure.
 type Params struct {
@@ -259,6 +264,12 @@ func (p *Params) SetStripeAccount(val string) {
 // its implementation of this interface.
 type ParamsContainer interface {
 	GetParams() *Params
+}
+
+type RawParams struct {
+	Params        `form:"*"`
+	APIMode       APIMode `form:"-"`
+	StripeContext string  `form:"-"`
 }
 
 // RangeQueryParams are a set of generic request parameters that are used on

--- a/rawrequest/client.go
+++ b/rawrequest/client.go
@@ -1,0 +1,32 @@
+// Package rawrequest provides sending stripe-flavored untyped HTTP calls
+package rawrequest
+
+import (
+	"net/http"
+
+	stripe "github.com/stripe/stripe-go/v79"
+)
+
+func getDefaultRequestOptions(params *stripe.RawParams) *stripe.RawParams {
+	if params == nil {
+		params = &stripe.RawParams{}
+	}
+
+	rawParams := stripe.RawParams{
+		Params:        params.Params,
+		APIMode:       stripe.V2APIMode, // most of this usage is probably v2, so default to that mode
+		StripeContext: params.StripeContext,
+	}
+
+	return &rawParams
+}
+
+func Get(path string, params *stripe.RawParams) (*stripe.APIResponse, error) {
+	return stripe.RawRequest(http.MethodGet, path, "", getDefaultRequestOptions(params))
+}
+func Post(path, content string, params *stripe.RawParams) (*stripe.APIResponse, error) {
+	return stripe.RawRequest(http.MethodPost, path, content, getDefaultRequestOptions(params))
+}
+func Delete(path string, params *stripe.RawParams) (*stripe.APIResponse, error) {
+	return stripe.RawRequest(http.MethodDelete, path, "", getDefaultRequestOptions(params))
+}

--- a/rawrequest/client.go
+++ b/rawrequest/client.go
@@ -7,26 +7,12 @@ import (
 	stripe "github.com/stripe/stripe-go/v79"
 )
 
-func getDefaultRequestOptions(params *stripe.RawParams) *stripe.RawParams {
-	if params == nil {
-		params = &stripe.RawParams{}
-	}
-
-	rawParams := stripe.RawParams{
-		Params:        params.Params,
-		APIMode:       stripe.V2APIMode, // most of this usage is probably v2, so default to that mode
-		StripeContext: params.StripeContext,
-	}
-
-	return &rawParams
-}
-
 func Get(path string, params *stripe.RawParams) (*stripe.APIResponse, error) {
-	return stripe.RawRequest(http.MethodGet, path, "", getDefaultRequestOptions(params))
+	return stripe.RawRequest(http.MethodGet, path, "", params)
 }
 func Post(path, content string, params *stripe.RawParams) (*stripe.APIResponse, error) {
-	return stripe.RawRequest(http.MethodPost, path, content, getDefaultRequestOptions(params))
+	return stripe.RawRequest(http.MethodPost, path, content, params)
 }
 func Delete(path string, params *stripe.RawParams) (*stripe.APIResponse, error) {
-	return stripe.RawRequest(http.MethodDelete, path, "", getDefaultRequestOptions(params))
+	return stripe.RawRequest(http.MethodDelete, path, "", params)
 }

--- a/rawrequest/client_test.go
+++ b/rawrequest/client_test.go
@@ -26,37 +26,39 @@ func stubAPIBackend(testServer *httptest.Server) {
 	stripe.SetBackend(stripe.APIBackend, backend)
 }
 
-func TestGetDefaultRequestOptionsCopiesParams(t *testing.T) {
-	headers := http.Header{}
-	headers.Set("foo", "bar")
+func TestV2PostRequest(t *testing.T) {
+	var body string
+	var path string
+	var method string
+	var contentType string
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req, _ := ioutil.ReadAll(r.Body)
+		r.Body.Close()
+		body = string(req)
+		path = r.URL.RequestURI()
+		method = r.Method
+		contentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+	}))
 
-	params := &stripe.RawParams{Params: stripe.Params{Headers: headers}, StripeContext: "acct_123"}
+	stubAPIBackend(testServer)
 
-	defaultRequestOptions := getDefaultRequestOptions(params)
-
-	assert.Equal(t, stripe.V2APIMode, defaultRequestOptions.APIMode)
-	assert.Equal(t, "bar", defaultRequestOptions.Headers.Get("foo"))
-	assert.Equal(t, "acct_123", defaultRequestOptions.StripeContext)
-}
-
-func TestGetDefaultRequestOptionsOverridesAPIMode(t *testing.T) {
-	params := &stripe.RawParams{APIMode: stripe.V1APIMode}
-
-	defaultRequestOptions := getDefaultRequestOptions(params)
-
-	assert.Equal(t, stripe.V1APIMode, params.APIMode) // original params should not be modified
-	assert.Equal(t, stripe.V2APIMode, defaultRequestOptions.APIMode)
-}
-
-func TestGetDefaultRequestOptionsWithNilParams(t *testing.T) {
 	var params *stripe.RawParams
-	defaultRequestOptions := getDefaultRequestOptions(params)
+
+	_, err := Post("/v2/abc", `{"xyz": {"def": "jih"}}`, params)
+	assert.NoError(t, err)
 
 	assert.Nil(t, params) // original params should not be modified
-	assert.Equal(t, stripe.V2APIMode, defaultRequestOptions.APIMode)
+	assert.Equal(t, `{"xyz": {"def": "jih"}}`, body)
+	assert.Equal(t, `/v2/abc`, path)
+	assert.Equal(t, `POST`, method)
+	assert.Equal(t, `application/json`, contentType)
+	assert.NoError(t, err)
+	defer testServer.Close()
 }
 
-func TestV2PostRequest(t *testing.T) {
+func TestRawV1PostRequest(t *testing.T) {
 	var body string
 	var path string
 	var method string
@@ -83,7 +85,7 @@ func TestV2PostRequest(t *testing.T) {
 	assert.Equal(t, `{"xyz": {"def": "jih"}}`, body)
 	assert.Equal(t, `/v1/abc`, path)
 	assert.Equal(t, `POST`, method)
-	assert.Equal(t, `application/json`, contentType)
+	assert.Equal(t, `application/x-www-form-urlencoded`, contentType)
 	assert.NoError(t, err)
 	defer testServer.Close()
 }
@@ -114,12 +116,11 @@ func TestV2GetRequestWithAdditionalHeaders(t *testing.T) {
 	headers.Set("foo", "bar")
 	params := &stripe.RawParams{Params: stripe.Params{Headers: headers}, StripeContext: "acct_123"}
 
-	_, err := Get("/v1/abc", params)
+	_, err := Get("/v2/abc", params)
 	assert.NoError(t, err)
 
-	assert.Equal(t, stripe.APIMode(""), params.APIMode) // original params should not be modified
 	assert.Equal(t, ``, body)
-	assert.Equal(t, `/v1/abc`, path)
+	assert.Equal(t, `/v2/abc`, path)
 	assert.Equal(t, `GET`, method)
 	assert.Equal(t, `application/json`, contentType)
 	assert.Equal(t, `bar`, fooHeader)

--- a/rawrequest/client_test.go
+++ b/rawrequest/client_test.go
@@ -1,0 +1,129 @@
+package rawrequest
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v79"
+	_ "github.com/stripe/stripe-go/v79/testing"
+)
+
+func stubAPIBackend(testServer *httptest.Server) {
+	backend := stripe.GetBackendWithConfig(
+		stripe.APIBackend,
+		&stripe.BackendConfig{
+			LeveledLogger: &stripe.LeveledLogger{
+				Level: stripe.LevelDebug,
+			},
+			MaxNetworkRetries: stripe.Int64(0),
+			URL:               stripe.String(testServer.URL),
+		},
+	).(*stripe.BackendImplementation)
+
+	stripe.SetBackend(stripe.APIBackend, backend)
+}
+
+func TestGetDefaultRequestOptionsCopiesParams(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("foo", "bar")
+
+	params := &stripe.RawParams{Params: stripe.Params{Headers: headers}, StripeContext: "acct_123"}
+
+	defaultRequestOptions := getDefaultRequestOptions(params)
+
+	assert.Equal(t, stripe.V2APIMode, defaultRequestOptions.APIMode)
+	assert.Equal(t, "bar", defaultRequestOptions.Headers.Get("foo"))
+	assert.Equal(t, "acct_123", defaultRequestOptions.StripeContext)
+}
+
+func TestGetDefaultRequestOptionsOverridesAPIMode(t *testing.T) {
+	params := &stripe.RawParams{APIMode: stripe.V1APIMode}
+
+	defaultRequestOptions := getDefaultRequestOptions(params)
+
+	assert.Equal(t, stripe.V1APIMode, params.APIMode) // original params should not be modified
+	assert.Equal(t, stripe.V2APIMode, defaultRequestOptions.APIMode)
+}
+
+func TestGetDefaultRequestOptionsWithNilParams(t *testing.T) {
+	var params *stripe.RawParams
+	defaultRequestOptions := getDefaultRequestOptions(params)
+
+	assert.Nil(t, params) // original params should not be modified
+	assert.Equal(t, stripe.V2APIMode, defaultRequestOptions.APIMode)
+}
+
+func TestV2PostRequest(t *testing.T) {
+	var body string
+	var path string
+	var method string
+	var contentType string
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req, _ := ioutil.ReadAll(r.Body)
+		r.Body.Close()
+		body = string(req)
+		path = r.URL.RequestURI()
+		method = r.Method
+		contentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+	}))
+
+	stubAPIBackend(testServer)
+
+	var params *stripe.RawParams
+
+	_, err := Post("/v1/abc", `{"xyz": {"def": "jih"}}`, params)
+	assert.NoError(t, err)
+
+	assert.Nil(t, params) // original params should not be modified
+	assert.Equal(t, `{"xyz": {"def": "jih"}}`, body)
+	assert.Equal(t, `/v1/abc`, path)
+	assert.Equal(t, `POST`, method)
+	assert.Equal(t, `application/json`, contentType)
+	assert.NoError(t, err)
+	defer testServer.Close()
+}
+
+func TestV2GetRequestWithAdditionalHeaders(t *testing.T) {
+	var body string
+	var path string
+	var method string
+	var contentType string
+	var fooHeader string
+	var stripeContext string
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req, _ := ioutil.ReadAll(r.Body)
+		r.Body.Close()
+		body = string(req)
+		path = r.URL.RequestURI()
+		method = r.Method
+		contentType = r.Header.Get("Content-Type")
+		fooHeader = r.Header.Get("foo")
+		stripeContext = r.Header.Get("Stripe-Context")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+	}))
+
+	stubAPIBackend(testServer)
+
+	headers := http.Header{}
+	headers.Set("foo", "bar")
+	params := &stripe.RawParams{Params: stripe.Params{Headers: headers}, StripeContext: "acct_123"}
+
+	_, err := Get("/v1/abc", params)
+	assert.NoError(t, err)
+
+	assert.Equal(t, stripe.APIMode(""), params.APIMode) // original params should not be modified
+	assert.Equal(t, ``, body)
+	assert.Equal(t, `/v1/abc`, path)
+	assert.Equal(t, `GET`, method)
+	assert.Equal(t, `application/json`, contentType)
+	assert.Equal(t, `bar`, fooHeader)
+	assert.Equal(t, `acct_123`, stripeContext)
+	assert.NoError(t, err)
+	defer testServer.Close()
+}

--- a/rawrequest/client_test.go
+++ b/rawrequest/client_test.go
@@ -78,11 +78,11 @@ func TestRawV1PostRequest(t *testing.T) {
 
 	var params *stripe.RawParams
 
-	_, err := Post("/v1/abc", `{"xyz": {"def": "jih"}}`, params)
+	_, err := Post("/v1/abc", `abc=123&a[name]=nested`, params)
 	assert.NoError(t, err)
 
 	assert.Nil(t, params) // original params should not be modified
-	assert.Equal(t, `{"xyz": {"def": "jih"}}`, body)
+	assert.Equal(t, `abc=123&a[name]=nested`, body)
 	assert.Equal(t, `/v1/abc`, path)
 	assert.Equal(t, `POST`, method)
 	assert.Equal(t, `application/x-www-form-urlencoded`, contentType)

--- a/stripe.go
+++ b/stripe.go
@@ -206,6 +206,10 @@ type Backend interface {
 	SetMaxNetworkRetries(maxNetworkRetries int64)
 }
 
+type RawRequestBackend interface {
+	RawRequest(method, path, key, content string, params *RawParams) (*APIResponse, error)
+}
+
 // BackendConfig is used to configure a new Stripe backend.
 type BackendConfig struct {
 	// EnableTelemetry allows request metrics (request id and duration) to be sent
@@ -417,6 +421,73 @@ func (s *BackendImplementation) CallMultipart(method, path, key, boundary string
 	return nil
 }
 
+// RawRequest is the Backend.RawRequest implementation for invoking Stripe APIs.
+func (s *BackendImplementation) RawRequest(method, path, key, content string, params *RawParams) (*APIResponse, error) {
+	var bodyBuffer = bytes.NewBuffer(nil)
+	var commonParams *Params
+	var err error
+	var contentType string
+	if method != http.MethodPost && method != http.MethodGet && method != http.MethodDelete {
+		return nil, fmt.Errorf("method must be POST, GET, or DELETE. Received %s", method)
+	}
+
+	paramsIsNil := params == nil || reflect.ValueOf(params).IsNil()
+
+	if paramsIsNil {
+		_, commonParams, err = extractParams(params)
+		if err != nil {
+			return nil, err
+		}
+		contentType = "application/x-www-form-urlencoded"
+	} else {
+		if params.APIMode == V1APIMode {
+			_, commonParams, err = extractParams(params)
+			if err != nil {
+				return nil, err
+			}
+			contentType = "application/x-www-form-urlencoded"
+		} else if params.APIMode == V2APIMode {
+			_, commonParams, err = extractParams(params)
+			if err != nil {
+				return nil, err
+			}
+			contentType = "application/json"
+		} else {
+			return nil, fmt.Errorf("Unknown API mode %s", params.APIMode)
+		}
+	}
+
+	bodyBuffer.WriteString(content)
+
+	req, err := s.NewRequest(method, path, key, contentType, commonParams)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !paramsIsNil {
+		if params.StripeContext != "" {
+			req.Header.Set("Stripe-Context", params.StripeContext)
+		}
+	}
+
+	handleResponse := func(res *http.Response, err error) (interface{}, error) {
+		return s.handleResponseBufferingErrors(res, err)
+	}
+
+	resp, result, requestDuration, err := s.requestWithRetriesAndTelemetry(req, bodyBuffer, handleResponse)
+	if err != nil {
+		return nil, err
+	}
+	requestID := resp.Header.Get("Request-Id")
+	s.maybeEnqueueTelemetryMetrics(requestID, requestDuration, []string{"raw_request"})
+	body, err := ioutil.ReadAll(result.(io.ReadCloser))
+	if err != nil {
+		return nil, err
+	}
+	return newAPIResponse(resp, body, requestDuration), nil
+}
+
 // CallRaw is the implementation for invoking Stripe APIs internally without a backend.
 func (s *BackendImplementation) CallRaw(method, path, key string, form *form.Values, params *Params, v LastResponseSetter) error {
 	var body string
@@ -424,7 +495,7 @@ func (s *BackendImplementation) CallRaw(method, path, key string, form *form.Val
 		body = form.Encode()
 
 		// On `GET`, move the payload into the URL
-		if method == http.MethodGet {
+		if method != http.MethodPost {
 			path += "?" + body
 			body = ""
 		}
@@ -670,36 +741,39 @@ func (s *BackendImplementation) logError(statusCode int, err error) {
 	}
 }
 
+func (s *BackendImplementation) handleResponseBufferingErrors(res *http.Response, err error) (io.ReadCloser, error) {
+	// Some sort of connection error
+	if err != nil {
+		s.LeveledLogger.Errorf("Request failed with error: %v", err)
+		return res.Body, err
+	}
+
+	// Successful response, return the body ReadCloser
+	if res.StatusCode < 400 {
+		return res.Body, err
+	}
+
+	// Failure: try and parse the json of the response
+	// when logging the error
+	var resBody []byte
+	resBody, err = ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err == nil {
+		err = s.ResponseToError(res, resBody)
+	} else {
+		s.logError(res.StatusCode, err)
+	}
+
+	return res.Body, err
+}
+
 // DoStreaming is used by CallStreaming to execute an API request. It uses the
 // backend's HTTP client to execure the request.  In successful cases, it sets
 // a StreamingLastResponse onto v, but in unsuccessful cases handles unmarshaling
 // errors returned by the API.
 func (s *BackendImplementation) DoStreaming(req *http.Request, body *bytes.Buffer, v StreamingLastResponseSetter) error {
 	handleResponse := func(res *http.Response, err error) (interface{}, error) {
-
-		// Some sort of connection error
-		if err != nil {
-			s.LeveledLogger.Errorf("Request failed with error: %v", err)
-			return res.Body, err
-		}
-
-		// Successful response, return the body ReadCloser
-		if res.StatusCode < 400 {
-			return res.Body, err
-		}
-
-		// Failure: try and parse the json of the response
-		// when logging the error
-		var resBody []byte
-		resBody, err = ioutil.ReadAll(res.Body)
-		res.Body.Close()
-		if err == nil {
-			err = s.ResponseToError(res, resBody)
-		} else {
-			s.logError(res.StatusCode, err)
-		}
-
-		return res.Body, err
+		return s.handleResponseBufferingErrors(res, err)
 	}
 
 	resp, result, requestDuration, err := s.requestWithRetriesAndTelemetry(req, body, handleResponse)
@@ -1494,4 +1568,11 @@ func normalizeURL(url string) string {
 	url = strings.TrimSuffix(url, "/v1")
 
 	return url
+}
+
+func RawRequest(method, path string, content string, params *RawParams) (*APIResponse, error) {
+	if bi, ok := GetBackend(APIBackend).(RawRequestBackend); ok {
+		return bi.RawRequest(method, path, Key, content, params)
+	}
+	return nil, fmt.Errorf("Error: cannot call RawRequest if backends.API is initialized with a backend that doesn't implement RawRequestBackend")
 }

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -549,7 +549,7 @@ func TestCall_TelemetryEnabled(t *testing.T) {
 	params.InternalSetUsage([]string{"llama", "bufo"})
 	for i := 0; i < 2; i++ {
 		var response testServerResponse
-		err := backend.Call("get", "/hello", "sk_test_xyz", params, &response)
+		err := backend.Call("GET", "/hello", "sk_test_xyz", params, &response)
 
 		assert.NoError(t, err)
 		assert.Equal(t, message, response.Message)

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -1312,13 +1312,13 @@ func TestRawRequestPreviewPost(t *testing.T) {
 		Object string `json:"object"`
 		XYZ    MyXYZ  `json:"xyz"`
 	}
-	params := &RawParams{Params: Params{}, APIMode: V2APIMode}
-	response, err := backend.RawRequest(http.MethodPost, "/v1/abcs", "sk_test_xyz", `{"foo":"myFoo","bar":{"baz":false}}`, params)
+	params := &RawParams{Params: Params{}}
+	response, err := backend.RawRequest(http.MethodPost, "/v2/abcs", "sk_test_xyz", `{"foo":"myFoo","bar":{"baz":false}}`, params)
 	assert.NoError(t, err)
 	myABC := &MyABC{}
 	assert.Nil(t, params.Headers)
 	assert.Equal(t, `{"foo":"myFoo","bar":{"baz":false}}`, body)
-	assert.Equal(t, `/v1/abcs`, path)
+	assert.Equal(t, `/v2/abcs`, path)
 	assert.Equal(t, `POST`, method)
 	assert.Equal(t, `application/json`, contentType)
 	// assert.Equal(t, previewVersion, stripeVersion)
@@ -1430,11 +1430,11 @@ func TestRawRequestPreviewGet(t *testing.T) {
 		},
 	).(*BackendImplementation)
 
-	params := &RawParams{Params: Params{}, APIMode: V2APIMode}
-	_, err := backend.RawRequest(http.MethodGet, "/v1/abc?foo=myFoo", "sk_test_xyz", ``, params)
+	params := &RawParams{Params: Params{}}
+	_, err := backend.RawRequest(http.MethodGet, "/v2/abc?foo=myFoo", "sk_test_xyz", ``, params)
 	assert.NoError(t, err)
 	assert.Equal(t, ``, body)
-	assert.Equal(t, `/v1/abc?foo=myFoo`, path)
+	assert.Equal(t, `/v2/abc?foo=myFoo`, path)
 	assert.Equal(t, `GET`, method)
 	assert.Equal(t, `application/json`, contentType)
 	// assert.Equal(t, previewVersion, stripeVersion)
@@ -1473,12 +1473,12 @@ func TestRawRequestWithAdditionalHeaders(t *testing.T) {
 
 	headers := http.Header{}
 	headers.Set("foo", "bar")
-	params := &RawParams{Params: Params{Headers: headers}, APIMode: V2APIMode, StripeContext: "acct_123"}
+	params := &RawParams{Params: Params{Headers: headers}, StripeContext: "acct_123"}
 
-	_, err := backend.RawRequest(http.MethodPost, "/v1/abc", "sk_test_xyz", `{"foo":"myFoo"}`, params)
+	_, err := backend.RawRequest(http.MethodPost, "/v2/abc", "sk_test_xyz", `{"foo":"myFoo"}`, params)
 	assert.NoError(t, err)
 	assert.Equal(t, `{"foo":"myFoo"}`, body)
-	assert.Equal(t, `/v1/abc`, path)
+	assert.Equal(t, `/v2/abc`, path)
 	assert.Equal(t, `POST`, method)
 	assert.Equal(t, `application/json`, contentType)
 	assert.Equal(t, `bar`, fooHeader)


### PR DESCRIPTION
### Why?

As the v2 API is releasing soon, we want Go to be able to make requests against the new endpoints despite not having generated types.

### What

This is a copy/paste of https://github.com/stripe/stripe-go/pull/1648 with a few key differences:

- updated README with a more modern example
- changed the `APIMode` constants from `"preview"` and `"standard"` to `"v1"` and `"v2"`
- ❗inferred API mode from path prefix instead of letting user specify it
- removed some assertions in tests that cared about the API version

Because we no longer needed to supply default values for API mode, I could remove the function that handled that.  I also adjusted tests that assumed you could set `content-type` and `v1` / `v2` independently (given that all v1 requests are form encoded and all v2 request are json).

### Manual Testing

1. Create a new folder, henceforth `myfolder`
2. In `myfolder/go.mod`, paste:

```go
module xavd.id/test/v2

go 1.22.4

require github.com/stripe/stripe-go/v79 v79.0.0
// may need to adjust this relative path for your filesystem:
replace github.com/stripe/stripe-go/v79 v79.0.0 => ../../../stripe-go
```

3. In `myfolder/main.go` paste:

```go
package main

import (
	"encoding/json"
	"fmt"

	"github.com/stripe/stripe-go/v79"
	"github.com/stripe/stripe-go/v79/form"
	"github.com/stripe/stripe-go/v79/rawrequest"
)

func do_thing() error {
	stripe.Key = "sk_test_..."

	payload := map[string]interface{}{
		"event_name": "hotdogs_eaten", // FIXME
		"payload": map[string]string{
			"value":              "123", 
			"stripe_customer_id": "cus_Quq8itmW58RMet", // FIXME
		},
	}

	// for a v2 request, json encode the payload
	body, err := json.Marshal(payload)
	if err != nil {
		return err
	}

	v2_resp, err := rawrequest.Post("/v2/billing/meter_events", string(body), nil)
	if err != nil {
		return err
	}

	var v2_response map[string]interface{}
	err = json.Unmarshal(v2_resp.RawJSON, &v2_response)
	if err != nil {
		return err
	}
	fmt.Printf("%#v\n", v2_response)

	// for a v1 request, form encode the payload
	formValues := &form.Values{}
	form.AppendTo(formValues, payload)
	content := formValues.Encode()

	v1_resp, err := rawrequest.Post("/v1/billing/meter_events", content, nil)
	if err != nil {
		return err
	}

	var v1_response map[string]interface{}
	err = json.Unmarshal(v1_resp.RawJSON, &v1_response)
	if err != nil {
		return err
	}
	fmt.Printf("%#v\n", v1_response)

	return nil
}

func main() {
	err := do_thing()
	if err != nil {
		fmt.Printf("Error: %s\n", err)
	}
}
```

Running that (with valid customer id and event name) should print 2 response bodies

### See Also

- [DEVSDK-2187](https://jira.corp.stripe.com/browse/DEVSDK-2187)