### PR TITLE
Added comments to v2 examples

### DIFF
--- a/example/v2/meter_event_stream/meter_event_stream.go
+++ b/example/v2/meter_event_stream/meter_event_stream.go
@@ -1,3 +1,14 @@
+// meter_event_stream.go - use the high-throughput meter event stream to report create billing meter events.
+//
+// This example uses the rawrequests module to make calls to /v2 APIs.
+//
+// In this example, we:
+//   - create a meter event session and store the session's authentication token
+//   - define an event with a payload
+//   - post the event to /v2/billing/meter_event_stream to create an event stream that reports this event
+//
+// This example expects a billing meter with an event_name of 'alpaca_ai_tokens'.  If you have
+// a different meter event name, you can change it before running this example.
 package main
 
 import (
@@ -92,7 +103,7 @@ func main() {
 
 	client := rawrequest.Client{B: b, Key: apiKey}
 
-	err = sendMeterEvent(client, "api_requests", customerID, "25")
+	err = sendMeterEvent(client, "alpaca_ai_tokens", customerID, "25")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/example/v2/thinevent_webhook_handler/thinevent_webhook_handler.go
+++ b/example/v2/thinevent_webhook_handler/thinevent_webhook_handler.go
@@ -1,3 +1,14 @@
+// thinevent_webhook_handler.go - receive and process thin events like the
+// v1.billing.meter.error_report_triggered event.
+//
+// This example uses the rawrequests module to make calls to /v2 APIs.
+//
+// In this example, we:
+//   - parse the incoming thin event payload and get the event id
+//   - get the full event from /v2/core/events/ with the event id from the thin event
+//   - if the full event is a v1.billing.meter.error_report_triggered, use the
+//     billing/meter package to retrieve the Billing Meter object associated with the
+//     event.
 package main
 
 import (


### PR DESCRIPTION
### Why?
In our recent SDK release we added a couple new examples along with a template to make it easy for us to create new examples.  Our documentation around examples was lacking.  This PR adds comments to explain each new example.

### What?
- added comment to meter_event_stream.go describing the example, and changed the event_name to match documentation
- added comment to thinevent_webhook_handler.go describing the example
