### PR TITLE
Fixes Beta SDK url in go get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ We would love for you to try these and share feedback with us before these featu
 To install a beta version of stripe-go use the commit notation of the `go get` command to point to a beta tag:
 
 ```
-go get -u github.com/stripe/stripe-go/v80@v77.1.0-beta.1
+go get -u github.com/stripe/stripe-go/v80@beta
 ```
 
 > **Note**


### PR DESCRIPTION
### Why
A user may want to install the beta version of the Stripe Go SDK in order to access unreleased functionality.  The URL in the readme was incorrect after our latest release.  This PR updates it to use the branch name so that only the base version changes on each major release.

### What
- change specific beta version to "beta" in the beta go get url