### PR TITLE
pin CI and fix formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   lint:
     name: Lint
 
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
 
     steps:
       - uses: extractions/setup-just@v2
@@ -38,7 +38,7 @@ jobs:
           just lint format-check
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     strategy:
       matrix:
         go:
@@ -69,7 +69,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' || github.event_name == 'push') &&
       startsWith(github.ref, 'refs/tags/v') &&
       endsWith(github.actor, '-stripe')
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: actions/checkout@v2
       - uses: stripe/openapi/actions/notify-release@master

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -3070,19 +3070,6 @@ func TestTerminalReadersProcessPaymentIntentPost(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestTerminalReadersProcessSetupIntentPost(t *testing.T) {
-	params := &stripe.TerminalReaderProcessSetupIntentParams{
-		SetupIntent:    stripe.String("seti_xxxxxxxxxxxxx"),
-		AllowRedisplay: stripe.String("always"),
-	}
-	result, err := terminal_reader.ProcessSetupIntent(
-		"tmr_xxxxxxxxxxxxx",
-		params,
-	)
-	assert.NotNil(t, result)
-	assert.Nil(t, err)
-}
-
 func TestTestHelpersCustomersFundCashBalancePost(t *testing.T) {
 	params := &stripe.TestHelpersCustomerFundCashBalanceParams{
 		Amount:   stripe.Int64(30),

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -3070,6 +3070,19 @@ func TestTerminalReadersProcessPaymentIntentPost(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestTerminalReadersProcessSetupIntentPost(t *testing.T) {
+	params := &stripe.TerminalReaderProcessSetupIntentParams{
+		SetupIntent:    stripe.String("seti_xxxxxxxxxxxxx"),
+		AllowRedisplay: stripe.String("always"),
+	}
+	result, err := terminal_reader.ProcessSetupIntent(
+		"tmr_xxxxxxxxxxxxx",
+		params,
+	)
+	assert.NotNil(t, result)
+	assert.Nil(t, err)
+}
+
 func TestTestHelpersCustomersFundCashBalancePost(t *testing.T) {
 	params := &stripe.TestHelpersCustomerFundCashBalanceParams{
 		Amount:   stripe.Int64(30),

--- a/justfile
+++ b/justfile
@@ -17,8 +17,9 @@ lint: install
     go vet ./...
     staticcheck
 
+# don't depend on `install` in this step! Before formatting, our `go` code isn't syntactically valid
 # ⭐ format all files
-format: install && _normalize-imports
+format: && _normalize-imports
     scripts/gofmt.sh
     goimports -w example/generated_examples_test.go
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We want to pin our CI ubuntu version to the latest possible so it doesn't auto-update on us, but we stay current ish.

We also fix a bug in generating the SDK where we install too early.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- pin ubuntu version in CI
- fix `just format` bug

### See Also
<!-- Include any links or additional information that help explain this change. -->
