### PR TITLE
add major version blurb to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## 81.0.0 - 2024-10-29
+
+While monthly releases within Stripe's [new API release schedule](https://stripe.com/blog/introducing-stripes-new-api-release-process) are compatible (and considered SEMVER minor), the we decided to ship `2024-10-28.acacia` as a SEMVER major. This ensures that everyone using `2024-09-30.acacia` on the `80.x.y` release line had access to [a bugfix for deserializing events from a different API release](https://github.com/stripe/stripe-go/pull/1940) (without having to update their API version). Going forward, we expect non-major API versions (e.g. the rest of the `Acacia` line) to be minor releases.
+
 * [#1931](https://github.com/stripe/stripe-go/pull/1931) This release changes the pinned API version to `2024-10-28.acacia`.
   * Add support for new resource `V2.EventDestinations`
   * Add support for `New`, `Retrieve`, `Update`, `List`, `Delete`, `Disable`, `Enable` and `Ping` methods on resource `V2.EventDestinations`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Historically, when upgrading webhooks to a new API version, you also had to upgrade your SDK version. Your webhook's API version needed to match the API version pinned by the SDK you were using to ensure successful deserialization of events. With the `2024-09-30.acacia` release, Stripe follows a [new API release process](https://stripe.com/blog/introducing-stripes-new-api-release-process). As a result, you can safely upgrade your webhook endpoints to any API version within a biannual release (like `acacia`) without upgrading the SDK.
 
-However, [a bug](https://github.com/stripe/stripe-go/pull/1940) in the `27.x.y` SDK releases meant that webhook version upgrades from the SDK's pinned `2024-09-30.acacia` version to the new `2024-10-28.acacia` version would fail. Therefore, we are shipping SDK support for `2024-10-28.acacia` as a major version to enforce the idea that an SDK upgrade is also required. Future API versions in the `acacia` line will be released as minor versions.
+However, [a bug](https://github.com/stripe/stripe-go/pull/1940) in the `80.x.y` SDK releases meant that webhook version upgrades from the SDK's pinned `2024-09-30.acacia` version to the new `2024-10-28.acacia` version would fail. Therefore, we are shipping SDK support for `2024-10-28.acacia` as a major version to enforce the idea that an SDK upgrade is also required. Future API versions in the `acacia` line will be released as minor versions.
 
 * [#1931](https://github.com/stripe/stripe-go/pull/1931) This release changes the pinned API version to `2024-10-28.acacia`.
   * Add support for new resource `V2.EventDestinations`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 81.0.0 - 2024-10-29
 
-While monthly releases within Stripe's [new API release schedule](https://stripe.com/blog/introducing-stripes-new-api-release-process) are compatible (and considered SEMVER minor), the we decided to ship `2024-10-28.acacia` as a SEMVER major. This ensures that everyone using `2024-09-30.acacia` on the `80.x.y` release line had access to [a bugfix for deserializing events from a different API release](https://github.com/stripe/stripe-go/pull/1940) (without having to update their API version). Going forward, we expect non-major API versions (e.g. the rest of the `Acacia` line) to be minor releases.
+Historically, when upgrading webhooks to a new API version, you also had to upgrade your SDK version. Your webhook's API version needed to match the API version pinned by the SDK you were using to ensure successful deserialization of events. With the `2024-09-30.acacia` release, Stripe follows a [new API release process](https://stripe.com/blog/introducing-stripes-new-api-release-process). As a result, you can safely upgrade your webhook endpoints to any API version within a biannual release (like `acacia`) without upgrading the SDK.
+
+However, [a bug](https://github.com/stripe/stripe-go/pull/1940) in the `27.x.y` SDK releases meant that webhook version upgrades from the SDK's pinned `2024-09-30.acacia` version to the new `2024-10-28.acacia` version would fail. Therefore, we are shipping SDK support for `2024-10-28.acacia` as a major version to enforce the idea that an SDK upgrade is also required. Future API versions in the `acacia` line will be released as minor versions.
 
 * [#1931](https://github.com/stripe/stripe-go/pull/1931) This release changes the pinned API version to `2024-10-28.acacia`.
   * Add support for new resource `V2.EventDestinations`


### PR DESCRIPTION
We released this API version as a major instead of a minor, so we're adding and explanation as to why.