### PR TITLE
add justfile, update readme, remove coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@master
 
       - name: Setup go
@@ -34,42 +35,33 @@ jobs:
 
       - name: lint
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.4.7 &&
-          go install golang.org/x/tools/cmd/goimports@v0.24.0 &&
-          $HOME/go/bin/staticcheck &&
-          make vet &&
-          make check-gofmt
+          just lint format-check
 
   test:
-     runs-on: ubuntu-latest
-     strategy:
-       matrix:
-         go:
-           - "1.23"
-           - "1.22"
-           - "1.21"
-           - "1.20"
-           - "1.19"
-           - "1.18"
-           - "1.17"
-           - "1.16"
-           - "1.15"
-     name: "Test: go v${{ matrix.go }}"
-     steps:
-       - uses: actions/checkout@v2
-       - name: Setup go
-         uses: actions/setup-go@v1
-         with:
-           go-version: ${{ matrix.go }}
-       - uses: stripe/openapi/actions/stripe-mock@master
-       - name: Test
-         run: make ci-test
-       - name: Coveralls
-         run: make coverage && make coveralls
-         if: matrix.go == '1.16'
-         env:
-           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           COVERALLS_FLAG_NAME: Go-${{ matrix.go }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - "1.23"
+          - "1.22"
+          - "1.21"
+          - "1.20"
+          - "1.19"
+          - "1.18"
+          - "1.17"
+          - "1.16"
+          - "1.15"
+    name: "Test: go v${{ matrix.go }}"
+    steps:
+      - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+      - uses: stripe/openapi/actions/stripe-mock@master
+      - name: Test
+        run: just ci-test
 
   publish:
     name: Publish

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# NOTE: this file is deprecated and slated for deletion; prefer using the equivalent `just` commands.
+
 all: test bench vet lint check-api-clients check-gofmt ci-test
 
 bench:
@@ -43,7 +45,7 @@ codegen-format: normalize-imports
 	go install golang.org/x/tools/cmd/goimports@v0.24.0 && goimports -w example/generated_examples_test.go
 
 CURRENT_MAJOR_VERSION := $(shell cat VERSION | sed 's/\..*//')
-normalize-imports:	
+normalize-imports:
 	@perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v$(CURRENT_MAJOR_VERSION)|' go.mod
 	@find . -name '*.go' -exec perl -pi -e 's|github.com/stripe/stripe-go/(v\d+\|\[MAJOR_VERSION\])|github.com/stripe/stripe-go/v$(CURRENT_MAJOR_VERSION)|' {} +
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/stripe/stripe-go)](https://pkg.go.dev/github.com/stripe/stripe-go/v81)
 [![Build Status](https://github.com/stripe/stripe-go/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-go/actions/workflows/ci.yml?query=branch%3Amaster)
-[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-go/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-go?branch=master)
 
 The official [Stripe][stripe] Go client library.
 
@@ -628,6 +627,7 @@ func make_raw_request() error {
 }
 
 ```
+
 See more examples in the [/example/v2 folder](example/v2).
 
 ## Support
@@ -641,19 +641,13 @@ the following guidelines in mind:
 
 1. Code must be `go fmt` compliant.
 2. All types, structs and funcs should be documented.
-3. Ensure that `make test` succeeds.
+3. Ensure that `just test` succeeds.
 
 ## Test
 
-The test suite needs testify's `require` package to run:
+We use [just](https://github.com/casey/just) for conveniently running development tasks. You can use them directly, or copy the commands out of the `justfile`. To our help docs, run `just`.
 
-    github.com/stretchr/testify/require
-
-Before running the tests, make sure to grab all of the package's dependencies:
-
-    go get -t -v
-
-It also depends on [stripe-mock][stripe-mock], so make sure to fetch and run it from a
+This package depends on [stripe-mock][stripe-mock], so make sure to fetch and run it from a
 background terminal ([stripe-mock's README][stripe-mock-usage] also contains
 instructions for installing via Homebrew and other methods):
 
@@ -662,15 +656,15 @@ instructions for installing via Homebrew and other methods):
 
 Run all tests:
 
-    make test
+    just test
 
 Run tests for one package:
 
-    go test ./invoice
+    just test ./invoice
 
 Run a single test:
 
-    go test ./invoice -run TestInvoiceGet
+    just test ./invoice -run TestInvoiceGet
 
 For any requests, bug or comments, please [open an issue][issues] or [submit a
 pull request][pulls].

--- a/README.md
+++ b/README.md
@@ -656,15 +656,24 @@ instructions for installing via Homebrew and other methods):
 
 Run all tests:
 
-    just test
+```sh
+just test
+# or: go test ./...
+```
 
 Run tests for one package:
 
-    just test ./invoice
+```sh
+just test ./invoice
+# or: go test ./invoice
+```
 
 Run a single test:
 
-    just test ./invoice -run TestInvoiceGet
+```sh
+just test ./invoice -run TestInvoiceGet
+# or: go test ./invoice -run TestInvoiceGet
+```
 
 For any requests, bug or comments, please [open an issue][issues] or [submit a
 pull request][pulls].

--- a/justfile
+++ b/justfile
@@ -3,10 +3,9 @@ set quiet
 import? '../sdk-codegen/justfile'
 
 # ensure tools installed with `go install` are available to call
-export PATH := `go env GOBIN` + ":" + env('PATH')
+export PATH := home_directory() + "/go/bin:" + env('PATH')
 
 _default:
-    echo {{ PATH }}
     just --list --unsorted
 
 # ⭐ run all unit tests, or pass a package name (./invoice) to only run those tests
@@ -15,9 +14,6 @@ test *args="./...":
 
 # check for potential mistakes (slow)
 lint: install
-    echo $PATH
-    go env GOBIN
-    ls $HOME/go/bin
     go vet ./...
     staticcheck
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,62 @@
+set quiet
+
+import? '../sdk-codegen/justfile'
+
+_default:
+    just --list --unsorted
+
+# ⭐ run all unit tests, or pass a package name (./invoice) to only run those tests
+test *args="./...":
+    go run scripts/test_with_stripe_mock/main.go -race {{ args }}
+
+# check for potential mistakes (slow)
+lint: install
+    go vet ./...
+    staticcheck
+
+# ⭐ format all files
+format: install
+    scripts/gofmt.sh
+    goimports -w example/generated_examples_test.go
+
+# verify, but don't modify, the formatting of the files
+format-check:
+    scripts/gofmt.sh check
+
+# ensures all client structs are properly registered
+check-api-clients:
+    go run scripts/check_api_clients/main.go
+
+ci-test: test bench check-api-clients
+
+# compile the project
+build:
+    go build ./...
+
+# install dependencies (including those needed for development). Mostly called by other recipes
+install:
+    go get
+    go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
+    go install golang.org/x/tools/cmd/goimports@v0.24.0
+
+# run benchmarking to check for performance regressions
+bench:
+    go test -race -bench . -run "Benchmark" ./form
+
+# called by tooling. It updates the package version in the `VERSION` file and `stripe.go`
+[private]
+update-version version: && _normalize-imports
+    echo "{{ version }}" > VERSION
+    perl -pi -e 's|const clientversion = "[.\d\-\w]+"|const clientversion = "{{ version }}"|' stripe.go
+
+# go imports use the package's major version in the path, so we need to update them
+# we also generate files with a placeholder `[MAJOR_VERSION]` that we need to replace
+# we can pull the major version out of the `VERSION` file
+# NOTE: because we run this _after_ other recipes that modify `VERSION`, it's important that we only read the file in the argument evaluation
+# (if it's a top-level variable, it's read when the file is parsed, which is too early)
+# arguments are only evaluated when the recipe starts
+# so, setting it as the default means we get both the variable and the lazy evaluation we need
+_normalize-imports major_version=replace_regex(`cat VERSION`, '\..*', ""):
+    perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v{{ major_version }}|' README.md
+    perl -pi -e 's|github.com/stripe/stripe-go/v\d+|github.com/stripe/stripe-go/v{{ major_version }}|' go.mod
+    find . -name '*.go' -exec perl -pi -e 's|github.com/stripe/stripe-go/(v\d+\|\[MAJOR_VERSION\])|github.com/stripe/stripe-go/v{{ major_version }}|' {} +

--- a/justfile
+++ b/justfile
@@ -15,6 +15,9 @@ test *args="./...":
 
 # check for potential mistakes (slow)
 lint: install
+    echo $PATH
+    go env GOBIN
+    ls $HOME/go/bin
     go vet ./...
     staticcheck
 

--- a/justfile
+++ b/justfile
@@ -2,7 +2,11 @@ set quiet
 
 import? '../sdk-codegen/justfile'
 
+# ensure tools installed with `go install` are available to call
+export PATH := `go env GOBIN` + ":" + env('PATH')
+
 _default:
+    echo {{ PATH }}
     just --list --unsorted
 
 # ⭐ run all unit tests, or pass a package name (./invoice) to only run those tests
@@ -15,7 +19,7 @@ lint: install
     staticcheck
 
 # ⭐ format all files
-format: install
+format: install && _normalize-imports
     scripts/gofmt.sh
     goimports -w example/generated_examples_test.go
 

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 set quiet
 
-import? '../sdk-codegen/justfile'
+import? '../sdk-codegen/utils.just'
 
 # ensure tools installed with `go install` are available to call
 export PATH := home_directory() + "/go/bin:" + env('PATH')
@@ -38,7 +38,7 @@ build:
 
 # install dependencies (including those needed for development). Mostly called by other recipes
 install:
-    go get
+    go get -t
     go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
     go install golang.org/x/tools/cmd/goimports@v0.24.0
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In an effort to modernize and simplify our local tooling, we're moving our dev commands from makefiles to [justfiles](https://github.com/casey/just). This is intended to be mostly a drop-in replacement, but some command names may change per standardization efforts.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add justfile
- tweak CI to use justfile
- remove coveralls from CI

### See Also
<!-- Include any links or additional information that help explain this change. -->

[DEVSDK-2325](https://go/j/DEVSDK-2325)