### PR TITLE
Remove  rawrequest Post, Get, and Delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,8 +627,8 @@ func make_raw_request() error {
 	return nil
 }
 
-See more examples in the [examples folder](examples/).
 ```
+See more examples in the [example folder](example/).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ func make_raw_request() error {
 }
 
 ```
-See more examples in the [example folder](example/).
+See more examples in the [/example/v2 folder](example/v2).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -574,6 +574,13 @@ import (
 func make_raw_request() error {
 	stripe.Key = "sk_test_123"
 
+	b, err := stripe.GetRawRequestBackend(stripe.APIBackend)
+	if err != nil {
+		return err
+	}
+
+	client := rawrequest.Client{B: b, Key: apiKey}
+
 	payload := map[string]interface{}{
 		"event_name": "hotdogs_eaten",
 		"payload": map[string]string{
@@ -588,7 +595,7 @@ func make_raw_request() error {
 		return err
 	}
 
-	v2_resp, err := rawrequest.Post("/v2/billing/meter_events", string(body), nil)
+	v2_resp, err := client.RawRequest(http.MethodPost, "/v2/billing/meter_events", string(body), nil)
 	if err != nil {
 		return err
 	}
@@ -605,7 +612,7 @@ func make_raw_request() error {
 	form.AppendTo(formValues, payload)
 	content := formValues.Encode()
 
-	v1_resp, err := rawrequest.Post("/v1/billing/meter_events", content, nil)
+	v1_resp, err := client.RawRequest(http.MethodPost, "/v1/billing/meter_events", content, nil)
 	if err != nil {
 		return err
 	}
@@ -619,6 +626,8 @@ func make_raw_request() error {
 
 	return nil
 }
+
+See more examples in the [examples folder](examples/).
 ```
 
 ## Support

--- a/rawrequest/client.go
+++ b/rawrequest/client.go
@@ -2,8 +2,6 @@
 package rawrequest
 
 import (
-	"net/http"
-
 	stripe "github.com/stripe/stripe-go/v80"
 )
 
@@ -15,16 +13,4 @@ type Client struct {
 
 func (c Client) RawRequest(method string, path string, content string, params *stripe.RawParams) (*stripe.APIResponse, error) {
 	return c.B.RawRequest(method, path, c.Key, content, params)
-}
-
-func Get(path string, params *stripe.RawParams) (*stripe.APIResponse, error) {
-	return stripe.RawRequest(http.MethodGet, path, "", params)
-}
-
-func Post(path, content string, params *stripe.RawParams) (*stripe.APIResponse, error) {
-	return stripe.RawRequest(http.MethodPost, path, content, params)
-}
-
-func Delete(path string, params *stripe.RawParams) (*stripe.APIResponse, error) {
-	return stripe.RawRequest(http.MethodDelete, path, "", params)
 }


### PR DESCRIPTION
### Why?
The `rawrequests` functions for Post, Get, and Delete methods rely on global configuration which can be cumbersome when using these methods to call `/v2/` APIs. Instead, the recommendation is to use the client model (introduced in https://github.com/stripe/stripe-go/pull/1929) which allows local configuration of backend and api key, which enables more flexible calls to new/preview/unsupported APIs.  

### What?
- removes rawrequest `Post`, `Get`, and `Delete`
- updates tests
- updates README.md

### See also
This is a follow up to https://github.com/stripe/stripe-go/pull/1929

## Changelog

The individual `rawrequests` functions for Post, Get, and Delete methods are removed in favor of the client model which allows local configuration of backend and api key, which enables more flexible calls to new/preview/unsupported APIs. 