### PR TITLE
Do not allow setting API Version directly 

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ We would love for you to try these and share feedback with us before these featu
 To install a beta version of stripe-go use the commit notation of the `go get` command to point to a beta tag:
 
 ```
-go get -u github.com/stripe/stripe-go/v80@v77.1.0-beta.1
+go get -u github.com/stripe/stripe-go/v80@beta
 ```
 
 > **Note**

--- a/stripe.go
+++ b/stripe.go
@@ -36,6 +36,9 @@ const (
 	// APIURL is the URL of the API service backend.
 	APIURL string = "https://api.stripe.com"
 
+	// APIVersion is the currently supported API version
+	APIVersion string = apiVersion
+
 	// ClientVersion is the version of the stripe-go library being used.
 	ClientVersion string = clientversion
 
@@ -80,9 +83,6 @@ var EnableTelemetry = true
 
 // Key is the Stripe API key used globally in the binding.
 var Key string
-
-// APIVersion is the currently supported API version
-var APIVersion string = apiVersion
 
 //
 // Public types
@@ -556,7 +556,7 @@ func (s *BackendImplementation) NewRequest(method, path, key, contentType string
 
 	req.Header.Add("Authorization", authorization)
 	req.Header.Add("Content-Type", contentType)
-	req.Header.Add("Stripe-Version", APIVersion)
+	req.Header.Add("Stripe-Version", apiVersionWithBetaHeaders)
 	req.Header.Add("User-Agent", encodedUserAgent)
 	req.Header.Add("X-Stripe-Client-User-Agent", getEncodedStripeUserAgent())
 
@@ -1382,10 +1382,10 @@ func StringSlice(v []string) []*string {
 }
 
 func AddBetaVersion(betaName string, betaVersion string) error {
-	if strings.Contains(APIVersion, "; "+betaName+"=") {
-		return fmt.Errorf("Stripe version header %s already contains entry for beta %s", APIVersion, betaName)
+	if strings.Contains(apiVersionWithBetaHeaders, "; "+betaName+"=") {
+		return fmt.Errorf("Stripe version header %s already contains entry for beta %s", apiVersionWithBetaHeaders, betaName)
 	}
-	APIVersion = fmt.Sprintf("%s; %s=%s", APIVersion, betaName, betaVersion)
+	apiVersionWithBetaHeaders = fmt.Sprintf("%s; %s=%s", apiVersionWithBetaHeaders, betaName, betaVersion)
 	return nil
 }
 
@@ -1458,6 +1458,9 @@ var backends Backends
 var encodedStripeUserAgent string
 var encodedStripeUserAgentReady *sync.Once
 var encodedUserAgent string
+
+// API Version with beta headers if any
+var apiVersionWithBetaHeaders string = apiVersion
 
 // The default HTTP client used for communication with any of Stripe's
 // backends.

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -1552,7 +1552,7 @@ func TestRawRequestTelemetry(t *testing.T) {
 
 func TestAddBetaVersion(t *testing.T) {
 	AddBetaVersion("feature_beta", "v3")
-	expectedAPIVersion := APIVersion+"; feature_beta=v3"
+	expectedAPIVersion := APIVersion + "; feature_beta=v3"
 	assert.Equal(t, expectedAPIVersion, apiVersionWithBetaHeaders)
 	err := AddBetaVersion("feature_beta", "v3")
 	assert.Equal(t, "Stripe version header "+expectedAPIVersion+" already contains entry for beta feature_beta", err.Error())

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -57,9 +57,8 @@ func TestApiVersion(t *testing.T) {
 	assert.Equal(t, APIVersion, req.Header.Get("Stripe-Version"))
 }
 
-func TestCanSetApiVersion(t *testing.T) {
-	oldVersion := APIVersion
-	APIVersion = "12-23-2022; feature_in_beta=v3"
+func TestCanSetBetaHeaders(t *testing.T) {
+	AddBetaVersion("feature_in_beta", "v3")
 
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	key := "apiKey"
@@ -67,9 +66,10 @@ func TestCanSetApiVersion(t *testing.T) {
 	req, err := c.NewRequest("", "", key, "", nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "12-23-2022; feature_in_beta=v3", req.Header.Get("Stripe-Version"))
+	assert.Equal(t, APIVersion+"; feature_in_beta=v3", req.Header.Get("Stripe-Version"))
 
-	APIVersion = oldVersion
+	// clean up
+	apiVersionWithBetaHeaders = APIVersion
 }
 
 func TestContext(t *testing.T) {
@@ -1551,11 +1551,11 @@ func TestRawRequestTelemetry(t *testing.T) {
 }
 
 func TestAddBetaVersion(t *testing.T) {
-	APIVersion = "2024-02-26"
 	AddBetaVersion("feature_beta", "v3")
-	assert.Equal(t, "2024-02-26; feature_beta=v3", APIVersion)
+	expectedAPIVersion := APIVersion+"; feature_beta=v3"
+	assert.Equal(t, expectedAPIVersion, apiVersionWithBetaHeaders)
 	err := AddBetaVersion("feature_beta", "v3")
-	assert.Equal(t, "Stripe version header 2024-02-26; feature_beta=v3 already contains entry for beta feature_beta", err.Error())
+	assert.Equal(t, "Stripe version header "+expectedAPIVersion+" already contains entry for beta feature_beta", err.Error())
 }
 
 //

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -187,6 +187,20 @@ type signedHeader struct {
 // Private functions
 //
 
+func isCompatibleAPIVersion(eventApiVersion string) bool {
+	// If the event api version is from before we started adding
+	// a release train, there's no way its compatible with this
+	// version
+	if !strings.Contains(eventApiVersion, ".") {
+		return false
+	}
+
+	// versions are yyyy-MM-dd.train
+	var eventReleaseTrain = strings.Split(eventApiVersion, ".")[1]
+	var currentReleaseTrain = strings.Split(stripe.APIVersion, ".")[1]
+	return eventReleaseTrain == currentReleaseTrain
+}
+
 func constructEvent(payload []byte, sigHeader string, secret string, options ConstructEventOptions) (stripe.Event, error) {
 	e := stripe.Event{}
 
@@ -203,10 +217,8 @@ func constructEvent(payload []byte, sigHeader string, secret string, options Con
 		return e, fmt.Errorf("Failed to parse webhook body json: %s", err.Error())
 	}
 
-	trimmedVersion := trimApiVersion(stripe.APIVersion)
-
-	if !options.IgnoreAPIVersionMismatch && trimmedVersion != e.APIVersion {
-		return e, fmt.Errorf("Received event with API version %s, but stripe-go %s expects API version %s. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this error by using `ConstructEventWithOptions(..., ConstructEventOptions{..., ignoreAPIVersionMismatch: true})`  but be wary that objects may be incorrectly deserialized.", e.APIVersion, stripe.ClientVersion, trimmedVersion)
+	if !options.IgnoreAPIVersionMismatch && !isCompatibleAPIVersion(e.APIVersion) {
+		return e, fmt.Errorf("Received event with API version %s, but stripe-go %s expects API version %s. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this error by using `ConstructEventWithOptions(..., ConstructEventOptions{..., ignoreAPIVersionMismatch: true})`  but be wary that objects may be incorrectly deserialized.", e.APIVersion, stripe.ClientVersion, stripe.APIVersion)
 	}
 
 	return e, nil


### PR DESCRIPTION
## Why?

When we introduced beta SDKs, we allowed users to directly update the global configuration for API Version since they needed to pass beta headers in #1529. We soon realized that was not safe and was error prone if users didnt pass in the right format and so introduced a helper method in #1819 and advertised that as the right way of doing things in the README

Proper deserialization of classes from Events can be guaranteed only when the Webhook API version matches the API version used to generate the SDKs. Therefore, in this PR we are dropping the ability to directly update the API version.

## What?

- Resolving merge conflicts coming from running the auto merge tool after #1940
- Rename the public variable `APIVersion` to a private variable `apiVersionWithBetaHeaders` and add a new constant for `APIVersion`
- Updated tests

## Changelog
* `stripe.APIVersion` is no longer settable. If you were using this to set the beta headers, use the helper method `stripe.AddBetaVersion()` instead.

