### PR TITLE
make optional event attributes optional

### DIFF
--- a/event.go
+++ b/event.go
@@ -297,7 +297,7 @@ type EventData struct {
 	// Object containing the API resource relevant to the event. For example, an `invoice.created` event will have a full [invoice object](https://stripe.com/docs/api#invoice_object) as the value of the object key.
 	Object map[string]interface{} `json:"-"`
 	// Object containing the names of the updated attributes and their values prior to the event (only included in events of type `*.updated`). If an array attribute has any updated elements, this object contains the entire array. In Stripe API versions 2017-04-06 or earlier, an updated array attribute in this object includes only the updated array elements.
-	PreviousAttributes map[string]interface{} `json:"previous_attributes"`
+	PreviousAttributes map[string]interface{} `json:"previous_attributes,omitempty"`
 	Raw                json.RawMessage        `json:"object"`
 }
 
@@ -348,7 +348,7 @@ type EventRequest struct {
 type Event struct {
 	APIResource
 	// The connected account that originates the event.
-	Account string `json:"account"`
+	Account string `json:"account,omitempty"`
 	// The Stripe API version used to render `data`. This property is populated only for events on or after October 31, 2014.
 	APIVersion string `json:"api_version"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.

--- a/event_test.go
+++ b/event_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"encoding/json"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -52,4 +53,45 @@ func TestGetObjectValue(t *testing.T) {
 	assert.PanicsWithValue(t, "Cannot descend into non-map non-slice object with key: bad_key", func() {
 		event.GetObjectValue("top_level_key", "bad_key")
 	})
+}
+
+func TestEmptyOptionalFields(t *testing.T) {
+
+	// Marshals from a JSON object - without optional attributes
+	{
+		v := Event{}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		expected := `{"api_version":"","created":0,"data":null,"id":"","livemode":false,"object":"","pending_webhooks":0,"request":null,"type":""}`
+		assert.Equal(t, expected, string(data))
+	}
+
+	// Marshals from a JSON object - with empty optional attributes
+	{
+		v := Event{Account: "", Data: &EventData{PreviousAttributes: map[string]interface{}{}}}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		expected := `{"api_version":"","created":0,"data":{"object":null},"id":"","livemode":false,"object":"","pending_webhooks":0,"request":null,"type":""}`
+		assert.Equal(t, expected, string(data))
+	}
+
+	// Marshals from a JSON object - with filled account attribute
+	{
+		v := Event{
+			Account: "",
+			Data: &EventData{
+				PreviousAttributes: map[string]interface{}{
+					"amount_paid": 0,
+				},
+			},
+		}
+		data, err := json.Marshal(&v)
+		assert.NoError(t, err)
+
+		expected := `{"api_version":"","created":0,"data":{"previous_attributes":{"amount_paid":0},"object":null},"id":"","livemode":false,"object":"","pending_webhooks":0,"request":null,"type":""}`
+		assert.Equal(t, expected, string(data))
+	}
+
 }


### PR DESCRIPTION
When my API receives a webhook request from Stripe via the CLI, I get the error `expected required property account to be present` and the location attribute is: `body`. After creating a manual request with the same body and adding the 'account' attribute (which is an empty string), I got the same error for the 'previous_attributes' attribute in the 'body.data' location. After adding that element as well, it worked.

I checked the stripe docs, I saw that the `account' attribute is a `nullable string'. The `previous_attributes` is a `nullable map`. However, the stripe-go-sdk considers these attributes to be required attributes.

[Stripe Docs - The Event object](https://docs.stripe.com/api/events/object)