### PR TITLE
Add tests for AddBetaVersion edge cases

### DIFF
--- a/stripe_test.go
+++ b/stripe_test.go
@@ -72,6 +72,34 @@ func TestCanSetBetaHeaders(t *testing.T) {
 	apiVersionWithBetaHeaders = APIVersion
 }
 
+func TestCannotSetSameBetaHeaderTwice(t *testing.T) {
+	err := AddBetaVersion("feature_in_beta", "v3")
+	assert.Nil(t, err)
+
+	err = AddBetaVersion("feature_in_beta", "v3")
+
+	assert.Contains(t, err.Error(), "already contains entry for beta feature_in_beta")
+
+	// clean up
+	apiVersionWithBetaHeaders = APIVersion
+}
+
+func TestCanSetSecondBetaHeaders(t *testing.T) {
+	AddBetaVersion("feature_in_beta", "v3")
+	AddBetaVersion("second_feature_in_beta", "v2")
+
+	c := GetBackend(APIBackend).(*BackendImplementation)
+	key := "apiKey"
+
+	req, err := c.NewRequest("", "", key, "", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, APIVersion+"; feature_in_beta=v3; second_feature_in_beta=v2", req.Header.Get("Stripe-Version"))
+
+	// clean up
+	apiVersionWithBetaHeaders = APIVersion
+}
+
 func TestContext(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	p := &Params{Context: context.Background()}


### PR DESCRIPTION
### Why
Follow up to https://github.com/stripe/stripe-go/pull/1941.  After fixing https://github.com/stripe/stripe-java/pull/1913, I double checked the other SDKs that were modified as part of that work.  The golang SDK is implemented correctly but it did not have unit tests for the edge cases in `AddBetaVersion`.  This PR implements the tests for these edge cases.

### What
- added tests to ensure AddBetaVersion returns an error when called with the same beta version twice, and allows AddBetaVersion to be called multiple times for different beta versions