### PR TITLE
Update webhook API version validation

### DIFF
--- a/webhook/client_test.go
+++ b/webhook/client_test.go
@@ -15,11 +15,25 @@ var testPayload = []byte(fmt.Sprintf(`{
   "object": "event",
   "api_version": "%s"
 }`, stripe.APIVersion))
+
+var testPayloadWithNewVersionInReleaseTrain = []byte(fmt.Sprintf(`{
+	"id": "evt_test_webhook",
+	"object": "event",
+	"api_version": "%s"
+  }`, "2099-10-10."+strings.Split(stripe.APIVersion, ".")[1]))
+
 var testPayloadWithAPIVersionMismatch = []byte(`{
 	"id": "evt_test_webhook",
 	"object": "event",
 	"api_version": "2020-01-01"
   }`)
+
+var testPayloadWithReleaseTrainVersionMismatch = []byte(`{
+	"id": "evt_test_webhook",
+	"object": "event",
+	"api_version": "2099-10-10.the_larch"
+  }`)
+
 var testSecret = "whsec_test_secret"
 
 func newSignedPayload(options ...func(*SignedPayload)) *SignedPayload {
@@ -179,7 +193,39 @@ func TestTokenNew(t *testing.T) {
 	}
 }
 
-func TestConstructEvent_ErrorOnAPIVersionMismatch(t *testing.T) {
+func TestConstructEvent_SuccessOnExpectedAPIVersion(t *testing.T) {
+	p := newSignedPayload(func(p *SignedPayload) {
+		p.Payload = testPayload
+	})
+
+	evt, err := ConstructEvent(p.Payload, p.Header, p.Secret)
+
+	if err != nil {
+		t.Errorf("Unexpected error in ConstructEvent: %v", err)
+	}
+
+	if evt.APIVersion != stripe.APIVersion {
+		t.Errorf("Expected API versions to match")
+	}
+}
+
+func TestConstructEvent_SuccessOnNewAPIVersionInExpectedReleaseTrain(t *testing.T) {
+	p := newSignedPayload(func(p *SignedPayload) {
+		p.Payload = testPayloadWithNewVersionInReleaseTrain
+	})
+
+	evt, err := ConstructEvent(p.Payload, p.Header, p.Secret)
+
+	if err != nil {
+		t.Errorf("Unexpected error in ConstructEvent: %v", err)
+	}
+
+	expectedSuffix := "." + strings.Split(stripe.APIVersion, ".")[1]
+	if !strings.HasSuffix(evt.APIVersion, expectedSuffix) {
+		t.Errorf("Expected API release trains to match")
+	}
+}
+func TestConstructEvent_ErrorOnLegacyAPIVersionMismatch(t *testing.T) {
 	p := newSignedPayload(func(p *SignedPayload) {
 		p.Payload = testPayloadWithAPIVersionMismatch
 	})
@@ -195,6 +241,21 @@ func TestConstructEvent_ErrorOnAPIVersionMismatch(t *testing.T) {
 	}
 }
 
+func TestConstructEvent_ErrorOnReleaseTrainMismatch(t *testing.T) {
+	p := newSignedPayload(func(p *SignedPayload) {
+		p.Payload = testPayloadWithReleaseTrainVersionMismatch
+	})
+
+	_, err := ConstructEvent(p.Payload, p.Header, p.Secret)
+
+	if err == nil {
+		t.Errorf("Expected error due to API version mismatch.")
+	}
+
+	if !strings.Contains(err.Error(), "Received event with API version") {
+		t.Errorf("Expected API version mismatch error but received %v", err)
+	}
+}
 func TestConstructEventWithOptions_IgnoreAPIVersionMismatch(t *testing.T) {
 
 	p := newSignedPayload(func(p *SignedPayload) {


### PR DESCRIPTION
### Why
[Stripe API versions now contain two parts](https://stripe.com/blog/introducing-stripes-new-api-release-process): a date part (as before) and an identifier.  The SDKs validate that webhook events received are in the shape expected by the pinned version in the SDK but going forward, that will be true for different versions with the same identifier.  For example, the September API release was 2024-09-30.acacia, and we expect that webhook events sent with version 2024-09-30.acacia will be compatible with an SDK pinned to 2025-10-28.acacia.  This PR updates the version checking logic to make sure we don't reject webhook events incorrectly.

### What
- replaced api version check in webhook/client with isCompatibleApiVersion which will test if the release identifier of the webhook event matches the pinned version or return false for any event api version that does not have a release identifier
- updated tests to match

## Changelog
- Update webhook event processing to accept events from any API version within the supported major release