### PR TITLE
Support time.Time instead of int64 for date fields

### DIFF
--- a/account.go
+++ b/account.go
@@ -9,6 +9,7 @@ package stripe
 import (
 	"encoding/json"
 	"github.com/stripe/stripe-go/v81/form"
+	"time"
 )
 
 // The business type. After you create an [Account Link](https://stripe.com/api/account_links) or [Account Session](https://stripe.com/api/account_sessions), this property is only returned for accounts where [controller.requirement_collection](https://stripe.com/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
@@ -935,7 +936,7 @@ type AccountCompanyAddressKanjiParams struct {
 // This hash is used to attest that the directors information provided to Stripe is both current and correct.
 type AccountCompanyDirectorshipDeclarationParams struct {
 	// The Unix timestamp marking when the directorship declaration attestation was made.
-	Date *int64 `form:"date"`
+	Date *time.Time `form:"date"`
 	// The IP address from which the directorship declaration attestation was made.
 	IP *string `form:"ip"`
 	// The user agent of the browser from which the directorship declaration attestation was made.
@@ -945,7 +946,7 @@ type AccountCompanyDirectorshipDeclarationParams struct {
 // This hash is used to attest that the beneficial owner information provided to Stripe is both current and correct.
 type AccountCompanyOwnershipDeclarationParams struct {
 	// The Unix timestamp marking when the beneficial owner attestation was made.
-	Date *int64 `form:"date"`
+	Date *time.Time `form:"date"`
 	// The IP address from which the beneficial owner attestation was made.
 	IP *string `form:"ip"`
 	// The user agent of the browser from which the beneficial owner attestation was made.
@@ -1180,7 +1181,7 @@ type AccountSettingsCapitalParams struct {
 // Details on the account's acceptance of the [Stripe Issuing Terms and Disclosures](https://stripe.com/issuing/connect/tos_acceptance).
 type AccountSettingsCardIssuingTOSAcceptanceParams struct {
 	// The Unix timestamp marking when the account representative accepted the service agreement.
-	Date *int64 `form:"date"`
+	Date *time.Time `form:"date"`
 	// The IP address from which the account representative accepted the service agreement.
 	IP *string `form:"ip"`
 	// The user agent of the browser from which the account representative accepted the service agreement.
@@ -1268,7 +1269,7 @@ type AccountSettingsTaxFormsParams struct {
 // Details on the account's acceptance of the Stripe Treasury Services Agreement.
 type AccountSettingsTreasuryTOSAcceptanceParams struct {
 	// The Unix timestamp marking when the account representative accepted the service agreement.
-	Date *int64 `form:"date"`
+	Date *time.Time `form:"date"`
 	// The IP address from which the account representative accepted the service agreement.
 	IP *string `form:"ip"`
 	// The user agent of the browser from which the account representative accepted the service agreement.
@@ -1310,7 +1311,7 @@ type AccountSettingsParams struct {
 // Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/connect/updating-accounts#tos-acceptance). This property can only be updated for accounts where [controller.requirement_collection](https://stripe.com/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts. This property defaults to a `full` service agreement when empty.
 type AccountTOSAcceptanceParams struct {
 	// The Unix timestamp marking when the account representative accepted their service agreement.
-	Date *int64 `form:"date"`
+	Date *time.Time `form:"date"`
 	// The IP address from which the account representative accepted their service agreement.
 	IP *string `form:"ip"`
 	// The user's service agreement type.
@@ -1617,7 +1618,7 @@ type AccountCompanyAddressKanji struct {
 // This hash is used to attest that the director information provided to Stripe is both current and correct.
 type AccountCompanyDirectorshipDeclaration struct {
 	// The Unix timestamp marking when the directorship declaration attestation was made.
-	Date int64 `json:"date"`
+	Date time.Time `json:"date"`
 	// The IP address from which the directorship declaration attestation was made.
 	IP string `json:"ip"`
 	// The user-agent string from the browser where the directorship declaration attestation was made.
@@ -1627,7 +1628,7 @@ type AccountCompanyDirectorshipDeclaration struct {
 // This hash is used to attest that the beneficial owner information provided to Stripe is both current and correct.
 type AccountCompanyOwnershipDeclaration struct {
 	// The Unix timestamp marking when the beneficial owner attestation was made.
-	Date int64 `json:"date"`
+	Date time.Time `json:"date"`
 	// The IP address from which the beneficial owner attestation was made.
 	IP string `json:"ip"`
 	// The user-agent string from the browser where the beneficial owner attestation was made.
@@ -1747,7 +1748,7 @@ type AccountFutureRequirements struct {
 	// Fields that are due and can be satisfied by providing the corresponding alternative fields instead.
 	Alternatives []*AccountFutureRequirementsAlternative `json:"alternatives"`
 	// Date on which `future_requirements` becomes the main `requirements` hash and `future_requirements` becomes empty. After the transition, `currently_due` requirements may immediately become `past_due`, but the account may also be given a grace period depending on its enablement state prior to transitioning.
-	CurrentDeadline int64 `json:"current_deadline"`
+	CurrentDeadline time.Time `json:"current_deadline"`
 	// Fields that need to be collected to keep the account enabled. If not collected by `future_requirements[current_deadline]`, these fields will transition to the main `requirements` hash.
 	CurrentlyDue []string `json:"currently_due"`
 	// This is typed as an enum for consistency with `requirements.disabled_reason`.
@@ -1789,7 +1790,7 @@ type AccountRequirements struct {
 	// Fields that are due and can be satisfied by providing the corresponding alternative fields instead.
 	Alternatives []*AccountRequirementsAlternative `json:"alternatives"`
 	// Date by which the fields in `currently_due` must be collected to keep the account enabled. These fields may disable the account sooner if the next threshold is reached before they are collected.
-	CurrentDeadline int64 `json:"current_deadline"`
+	CurrentDeadline time.Time `json:"current_deadline"`
 	// Fields that need to be collected to keep the account enabled. If not collected by `current_deadline`, these fields appear in `past_due` as well, and the account is disabled.
 	CurrentlyDue []string `json:"currently_due"`
 	// If the account is disabled, this enum describes why. [Learn more about handling verification issues](https://stripe.com/docs/connect/handling-api-verification).
@@ -1845,7 +1846,7 @@ type AccountSettingsCapital struct {
 }
 type AccountSettingsCardIssuingTOSAcceptance struct {
 	// The Unix timestamp marking when the account representative accepted the service agreement.
-	Date int64 `json:"date"`
+	Date time.Time `json:"date"`
 	// The IP address from which the account representative accepted the service agreement.
 	IP string `json:"ip"`
 	// The user agent of the browser from which the account representative accepted the service agreement.
@@ -1918,7 +1919,7 @@ type AccountSettingsTaxForms struct {
 }
 type AccountSettingsTreasuryTOSAcceptance struct {
 	// The Unix timestamp marking when the account representative accepted the service agreement.
-	Date int64 `json:"date"`
+	Date time.Time `json:"date"`
 	// The IP address from which the account representative accepted the service agreement.
 	IP string `json:"ip"`
 	// The user agent of the browser from which the account representative accepted the service agreement.
@@ -1946,7 +1947,7 @@ type AccountSettings struct {
 }
 type AccountTOSAcceptance struct {
 	// The Unix timestamp marking when the account representative accepted their service agreement
-	Date int64 `json:"date"`
+	Date time.Time `json:"date"`
 	// The IP address from which the account representative accepted their service agreement
 	IP string `json:"ip"`
 	// The user's service agreement type
@@ -1981,7 +1982,7 @@ type Account struct {
 	// The account's country.
 	Country string `json:"country"`
 	// Time at which the account was connected. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts).
 	DefaultCurrency Currency `json:"default_currency"`
 	Deleted         bool     `json:"deleted"`
@@ -2052,12 +2053,17 @@ func (a *Account) UnmarshalJSON(data []byte) error {
 	}
 
 	type account Account
-	var v account
+	v := struct {
+		Created int64 `json:"created"`
+		*account
+	}{
+		account: (*account)(a),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*a = Account(v)
+	a.Created = time.Unix(v.Created, 0)
 	return nil
 }
 
@@ -2086,4 +2092,274 @@ func (a *AccountExternalAccount) UnmarshalJSON(data []byte) error {
 		err = json.Unmarshal(data, &a.Card)
 	}
 	return err
+}
+
+// UnmarshalJSON handles deserialization of an AccountCompanyDirectorshipDeclaration.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (a *AccountCompanyDirectorshipDeclaration) UnmarshalJSON(data []byte) error {
+	type accountCompanyDirectorshipDeclaration AccountCompanyDirectorshipDeclaration
+	v := struct {
+		Date int64 `json:"date"`
+		*accountCompanyDirectorshipDeclaration
+	}{
+		accountCompanyDirectorshipDeclaration: (*accountCompanyDirectorshipDeclaration)(a),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	a.Date = time.Unix(v.Date, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an AccountCompanyOwnershipDeclaration.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (a *AccountCompanyOwnershipDeclaration) UnmarshalJSON(data []byte) error {
+	type accountCompanyOwnershipDeclaration AccountCompanyOwnershipDeclaration
+	v := struct {
+		Date int64 `json:"date"`
+		*accountCompanyOwnershipDeclaration
+	}{
+		accountCompanyOwnershipDeclaration: (*accountCompanyOwnershipDeclaration)(a),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	a.Date = time.Unix(v.Date, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an AccountFutureRequirements.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (a *AccountFutureRequirements) UnmarshalJSON(data []byte) error {
+	type accountFutureRequirements AccountFutureRequirements
+	v := struct {
+		CurrentDeadline int64 `json:"current_deadline"`
+		*accountFutureRequirements
+	}{
+		accountFutureRequirements: (*accountFutureRequirements)(a),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	a.CurrentDeadline = time.Unix(v.CurrentDeadline, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an AccountRequirements.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (a *AccountRequirements) UnmarshalJSON(data []byte) error {
+	type accountRequirements AccountRequirements
+	v := struct {
+		CurrentDeadline int64 `json:"current_deadline"`
+		*accountRequirements
+	}{
+		accountRequirements: (*accountRequirements)(a),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	a.CurrentDeadline = time.Unix(v.CurrentDeadline, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an AccountSettingsCardIssuingTOSAcceptance.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (a *AccountSettingsCardIssuingTOSAcceptance) UnmarshalJSON(data []byte) error {
+	type accountSettingsCardIssuingTOSAcceptance AccountSettingsCardIssuingTOSAcceptance
+	v := struct {
+		Date int64 `json:"date"`
+		*accountSettingsCardIssuingTOSAcceptance
+	}{
+		accountSettingsCardIssuingTOSAcceptance: (*accountSettingsCardIssuingTOSAcceptance)(a),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	a.Date = time.Unix(v.Date, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an AccountSettingsTreasuryTOSAcceptance.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (a *AccountSettingsTreasuryTOSAcceptance) UnmarshalJSON(data []byte) error {
+	type accountSettingsTreasuryTOSAcceptance AccountSettingsTreasuryTOSAcceptance
+	v := struct {
+		Date int64 `json:"date"`
+		*accountSettingsTreasuryTOSAcceptance
+	}{
+		accountSettingsTreasuryTOSAcceptance: (*accountSettingsTreasuryTOSAcceptance)(a),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	a.Date = time.Unix(v.Date, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an AccountTOSAcceptance.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (a *AccountTOSAcceptance) UnmarshalJSON(data []byte) error {
+	type accountTOSAcceptance AccountTOSAcceptance
+	v := struct {
+		Date int64 `json:"date"`
+		*accountTOSAcceptance
+	}{
+		accountTOSAcceptance: (*accountTOSAcceptance)(a),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	a.Date = time.Unix(v.Date, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an AccountCompanyDirectorshipDeclaration.
+// This custom marshaling is needed to handle the time fields correctly.
+func (a AccountCompanyDirectorshipDeclaration) MarshalJSON() ([]byte, error) {
+	type accountCompanyDirectorshipDeclaration AccountCompanyDirectorshipDeclaration
+	v := struct {
+		Date int64 `json:"date"`
+		accountCompanyDirectorshipDeclaration
+	}{
+		accountCompanyDirectorshipDeclaration: (accountCompanyDirectorshipDeclaration)(a),
+		Date:                                  a.Date.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an AccountCompanyOwnershipDeclaration.
+// This custom marshaling is needed to handle the time fields correctly.
+func (a AccountCompanyOwnershipDeclaration) MarshalJSON() ([]byte, error) {
+	type accountCompanyOwnershipDeclaration AccountCompanyOwnershipDeclaration
+	v := struct {
+		Date int64 `json:"date"`
+		accountCompanyOwnershipDeclaration
+	}{
+		accountCompanyOwnershipDeclaration: (accountCompanyOwnershipDeclaration)(a),
+		Date:                               a.Date.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an AccountFutureRequirements.
+// This custom marshaling is needed to handle the time fields correctly.
+func (a AccountFutureRequirements) MarshalJSON() ([]byte, error) {
+	type accountFutureRequirements AccountFutureRequirements
+	v := struct {
+		CurrentDeadline int64 `json:"current_deadline"`
+		accountFutureRequirements
+	}{
+		accountFutureRequirements: (accountFutureRequirements)(a),
+		CurrentDeadline:           a.CurrentDeadline.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an AccountRequirements.
+// This custom marshaling is needed to handle the time fields correctly.
+func (a AccountRequirements) MarshalJSON() ([]byte, error) {
+	type accountRequirements AccountRequirements
+	v := struct {
+		CurrentDeadline int64 `json:"current_deadline"`
+		accountRequirements
+	}{
+		accountRequirements: (accountRequirements)(a),
+		CurrentDeadline:     a.CurrentDeadline.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an AccountSettingsCardIssuingTOSAcceptance.
+// This custom marshaling is needed to handle the time fields correctly.
+func (a AccountSettingsCardIssuingTOSAcceptance) MarshalJSON() ([]byte, error) {
+	type accountSettingsCardIssuingTOSAcceptance AccountSettingsCardIssuingTOSAcceptance
+	v := struct {
+		Date int64 `json:"date"`
+		accountSettingsCardIssuingTOSAcceptance
+	}{
+		accountSettingsCardIssuingTOSAcceptance: (accountSettingsCardIssuingTOSAcceptance)(a),
+		Date:                                    a.Date.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an AccountSettingsTreasuryTOSAcceptance.
+// This custom marshaling is needed to handle the time fields correctly.
+func (a AccountSettingsTreasuryTOSAcceptance) MarshalJSON() ([]byte, error) {
+	type accountSettingsTreasuryTOSAcceptance AccountSettingsTreasuryTOSAcceptance
+	v := struct {
+		Date int64 `json:"date"`
+		accountSettingsTreasuryTOSAcceptance
+	}{
+		accountSettingsTreasuryTOSAcceptance: (accountSettingsTreasuryTOSAcceptance)(a),
+		Date:                                 a.Date.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an AccountTOSAcceptance.
+// This custom marshaling is needed to handle the time fields correctly.
+func (a AccountTOSAcceptance) MarshalJSON() ([]byte, error) {
+	type accountTOSAcceptance AccountTOSAcceptance
+	v := struct {
+		Date int64 `json:"date"`
+		accountTOSAcceptance
+	}{
+		accountTOSAcceptance: (accountTOSAcceptance)(a),
+		Date:                 a.Date.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an Account.
+// This custom marshaling is needed to handle the time fields correctly.
+func (a Account) MarshalJSON() ([]byte, error) {
+	type account Account
+	v := struct {
+		Created int64 `json:"created"`
+		account
+	}{
+		account: (account)(a),
+		Created: a.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/account_test.go
+++ b/account_test.go
@@ -3,6 +3,7 @@ package stripe
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	assert "github.com/stretchr/testify/require"
 	"github.com/stripe/stripe-go/v81/form"
@@ -138,7 +139,7 @@ func TestAccount_Unmarshal(t *testing.T) {
 	assert.Equal(t, "value1", account.Metadata["key1"])
 	assert.Equal(t, "value2", account.Metadata["key2"])
 
-	assert.Equal(t, int64(1234567890), account.Requirements.CurrentDeadline)
+	assert.Equal(t, time.Unix(1234567890, 0), account.Requirements.CurrentDeadline)
 	assert.Equal(t, 2, len(account.Requirements.CurrentlyDue))
 	assert.Equal(t, AccountRequirementsDisabledReasonRejectedFraud, account.Requirements.DisabledReason)
 	assert.Equal(t, 1, len(account.Requirements.Errors))
@@ -156,7 +157,7 @@ func TestAccount_Unmarshal(t *testing.T) {
 	assert.Equal(t, int64(2), account.Settings.Payouts.Schedule.DelayDays)
 	assert.Equal(t, AccountSettingsPayoutsScheduleIntervalWeekly, account.Settings.Payouts.Schedule.Interval)
 
-	assert.Equal(t, int64(1528573382), account.TOSAcceptance.Date)
+	assert.Equal(t, time.Unix(1528573382, 0), account.TOSAcceptance.Date)
 	assert.Equal(t, "127.0.0.1", account.TOSAcceptance.IP)
 	assert.Equal(t, "user agent", account.TOSAcceptance.UserAgent)
 	assert.Equal(t, AccountTOSAcceptanceServiceAgreementRecipient, account.TOSAcceptance.ServiceAgreement)

--- a/billing_alerttriggered.go
+++ b/billing_alerttriggered.go
@@ -6,11 +6,16 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 type BillingAlertTriggered struct {
 	// A billing alert is a resource that notifies you when a certain usage threshold on a meter is crossed. For example, you might create a billing alert to notify you when a certain user made 100 API requests.
 	Alert *BillingAlert `json:"alert"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// ID of customer for which the alert triggered
 	Customer string `json:"customer"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -19,4 +24,40 @@ type BillingAlertTriggered struct {
 	Object string `json:"object"`
 	// The value triggering the alert
 	Value int64 `json:"value"`
+}
+
+// UnmarshalJSON handles deserialization of a BillingAlertTriggered.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (b *BillingAlertTriggered) UnmarshalJSON(data []byte) error {
+	type billingAlertTriggered BillingAlertTriggered
+	v := struct {
+		Created int64 `json:"created"`
+		*billingAlertTriggered
+	}{
+		billingAlertTriggered: (*billingAlertTriggered)(b),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	b.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a BillingAlertTriggered.
+// This custom marshaling is needed to handle the time fields correctly.
+func (b BillingAlertTriggered) MarshalJSON() ([]byte, error) {
+	type billingAlertTriggered BillingAlertTriggered
+	v := struct {
+		Created int64 `json:"created"`
+		billingAlertTriggered
+	}{
+		billingAlertTriggered: (billingAlertTriggered)(b),
+		Created:               b.Created.Unix(),
+	}
+	bb, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return bb, err
 }

--- a/billing_creditgrant.go
+++ b/billing_creditgrant.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // The type of this amount. We currently only support `monetary` billing credits.
 type BillingCreditGrantAmountType string
@@ -87,11 +90,11 @@ type BillingCreditGrantParams struct {
 	// ID of the customer to receive the billing credits.
 	Customer *string `form:"customer"`
 	// The time when the billing credits become effective-when they're eligible for use. It defaults to the current timestamp if not specified.
-	EffectiveAt *int64 `form:"effective_at"`
+	EffectiveAt *time.Time `form:"effective_at"`
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// The time when the billing credits created by this credit grant expire. If set to empty, the billing credits never expire.
-	ExpiresAt *int64 `form:"expires_at"`
+	ExpiresAt *time.Time `form:"expires_at"`
 	// Set of key-value pairs that you can attach to an object. You can use this to store additional information about the object (for example, cost basis) in a structured format.
 	Metadata map[string]string `form:"metadata"`
 	// A descriptive name shown in the Dashboard.
@@ -167,13 +170,13 @@ type BillingCreditGrant struct {
 	// The category of this credit grant. This is for tracking purposes and isn't displayed to the customer.
 	Category BillingCreditGrantCategory `json:"category"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// ID of the customer receiving the billing credits.
 	Customer *Customer `json:"customer"`
 	// The time when the billing credits become effective-when they're eligible for use.
-	EffectiveAt int64 `json:"effective_at"`
+	EffectiveAt time.Time `json:"effective_at"`
 	// The time when the billing credits expire. If not present, the billing credits don't expire.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -187,9 +190,9 @@ type BillingCreditGrant struct {
 	// ID of the test clock this credit grant belongs to.
 	TestClock *TestHelpersTestClock `json:"test_clock"`
 	// Time at which the object was last updated. Measured in seconds since the Unix epoch.
-	Updated int64 `json:"updated"`
+	Updated time.Time `json:"updated"`
 	// The time when this credit grant was voided. If not present, the credit grant hasn't been voided.
-	VoidedAt int64 `json:"voided_at"`
+	VoidedAt time.Time `json:"voided_at"`
 }
 
 // BillingCreditGrantList is a list of CreditGrants as retrieved from a list endpoint.
@@ -209,11 +212,50 @@ func (b *BillingCreditGrant) UnmarshalJSON(data []byte) error {
 	}
 
 	type billingCreditGrant BillingCreditGrant
-	var v billingCreditGrant
+	v := struct {
+		Created     int64 `json:"created"`
+		EffectiveAt int64 `json:"effective_at"`
+		ExpiresAt   int64 `json:"expires_at"`
+		Updated     int64 `json:"updated"`
+		VoidedAt    int64 `json:"voided_at"`
+		*billingCreditGrant
+	}{
+		billingCreditGrant: (*billingCreditGrant)(b),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*b = BillingCreditGrant(v)
+	b.Created = time.Unix(v.Created, 0)
+	b.EffectiveAt = time.Unix(v.EffectiveAt, 0)
+	b.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	b.Updated = time.Unix(v.Updated, 0)
+	b.VoidedAt = time.Unix(v.VoidedAt, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a BillingCreditGrant.
+// This custom marshaling is needed to handle the time fields correctly.
+func (b BillingCreditGrant) MarshalJSON() ([]byte, error) {
+	type billingCreditGrant BillingCreditGrant
+	v := struct {
+		Created     int64 `json:"created"`
+		EffectiveAt int64 `json:"effective_at"`
+		ExpiresAt   int64 `json:"expires_at"`
+		Updated     int64 `json:"updated"`
+		VoidedAt    int64 `json:"voided_at"`
+		billingCreditGrant
+	}{
+		billingCreditGrant: (billingCreditGrant)(b),
+		Created:            b.Created.Unix(),
+		EffectiveAt:        b.EffectiveAt.Unix(),
+		ExpiresAt:          b.ExpiresAt.Unix(),
+		Updated:            b.Updated.Unix(),
+		VoidedAt:           b.VoidedAt.Unix(),
+	}
+	bb, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return bb, err
 }

--- a/billing_meter.go
+++ b/billing_meter.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // The method for mapping a meter event to a customer.
 type BillingMeterCustomerMappingType string
@@ -137,7 +140,7 @@ type BillingMeterDefaultAggregation struct {
 }
 type BillingMeterStatusTransitions struct {
 	// The time the meter was deactivated, if any. Measured in seconds since Unix epoch.
-	DeactivatedAt int64 `json:"deactivated_at"`
+	DeactivatedAt time.Time `json:"deactivated_at"`
 }
 type BillingMeterValueSettings struct {
 	// The key in the meter event payload to use as the value for this meter.
@@ -150,7 +153,7 @@ type BillingMeterValueSettings struct {
 type BillingMeter struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created            int64                           `json:"created"`
+	Created            time.Time                       `json:"created"`
 	CustomerMapping    *BillingMeterCustomerMapping    `json:"customer_mapping"`
 	DefaultAggregation *BillingMeterDefaultAggregation `json:"default_aggregation"`
 	// The meter's name.
@@ -169,7 +172,7 @@ type BillingMeter struct {
 	Status            BillingMeterStatus             `json:"status"`
 	StatusTransitions *BillingMeterStatusTransitions `json:"status_transitions"`
 	// Time at which the object was last updated. Measured in seconds since the Unix epoch.
-	Updated       int64                      `json:"updated"`
+	Updated       time.Time                  `json:"updated"`
 	ValueSettings *BillingMeterValueSettings `json:"value_settings"`
 }
 
@@ -190,11 +193,74 @@ func (b *BillingMeter) UnmarshalJSON(data []byte) error {
 	}
 
 	type billingMeter BillingMeter
-	var v billingMeter
+	v := struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+		*billingMeter
+	}{
+		billingMeter: (*billingMeter)(b),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*b = BillingMeter(v)
+	b.Created = time.Unix(v.Created, 0)
+	b.Updated = time.Unix(v.Updated, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a BillingMeterStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (b *BillingMeterStatusTransitions) UnmarshalJSON(data []byte) error {
+	type billingMeterStatusTransitions BillingMeterStatusTransitions
+	v := struct {
+		DeactivatedAt int64 `json:"deactivated_at"`
+		*billingMeterStatusTransitions
+	}{
+		billingMeterStatusTransitions: (*billingMeterStatusTransitions)(b),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	b.DeactivatedAt = time.Unix(v.DeactivatedAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a BillingMeterStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (b BillingMeterStatusTransitions) MarshalJSON() ([]byte, error) {
+	type billingMeterStatusTransitions BillingMeterStatusTransitions
+	v := struct {
+		DeactivatedAt int64 `json:"deactivated_at"`
+		billingMeterStatusTransitions
+	}{
+		billingMeterStatusTransitions: (billingMeterStatusTransitions)(b),
+		DeactivatedAt:                 b.DeactivatedAt.Unix(),
+	}
+	bb, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return bb, err
+}
+
+// MarshalJSON handles serialization of a BillingMeter.
+// This custom marshaling is needed to handle the time fields correctly.
+func (b BillingMeter) MarshalJSON() ([]byte, error) {
+	type billingMeter BillingMeter
+	v := struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+		billingMeter
+	}{
+		billingMeter: (billingMeter)(b),
+		Created:      b.Created.Unix(),
+		Updated:      b.Updated.Unix(),
+	}
+	bb, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return bb, err
 }

--- a/billing_metererrorreport.go
+++ b/billing_metererrorreport.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 type BillingMeterErrorReportReasonErrorTypeSampleErrorAPIRequest struct {
 	// Unique identifier for the object.
 	ID string `json:"id"`
@@ -49,7 +54,47 @@ type BillingMeterErrorReport struct {
 	// Summary of invalid events
 	Summary string `json:"summary"`
 	// Time when validation ended. Measured in seconds since the Unix epoch
-	ValidationEnd int64 `json:"validation_end"`
+	ValidationEnd time.Time `json:"validation_end"`
 	// Time when validation started. Measured in seconds since the Unix epoch
-	ValidationStart int64 `json:"validation_start"`
+	ValidationStart time.Time `json:"validation_start"`
+}
+
+// UnmarshalJSON handles deserialization of a BillingMeterErrorReport.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (b *BillingMeterErrorReport) UnmarshalJSON(data []byte) error {
+	type billingMeterErrorReport BillingMeterErrorReport
+	v := struct {
+		ValidationEnd   int64 `json:"validation_end"`
+		ValidationStart int64 `json:"validation_start"`
+		*billingMeterErrorReport
+	}{
+		billingMeterErrorReport: (*billingMeterErrorReport)(b),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	b.ValidationEnd = time.Unix(v.ValidationEnd, 0)
+	b.ValidationStart = time.Unix(v.ValidationStart, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a BillingMeterErrorReport.
+// This custom marshaling is needed to handle the time fields correctly.
+func (b BillingMeterErrorReport) MarshalJSON() ([]byte, error) {
+	type billingMeterErrorReport BillingMeterErrorReport
+	v := struct {
+		ValidationEnd   int64 `json:"validation_end"`
+		ValidationStart int64 `json:"validation_start"`
+		billingMeterErrorReport
+	}{
+		billingMeterErrorReport: (billingMeterErrorReport)(b),
+		ValidationEnd:           b.ValidationEnd.Unix(),
+		ValidationStart:         b.ValidationStart.Unix(),
+	}
+	bb, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return bb, err
 }

--- a/billing_meterevent.go
+++ b/billing_meterevent.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Creates a billing meter event.
 type BillingMeterEventParams struct {
 	Params `form:"*"`
@@ -18,7 +23,7 @@ type BillingMeterEventParams struct {
 	// The payload of the event. This must contain the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://docs.stripe.com/billing/subscriptions/usage-based/recording-usage#payload-key-overrides).
 	Payload map[string]string `form:"payload"`
 	// The time of the event. Measured in seconds since the Unix epoch. Must be within the past 35 calendar days or up to 5 minutes in the future. Defaults to current timestamp if not specified.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 }
 
 // AddExpand appends a new field to expand.
@@ -30,7 +35,7 @@ func (p *BillingMeterEventParams) AddExpand(f string) {
 type BillingMeterEvent struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The name of the meter event. Corresponds with the `event_name` field on a meter.
 	EventName string `json:"event_name"`
 	// A unique identifier for the event.
@@ -42,5 +47,45 @@ type BillingMeterEvent struct {
 	// The payload of the event. This contains the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://stripe.com/docs/billing/subscriptions/usage-based/recording-usage#payload-key-overrides).
 	Payload map[string]string `json:"payload"`
 	// The timestamp passed in when creating the event. Measured in seconds since the Unix epoch.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// UnmarshalJSON handles deserialization of a BillingMeterEvent.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (b *BillingMeterEvent) UnmarshalJSON(data []byte) error {
+	type billingMeterEvent BillingMeterEvent
+	v := struct {
+		Created   int64 `json:"created"`
+		Timestamp int64 `json:"timestamp"`
+		*billingMeterEvent
+	}{
+		billingMeterEvent: (*billingMeterEvent)(b),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	b.Created = time.Unix(v.Created, 0)
+	b.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a BillingMeterEvent.
+// This custom marshaling is needed to handle the time fields correctly.
+func (b BillingMeterEvent) MarshalJSON() ([]byte, error) {
+	type billingMeterEvent BillingMeterEvent
+	v := struct {
+		Created   int64 `json:"created"`
+		Timestamp int64 `json:"timestamp"`
+		billingMeterEvent
+	}{
+		billingMeterEvent: (billingMeterEvent)(b),
+		Created:           b.Created.Unix(),
+		Timestamp:         b.Timestamp.Unix(),
+	}
+	bb, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return bb, err
 }

--- a/billing_metereventsummary.go
+++ b/billing_metereventsummary.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Retrieve a list of billing meter event summaries.
 type BillingMeterEventSummaryListParams struct {
 	ListParams `form:"*"`
@@ -13,11 +18,11 @@ type BillingMeterEventSummaryListParams struct {
 	// The customer for which to fetch event summaries.
 	Customer *string `form:"customer"`
 	// The timestamp from when to stop aggregating meter events (exclusive). Must be aligned with minute boundaries.
-	EndTime *int64 `form:"end_time"`
+	EndTime *time.Time `form:"end_time"`
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// The timestamp from when to start aggregating meter events (inclusive). Must be aligned with minute boundaries.
-	StartTime *int64 `form:"start_time"`
+	StartTime *time.Time `form:"start_time"`
 	// Specifies what granularity to use when generating event summaries. If not specified, a single event summary would be returned for the specified time range. For hourly granularity, start and end times must align with hour boundaries (e.g., 00:00, 01:00, ..., 23:00). For daily granularity, start and end times must align with UTC day boundaries (00:00 UTC).
 	ValueGroupingWindow *string `form:"value_grouping_window"`
 }
@@ -33,7 +38,7 @@ type BillingMeterEventSummary struct {
 	// Aggregated value of all the events within `start_time` (inclusive) and `end_time` (inclusive). The aggregation strategy is defined on meter via `default_aggregation`.
 	AggregatedValue float64 `json:"aggregated_value"`
 	// End timestamp for this event summary (exclusive). Must be aligned with minute boundaries.
-	EndTime int64 `json:"end_time"`
+	EndTime time.Time `json:"end_time"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -43,7 +48,7 @@ type BillingMeterEventSummary struct {
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// Start timestamp for this event summary (inclusive). Must be aligned with minute boundaries.
-	StartTime int64 `json:"start_time"`
+	StartTime time.Time `json:"start_time"`
 }
 
 // BillingMeterEventSummaryList is a list of MeterEventSummaries as retrieved from a list endpoint.
@@ -51,4 +56,44 @@ type BillingMeterEventSummaryList struct {
 	APIResource
 	ListMeta
 	Data []*BillingMeterEventSummary `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a BillingMeterEventSummary.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (b *BillingMeterEventSummary) UnmarshalJSON(data []byte) error {
+	type billingMeterEventSummary BillingMeterEventSummary
+	v := struct {
+		EndTime   int64 `json:"end_time"`
+		StartTime int64 `json:"start_time"`
+		*billingMeterEventSummary
+	}{
+		billingMeterEventSummary: (*billingMeterEventSummary)(b),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	b.EndTime = time.Unix(v.EndTime, 0)
+	b.StartTime = time.Unix(v.StartTime, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a BillingMeterEventSummary.
+// This custom marshaling is needed to handle the time fields correctly.
+func (b BillingMeterEventSummary) MarshalJSON() ([]byte, error) {
+	type billingMeterEventSummary BillingMeterEventSummary
+	v := struct {
+		EndTime   int64 `json:"end_time"`
+		StartTime int64 `json:"start_time"`
+		billingMeterEventSummary
+	}{
+		billingMeterEventSummary: (billingMeterEventSummary)(b),
+		EndTime:                  b.EndTime.Unix(),
+		StartTime:                b.StartTime.Unix(),
+	}
+	bb, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return bb, err
 }

--- a/billingportal_configuration.go
+++ b/billingportal_configuration.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // The types of customer updates that are supported. When empty, customers are not updateable.
 type BillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdate string
@@ -330,7 +333,7 @@ type BillingPortalConfiguration struct {
 	Application     *Application                               `json:"application"`
 	BusinessProfile *BillingPortalConfigurationBusinessProfile `json:"business_profile"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The default URL to redirect customers to when they click on the portal's link to return to your website. This can be [overriden](https://stripe.com/docs/api/customer_portal/sessions/create#create_portal_session-return_url) when creating the session.
 	DefaultReturnURL string                              `json:"default_return_url"`
 	Features         *BillingPortalConfigurationFeatures `json:"features"`
@@ -346,7 +349,7 @@ type BillingPortalConfiguration struct {
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// Time at which the object was last updated. Measured in seconds since the Unix epoch.
-	Updated int64 `json:"updated"`
+	Updated time.Time `json:"updated"`
 }
 
 // BillingPortalConfigurationList is a list of Configurations as retrieved from a list endpoint.
@@ -366,11 +369,38 @@ func (b *BillingPortalConfiguration) UnmarshalJSON(data []byte) error {
 	}
 
 	type billingPortalConfiguration BillingPortalConfiguration
-	var v billingPortalConfiguration
+	v := struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+		*billingPortalConfiguration
+	}{
+		billingPortalConfiguration: (*billingPortalConfiguration)(b),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*b = BillingPortalConfiguration(v)
+	b.Created = time.Unix(v.Created, 0)
+	b.Updated = time.Unix(v.Updated, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a BillingPortalConfiguration.
+// This custom marshaling is needed to handle the time fields correctly.
+func (b BillingPortalConfiguration) MarshalJSON() ([]byte, error) {
+	type billingPortalConfiguration BillingPortalConfiguration
+	v := struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+		billingPortalConfiguration
+	}{
+		billingPortalConfiguration: (billingPortalConfiguration)(b),
+		Created:                    b.Created.Unix(),
+		Updated:                    b.Updated.Unix(),
+	}
+	bb, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return bb, err
 }

--- a/capital_financingoffer.go
+++ b/capital_financingoffer.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The type of financing being offered.
 type CapitalFinancingOfferFinancingType string
 
@@ -156,9 +161,9 @@ type CapitalFinancingOffer struct {
 	// The ID of the merchant associated with this financing object.
 	Account string `json:"account"`
 	// The time at which this financing offer was charged off, if applicable. Given in seconds since unix epoch.
-	ChargedOffAt int64 `json:"charged_off_at"`
+	ChargedOffAt time.Time `json:"charged_off_at"`
 	// Time at which the offer was created. Given in seconds since unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Time at which the offer expires. Given in seconds since unix epoch.
 	ExpiresAfter float64 `json:"expires_after"`
 	// The type of financing being offered.
@@ -192,4 +197,44 @@ type CapitalFinancingOfferList struct {
 	APIResource
 	ListMeta
 	Data []*CapitalFinancingOffer `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a CapitalFinancingOffer.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *CapitalFinancingOffer) UnmarshalJSON(data []byte) error {
+	type capitalFinancingOffer CapitalFinancingOffer
+	v := struct {
+		ChargedOffAt int64 `json:"charged_off_at"`
+		Created      int64 `json:"created"`
+		*capitalFinancingOffer
+	}{
+		capitalFinancingOffer: (*capitalFinancingOffer)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.ChargedOffAt = time.Unix(v.ChargedOffAt, 0)
+	c.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a CapitalFinancingOffer.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c CapitalFinancingOffer) MarshalJSON() ([]byte, error) {
+	type capitalFinancingOffer CapitalFinancingOffer
+	v := struct {
+		ChargedOffAt int64 `json:"charged_off_at"`
+		Created      int64 `json:"created"`
+		capitalFinancingOffer
+	}{
+		capitalFinancingOffer: (capitalFinancingOffer)(c),
+		ChargedOffAt:          c.ChargedOffAt.Unix(),
+		Created:               c.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/capital_financingtransaction.go
+++ b/capital_financingtransaction.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The reason for the financing transaction (if applicable).
 type CapitalFinancingTransactionDetailsReason string
 
@@ -99,7 +104,7 @@ type CapitalFinancingTransaction struct {
 	// The ID of the merchant associated with this financing transaction.
 	Account string `json:"account"`
 	// Time at which the financing transaction was created. Given in seconds since unix epoch.
-	CreatedAt int64 `json:"created_at"`
+	CreatedAt time.Time `json:"created_at"`
 	// This is an object representing a transaction on a Capital financing offer.
 	Details *CapitalFinancingTransactionDetails `json:"details"`
 	// The Capital financing offer for this financing transaction.
@@ -125,4 +130,40 @@ type CapitalFinancingTransactionList struct {
 	APIResource
 	ListMeta
 	Data []*CapitalFinancingTransaction `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a CapitalFinancingTransaction.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *CapitalFinancingTransaction) UnmarshalJSON(data []byte) error {
+	type capitalFinancingTransaction CapitalFinancingTransaction
+	v := struct {
+		CreatedAt int64 `json:"created_at"`
+		*capitalFinancingTransaction
+	}{
+		capitalFinancingTransaction: (*capitalFinancingTransaction)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.CreatedAt = time.Unix(v.CreatedAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a CapitalFinancingTransaction.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c CapitalFinancingTransaction) MarshalJSON() ([]byte, error) {
+	type capitalFinancingTransaction CapitalFinancingTransaction
+	v := struct {
+		CreatedAt int64 `json:"created_at"`
+		capitalFinancingTransaction
+	}{
+		capitalFinancingTransaction: (capitalFinancingTransaction)(c),
+		CreatedAt:                   c.CreatedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/charge.go
+++ b/charge.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Assessments from Stripe. If set, the value is `fraudulent`.
 type ChargeFraudStripeReport string
@@ -613,7 +616,7 @@ type ChargePaymentDetailsCarRentalParams struct {
 	// Car pick-up address.
 	PickupAddress *AddressParams `form:"pickup_address"`
 	// Car pick-up time. Measured in seconds since the Unix epoch.
-	PickupAt *int64 `form:"pickup_at"`
+	PickupAt *time.Time `form:"pickup_at"`
 	// Rental rate.
 	RateAmount *int64 `form:"rate_amount"`
 	// The frequency at which the rate amount is applied. One of `day`, `week` or `month`
@@ -623,7 +626,7 @@ type ChargePaymentDetailsCarRentalParams struct {
 	// Car return address.
 	ReturnAddress *AddressParams `form:"return_address"`
 	// Car return time. Measured in seconds since the Unix epoch.
-	ReturnAt *int64 `form:"return_at"`
+	ReturnAt *time.Time `form:"return_at"`
 	// Indicates whether the goods or services are tax-exempt or tax is not collected.
 	TaxExempt *bool `form:"tax_exempt"`
 }
@@ -665,13 +668,13 @@ type ChargePaymentDetailsEventDetailsParams struct {
 	// Delivery details for this purchase.
 	Delivery *ChargePaymentDetailsEventDetailsDeliveryParams `form:"delivery"`
 	// Event end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Type of the event entertainment (concert, sports event etc)
 	Genre *string `form:"genre"`
 	// The name of the event.
 	Name *string `form:"name"`
 	// Event start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Affiliate details for this purchase.
@@ -711,11 +714,11 @@ type ChargePaymentDetailsFlightSegmentParams struct {
 	// The International Air Transport Association (IATA) airport code for the arrival airport.
 	ArrivalAirport *string `form:"arrival_airport"`
 	// The arrival time for the flight segment. Measured in seconds since the Unix epoch.
-	ArrivesAt *int64 `form:"arrives_at"`
+	ArrivesAt *time.Time `form:"arrives_at"`
 	// The International Air Transport Association (IATA) carrier code of the carrier operating the flight segment.
 	Carrier *string `form:"carrier"`
 	// The departure time for the flight segment. Measured in seconds since the Unix epoch.
-	DepartsAt *int64 `form:"departs_at"`
+	DepartsAt *time.Time `form:"departs_at"`
 	// The International Air Transport Association (IATA) airport code for the departure airport.
 	DepartureAirport *string `form:"departure_airport"`
 	// The flight number associated with the segment
@@ -787,9 +790,9 @@ type ChargePaymentDetailsLodgingParams struct {
 	// The lodging category
 	Category *string `form:"category"`
 	// Loding check-in time. Measured in seconds since the Unix epoch.
-	CheckinAt *int64 `form:"checkin_at"`
+	CheckinAt *time.Time `form:"checkin_at"`
 	// Lodging check-out time. Measured in seconds since the Unix epoch.
-	CheckoutAt *int64 `form:"checkout_at"`
+	CheckoutAt *time.Time `form:"checkout_at"`
 	// The customer service phone number of the lodging company.
 	CustomerServicePhoneNumber *string `form:"customer_service_phone_number"`
 	// The daily lodging room rate.
@@ -843,11 +846,11 @@ type ChargePaymentDetailsSubscriptionParams struct {
 	// Subscription billing details for this purchase.
 	BillingInterval *ChargePaymentDetailsSubscriptionBillingIntervalParams `form:"billing_interval"`
 	// Subscription end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Name of the product on subscription. e.g. Apple Music Subscription
 	Name *string `form:"name"`
 	// Subscription start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Provides industry-specific information about the charge.
@@ -940,7 +943,7 @@ type ChargeCapturePaymentDetailsCarRentalParams struct {
 	// Car pick-up address.
 	PickupAddress *AddressParams `form:"pickup_address"`
 	// Car pick-up time. Measured in seconds since the Unix epoch.
-	PickupAt *int64 `form:"pickup_at"`
+	PickupAt *time.Time `form:"pickup_at"`
 	// Rental rate.
 	RateAmount *int64 `form:"rate_amount"`
 	// The frequency at which the rate amount is applied. One of `day`, `week` or `month`
@@ -950,7 +953,7 @@ type ChargeCapturePaymentDetailsCarRentalParams struct {
 	// Car return address.
 	ReturnAddress *AddressParams `form:"return_address"`
 	// Car return time. Measured in seconds since the Unix epoch.
-	ReturnAt *int64 `form:"return_at"`
+	ReturnAt *time.Time `form:"return_at"`
 	// Indicates whether the goods or services are tax-exempt or tax is not collected.
 	TaxExempt *bool `form:"tax_exempt"`
 }
@@ -992,13 +995,13 @@ type ChargeCapturePaymentDetailsEventDetailsParams struct {
 	// Delivery details for this purchase.
 	Delivery *ChargeCapturePaymentDetailsEventDetailsDeliveryParams `form:"delivery"`
 	// Event end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Type of the event entertainment (concert, sports event etc)
 	Genre *string `form:"genre"`
 	// The name of the event.
 	Name *string `form:"name"`
 	// Event start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Affiliate details for this purchase.
@@ -1038,11 +1041,11 @@ type ChargeCapturePaymentDetailsFlightSegmentParams struct {
 	// The International Air Transport Association (IATA) airport code for the arrival airport.
 	ArrivalAirport *string `form:"arrival_airport"`
 	// The arrival time for the flight segment. Measured in seconds since the Unix epoch.
-	ArrivesAt *int64 `form:"arrives_at"`
+	ArrivesAt *time.Time `form:"arrives_at"`
 	// The International Air Transport Association (IATA) carrier code of the carrier operating the flight segment.
 	Carrier *string `form:"carrier"`
 	// The departure time for the flight segment. Measured in seconds since the Unix epoch.
-	DepartsAt *int64 `form:"departs_at"`
+	DepartsAt *time.Time `form:"departs_at"`
 	// The International Air Transport Association (IATA) airport code for the departure airport.
 	DepartureAirport *string `form:"departure_airport"`
 	// The flight number associated with the segment
@@ -1114,9 +1117,9 @@ type ChargeCapturePaymentDetailsLodgingParams struct {
 	// The lodging category
 	Category *string `form:"category"`
 	// Loding check-in time. Measured in seconds since the Unix epoch.
-	CheckinAt *int64 `form:"checkin_at"`
+	CheckinAt *time.Time `form:"checkin_at"`
 	// Lodging check-out time. Measured in seconds since the Unix epoch.
-	CheckoutAt *int64 `form:"checkout_at"`
+	CheckoutAt *time.Time `form:"checkout_at"`
 	// The customer service phone number of the lodging company.
 	CustomerServicePhoneNumber *string `form:"customer_service_phone_number"`
 	// The daily lodging room rate.
@@ -1170,11 +1173,11 @@ type ChargeCapturePaymentDetailsSubscriptionParams struct {
 	// Subscription billing details for this purchase.
 	BillingInterval *ChargeCapturePaymentDetailsSubscriptionBillingIntervalParams `form:"billing_interval"`
 	// Subscription end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Name of the product on subscription. e.g. Apple Music Subscription
 	Name *string `form:"name"`
 	// Subscription start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Provides industry-specific information about the charge.
@@ -1572,7 +1575,7 @@ type ChargePaymentMethodDetailsCard struct {
 	// Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`.
 	Brand PaymentMethodCardBrand `json:"brand"`
 	// When using manual capture, a future timestamp at which the charge will be automatically refunded if uncaptured.
-	CaptureBefore int64 `json:"capture_before"`
+	CaptureBefore time.Time `json:"capture_before"`
 	// Check results by Card networks on Card address and CVC at time of payment.
 	Checks *ChargePaymentMethodDetailsCardChecks `json:"checks"`
 	// Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
@@ -1628,7 +1631,7 @@ type ChargePaymentMethodDetailsCard struct {
 // Details about payments collected offline.
 type ChargePaymentMethodDetailsCardPresentOffline struct {
 	// Time at which the payment was collected while offline
-	StoredAt int64 `json:"stored_at"`
+	StoredAt time.Time `json:"stored_at"`
 	// The method used to process this payment method offline. Only deferred is allowed.
 	Type ChargePaymentMethodDetailsCardPresentOfflineType `json:"type"`
 }
@@ -1666,7 +1669,7 @@ type ChargePaymentMethodDetailsCardPresent struct {
 	// The [product code](https://stripe.com/docs/card-product-codes) that identifies the specific program or product associated with a card.
 	BrandProduct string `json:"brand_product"`
 	// When using manual capture, a future timestamp after which the charge will be automatically refunded if uncaptured.
-	CaptureBefore int64 `json:"capture_before"`
+	CaptureBefore time.Time `json:"capture_before"`
 	// The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`). In some cases, the cardholder name may not be available depending on how the issuer has configured the card. Cardholder name is typically not available on swipe or contactless payments, such as those made with Apple Pay and Google Pay.
 	CardholderName string `json:"cardholder_name"`
 	// Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
@@ -2219,7 +2222,7 @@ type Charge struct {
 	// If the charge was created without capturing, this Boolean represents whether it is still uncaptured or has since been captured.
 	Captured bool `json:"captured"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// ID of the customer this charge is for if one exists.
@@ -2319,11 +2322,142 @@ func (c *Charge) UnmarshalJSON(data []byte) error {
 	}
 
 	type charge Charge
-	var v charge
+	v := struct {
+		Created int64 `json:"created"`
+		*charge
+	}{
+		charge: (*charge)(c),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*c = Charge(v)
+	c.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a ChargePaymentMethodDetailsCard.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *ChargePaymentMethodDetailsCard) UnmarshalJSON(data []byte) error {
+	type chargePaymentMethodDetailsCard ChargePaymentMethodDetailsCard
+	v := struct {
+		CaptureBefore int64 `json:"capture_before"`
+		*chargePaymentMethodDetailsCard
+	}{
+		chargePaymentMethodDetailsCard: (*chargePaymentMethodDetailsCard)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.CaptureBefore = time.Unix(v.CaptureBefore, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a ChargePaymentMethodDetailsCardPresentOffline.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *ChargePaymentMethodDetailsCardPresentOffline) UnmarshalJSON(data []byte) error {
+	type chargePaymentMethodDetailsCardPresentOffline ChargePaymentMethodDetailsCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		*chargePaymentMethodDetailsCardPresentOffline
+	}{
+		chargePaymentMethodDetailsCardPresentOffline: (*chargePaymentMethodDetailsCardPresentOffline)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.StoredAt = time.Unix(v.StoredAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a ChargePaymentMethodDetailsCardPresent.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *ChargePaymentMethodDetailsCardPresent) UnmarshalJSON(data []byte) error {
+	type chargePaymentMethodDetailsCardPresent ChargePaymentMethodDetailsCardPresent
+	v := struct {
+		CaptureBefore int64 `json:"capture_before"`
+		*chargePaymentMethodDetailsCardPresent
+	}{
+		chargePaymentMethodDetailsCardPresent: (*chargePaymentMethodDetailsCardPresent)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.CaptureBefore = time.Unix(v.CaptureBefore, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a ChargePaymentMethodDetailsCard.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c ChargePaymentMethodDetailsCard) MarshalJSON() ([]byte, error) {
+	type chargePaymentMethodDetailsCard ChargePaymentMethodDetailsCard
+	v := struct {
+		CaptureBefore int64 `json:"capture_before"`
+		chargePaymentMethodDetailsCard
+	}{
+		chargePaymentMethodDetailsCard: (chargePaymentMethodDetailsCard)(c),
+		CaptureBefore:                  c.CaptureBefore.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a ChargePaymentMethodDetailsCardPresentOffline.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c ChargePaymentMethodDetailsCardPresentOffline) MarshalJSON() ([]byte, error) {
+	type chargePaymentMethodDetailsCardPresentOffline ChargePaymentMethodDetailsCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		chargePaymentMethodDetailsCardPresentOffline
+	}{
+		chargePaymentMethodDetailsCardPresentOffline: (chargePaymentMethodDetailsCardPresentOffline)(c),
+		StoredAt: c.StoredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a ChargePaymentMethodDetailsCardPresent.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c ChargePaymentMethodDetailsCardPresent) MarshalJSON() ([]byte, error) {
+	type chargePaymentMethodDetailsCardPresent ChargePaymentMethodDetailsCardPresent
+	v := struct {
+		CaptureBefore int64 `json:"capture_before"`
+		chargePaymentMethodDetailsCardPresent
+	}{
+		chargePaymentMethodDetailsCardPresent: (chargePaymentMethodDetailsCardPresent)(c),
+		CaptureBefore:                         c.CaptureBefore.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a Charge.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c Charge) MarshalJSON() ([]byte, error) {
+	type charge Charge
+	v := struct {
+		Created int64 `json:"created"`
+		charge
+	}{
+		charge:  (charge)(c),
+		Created: c.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/confirmationtoken.go
+++ b/confirmationtoken.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // This field indicates whether this payment method can be shown again to its customer in a checkout flow. Stripe products such as Checkout and Elements use this field to determine whether a payment method can be shown as a saved payment method in a checkout flow. The field defaults to “unspecified”.
 type ConfirmationTokenPaymentMethodPreviewAllowRedisplay string
 
@@ -564,7 +569,7 @@ type ConfirmationTokenPaymentMethodPreviewCardChecks struct {
 // Details about payments collected offline.
 type ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline struct {
 	// Time at which the payment was collected while offline
-	StoredAt int64 `json:"stored_at"`
+	StoredAt time.Time `json:"stored_at"`
 	// The method used to process this payment method offline. Only deferred is allowed.
 	Type ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOfflineType `json:"type"`
 }
@@ -602,7 +607,7 @@ type ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsC
 	// The [product code](https://stripe.com/docs/card-product-codes) that identifies the specific program or product associated with a card.
 	BrandProduct string `json:"brand_product"`
 	// When using manual capture, a future timestamp after which the charge will be automatically refunded if uncaptured.
-	CaptureBefore int64 `json:"capture_before"`
+	CaptureBefore time.Time `json:"capture_before"`
 	// The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`). In some cases, the cardholder name may not be available depending on how the issuer has configured the card. Cardholder name is typically not available on swipe or contactless payments, such as those made with Apple Pay and Google Pay.
 	CardholderName string `json:"cardholder_name"`
 	// Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
@@ -768,7 +773,7 @@ type ConfirmationTokenPaymentMethodPreviewCardPresentNetworks struct {
 // Details about payment methods collected offline.
 type ConfirmationTokenPaymentMethodPreviewCardPresentOffline struct {
 	// Time at which the payment was collected while offline
-	StoredAt int64 `json:"stored_at"`
+	StoredAt time.Time `json:"stored_at"`
 	// The method used to process this payment method offline. Only deferred is allowed.
 	Type ConfirmationTokenPaymentMethodPreviewCardPresentOfflineType `json:"type"`
 }
@@ -1123,9 +1128,9 @@ type ConfirmationTokenShipping struct {
 type ConfirmationToken struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Time at which this ConfirmationToken expires and can no longer be used to confirm a PaymentIntent or SetupIntent.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -1152,4 +1157,152 @@ type ConfirmationToken struct {
 	Shipping *ConfirmationTokenShipping `json:"shipping"`
 	// Indicates whether the Stripe SDK is used to handle confirmation flow. Defaults to `true` on ConfirmationToken.
 	UseStripeSDK bool `json:"use_stripe_sdk"`
+}
+
+// UnmarshalJSON handles deserialization of a ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline) UnmarshalJSON(data []byte) error {
+	type confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		*confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline
+	}{
+		confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline: (*confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.StoredAt = time.Unix(v.StoredAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent) UnmarshalJSON(data []byte) error {
+	type confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent
+	v := struct {
+		CaptureBefore int64 `json:"capture_before"`
+		*confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent
+	}{
+		confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent: (*confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.CaptureBefore = time.Unix(v.CaptureBefore, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a ConfirmationTokenPaymentMethodPreviewCardPresentOffline.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *ConfirmationTokenPaymentMethodPreviewCardPresentOffline) UnmarshalJSON(data []byte) error {
+	type confirmationTokenPaymentMethodPreviewCardPresentOffline ConfirmationTokenPaymentMethodPreviewCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		*confirmationTokenPaymentMethodPreviewCardPresentOffline
+	}{
+		confirmationTokenPaymentMethodPreviewCardPresentOffline: (*confirmationTokenPaymentMethodPreviewCardPresentOffline)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.StoredAt = time.Unix(v.StoredAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a ConfirmationToken.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *ConfirmationToken) UnmarshalJSON(data []byte) error {
+	type confirmationToken ConfirmationToken
+	v := struct {
+		Created   int64 `json:"created"`
+		ExpiresAt int64 `json:"expires_at"`
+		*confirmationToken
+	}{
+		confirmationToken: (*confirmationToken)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.Created = time.Unix(v.Created, 0)
+	c.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline) MarshalJSON() ([]byte, error) {
+	type confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline
+	}{
+		confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline: (confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresentOffline)(c),
+		StoredAt: c.StoredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent) MarshalJSON() ([]byte, error) {
+	type confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent ConfirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent
+	v := struct {
+		CaptureBefore int64 `json:"capture_before"`
+		confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent
+	}{
+		confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent: (confirmationTokenPaymentMethodPreviewCardGeneratedFromPaymentMethodDetailsCardPresent)(c),
+		CaptureBefore: c.CaptureBefore.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a ConfirmationTokenPaymentMethodPreviewCardPresentOffline.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c ConfirmationTokenPaymentMethodPreviewCardPresentOffline) MarshalJSON() ([]byte, error) {
+	type confirmationTokenPaymentMethodPreviewCardPresentOffline ConfirmationTokenPaymentMethodPreviewCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		confirmationTokenPaymentMethodPreviewCardPresentOffline
+	}{
+		confirmationTokenPaymentMethodPreviewCardPresentOffline: (confirmationTokenPaymentMethodPreviewCardPresentOffline)(c),
+		StoredAt: c.StoredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a ConfirmationToken.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c ConfirmationToken) MarshalJSON() ([]byte, error) {
+	type confirmationToken ConfirmationToken
+	v := struct {
+		Created   int64 `json:"created"`
+		ExpiresAt int64 `json:"expires_at"`
+		confirmationToken
+	}{
+		confirmationToken: (confirmationToken)(c),
+		Created:           c.Created.Unix(),
+		ExpiresAt:         c.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/coupon.go
+++ b/coupon.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // One of `forever`, `once`, and `repeating`. Describes how long a customer who applies this coupon will get the discount.
 type CouponDuration string
@@ -47,7 +50,7 @@ type CouponParams struct {
 	// A positive float larger than 0, and smaller or equal to 100, that represents the discount the coupon will apply (required if `amount_off` is not passed).
 	PercentOff *float64 `form:"percent_off"`
 	// Unix timestamp specifying the last time at which the coupon can be redeemed. After the redeem_by date, the coupon can no longer be applied to new customers.
-	RedeemBy *int64 `form:"redeem_by"`
+	RedeemBy *time.Time `form:"redeem_by"`
 }
 
 // AddExpand appends a new field to expand.
@@ -111,7 +114,7 @@ type Coupon struct {
 	AmountOff int64            `json:"amount_off"`
 	AppliesTo *CouponAppliesTo `json:"applies_to"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// If `amount_off` has been set, the three-letter [ISO code for the currency](https://stripe.com/docs/currencies) of the amount to take off.
 	Currency Currency `json:"currency"`
 	// Coupons defined in each available currency option. Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
@@ -136,7 +139,7 @@ type Coupon struct {
 	// Percent that will be taken off the subtotal of any invoices for this customer for the duration of the coupon. For example, a coupon with percent_off of 50 will make a $ (or local equivalent)100 invoice $ (or local equivalent)50 instead.
 	PercentOff float64 `json:"percent_off"`
 	// Date after which the coupon can no longer be redeemed.
-	RedeemBy int64 `json:"redeem_by"`
+	RedeemBy time.Time `json:"redeem_by"`
 	// Number of times this coupon has been applied to a customer.
 	TimesRedeemed int64 `json:"times_redeemed"`
 	// Taking account of the above properties, whether this coupon can still be applied to a customer.
@@ -160,11 +163,38 @@ func (c *Coupon) UnmarshalJSON(data []byte) error {
 	}
 
 	type coupon Coupon
-	var v coupon
+	v := struct {
+		Created  int64 `json:"created"`
+		RedeemBy int64 `json:"redeem_by"`
+		*coupon
+	}{
+		coupon: (*coupon)(c),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*c = Coupon(v)
+	c.Created = time.Unix(v.Created, 0)
+	c.RedeemBy = time.Unix(v.RedeemBy, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a Coupon.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c Coupon) MarshalJSON() ([]byte, error) {
+	type coupon Coupon
+	v := struct {
+		Created  int64 `json:"created"`
+		RedeemBy int64 `json:"redeem_by"`
+		coupon
+	}{
+		coupon:   (coupon)(c),
+		Created:  c.Created.Unix(),
+		RedeemBy: c.RedeemBy.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/customer.go
+++ b/customer.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Surfaces if automatic tax computation is possible given the current customer location information.
 type CustomerTaxAutomaticTax string
@@ -340,7 +343,7 @@ type Customer struct {
 	// The current funds being held by Stripe on behalf of the customer. You can apply these funds towards payment intents when the source is "cash_balance". The `settings[reconciliation_mode]` field describes if these funds apply to these payment intents manually or automatically.
 	CashBalance *CashBalance `json:"cash_balance"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) the customer can be charged in for recurring billing purposes.
 	Currency Currency `json:"currency"`
 	// ID of the default payment source for the customer.
@@ -419,11 +422,34 @@ func (c *Customer) UnmarshalJSON(data []byte) error {
 	}
 
 	type customer Customer
-	var v customer
+	v := struct {
+		Created int64 `json:"created"`
+		*customer
+	}{
+		customer: (*customer)(c),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*c = Customer(v)
+	c.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a Customer.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c Customer) MarshalJSON() ([]byte, error) {
+	type customer Customer
+	v := struct {
+		Created int64 `json:"created"`
+		customer
+	}{
+		customer: (customer)(c),
+		Created:  c.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/customersession.go
+++ b/customersession.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // A list of [`allow_redisplay`](https://docs.stripe.com/api/payment_methods/object#payment_method_object-allow_redisplay) values that controls which saved payment methods the Payment Element displays by filtering to only show payment methods with an `allow_redisplay` value that is present in this list.
 //
 // If not specified, defaults to ["always"]. In order to display all saved payment methods, specify ["always", "limited", "unspecified"].
@@ -199,13 +204,53 @@ type CustomerSession struct {
 	// Configuration for the components supported by this Customer Session.
 	Components *CustomerSessionComponents `json:"components"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The Customer the Customer Session was created for.
 	Customer *Customer `json:"customer"`
 	// The timestamp at which this Customer Session will expire.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
 	Livemode bool `json:"livemode"`
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
+}
+
+// UnmarshalJSON handles deserialization of a CustomerSession.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (c *CustomerSession) UnmarshalJSON(data []byte) error {
+	type customerSession CustomerSession
+	v := struct {
+		Created   int64 `json:"created"`
+		ExpiresAt int64 `json:"expires_at"`
+		*customerSession
+	}{
+		customerSession: (*customerSession)(c),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	c.Created = time.Unix(v.Created, 0)
+	c.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a CustomerSession.
+// This custom marshaling is needed to handle the time fields correctly.
+func (c CustomerSession) MarshalJSON() ([]byte, error) {
+	type customerSession CustomerSession
+	v := struct {
+		Created   int64 `json:"created"`
+		ExpiresAt int64 `json:"expires_at"`
+		customerSession
+	}{
+		customerSession: (customerSession)(c),
+		Created:         c.Created.Unix(),
+		ExpiresAt:       c.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/dispute.go
+++ b/dispute.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // List of eligibility types that are included in `enhanced_evidence`.
 type DisputeEnhancedEligibilityType string
@@ -415,7 +418,7 @@ type DisputeEvidenceDetailsEnhancedEligibility struct {
 }
 type DisputeEvidenceDetails struct {
 	// Date by which evidence must be submitted in order to successfully challenge dispute. Will be 0 if the customer's bank or credit card company doesn't allow a response for this particular dispute.
-	DueBy               int64                                      `json:"due_by"`
+	DueBy               time.Time                                  `json:"due_by"`
 	EnhancedEligibility *DisputeEvidenceDetailsEnhancedEligibility `json:"enhanced_eligibility"`
 	// Whether evidence has been staged for this dispute.
 	HasEvidence bool `json:"has_evidence"`
@@ -469,7 +472,7 @@ type Dispute struct {
 	// ID of the charge that's disputed.
 	Charge *Charge `json:"charge"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// List of eligibility types that are included in `enhanced_evidence`.
@@ -514,11 +517,70 @@ func (d *Dispute) UnmarshalJSON(data []byte) error {
 	}
 
 	type dispute Dispute
-	var v dispute
+	v := struct {
+		Created int64 `json:"created"`
+		*dispute
+	}{
+		dispute: (*dispute)(d),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*d = Dispute(v)
+	d.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a DisputeEvidenceDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (d *DisputeEvidenceDetails) UnmarshalJSON(data []byte) error {
+	type disputeEvidenceDetails DisputeEvidenceDetails
+	v := struct {
+		DueBy int64 `json:"due_by"`
+		*disputeEvidenceDetails
+	}{
+		disputeEvidenceDetails: (*disputeEvidenceDetails)(d),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	d.DueBy = time.Unix(v.DueBy, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a DisputeEvidenceDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (d DisputeEvidenceDetails) MarshalJSON() ([]byte, error) {
+	type disputeEvidenceDetails DisputeEvidenceDetails
+	v := struct {
+		DueBy int64 `json:"due_by"`
+		disputeEvidenceDetails
+	}{
+		disputeEvidenceDetails: (disputeEvidenceDetails)(d),
+		DueBy:                  d.DueBy.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a Dispute.
+// This custom marshaling is needed to handle the time fields correctly.
+func (d Dispute) MarshalJSON() ([]byte, error) {
+	type dispute Dispute
+	v := struct {
+		Created int64 `json:"created"`
+		dispute
+	}{
+		dispute: (dispute)(d),
+		Created: d.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/ephemeralkey.go
+++ b/ephemeralkey.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Invalidates a short-lived API key for a given resource.
 type EphemeralKeyParams struct {
@@ -32,9 +35,9 @@ func (p *EphemeralKeyParams) AddExpand(f string) {
 type EphemeralKey struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Time at which the key will expire. Measured in seconds since the Unix epoch.
-	Expires int64 `json:"expires"`
+	Expires time.Time `json:"expires"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -58,11 +61,19 @@ type EphemeralKey struct {
 
 func (e *EphemeralKey) UnmarshalJSON(data []byte) error {
 	type ephemeralKey EphemeralKey
-	var ee ephemeralKey
-	err := json.Unmarshal(data, &ee)
-	if err == nil {
-		*e = EphemeralKey(ee)
+	v := struct {
+		Created int64 `json:"created"`
+		Expires int64 `json:"expires"`
+		*ephemeralKey
+	}{
+		ephemeralKey: (*ephemeralKey)(e),
 	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	e.Created = time.Unix(v.Created, 0)
+	e.Expires = time.Unix(v.Expires, 0)
 
 	// Go does guarantee the longevity of `data`, so copy when assigning `RawJSON`
 	// See https://golang.org/pkg/encoding/json/#Unmarshaler
@@ -70,4 +81,24 @@ func (e *EphemeralKey) UnmarshalJSON(data []byte) error {
 	e.RawJSON = append(e.RawJSON[:0], data...)
 
 	return nil
+}
+
+// MarshalJSON handles serialization of an EphemeralKey.
+// This custom marshaling is needed to handle the time fields correctly.
+func (e EphemeralKey) MarshalJSON() ([]byte, error) {
+	type ephemeralKey EphemeralKey
+	v := struct {
+		Created int64 `json:"created"`
+		Expires int64 `json:"expires"`
+		ephemeralKey
+	}{
+		ephemeralKey: (ephemeralKey)(e),
+		Created:      e.Created.Unix(),
+		Expires:      e.Expires.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/event.go
+++ b/event.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
 )
 
 // The type of the `automation_action`.
@@ -432,7 +433,7 @@ type Event struct {
 	// The Stripe API version used to render `data`. This property is populated only for events on or after October 31, 2014.
 	APIVersion string `json:"api_version"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64      `json:"created"`
+	Created time.Time  `json:"created"`
 	Data    *EventData `json:"data"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
@@ -515,4 +516,40 @@ func getValue(m map[string]interface{}, keys []string) string {
 	}
 
 	return fmt.Sprintf("%v", node)
+}
+
+// UnmarshalJSON handles deserialization of an Event.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (e *Event) UnmarshalJSON(data []byte) error {
+	type event Event
+	v := struct {
+		Created int64 `json:"created"`
+		*event
+	}{
+		event: (*event)(e),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	e.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an Event.
+// This custom marshaling is needed to handle the time fields correctly.
+func (e Event) MarshalJSON() ([]byte, error) {
+	type event Event
+	v := struct {
+		Created int64 `json:"created"`
+		event
+	}{
+		event:   (event)(e),
+		Created: e.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -2338,8 +2338,8 @@ func TestReportingReportRunsPost(t *testing.T) {
 	params := &stripe.ReportingReportRunParams{
 		ReportType: stripe.String("balance.summary.1"),
 		Parameters: &stripe.ReportingReportRunParametersParams{
-			IntervalStart: stripe.Int64(1522540800),
-			IntervalEnd:   stripe.Int64(1525132800),
+			IntervalStart: stripe.UnixTime(1522540800),
+			IntervalEnd:   stripe.UnixTime(1525132800),
 		},
 	}
 	result, err := reporting_reportrun.New(params)
@@ -2607,7 +2607,7 @@ func TestSubscriptionItemsUsageRecordSummariesGet(t *testing.T) {
 func TestSubscriptionItemsUsageRecordsPost(t *testing.T) {
 	params := &stripe.UsageRecordParams{
 		Quantity:         stripe.Int64(100),
-		Timestamp:        stripe.Int64(1571252444),
+		Timestamp:        stripe.UnixTime(1571252444),
 		SubscriptionItem: stripe.String("si_xxxxxxxxxxxxx"),
 	}
 	result, err := usagerecord.New(params)
@@ -2640,7 +2640,7 @@ func TestSubscriptionSchedulesGet2(t *testing.T) {
 func TestSubscriptionSchedulesPost(t *testing.T) {
 	params := &stripe.SubscriptionScheduleParams{
 		Customer:    stripe.String("cus_xxxxxxxxxxxxx"),
-		StartDate:   stripe.Int64(1676070661),
+		StartDate:   stripe.UnixTime(1676070661),
 		EndBehavior: stripe.String(string(stripe.SubscriptionScheduleEndBehaviorRelease)),
 		Phases: []*stripe.SubscriptionSchedulePhaseParams{
 			{
@@ -3117,7 +3117,7 @@ func TestTestHelpersIssuingAuthorizationsCapturePost(t *testing.T) {
 		CloseAuthorization: stripe.Bool(true),
 		PurchaseDetails: &stripe.TestHelpersIssuingAuthorizationCapturePurchaseDetailsParams{
 			Flight: &stripe.TestHelpersIssuingAuthorizationCapturePurchaseDetailsFlightParams{
-				DepartureAt:   stripe.Int64(1633651200),
+				DepartureAt:   stripe.UnixTime(1633651200),
 				PassengerName: stripe.String("John Doe"),
 				Refundable:    stripe.Bool(true),
 				Segments: []*stripe.TestHelpersIssuingAuthorizationCapturePurchaseDetailsFlightSegmentParams{
@@ -3139,7 +3139,7 @@ func TestTestHelpersIssuingAuthorizationsCapturePost(t *testing.T) {
 				QuantityDecimal: stripe.Float64(10),
 			},
 			Lodging: &stripe.TestHelpersIssuingAuthorizationCapturePurchaseDetailsLodgingParams{
-				CheckInAt: stripe.Int64(1633651200),
+				CheckInAt: stripe.UnixTime(1633651200),
 				Nights:    stripe.Int64(2),
 			},
 			Receipt: []*stripe.TestHelpersIssuingAuthorizationCapturePurchaseDetailsReceiptParams{
@@ -3314,7 +3314,7 @@ func TestTestHelpersIssuingTransactionsCreateForceCapturePost(t *testing.T) {
 		},
 		PurchaseDetails: &stripe.TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsParams{
 			Flight: &stripe.TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsFlightParams{
-				DepartureAt:   stripe.Int64(1633651200),
+				DepartureAt:   stripe.UnixTime(1633651200),
 				PassengerName: stripe.String("John Doe"),
 				Refundable:    stripe.Bool(true),
 				Segments: []*stripe.TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsFlightSegmentParams{
@@ -3336,7 +3336,7 @@ func TestTestHelpersIssuingTransactionsCreateForceCapturePost(t *testing.T) {
 				QuantityDecimal: stripe.Float64(10),
 			},
 			Lodging: &stripe.TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsLodgingParams{
-				CheckInAt: stripe.Int64(1533651200),
+				CheckInAt: stripe.UnixTime(1533651200),
 				Nights:    stripe.Int64(2),
 			},
 			Receipt: []*stripe.TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsReceiptParams{
@@ -3372,7 +3372,7 @@ func TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPost(t *testing.T) {
 		},
 		PurchaseDetails: &stripe.TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsParams{
 			Flight: &stripe.TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsFlightParams{
-				DepartureAt:   stripe.Int64(1533651200),
+				DepartureAt:   stripe.UnixTime(1533651200),
 				PassengerName: stripe.String("John Doe"),
 				Refundable:    stripe.Bool(true),
 				Segments: []*stripe.TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsFlightSegmentParams{
@@ -3394,7 +3394,7 @@ func TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPost(t *testing.T) {
 				QuantityDecimal: stripe.Float64(10),
 			},
 			Lodging: &stripe.TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsLodgingParams{
-				CheckInAt: stripe.Int64(1533651200),
+				CheckInAt: stripe.UnixTime(1533651200),
 				Nights:    stripe.Int64(2),
 			},
 			Receipt: []*stripe.TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsReceiptParams{
@@ -3434,7 +3434,7 @@ func TestTestHelpersRefundsExpirePost(t *testing.T) {
 
 func TestTestHelpersTestClocksAdvancePost(t *testing.T) {
 	params := &stripe.TestHelpersTestClockAdvanceParams{
-		FrozenTime: stripe.Int64(142),
+		FrozenTime: stripe.UnixTime(142),
 	}
 	result, err := testhelpers_testclock.Advance("clock_xyz", params)
 	assert.NotNil(t, result)
@@ -3443,7 +3443,7 @@ func TestTestHelpersTestClocksAdvancePost(t *testing.T) {
 
 func TestTestHelpersTestClocksAdvancePost2(t *testing.T) {
 	params := &stripe.TestHelpersTestClockAdvanceParams{
-		FrozenTime: stripe.Int64(1675552261),
+		FrozenTime: stripe.UnixTime(1675552261),
 	}
 	result, err := testhelpers_testclock.Advance("clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
@@ -3495,7 +3495,7 @@ func TestTestHelpersTestClocksGet4(t *testing.T) {
 
 func TestTestHelpersTestClocksPost(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{
-		FrozenTime: stripe.Int64(123),
+		FrozenTime: stripe.UnixTime(123),
 		Name:       stripe.String("cogsworth"),
 	}
 	result, err := testhelpers_testclock.New(params)
@@ -3505,7 +3505,7 @@ func TestTestHelpersTestClocksPost(t *testing.T) {
 
 func TestTestHelpersTestClocksPost2(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{
-		FrozenTime: stripe.Int64(1577836800),
+		FrozenTime: stripe.UnixTime(1577836800),
 	}
 	result, err := testhelpers_testclock.New(params)
 	assert.NotNil(t, result)

--- a/feerefund.go
+++ b/feerefund.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.
 type FeeRefundParams struct {
@@ -60,7 +63,7 @@ type FeeRefund struct {
 	// Balance transaction that describes the impact on your account balance.
 	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// ID of the application fee that was refunded.
@@ -90,11 +93,34 @@ func (f *FeeRefund) UnmarshalJSON(data []byte) error {
 	}
 
 	type feeRefund FeeRefund
-	var v feeRefund
+	v := struct {
+		Created int64 `json:"created"`
+		*feeRefund
+	}{
+		feeRefund: (*feeRefund)(f),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*f = FeeRefund(v)
+	f.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a FeeRefund.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FeeRefund) MarshalJSON() ([]byte, error) {
+	type feeRefund FeeRefund
+	v := struct {
+		Created int64 `json:"created"`
+		feeRefund
+	}{
+		feeRefund: (feeRefund)(f),
+		Created:   f.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/filelink.go
+++ b/filelink.go
@@ -6,7 +6,11 @@
 
 package stripe
 
-import "github.com/stripe/stripe-go/v81/form"
+import (
+	"encoding/json"
+	"github.com/stripe/stripe-go/v81/form"
+	"time"
+)
 
 // Returns a list of file links.
 type FileLinkListParams struct {
@@ -34,8 +38,8 @@ type FileLinkParams struct {
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// A future timestamp after which the link will no longer be usable, or `now` to expire the link immediately.
-	ExpiresAt    *int64 `form:"expires_at"`
-	ExpiresAtNow *bool  `form:"-"` // See custom AppendTo
+	ExpiresAt    *time.Time `form:"expires_at"`
+	ExpiresAtNow *bool      `form:"-"` // See custom AppendTo
 	// The ID of the file. The file's `purpose` must be one of the following: `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `finance_report_run`, `financial_account_statement`, `identity_document_downloadable`, `issuing_regulatory_reporting`, `pci_document`, `selfie`, `sigma_scheduled_query`, `tax_document_user_upload`, or `terminal_reader_splashscreen`.
 	File *string `form:"file"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
@@ -69,11 +73,11 @@ func (p *FileLinkParams) AppendTo(body *form.Values, keyParts []string) {
 type FileLink struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Returns if the link is already expired.
 	Expired bool `json:"expired"`
 	// Time that the link expires.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The file object this link points to.
 	File *File `json:"file"`
 	// Unique identifier for the object.
@@ -93,4 +97,44 @@ type FileLinkList struct {
 	APIResource
 	ListMeta
 	Data []*FileLink `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a FileLink.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FileLink) UnmarshalJSON(data []byte) error {
+	type fileLink FileLink
+	v := struct {
+		Created   int64 `json:"created"`
+		ExpiresAt int64 `json:"expires_at"`
+		*fileLink
+	}{
+		fileLink: (*fileLink)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.Created = time.Unix(v.Created, 0)
+	f.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a FileLink.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FileLink) MarshalJSON() ([]byte, error) {
+	type fileLink FileLink
+	v := struct {
+		Created   int64 `json:"created"`
+		ExpiresAt int64 `json:"expires_at"`
+		fileLink
+	}{
+		fileLink:  (fileLink)(f),
+		Created:   f.Created.Unix(),
+		ExpiresAt: f.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/financialconnections_account.go
+++ b/financialconnections_account.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Type of account holder that this account belongs to.
 type FinancialConnectionsAccountAccountHolderType string
 
@@ -275,7 +280,7 @@ type FinancialConnectionsAccountBalanceCredit struct {
 // The most recent information about the account's balance.
 type FinancialConnectionsAccountBalance struct {
 	// The time that the external institution calculated this balance. Measured in seconds since the Unix epoch.
-	AsOf   int64                                     `json:"as_of"`
+	AsOf   time.Time                                 `json:"as_of"`
 	Cash   *FinancialConnectionsAccountBalanceCash   `json:"cash"`
 	Credit *FinancialConnectionsAccountBalanceCredit `json:"credit"`
 	// The balances owed to (or by) the account holder, before subtracting any outbound pending transactions or adding any inbound pending transactions.
@@ -291,9 +296,9 @@ type FinancialConnectionsAccountBalance struct {
 // The state of the most recent attempt to refresh the account balance.
 type FinancialConnectionsAccountBalanceRefresh struct {
 	// The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
-	LastAttemptedAt int64 `json:"last_attempted_at"`
+	LastAttemptedAt time.Time `json:"last_attempted_at"`
 	// Time at which the next balance refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
-	NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+	NextRefreshAvailableAt time.Time `json:"next_refresh_available_at"`
 	// The status of the last refresh attempt.
 	Status FinancialConnectionsAccountBalanceRefreshStatus `json:"status"`
 }
@@ -301,9 +306,9 @@ type FinancialConnectionsAccountBalanceRefresh struct {
 // The state of the most recent attempt to refresh the account's inferred balance history.
 type FinancialConnectionsAccountInferredBalancesRefresh struct {
 	// The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
-	LastAttemptedAt int64 `json:"last_attempted_at"`
+	LastAttemptedAt time.Time `json:"last_attempted_at"`
 	// Time at which the next inferred balance refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
-	NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+	NextRefreshAvailableAt time.Time `json:"next_refresh_available_at"`
 	// The status of the last refresh attempt.
 	Status FinancialConnectionsAccountInferredBalancesRefreshStatus `json:"status"`
 }
@@ -311,9 +316,9 @@ type FinancialConnectionsAccountInferredBalancesRefresh struct {
 // The state of the most recent attempt to refresh the account owners.
 type FinancialConnectionsAccountOwnershipRefresh struct {
 	// The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
-	LastAttemptedAt int64 `json:"last_attempted_at"`
+	LastAttemptedAt time.Time `json:"last_attempted_at"`
 	// Time at which the next ownership refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
-	NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+	NextRefreshAvailableAt time.Time `json:"next_refresh_available_at"`
 	// The status of the last refresh attempt.
 	Status FinancialConnectionsAccountOwnershipRefreshStatus `json:"status"`
 }
@@ -323,9 +328,9 @@ type FinancialConnectionsAccountTransactionRefresh struct {
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
-	LastAttemptedAt int64 `json:"last_attempted_at"`
+	LastAttemptedAt time.Time `json:"last_attempted_at"`
 	// Time at which the next transaction refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
-	NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+	NextRefreshAvailableAt time.Time `json:"next_refresh_available_at"`
 	// The status of the last refresh attempt.
 	Status FinancialConnectionsAccountTransactionRefreshStatus `json:"status"`
 }
@@ -342,7 +347,7 @@ type FinancialConnectionsAccount struct {
 	// The type of the account. Account category is further divided in `subcategory`.
 	Category FinancialConnectionsAccountCategory `json:"category"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// A human-readable name that has been assigned to this account, either by the account holder or by the institution.
 	DisplayName string `json:"display_name"`
 	// Unique identifier for the object.
@@ -393,4 +398,236 @@ type FinancialConnectionsAccountList struct {
 	APIResource
 	ListMeta
 	Data []*FinancialConnectionsAccount `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsAccountBalance.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsAccountBalance) UnmarshalJSON(data []byte) error {
+	type financialConnectionsAccountBalance FinancialConnectionsAccountBalance
+	v := struct {
+		AsOf int64 `json:"as_of"`
+		*financialConnectionsAccountBalance
+	}{
+		financialConnectionsAccountBalance: (*financialConnectionsAccountBalance)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.AsOf = time.Unix(v.AsOf, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsAccountBalanceRefresh.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsAccountBalanceRefresh) UnmarshalJSON(data []byte) error {
+	type financialConnectionsAccountBalanceRefresh FinancialConnectionsAccountBalanceRefresh
+	v := struct {
+		LastAttemptedAt        int64 `json:"last_attempted_at"`
+		NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+		*financialConnectionsAccountBalanceRefresh
+	}{
+		financialConnectionsAccountBalanceRefresh: (*financialConnectionsAccountBalanceRefresh)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.LastAttemptedAt = time.Unix(v.LastAttemptedAt, 0)
+	f.NextRefreshAvailableAt = time.Unix(v.NextRefreshAvailableAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsAccountInferredBalancesRefresh.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsAccountInferredBalancesRefresh) UnmarshalJSON(data []byte) error {
+	type financialConnectionsAccountInferredBalancesRefresh FinancialConnectionsAccountInferredBalancesRefresh
+	v := struct {
+		LastAttemptedAt        int64 `json:"last_attempted_at"`
+		NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+		*financialConnectionsAccountInferredBalancesRefresh
+	}{
+		financialConnectionsAccountInferredBalancesRefresh: (*financialConnectionsAccountInferredBalancesRefresh)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.LastAttemptedAt = time.Unix(v.LastAttemptedAt, 0)
+	f.NextRefreshAvailableAt = time.Unix(v.NextRefreshAvailableAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsAccountOwnershipRefresh.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsAccountOwnershipRefresh) UnmarshalJSON(data []byte) error {
+	type financialConnectionsAccountOwnershipRefresh FinancialConnectionsAccountOwnershipRefresh
+	v := struct {
+		LastAttemptedAt        int64 `json:"last_attempted_at"`
+		NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+		*financialConnectionsAccountOwnershipRefresh
+	}{
+		financialConnectionsAccountOwnershipRefresh: (*financialConnectionsAccountOwnershipRefresh)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.LastAttemptedAt = time.Unix(v.LastAttemptedAt, 0)
+	f.NextRefreshAvailableAt = time.Unix(v.NextRefreshAvailableAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsAccountTransactionRefresh.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsAccountTransactionRefresh) UnmarshalJSON(data []byte) error {
+	type financialConnectionsAccountTransactionRefresh FinancialConnectionsAccountTransactionRefresh
+	v := struct {
+		LastAttemptedAt        int64 `json:"last_attempted_at"`
+		NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+		*financialConnectionsAccountTransactionRefresh
+	}{
+		financialConnectionsAccountTransactionRefresh: (*financialConnectionsAccountTransactionRefresh)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.LastAttemptedAt = time.Unix(v.LastAttemptedAt, 0)
+	f.NextRefreshAvailableAt = time.Unix(v.NextRefreshAvailableAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsAccount.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsAccount) UnmarshalJSON(data []byte) error {
+	type financialConnectionsAccount FinancialConnectionsAccount
+	v := struct {
+		Created int64 `json:"created"`
+		*financialConnectionsAccount
+	}{
+		financialConnectionsAccount: (*financialConnectionsAccount)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsAccountBalance.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsAccountBalance) MarshalJSON() ([]byte, error) {
+	type financialConnectionsAccountBalance FinancialConnectionsAccountBalance
+	v := struct {
+		AsOf int64 `json:"as_of"`
+		financialConnectionsAccountBalance
+	}{
+		financialConnectionsAccountBalance: (financialConnectionsAccountBalance)(f),
+		AsOf:                               f.AsOf.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsAccountBalanceRefresh.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsAccountBalanceRefresh) MarshalJSON() ([]byte, error) {
+	type financialConnectionsAccountBalanceRefresh FinancialConnectionsAccountBalanceRefresh
+	v := struct {
+		LastAttemptedAt        int64 `json:"last_attempted_at"`
+		NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+		financialConnectionsAccountBalanceRefresh
+	}{
+		financialConnectionsAccountBalanceRefresh: (financialConnectionsAccountBalanceRefresh)(f),
+		LastAttemptedAt:        f.LastAttemptedAt.Unix(),
+		NextRefreshAvailableAt: f.NextRefreshAvailableAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsAccountInferredBalancesRefresh.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsAccountInferredBalancesRefresh) MarshalJSON() ([]byte, error) {
+	type financialConnectionsAccountInferredBalancesRefresh FinancialConnectionsAccountInferredBalancesRefresh
+	v := struct {
+		LastAttemptedAt        int64 `json:"last_attempted_at"`
+		NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+		financialConnectionsAccountInferredBalancesRefresh
+	}{
+		financialConnectionsAccountInferredBalancesRefresh: (financialConnectionsAccountInferredBalancesRefresh)(f),
+		LastAttemptedAt:        f.LastAttemptedAt.Unix(),
+		NextRefreshAvailableAt: f.NextRefreshAvailableAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsAccountOwnershipRefresh.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsAccountOwnershipRefresh) MarshalJSON() ([]byte, error) {
+	type financialConnectionsAccountOwnershipRefresh FinancialConnectionsAccountOwnershipRefresh
+	v := struct {
+		LastAttemptedAt        int64 `json:"last_attempted_at"`
+		NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+		financialConnectionsAccountOwnershipRefresh
+	}{
+		financialConnectionsAccountOwnershipRefresh: (financialConnectionsAccountOwnershipRefresh)(f),
+		LastAttemptedAt:        f.LastAttemptedAt.Unix(),
+		NextRefreshAvailableAt: f.NextRefreshAvailableAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsAccountTransactionRefresh.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsAccountTransactionRefresh) MarshalJSON() ([]byte, error) {
+	type financialConnectionsAccountTransactionRefresh FinancialConnectionsAccountTransactionRefresh
+	v := struct {
+		LastAttemptedAt        int64 `json:"last_attempted_at"`
+		NextRefreshAvailableAt int64 `json:"next_refresh_available_at"`
+		financialConnectionsAccountTransactionRefresh
+	}{
+		financialConnectionsAccountTransactionRefresh: (financialConnectionsAccountTransactionRefresh)(f),
+		LastAttemptedAt:        f.LastAttemptedAt.Unix(),
+		NextRefreshAvailableAt: f.NextRefreshAvailableAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsAccount.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsAccount) MarshalJSON() ([]byte, error) {
+	type financialConnectionsAccount FinancialConnectionsAccount
+	v := struct {
+		Created int64 `json:"created"`
+		financialConnectionsAccount
+	}{
+		financialConnectionsAccount: (financialConnectionsAccount)(f),
+		Created:                     f.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/financialconnections_accountinferredbalance.go
+++ b/financialconnections_accountinferredbalance.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Lists the recorded inferred balances for a Financial Connections Account.
 type FinancialConnectionsAccountInferredBalanceListParams struct {
 	ListParams `form:"*"`
@@ -22,7 +27,7 @@ func (p *FinancialConnectionsAccountInferredBalanceListParams) AddExpand(f strin
 // A historical balance for the account on a particular day. It may be sourced from a balance snapshot provided by a financial institution, or inferred using transactions data.
 type FinancialConnectionsAccountInferredBalance struct {
 	// The time for which this balance was calculated, measured in seconds since the Unix epoch. If the balance was computed by Stripe and not provided directly by a financial institution, it will always be 23:59:59 UTC.
-	AsOf int64 `json:"as_of"`
+	AsOf time.Time `json:"as_of"`
 	// The balances owed to (or by) the account holder, before subtracting any outbound pending transactions or adding any inbound pending transactions.
 	//
 	// Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
@@ -40,4 +45,40 @@ type FinancialConnectionsAccountInferredBalanceList struct {
 	APIResource
 	ListMeta
 	Data []*FinancialConnectionsAccountInferredBalance `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsAccountInferredBalance.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsAccountInferredBalance) UnmarshalJSON(data []byte) error {
+	type financialConnectionsAccountInferredBalance FinancialConnectionsAccountInferredBalance
+	v := struct {
+		AsOf int64 `json:"as_of"`
+		*financialConnectionsAccountInferredBalance
+	}{
+		financialConnectionsAccountInferredBalance: (*financialConnectionsAccountInferredBalance)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.AsOf = time.Unix(v.AsOf, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsAccountInferredBalance.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsAccountInferredBalance) MarshalJSON() ([]byte, error) {
+	type financialConnectionsAccountInferredBalance FinancialConnectionsAccountInferredBalance
+	v := struct {
+		AsOf int64 `json:"as_of"`
+		financialConnectionsAccountInferredBalance
+	}{
+		financialConnectionsAccountInferredBalance: (financialConnectionsAccountInferredBalance)(f),
+		AsOf: f.AsOf.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/financialconnections_accountownership.go
+++ b/financialconnections_accountownership.go
@@ -6,12 +6,15 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Describes a snapshot of the owners of an account at a particular point in time.
 type FinancialConnectionsAccountOwnership struct {
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// String representing the object's type. Objects of the same type share the same value.
@@ -30,11 +33,34 @@ func (f *FinancialConnectionsAccountOwnership) UnmarshalJSON(data []byte) error 
 	}
 
 	type financialConnectionsAccountOwnership FinancialConnectionsAccountOwnership
-	var v financialConnectionsAccountOwnership
+	v := struct {
+		Created int64 `json:"created"`
+		*financialConnectionsAccountOwnership
+	}{
+		financialConnectionsAccountOwnership: (*financialConnectionsAccountOwnership)(f),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*f = FinancialConnectionsAccountOwnership(v)
+	f.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsAccountOwnership.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsAccountOwnership) MarshalJSON() ([]byte, error) {
+	type financialConnectionsAccountOwnership FinancialConnectionsAccountOwnership
+	v := struct {
+		Created int64 `json:"created"`
+		financialConnectionsAccountOwnership
+	}{
+		financialConnectionsAccountOwnership: (financialConnectionsAccountOwnership)(f),
+		Created:                              f.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/financialconnections_transaction.go
+++ b/financialconnections_transaction.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The status of the transaction.
 type FinancialConnectionsTransactionStatus string
 
@@ -56,9 +61,9 @@ func (p *FinancialConnectionsTransactionParams) AddExpand(f string) {
 
 type FinancialConnectionsTransactionStatusTransitions struct {
 	// Time at which this transaction posted. Measured in seconds since the Unix epoch.
-	PostedAt int64 `json:"posted_at"`
+	PostedAt time.Time `json:"posted_at"`
 	// Time at which this transaction was voided. Measured in seconds since the Unix epoch.
-	VoidAt int64 `json:"void_at"`
+	VoidAt time.Time `json:"void_at"`
 }
 
 // A Transaction represents a real transaction that affects a Financial Connections Account balance.
@@ -82,11 +87,11 @@ type FinancialConnectionsTransaction struct {
 	Status            FinancialConnectionsTransactionStatus             `json:"status"`
 	StatusTransitions *FinancialConnectionsTransactionStatusTransitions `json:"status_transitions"`
 	// Time at which the transaction was transacted. Measured in seconds since the Unix epoch.
-	TransactedAt int64 `json:"transacted_at"`
+	TransactedAt time.Time `json:"transacted_at"`
 	// The token of the transaction refresh that last updated or created this transaction.
 	TransactionRefresh string `json:"transaction_refresh"`
 	// Time at which the object was last updated. Measured in seconds since the Unix epoch.
-	Updated int64 `json:"updated"`
+	Updated time.Time `json:"updated"`
 }
 
 // FinancialConnectionsTransactionList is a list of Transactions as retrieved from a list endpoint.
@@ -94,4 +99,84 @@ type FinancialConnectionsTransactionList struct {
 	APIResource
 	ListMeta
 	Data []*FinancialConnectionsTransaction `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsTransactionStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsTransactionStatusTransitions) UnmarshalJSON(data []byte) error {
+	type financialConnectionsTransactionStatusTransitions FinancialConnectionsTransactionStatusTransitions
+	v := struct {
+		PostedAt int64 `json:"posted_at"`
+		VoidAt   int64 `json:"void_at"`
+		*financialConnectionsTransactionStatusTransitions
+	}{
+		financialConnectionsTransactionStatusTransitions: (*financialConnectionsTransactionStatusTransitions)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.PostedAt = time.Unix(v.PostedAt, 0)
+	f.VoidAt = time.Unix(v.VoidAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a FinancialConnectionsTransaction.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *FinancialConnectionsTransaction) UnmarshalJSON(data []byte) error {
+	type financialConnectionsTransaction FinancialConnectionsTransaction
+	v := struct {
+		TransactedAt int64 `json:"transacted_at"`
+		Updated      int64 `json:"updated"`
+		*financialConnectionsTransaction
+	}{
+		financialConnectionsTransaction: (*financialConnectionsTransaction)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.TransactedAt = time.Unix(v.TransactedAt, 0)
+	f.Updated = time.Unix(v.Updated, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsTransactionStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsTransactionStatusTransitions) MarshalJSON() ([]byte, error) {
+	type financialConnectionsTransactionStatusTransitions FinancialConnectionsTransactionStatusTransitions
+	v := struct {
+		PostedAt int64 `json:"posted_at"`
+		VoidAt   int64 `json:"void_at"`
+		financialConnectionsTransactionStatusTransitions
+	}{
+		financialConnectionsTransactionStatusTransitions: (financialConnectionsTransactionStatusTransitions)(f),
+		PostedAt: f.PostedAt.Unix(),
+		VoidAt:   f.VoidAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a FinancialConnectionsTransaction.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f FinancialConnectionsTransaction) MarshalJSON() ([]byte, error) {
+	type financialConnectionsTransaction FinancialConnectionsTransaction
+	v := struct {
+		TransactedAt int64 `json:"transacted_at"`
+		Updated      int64 `json:"updated"`
+		financialConnectionsTransaction
+	}{
+		financialConnectionsTransaction: (financialConnectionsTransaction)(f),
+		TransactedAt:                    f.TransactedAt.Unix(),
+		Updated:                         f.Updated.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/form/form.go
+++ b/form/form.go
@@ -469,8 +469,8 @@ func makeStructEncoder(t reflect.Type) *structEncoder {
 }
 
 func makeTypeEncoder(t reflect.Type) encoderFunc {
-	// For time.Time, we want to encode it as a Unix timestamp,
-	// and don't want to recurse into it.
+	// For time.Time, we want to encode imediately it as a Unix timestamp,
+	// and don't want to inspect into it and encode it as a struct.
 	if t == reflect.TypeOf(time.Time{}) {
 		return timeEncoder
 	}

--- a/forwarding_request.go
+++ b/forwarding_request.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The field kinds to be replaced in the forwarded request.
 type ForwardingRequestReplacement string
 
@@ -150,7 +155,7 @@ type ForwardingRequestResponseDetails struct {
 type ForwardingRequest struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -178,4 +183,40 @@ type ForwardingRequestList struct {
 	APIResource
 	ListMeta
 	Data []*ForwardingRequest `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a ForwardingRequest.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (f *ForwardingRequest) UnmarshalJSON(data []byte) error {
+	type forwardingRequest ForwardingRequest
+	v := struct {
+		Created int64 `json:"created"`
+		*forwardingRequest
+	}{
+		forwardingRequest: (*forwardingRequest)(f),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	f.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a ForwardingRequest.
+// This custom marshaling is needed to handle the time fields correctly.
+func (f ForwardingRequest) MarshalJSON() ([]byte, error) {
+	type forwardingRequest ForwardingRequest
+	v := struct {
+		Created int64 `json:"created"`
+		forwardingRequest
+	}{
+		forwardingRequest: (forwardingRequest)(f),
+		Created:           f.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/giftcards_card.go
+++ b/giftcards_card.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The type of event that created this object.
 type GiftCardsCardCreatedByType string
 
@@ -128,7 +133,7 @@ type GiftCardsCard struct {
 	// Code used to redeem this gift card.
 	Code string `json:"code"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The related Stripe objects that created this gift card.
 	CreatedBy *GiftCardsCardCreatedBy `json:"created_by"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -148,4 +153,40 @@ type GiftCardsCardList struct {
 	APIResource
 	ListMeta
 	Data []*GiftCardsCard `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a GiftCardsCard.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (g *GiftCardsCard) UnmarshalJSON(data []byte) error {
+	type giftCardsCard GiftCardsCard
+	v := struct {
+		Created int64 `json:"created"`
+		*giftCardsCard
+	}{
+		giftCardsCard: (*giftCardsCard)(g),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	g.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a GiftCardsCard.
+// This custom marshaling is needed to handle the time fields correctly.
+func (g GiftCardsCard) MarshalJSON() ([]byte, error) {
+	type giftCardsCard GiftCardsCard
+	v := struct {
+		Created int64 `json:"created"`
+		giftCardsCard
+	}{
+		giftCardsCard: (giftCardsCard)(g),
+		Created:       g.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/giftcards_transaction.go
+++ b/giftcards_transaction.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The type of event that created this object.
 type GiftCardsTransactionCreatedByType string
 
@@ -155,9 +160,9 @@ type GiftCardsTransaction struct {
 	// The amount of this transaction. A positive value indicates that funds were added to the gift card. A negative value indicates that funds were removed from the gift card.
 	Amount int64 `json:"amount"`
 	// Time at which the transaction was confirmed. Measured in seconds since the Unix epoch.
-	ConfirmedAt int64 `json:"confirmed_at"`
+	ConfirmedAt time.Time `json:"confirmed_at"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The related Stripe objects that created this gift card transaction.
 	CreatedBy *GiftCardsTransactionCreatedBy `json:"created_by"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -183,4 +188,44 @@ type GiftCardsTransactionList struct {
 	APIResource
 	ListMeta
 	Data []*GiftCardsTransaction `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a GiftCardsTransaction.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (g *GiftCardsTransaction) UnmarshalJSON(data []byte) error {
+	type giftCardsTransaction GiftCardsTransaction
+	v := struct {
+		ConfirmedAt int64 `json:"confirmed_at"`
+		Created     int64 `json:"created"`
+		*giftCardsTransaction
+	}{
+		giftCardsTransaction: (*giftCardsTransaction)(g),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	g.ConfirmedAt = time.Unix(v.ConfirmedAt, 0)
+	g.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a GiftCardsTransaction.
+// This custom marshaling is needed to handle the time fields correctly.
+func (g GiftCardsTransaction) MarshalJSON() ([]byte, error) {
+	type giftCardsTransaction GiftCardsTransaction
+	v := struct {
+		ConfirmedAt int64 `json:"confirmed_at"`
+		Created     int64 `json:"created"`
+		giftCardsTransaction
+	}{
+		giftCardsTransaction: (giftCardsTransaction)(g),
+		ConfirmedAt:          g.ConfirmedAt.Unix(),
+		Created:              g.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/invoice.go
+++ b/invoice.go
@@ -9,6 +9,7 @@ package stripe
 import (
 	"encoding/json"
 	"github.com/stripe/stripe-go/v81/form"
+	"time"
 )
 
 // The status of the payment, one of `open`, `paid`, or `past_due`
@@ -311,7 +312,7 @@ type InvoiceParams struct {
 	// Controls whether Stripe performs [automatic collection](https://stripe.com/docs/invoicing/integration/automatic-advancement-collection) of the invoice. If `false`, the invoice's state doesn't automatically advance without an explicit action.
 	AutoAdvance *bool `form:"auto_advance"`
 	// The time when this invoice should be scheduled to finalize. The invoice will be finalized at this time if it is still in draft state. To turn off automatic finalization, set `auto_advance` to false.
-	AutomaticallyFinalizesAt *int64 `form:"automatically_finalizes_at"`
+	AutomaticallyFinalizesAt *time.Time `form:"automatically_finalizes_at"`
 	// Settings for automatic tax lookup for this invoice.
 	AutomaticTax *InvoiceAutomaticTaxParams `form:"automatic_tax"`
 	// Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions. Defaults to `charge_automatically`.
@@ -337,9 +338,9 @@ type InvoiceParams struct {
 	// The coupons and promotion codes to redeem into discounts for the invoice. If not specified, inherits the discount from the invoice's customer. Pass an empty string to avoid inheriting any discounts.
 	Discounts []*InvoiceDiscountParams `form:"discounts"`
 	// The date on which payment for this invoice is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices.
-	DueDate *int64 `form:"due_date"`
+	DueDate *time.Time `form:"due_date"`
 	// The date when this invoice is in effect. Same as `finalized_at` unless overwritten. When defined, this value replaces the system-generated 'Date of issue' printed on the invoice PDF and receipt.
-	EffectiveAt *int64 `form:"effective_at"`
+	EffectiveAt *time.Time `form:"effective_at"`
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// Footer to be displayed on the invoice.
@@ -395,7 +396,7 @@ type InvoiceAmountsDueParams struct {
 	// An arbitrary string attached to the object. Often useful for displaying to users.
 	Description *string `form:"description"`
 	// Date on which a payment plan's payment is due.
-	DueDate *int64 `form:"due_date"`
+	DueDate *time.Time `form:"due_date"`
 }
 
 // The account that's liable for tax. If set, the business address and tax registrations required to perform the tax calculation are loaded from this account. The tax transaction is returned in the report of the connected account.
@@ -435,7 +436,7 @@ type InvoiceDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -810,9 +811,9 @@ type InvoiceUpcomingCustomerDetailsParams struct {
 // The period associated with this invoice item. When set to different values, the period will be rendered on the invoice. If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue. See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
 type InvoiceUpcomingInvoiceItemPeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start. This value is inclusive.
-	End *int64 `form:"end"`
+	End *time.Time `form:"end"`
 	// The start of the period. This value is inclusive.
-	Start *int64 `form:"start"`
+	Start *time.Time `form:"start"`
 }
 
 // List of invoice items to add or update in the upcoming invoice preview (up to 250).
@@ -889,7 +890,7 @@ type InvoiceUpcomingScheduleDetailsAmendmentAmendmentEndParams struct {
 	// Time span for the amendment starting from the `amendment_start`.
 	Duration *InvoiceUpcomingScheduleDetailsAmendmentAmendmentEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the amendment to end. Must be after the `amendment_start`.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of three ways to pass the `amendment_end`.
 	Type *string `form:"type"`
 }
@@ -913,7 +914,7 @@ type InvoiceUpcomingScheduleDetailsAmendmentAmendmentStartParams struct {
 	// Use the `end` time of a given discount.
 	DiscountEnd *InvoiceUpcomingScheduleDetailsAmendmentAmendmentStartDiscountEndParams `form:"discount_end"`
 	// A precise Unix timestamp for the amendment to start.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of three ways to pass the `amendment_start`.
 	Type *string `form:"type"`
 }
@@ -983,7 +984,7 @@ type InvoiceUpcomingScheduleDetailsAmendmentItemActionAddDiscountDiscountEndPara
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingScheduleDetailsAmendmentItemActionAddDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -1052,7 +1053,7 @@ type InvoiceUpcomingScheduleDetailsAmendmentItemActionSetDiscountDiscountEndPara
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingScheduleDetailsAmendmentItemActionSetDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -1189,7 +1190,7 @@ type InvoiceUpcomingScheduleDetailsPhaseAddInvoiceItemDiscountDiscountEndParams 
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingScheduleDetailsPhaseAddInvoiceItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -1271,7 +1272,7 @@ type InvoiceUpcomingScheduleDetailsPhaseDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingScheduleDetailsPhaseDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -1325,7 +1326,7 @@ type InvoiceUpcomingScheduleDetailsPhaseItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingScheduleDetailsPhaseItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -1458,8 +1459,8 @@ type InvoiceUpcomingScheduleDetailsPhaseParams struct {
 	// The coupons to redeem into discounts for the schedule phase. If not specified, inherits the discount from the subscription's customer. Pass an empty string to avoid inheriting any discounts.
 	Discounts []*InvoiceUpcomingScheduleDetailsPhaseDiscountParams `form:"discounts"`
 	// The date at which this phase of the subscription schedule ends. If set, `iterations` must not be set.
-	EndDate    *int64 `form:"end_date"`
-	EndDateNow *bool  `form:"-"` // See custom AppendTo
+	EndDate    *time.Time `form:"end_date"`
+	EndDateNow *bool      `form:"-"` // See custom AppendTo
 	// All invoices will be billed using the specified settings.
 	InvoiceSettings *InvoiceUpcomingScheduleDetailsPhaseInvoiceSettingsParams `form:"invoice_settings"`
 	// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
@@ -1475,8 +1476,8 @@ type InvoiceUpcomingScheduleDetailsPhaseParams struct {
 	// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase. The default value is `create_prorations`. This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase. It's different from the request-level [proration_behavior](https://stripe.com/docs/api/subscription_schedules/update#update_subscription_schedule-proration_behavior) parameter which controls what happens if the update request affects the billing configuration of the current phase.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// The date at which this phase of the subscription schedule starts or `now`. Must be set on the first phase.
-	StartDate    *int64 `form:"start_date"`
-	StartDateNow *bool  `form:"-"` // See custom AppendTo
+	StartDate    *time.Time `form:"start_date"`
+	StartDateNow *bool      `form:"-"` // See custom AppendTo
 	// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
 	TransferData *InvoiceUpcomingScheduleDetailsPhaseTransferDataParams `form:"transfer_data"`
 	// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
@@ -1484,8 +1485,8 @@ type InvoiceUpcomingScheduleDetailsPhaseParams struct {
 	// Specify trial behavior when crossing phase boundaries
 	TrialContinuation *string `form:"trial_continuation"`
 	// Sets the phase to trialing from the start date to this date. Must be before the phase end date, can not be combined with `trial`
-	TrialEnd    *int64 `form:"trial_end"`
-	TrialEndNow *bool  `form:"-"` // See custom AppendTo
+	TrialEnd    *time.Time `form:"trial_end"`
+	TrialEndNow *bool      `form:"-"` // See custom AppendTo
 	// Settings related to subscription trials.
 	TrialSettings *InvoiceUpcomingScheduleDetailsPhaseTrialSettingsParams `form:"trial_settings"`
 }
@@ -1533,7 +1534,7 @@ type InvoiceUpcomingScheduleDetailsPrebillingBillUntilParams struct {
 	// Time span for prebilling, starting from `bill_from`.
 	Duration *InvoiceUpcomingScheduleDetailsPrebillingBillUntilDurationParams `form:"duration"`
 	// End the prebilled period at a precise integer timestamp, starting from the Unix epoch.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of several ways to pass the `bill_until` value.
 	Type *string `form:"type"`
 }
@@ -1581,7 +1582,7 @@ type InvoiceUpcomingSubscriptionDetailsItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingSubscriptionDetailsItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -1666,11 +1667,11 @@ type InvoiceUpcomingSubscriptionDetailsPrebillingParams struct {
 // The subscription creation or modification params to apply as a preview. Cannot be used with `schedule` or `schedule_details` fields.
 type InvoiceUpcomingSubscriptionDetailsParams struct {
 	// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`.
-	BillingCycleAnchor          *int64 `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow       *bool  `form:"-"` // See custom AppendTo
-	BillingCycleAnchorUnchanged *bool  `form:"-"` // See custom AppendTo
+	BillingCycleAnchor          *time.Time `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       *bool      `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged *bool      `form:"-"` // See custom AppendTo
 	// A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
-	CancelAt *int64 `form:"cancel_at"`
+	CancelAt *time.Time `form:"cancel_at"`
 	// Indicate whether this subscription should cancel at the end of the current period (`current_period_end`). Defaults to `false`.
 	CancelAtPeriodEnd *bool `form:"cancel_at_period_end"`
 	// This simulates the subscription being canceled or expired immediately.
@@ -1684,14 +1685,14 @@ type InvoiceUpcomingSubscriptionDetailsParams struct {
 	// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. The default value is `create_prorations`.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// If previewing an update to a subscription, and doing proration, `subscription_details.proration_date` forces the proration to be calculated as though the update was done at the specified time. The time given must be within the current subscription period and within the current phase of the schedule backing this subscription, if the schedule exists. If set, `subscription`, and one of `subscription_details.items`, or `subscription_details.trial_end` are required. Also, `subscription_details.proration_behavior` cannot be set to 'none'.
-	ProrationDate *int64 `form:"proration_date"`
+	ProrationDate *time.Time `form:"proration_date"`
 	// For paused subscriptions, setting `subscription_details.resume_at` to `now` will preview the invoice that will be generated if the subscription is resumed.
 	ResumeAt *string `form:"resume_at"`
 	// Date a subscription is intended to start (can be future or past).
-	StartDate *int64 `form:"start_date"`
+	StartDate *time.Time `form:"start_date"`
 	// If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_details.items` or `subscription` is required.
-	TrialEnd    *int64 `form:"trial_end"`
-	TrialEndNow *bool  `form:"-"` // See custom AppendTo
+	TrialEnd    *time.Time `form:"trial_end"`
+	TrialEndNow *bool      `form:"-"` // See custom AppendTo
 }
 
 // AppendTo implements custom encoding logic for InvoiceUpcomingSubscriptionDetailsParams.
@@ -1751,11 +1752,11 @@ type InvoiceUpcomingParams struct {
 	// The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If not provided, but a `subscription_details.items` is provided, you will preview creating a subscription with those items. If neither `subscription` nor `subscription_details.items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions.
 	Subscription *string `form:"subscription"`
 	// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`. This field has been deprecated and will be removed in a future API version. Use `subscription_details.billing_cycle_anchor` instead.
-	SubscriptionBillingCycleAnchor          *int64 `form:"subscription_billing_cycle_anchor"`
-	SubscriptionBillingCycleAnchorNow       *bool  `form:"-"` // See custom AppendTo
-	SubscriptionBillingCycleAnchorUnchanged *bool  `form:"-"` // See custom AppendTo
+	SubscriptionBillingCycleAnchor          *time.Time `form:"subscription_billing_cycle_anchor"`
+	SubscriptionBillingCycleAnchorNow       *bool      `form:"-"` // See custom AppendTo
+	SubscriptionBillingCycleAnchorUnchanged *bool      `form:"-"` // See custom AppendTo
 	// A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. This field has been deprecated and will be removed in a future API version. Use `subscription_details.cancel_at` instead.
-	SubscriptionCancelAt *int64 `form:"subscription_cancel_at"`
+	SubscriptionCancelAt *time.Time `form:"subscription_cancel_at"`
 	// Indicate whether this subscription should cancel at the end of the current period (`current_period_end`). Defaults to `false`. This field has been deprecated and will be removed in a future API version. Use `subscription_details.cancel_at_period_end` instead.
 	SubscriptionCancelAtPeriodEnd *bool `form:"subscription_cancel_at_period_end"`
 	// This simulates the subscription being canceled or expired immediately. This field has been deprecated and will be removed in a future API version. Use `subscription_details.cancel_now` instead.
@@ -1771,14 +1772,14 @@ type InvoiceUpcomingParams struct {
 	// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. The default value is `create_prorations`. This field has been deprecated and will be removed in a future API version. Use `subscription_details.proration_behavior` instead.
 	SubscriptionProrationBehavior *string `form:"subscription_proration_behavior"`
 	// If previewing an update to a subscription, and doing proration, `subscription_proration_date` forces the proration to be calculated as though the update was done at the specified time. The time given must be within the current subscription period and within the current phase of the schedule backing this subscription, if the schedule exists. If set, `subscription`, and one of `subscription_items`, or `subscription_trial_end` are required. Also, `subscription_proration_behavior` cannot be set to 'none'. This field has been deprecated and will be removed in a future API version. Use `subscription_details.proration_date` instead.
-	SubscriptionProrationDate *int64 `form:"subscription_proration_date"`
+	SubscriptionProrationDate *time.Time `form:"subscription_proration_date"`
 	// For paused subscriptions, setting `subscription_resume_at` to `now` will preview the invoice that will be generated if the subscription is resumed. This field has been deprecated and will be removed in a future API version. Use `subscription_details.resume_at` instead.
 	SubscriptionResumeAt *string `form:"subscription_resume_at"`
 	// Date a subscription is intended to start (can be future or past). This field has been deprecated and will be removed in a future API version. Use `subscription_details.start_date` instead.
-	SubscriptionStartDate *int64 `form:"subscription_start_date"`
+	SubscriptionStartDate *time.Time `form:"subscription_start_date"`
 	// If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_items` or `subscription` is required. This field has been deprecated and will be removed in a future API version. Use `subscription_details.trial_end` instead.
-	SubscriptionTrialEnd    *int64 `form:"subscription_trial_end"`
-	SubscriptionTrialEndNow *bool  `form:"-"` // See custom AppendTo
+	SubscriptionTrialEnd    *time.Time `form:"subscription_trial_end"`
+	SubscriptionTrialEndNow *bool      `form:"-"` // See custom AppendTo
 	// Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
 	SubscriptionTrialFromPlan *bool `form:"subscription_trial_from_plan"`
 }
@@ -1868,7 +1869,7 @@ type InvoiceUpcomingLinesDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -1898,7 +1899,7 @@ type InvoiceUpcomingLinesInvoiceItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesInvoiceItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -1918,9 +1919,9 @@ type InvoiceUpcomingLinesInvoiceItemDiscountParams struct {
 // The period associated with this invoice item. When set to different values, the period will be rendered on the invoice. If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue. See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
 type InvoiceUpcomingLinesInvoiceItemPeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start. This value is inclusive.
-	End *int64 `form:"end"`
+	End *time.Time `form:"end"`
 	// The start of the period. This value is inclusive.
-	Start *int64 `form:"start"`
+	Start *time.Time `form:"start"`
 }
 
 // Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline. One of `price` or `price_data` is required.
@@ -2011,7 +2012,7 @@ type InvoiceUpcomingLinesScheduleDetailsAmendmentAmendmentEndParams struct {
 	// Time span for the amendment starting from the `amendment_start`.
 	Duration *InvoiceUpcomingLinesScheduleDetailsAmendmentAmendmentEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the amendment to end. Must be after the `amendment_start`.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of three ways to pass the `amendment_end`.
 	Type *string `form:"type"`
 }
@@ -2035,7 +2036,7 @@ type InvoiceUpcomingLinesScheduleDetailsAmendmentAmendmentStartParams struct {
 	// Use the `end` time of a given discount.
 	DiscountEnd *InvoiceUpcomingLinesScheduleDetailsAmendmentAmendmentStartDiscountEndParams `form:"discount_end"`
 	// A precise Unix timestamp for the amendment to start.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of three ways to pass the `amendment_start`.
 	Type *string `form:"type"`
 }
@@ -2105,7 +2106,7 @@ type InvoiceUpcomingLinesScheduleDetailsAmendmentItemActionAddDiscountDiscountEn
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesScheduleDetailsAmendmentItemActionAddDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -2174,7 +2175,7 @@ type InvoiceUpcomingLinesScheduleDetailsAmendmentItemActionSetDiscountDiscountEn
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesScheduleDetailsAmendmentItemActionSetDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -2311,7 +2312,7 @@ type InvoiceUpcomingLinesScheduleDetailsPhaseAddInvoiceItemDiscountDiscountEndPa
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesScheduleDetailsPhaseAddInvoiceItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -2393,7 +2394,7 @@ type InvoiceUpcomingLinesScheduleDetailsPhaseDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesScheduleDetailsPhaseDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -2447,7 +2448,7 @@ type InvoiceUpcomingLinesScheduleDetailsPhaseItemDiscountDiscountEndParams struc
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesScheduleDetailsPhaseItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -2580,8 +2581,8 @@ type InvoiceUpcomingLinesScheduleDetailsPhaseParams struct {
 	// The coupons to redeem into discounts for the schedule phase. If not specified, inherits the discount from the subscription's customer. Pass an empty string to avoid inheriting any discounts.
 	Discounts []*InvoiceUpcomingLinesScheduleDetailsPhaseDiscountParams `form:"discounts"`
 	// The date at which this phase of the subscription schedule ends. If set, `iterations` must not be set.
-	EndDate    *int64 `form:"end_date"`
-	EndDateNow *bool  `form:"-"` // See custom AppendTo
+	EndDate    *time.Time `form:"end_date"`
+	EndDateNow *bool      `form:"-"` // See custom AppendTo
 	// All invoices will be billed using the specified settings.
 	InvoiceSettings *InvoiceUpcomingLinesScheduleDetailsPhaseInvoiceSettingsParams `form:"invoice_settings"`
 	// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
@@ -2597,8 +2598,8 @@ type InvoiceUpcomingLinesScheduleDetailsPhaseParams struct {
 	// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase. The default value is `create_prorations`. This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase. It's different from the request-level [proration_behavior](https://stripe.com/docs/api/subscription_schedules/update#update_subscription_schedule-proration_behavior) parameter which controls what happens if the update request affects the billing configuration of the current phase.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// The date at which this phase of the subscription schedule starts or `now`. Must be set on the first phase.
-	StartDate    *int64 `form:"start_date"`
-	StartDateNow *bool  `form:"-"` // See custom AppendTo
+	StartDate    *time.Time `form:"start_date"`
+	StartDateNow *bool      `form:"-"` // See custom AppendTo
 	// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
 	TransferData *InvoiceUpcomingLinesScheduleDetailsPhaseTransferDataParams `form:"transfer_data"`
 	// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
@@ -2606,8 +2607,8 @@ type InvoiceUpcomingLinesScheduleDetailsPhaseParams struct {
 	// Specify trial behavior when crossing phase boundaries
 	TrialContinuation *string `form:"trial_continuation"`
 	// Sets the phase to trialing from the start date to this date. Must be before the phase end date, can not be combined with `trial`
-	TrialEnd    *int64 `form:"trial_end"`
-	TrialEndNow *bool  `form:"-"` // See custom AppendTo
+	TrialEnd    *time.Time `form:"trial_end"`
+	TrialEndNow *bool      `form:"-"` // See custom AppendTo
 	// Settings related to subscription trials.
 	TrialSettings *InvoiceUpcomingLinesScheduleDetailsPhaseTrialSettingsParams `form:"trial_settings"`
 }
@@ -2655,7 +2656,7 @@ type InvoiceUpcomingLinesScheduleDetailsPrebillingBillUntilParams struct {
 	// Time span for prebilling, starting from `bill_from`.
 	Duration *InvoiceUpcomingLinesScheduleDetailsPrebillingBillUntilDurationParams `form:"duration"`
 	// End the prebilled period at a precise integer timestamp, starting from the Unix epoch.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of several ways to pass the `bill_until` value.
 	Type *string `form:"type"`
 }
@@ -2703,7 +2704,7 @@ type InvoiceUpcomingLinesSubscriptionDetailsItemDiscountDiscountEndParams struct
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesSubscriptionDetailsItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -2788,11 +2789,11 @@ type InvoiceUpcomingLinesSubscriptionDetailsPrebillingParams struct {
 // The subscription creation or modification params to apply as a preview. Cannot be used with `schedule` or `schedule_details` fields.
 type InvoiceUpcomingLinesSubscriptionDetailsParams struct {
 	// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`.
-	BillingCycleAnchor          *int64 `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow       *bool  `form:"-"` // See custom AppendTo
-	BillingCycleAnchorUnchanged *bool  `form:"-"` // See custom AppendTo
+	BillingCycleAnchor          *time.Time `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       *bool      `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged *bool      `form:"-"` // See custom AppendTo
 	// A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
-	CancelAt *int64 `form:"cancel_at"`
+	CancelAt *time.Time `form:"cancel_at"`
 	// Indicate whether this subscription should cancel at the end of the current period (`current_period_end`). Defaults to `false`.
 	CancelAtPeriodEnd *bool `form:"cancel_at_period_end"`
 	// This simulates the subscription being canceled or expired immediately.
@@ -2806,14 +2807,14 @@ type InvoiceUpcomingLinesSubscriptionDetailsParams struct {
 	// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. The default value is `create_prorations`.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// If previewing an update to a subscription, and doing proration, `subscription_details.proration_date` forces the proration to be calculated as though the update was done at the specified time. The time given must be within the current subscription period and within the current phase of the schedule backing this subscription, if the schedule exists. If set, `subscription`, and one of `subscription_details.items`, or `subscription_details.trial_end` are required. Also, `subscription_details.proration_behavior` cannot be set to 'none'.
-	ProrationDate *int64 `form:"proration_date"`
+	ProrationDate *time.Time `form:"proration_date"`
 	// For paused subscriptions, setting `subscription_details.resume_at` to `now` will preview the invoice that will be generated if the subscription is resumed.
 	ResumeAt *string `form:"resume_at"`
 	// Date a subscription is intended to start (can be future or past).
-	StartDate *int64 `form:"start_date"`
+	StartDate *time.Time `form:"start_date"`
 	// If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_details.items` or `subscription` is required.
-	TrialEnd    *int64 `form:"trial_end"`
-	TrialEndNow *bool  `form:"-"` // See custom AppendTo
+	TrialEnd    *time.Time `form:"trial_end"`
+	TrialEndNow *bool      `form:"-"` // See custom AppendTo
 }
 
 // AppendTo implements custom encoding logic for InvoiceUpcomingLinesSubscriptionDetailsParams.
@@ -2848,7 +2849,7 @@ type InvoiceUpcomingLinesSubscriptionItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpcomingLinesSubscriptionItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -2962,11 +2963,11 @@ type InvoiceUpcomingLinesParams struct {
 	// The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If not provided, but a `subscription_details.items` is provided, you will preview creating a subscription with those items. If neither `subscription` nor `subscription_details.items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions.
 	Subscription *string `form:"subscription"`
 	// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`. This field has been deprecated and will be removed in a future API version. Use `subscription_details.billing_cycle_anchor` instead.
-	SubscriptionBillingCycleAnchor          *int64 `form:"subscription_billing_cycle_anchor"`
-	SubscriptionBillingCycleAnchorNow       *bool  `form:"-"` // See custom AppendTo
-	SubscriptionBillingCycleAnchorUnchanged *bool  `form:"-"` // See custom AppendTo
+	SubscriptionBillingCycleAnchor          *time.Time `form:"subscription_billing_cycle_anchor"`
+	SubscriptionBillingCycleAnchorNow       *bool      `form:"-"` // See custom AppendTo
+	SubscriptionBillingCycleAnchorUnchanged *bool      `form:"-"` // See custom AppendTo
 	// A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. This field has been deprecated and will be removed in a future API version. Use `subscription_details.cancel_at` instead.
-	SubscriptionCancelAt *int64 `form:"subscription_cancel_at"`
+	SubscriptionCancelAt *time.Time `form:"subscription_cancel_at"`
 	// Indicate whether this subscription should cancel at the end of the current period (`current_period_end`). Defaults to `false`. This field has been deprecated and will be removed in a future API version. Use `subscription_details.cancel_at_period_end` instead.
 	SubscriptionCancelAtPeriodEnd *bool `form:"subscription_cancel_at_period_end"`
 	// This simulates the subscription being canceled or expired immediately. This field has been deprecated and will be removed in a future API version. Use `subscription_details.cancel_now` instead.
@@ -2982,14 +2983,14 @@ type InvoiceUpcomingLinesParams struct {
 	// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. The default value is `create_prorations`. This field has been deprecated and will be removed in a future API version. Use `subscription_details.proration_behavior` instead.
 	SubscriptionProrationBehavior *string `form:"subscription_proration_behavior"`
 	// If previewing an update to a subscription, and doing proration, `subscription_proration_date` forces the proration to be calculated as though the update was done at the specified time. The time given must be within the current subscription period and within the current phase of the schedule backing this subscription, if the schedule exists. If set, `subscription`, and one of `subscription_items`, or `subscription_trial_end` are required. Also, `subscription_proration_behavior` cannot be set to 'none'. This field has been deprecated and will be removed in a future API version. Use `subscription_details.proration_date` instead.
-	SubscriptionProrationDate *int64 `form:"subscription_proration_date"`
+	SubscriptionProrationDate *time.Time `form:"subscription_proration_date"`
 	// For paused subscriptions, setting `subscription_resume_at` to `now` will preview the invoice that will be generated if the subscription is resumed. This field has been deprecated and will be removed in a future API version. Use `subscription_details.resume_at` instead.
 	SubscriptionResumeAt *string `form:"subscription_resume_at"`
 	// Date a subscription is intended to start (can be future or past). This field has been deprecated and will be removed in a future API version. Use `subscription_details.start_date` instead.
-	SubscriptionStartDate *int64 `form:"subscription_start_date"`
+	SubscriptionStartDate *time.Time `form:"subscription_start_date"`
 	// If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_items` or `subscription` is required. This field has been deprecated and will be removed in a future API version. Use `subscription_details.trial_end` instead.
-	SubscriptionTrialEnd    *int64 `form:"subscription_trial_end"`
-	SubscriptionTrialEndNow *bool  `form:"-"` // See custom AppendTo
+	SubscriptionTrialEnd    *time.Time `form:"subscription_trial_end"`
+	SubscriptionTrialEndNow *bool      `form:"-"` // See custom AppendTo
 	// Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
 	SubscriptionTrialFromPlan *bool `form:"subscription_trial_from_plan"`
 }
@@ -3025,7 +3026,7 @@ type InvoiceAddLinesLineDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceAddLinesLineDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -3045,9 +3046,9 @@ type InvoiceAddLinesLineDiscountParams struct {
 // The period associated with this invoice item. When set to different values, the period will be rendered on the invoice. If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue. See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
 type InvoiceAddLinesLinePeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start. This value is inclusive.
-	End *int64 `form:"end"`
+	End *time.Time `form:"end"`
 	// The start of the period. This value is inclusive.
-	Start *int64 `form:"start"`
+	Start *time.Time `form:"start"`
 }
 
 // Data used to generate a new product object inline. One of `product` or `product_data` is required.
@@ -3189,7 +3190,7 @@ type InvoiceAttachPaymentPaymentRecordDataParams struct {
 	// The type of money movement for this out of band payment record.
 	MoneyMovementType *string `form:"money_movement_type"`
 	// The timestamp when this out of band payment was paid.
-	PaidAt *int64 `form:"paid_at"`
+	PaidAt *time.Time `form:"paid_at"`
 	// The reference for this out of band payment record.
 	PaymentReference *string `form:"payment_reference"`
 }
@@ -3362,7 +3363,7 @@ type InvoiceUpdateLinesLineDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceUpdateLinesLineDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -3382,9 +3383,9 @@ type InvoiceUpdateLinesLineDiscountParams struct {
 // The period associated with this invoice item. When set to different values, the period will be rendered on the invoice. If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue. See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
 type InvoiceUpdateLinesLinePeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start. This value is inclusive.
-	End *int64 `form:"end"`
+	End *time.Time `form:"end"`
 	// The start of the period. This value is inclusive.
-	Start *int64 `form:"start"`
+	Start *time.Time `form:"start"`
 }
 
 // Data used to generate a new product object inline. One of `product` or `product_data` is required.
@@ -3596,7 +3597,7 @@ type InvoiceCreatePreviewDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceCreatePreviewDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -3626,7 +3627,7 @@ type InvoiceCreatePreviewInvoiceItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceCreatePreviewInvoiceItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -3646,9 +3647,9 @@ type InvoiceCreatePreviewInvoiceItemDiscountParams struct {
 // The period associated with this invoice item. When set to different values, the period will be rendered on the invoice. If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue. See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
 type InvoiceCreatePreviewInvoiceItemPeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start. This value is inclusive.
-	End *int64 `form:"end"`
+	End *time.Time `form:"end"`
 	// The start of the period. This value is inclusive.
-	Start *int64 `form:"start"`
+	Start *time.Time `form:"start"`
 }
 
 // Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline. One of `price` or `price_data` is required.
@@ -3739,7 +3740,7 @@ type InvoiceCreatePreviewScheduleDetailsAmendmentAmendmentEndParams struct {
 	// Time span for the amendment starting from the `amendment_start`.
 	Duration *InvoiceCreatePreviewScheduleDetailsAmendmentAmendmentEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the amendment to end. Must be after the `amendment_start`.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of three ways to pass the `amendment_end`.
 	Type *string `form:"type"`
 }
@@ -3763,7 +3764,7 @@ type InvoiceCreatePreviewScheduleDetailsAmendmentAmendmentStartParams struct {
 	// Use the `end` time of a given discount.
 	DiscountEnd *InvoiceCreatePreviewScheduleDetailsAmendmentAmendmentStartDiscountEndParams `form:"discount_end"`
 	// A precise Unix timestamp for the amendment to start.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of three ways to pass the `amendment_start`.
 	Type *string `form:"type"`
 }
@@ -3833,7 +3834,7 @@ type InvoiceCreatePreviewScheduleDetailsAmendmentItemActionAddDiscountDiscountEn
 	// Time span for the redeemed discount.
 	Duration *InvoiceCreatePreviewScheduleDetailsAmendmentItemActionAddDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -3902,7 +3903,7 @@ type InvoiceCreatePreviewScheduleDetailsAmendmentItemActionSetDiscountDiscountEn
 	// Time span for the redeemed discount.
 	Duration *InvoiceCreatePreviewScheduleDetailsAmendmentItemActionSetDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -4039,7 +4040,7 @@ type InvoiceCreatePreviewScheduleDetailsPhaseAddInvoiceItemDiscountDiscountEndPa
 	// Time span for the redeemed discount.
 	Duration *InvoiceCreatePreviewScheduleDetailsPhaseAddInvoiceItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -4121,7 +4122,7 @@ type InvoiceCreatePreviewScheduleDetailsPhaseDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceCreatePreviewScheduleDetailsPhaseDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -4175,7 +4176,7 @@ type InvoiceCreatePreviewScheduleDetailsPhaseItemDiscountDiscountEndParams struc
 	// Time span for the redeemed discount.
 	Duration *InvoiceCreatePreviewScheduleDetailsPhaseItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -4308,8 +4309,8 @@ type InvoiceCreatePreviewScheduleDetailsPhaseParams struct {
 	// The coupons to redeem into discounts for the schedule phase. If not specified, inherits the discount from the subscription's customer. Pass an empty string to avoid inheriting any discounts.
 	Discounts []*InvoiceCreatePreviewScheduleDetailsPhaseDiscountParams `form:"discounts"`
 	// The date at which this phase of the subscription schedule ends. If set, `iterations` must not be set.
-	EndDate    *int64 `form:"end_date"`
-	EndDateNow *bool  `form:"-"` // See custom AppendTo
+	EndDate    *time.Time `form:"end_date"`
+	EndDateNow *bool      `form:"-"` // See custom AppendTo
 	// All invoices will be billed using the specified settings.
 	InvoiceSettings *InvoiceCreatePreviewScheduleDetailsPhaseInvoiceSettingsParams `form:"invoice_settings"`
 	// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
@@ -4325,8 +4326,8 @@ type InvoiceCreatePreviewScheduleDetailsPhaseParams struct {
 	// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase. The default value is `create_prorations`. This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase. It's different from the request-level [proration_behavior](https://stripe.com/docs/api/subscription_schedules/update#update_subscription_schedule-proration_behavior) parameter which controls what happens if the update request affects the billing configuration of the current phase.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// The date at which this phase of the subscription schedule starts or `now`. Must be set on the first phase.
-	StartDate    *int64 `form:"start_date"`
-	StartDateNow *bool  `form:"-"` // See custom AppendTo
+	StartDate    *time.Time `form:"start_date"`
+	StartDateNow *bool      `form:"-"` // See custom AppendTo
 	// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
 	TransferData *InvoiceCreatePreviewScheduleDetailsPhaseTransferDataParams `form:"transfer_data"`
 	// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
@@ -4334,8 +4335,8 @@ type InvoiceCreatePreviewScheduleDetailsPhaseParams struct {
 	// Specify trial behavior when crossing phase boundaries
 	TrialContinuation *string `form:"trial_continuation"`
 	// Sets the phase to trialing from the start date to this date. Must be before the phase end date, can not be combined with `trial`
-	TrialEnd    *int64 `form:"trial_end"`
-	TrialEndNow *bool  `form:"-"` // See custom AppendTo
+	TrialEnd    *time.Time `form:"trial_end"`
+	TrialEndNow *bool      `form:"-"` // See custom AppendTo
 	// Settings related to subscription trials.
 	TrialSettings *InvoiceCreatePreviewScheduleDetailsPhaseTrialSettingsParams `form:"trial_settings"`
 }
@@ -4383,7 +4384,7 @@ type InvoiceCreatePreviewScheduleDetailsPrebillingBillUntilParams struct {
 	// Time span for prebilling, starting from `bill_from`.
 	Duration *InvoiceCreatePreviewScheduleDetailsPrebillingBillUntilDurationParams `form:"duration"`
 	// End the prebilled period at a precise integer timestamp, starting from the Unix epoch.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of several ways to pass the `bill_until` value.
 	Type *string `form:"type"`
 }
@@ -4431,7 +4432,7 @@ type InvoiceCreatePreviewSubscriptionDetailsItemDiscountDiscountEndParams struct
 	// Time span for the redeemed discount.
 	Duration *InvoiceCreatePreviewSubscriptionDetailsItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -4516,11 +4517,11 @@ type InvoiceCreatePreviewSubscriptionDetailsPrebillingParams struct {
 // The subscription creation or modification params to apply as a preview. Cannot be used with `schedule` or `schedule_details` fields.
 type InvoiceCreatePreviewSubscriptionDetailsParams struct {
 	// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`.
-	BillingCycleAnchor          *int64 `form:"billing_cycle_anchor"`
-	BillingCycleAnchorNow       *bool  `form:"-"` // See custom AppendTo
-	BillingCycleAnchorUnchanged *bool  `form:"-"` // See custom AppendTo
+	BillingCycleAnchor          *time.Time `form:"billing_cycle_anchor"`
+	BillingCycleAnchorNow       *bool      `form:"-"` // See custom AppendTo
+	BillingCycleAnchorUnchanged *bool      `form:"-"` // See custom AppendTo
 	// A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
-	CancelAt *int64 `form:"cancel_at"`
+	CancelAt *time.Time `form:"cancel_at"`
 	// Indicate whether this subscription should cancel at the end of the current period (`current_period_end`). Defaults to `false`.
 	CancelAtPeriodEnd *bool `form:"cancel_at_period_end"`
 	// This simulates the subscription being canceled or expired immediately.
@@ -4534,14 +4535,14 @@ type InvoiceCreatePreviewSubscriptionDetailsParams struct {
 	// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. The default value is `create_prorations`.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// If previewing an update to a subscription, and doing proration, `subscription_details.proration_date` forces the proration to be calculated as though the update was done at the specified time. The time given must be within the current subscription period and within the current phase of the schedule backing this subscription, if the schedule exists. If set, `subscription`, and one of `subscription_details.items`, or `subscription_details.trial_end` are required. Also, `subscription_details.proration_behavior` cannot be set to 'none'.
-	ProrationDate *int64 `form:"proration_date"`
+	ProrationDate *time.Time `form:"proration_date"`
 	// For paused subscriptions, setting `subscription_details.resume_at` to `now` will preview the invoice that will be generated if the subscription is resumed.
 	ResumeAt *string `form:"resume_at"`
 	// Date a subscription is intended to start (can be future or past).
-	StartDate *int64 `form:"start_date"`
+	StartDate *time.Time `form:"start_date"`
 	// If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_details.items` or `subscription` is required.
-	TrialEnd    *int64 `form:"trial_end"`
-	TrialEndNow *bool  `form:"-"` // See custom AppendTo
+	TrialEnd    *time.Time `form:"trial_end"`
+	TrialEndNow *bool      `form:"-"` // See custom AppendTo
 }
 
 // AppendTo implements custom encoding logic for InvoiceCreatePreviewSubscriptionDetailsParams.
@@ -4629,9 +4630,9 @@ type InvoiceAmountsDue struct {
 	// An arbitrary string attached to the object. Often useful for displaying to users.
 	Description string `json:"description"`
 	// Date on which a payment plan's payment is due.
-	DueDate int64 `json:"due_date"`
+	DueDate time.Time `json:"due_date"`
 	// Timestamp when the payment was paid.
-	PaidAt int64 `json:"paid_at"`
+	PaidAt time.Time `json:"paid_at"`
 	// The status of the payment, one of `open`, `paid`, or `past_due`
 	Status InvoiceAmountsDueStatus `json:"status"`
 }
@@ -4832,13 +4833,13 @@ type InvoiceShippingCost struct {
 }
 type InvoiceStatusTransitions struct {
 	// The time that the invoice draft was finalized.
-	FinalizedAt int64 `json:"finalized_at"`
+	FinalizedAt time.Time `json:"finalized_at"`
 	// The time that the invoice was marked uncollectible.
-	MarkedUncollectibleAt int64 `json:"marked_uncollectible_at"`
+	MarkedUncollectibleAt time.Time `json:"marked_uncollectible_at"`
 	// The time that the invoice was paid.
-	PaidAt int64 `json:"paid_at"`
+	PaidAt time.Time `json:"paid_at"`
 	// The time that the invoice was voided.
-	VoidedAt int64 `json:"voided_at"`
+	VoidedAt time.Time `json:"voided_at"`
 }
 
 // If specified, payment collection for this subscription will be paused. Note that the subscription status will be unchanged and will not be updated to `paused`. Learn more about [pausing collection](https://stripe.com/docs/billing/subscriptions/pause-payment).
@@ -4846,7 +4847,7 @@ type InvoiceSubscriptionDetailsPauseCollection struct {
 	// The payment collection behavior for this subscription while paused. One of `keep_as_draft`, `mark_uncollectible`, or `void`.
 	Behavior InvoiceSubscriptionDetailsPauseCollectionBehavior `json:"behavior"`
 	// The time after which the subscription will resume collecting payments.
-	ResumesAt int64 `json:"resumes_at"`
+	ResumesAt time.Time `json:"resumes_at"`
 }
 
 // Details about the subscription that created this invoice.
@@ -4987,7 +4988,7 @@ type Invoice struct {
 	// Controls whether Stripe performs [automatic collection](https://stripe.com/docs/invoicing/integration/automatic-advancement-collection) of the invoice. If `false`, the invoice's state doesn't automatically advance without an explicit action.
 	AutoAdvance bool `json:"auto_advance"`
 	// The time when this invoice is currently scheduled to be automatically finalized. The field will be `null` if the invoice is not scheduled to finalize in the future. If the invoice is not in the draft state, this field will always be `null` - see `finalized_at` for the time when an already-finalized invoice was finalized.
-	AutomaticallyFinalizesAt int64                `json:"automatically_finalizes_at"`
+	AutomaticallyFinalizesAt time.Time            `json:"automatically_finalizes_at"`
 	AutomaticTax             *InvoiceAutomaticTax `json:"automatic_tax"`
 	// Indicates the reason why the invoice was created.
 	//
@@ -5004,7 +5005,7 @@ type Invoice struct {
 	// Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions.
 	CollectionMethod InvoiceCollectionMethod `json:"collection_method"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// The ID of the customer who will be billed.
@@ -5041,9 +5042,9 @@ type Invoice struct {
 	// The discounts applied to the invoice. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
 	Discounts []*Discount `json:"discounts"`
 	// The date on which payment for this invoice is due. This value will be `null` for invoices where `collection_method=charge_automatically`.
-	DueDate int64 `json:"due_date"`
+	DueDate time.Time `json:"due_date"`
 	// The date when this invoice is in effect. Same as `finalized_at` unless overwritten. When defined, this value replaces the system-generated 'Date of issue' printed on the invoice PDF and receipt.
-	EffectiveAt int64 `json:"effective_at"`
+	EffectiveAt time.Time `json:"effective_at"`
 	// Ending customer balance after the invoice is finalized. Invoices are finalized approximately an hour after successful webhook delivery or when payment collection is attempted for the invoice. If the invoice has not been finalized yet, this will be null.
 	EndingBalance int64 `json:"ending_balance"`
 	// Footer displayed on the invoice.
@@ -5068,7 +5069,7 @@ type Invoice struct {
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
 	Metadata map[string]string `json:"metadata"`
 	// The time at which payment will next be attempted. This value will be `null` for invoices where `collection_method=send_invoice`.
-	NextPaymentAttempt int64 `json:"next_payment_attempt"`
+	NextPaymentAttempt time.Time `json:"next_payment_attempt"`
 	// A unique, identifying string that appears on emails sent to the customer for this invoice. This starts with the customer's unique invoice_prefix if it is specified.
 	Number string `json:"number"`
 	// String representing the object's type. Objects of the same type share the same value.
@@ -5085,9 +5086,9 @@ type Invoice struct {
 	Payments        *InvoicePaymentList     `json:"payments"`
 	PaymentSettings *InvoicePaymentSettings `json:"payment_settings"`
 	// End of the usage period during which invoice items were added to this invoice. This looks back one period for a subscription invoice. Use the [line item period](https://stripe.com/api/invoices/line_item#invoice_line_item_object-period) to get the service period for each price.
-	PeriodEnd int64 `json:"period_end"`
+	PeriodEnd time.Time `json:"period_end"`
 	// Start of the usage period during which invoice items were added to this invoice. This looks back one period for a subscription invoice. Use the [line item period](https://stripe.com/api/invoices/line_item#invoice_line_item_object-period) to get the service period for each price.
-	PeriodStart int64 `json:"period_start"`
+	PeriodStart time.Time `json:"period_start"`
 	// Total amount of all post-payment credit notes issued for this invoice.
 	PostPaymentCreditNotesAmount int64 `json:"post_payment_credit_notes_amount"`
 	// Total amount of all pre-payment credit notes issued for this invoice.
@@ -5114,7 +5115,7 @@ type Invoice struct {
 	// Details about the subscription that created this invoice.
 	SubscriptionDetails *InvoiceSubscriptionDetails `json:"subscription_details"`
 	// Only set for upcoming invoices that preview prorations. The time used to calculate prorations.
-	SubscriptionProrationDate int64 `json:"subscription_proration_date"`
+	SubscriptionProrationDate time.Time `json:"subscription_proration_date"`
 	// Total of all subscriptions, invoice items, and prorations on the invoice before any invoice level discount or exclusive tax is applied. Item discounts are already incorporated
 	Subtotal int64 `json:"subtotal"`
 	// The integer amount in cents (or local equivalent) representing the subtotal of the invoice before any invoice level discount or tax is applied. Item discounts are already incorporated
@@ -5139,7 +5140,7 @@ type Invoice struct {
 	// The account (if any) the payment will be attributed to for tax reporting, and where funds from the payment will be transferred to for the invoice.
 	TransferData *InvoiceTransferData `json:"transfer_data"`
 	// Invoices are automatically paid or sent 1 hour after webhooks are delivered, or until all webhook delivery attempts have [been exhausted](https://stripe.com/docs/billing/webhooks#understand). This field tracks the time when webhooks for this invoice were successfully delivered. If the invoice had no webhooks to deliver, this will be set while the invoice is being created.
-	WebhooksDeliveredAt int64 `json:"webhooks_delivered_at"`
+	WebhooksDeliveredAt time.Time `json:"webhooks_delivered_at"`
 }
 
 // InvoiceList is a list of Invoices as retrieved from a list endpoint.
@@ -5166,11 +5167,190 @@ func (i *Invoice) UnmarshalJSON(data []byte) error {
 	}
 
 	type invoice Invoice
-	var v invoice
+	v := struct {
+		AutomaticallyFinalizesAt  int64 `json:"automatically_finalizes_at"`
+		Created                   int64 `json:"created"`
+		DueDate                   int64 `json:"due_date"`
+		EffectiveAt               int64 `json:"effective_at"`
+		NextPaymentAttempt        int64 `json:"next_payment_attempt"`
+		PeriodEnd                 int64 `json:"period_end"`
+		PeriodStart               int64 `json:"period_start"`
+		SubscriptionProrationDate int64 `json:"subscription_proration_date"`
+		WebhooksDeliveredAt       int64 `json:"webhooks_delivered_at"`
+		*invoice
+	}{
+		invoice: (*invoice)(i),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*i = Invoice(v)
+	i.AutomaticallyFinalizesAt = time.Unix(v.AutomaticallyFinalizesAt, 0)
+	i.Created = time.Unix(v.Created, 0)
+	i.DueDate = time.Unix(v.DueDate, 0)
+	i.EffectiveAt = time.Unix(v.EffectiveAt, 0)
+	i.NextPaymentAttempt = time.Unix(v.NextPaymentAttempt, 0)
+	i.PeriodEnd = time.Unix(v.PeriodEnd, 0)
+	i.PeriodStart = time.Unix(v.PeriodStart, 0)
+	i.SubscriptionProrationDate = time.Unix(v.SubscriptionProrationDate, 0)
+	i.WebhooksDeliveredAt = time.Unix(v.WebhooksDeliveredAt, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of an InvoiceAmountsDue.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *InvoiceAmountsDue) UnmarshalJSON(data []byte) error {
+	type invoiceAmountsDue InvoiceAmountsDue
+	v := struct {
+		DueDate int64 `json:"due_date"`
+		PaidAt  int64 `json:"paid_at"`
+		*invoiceAmountsDue
+	}{
+		invoiceAmountsDue: (*invoiceAmountsDue)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.DueDate = time.Unix(v.DueDate, 0)
+	i.PaidAt = time.Unix(v.PaidAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an InvoiceStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *InvoiceStatusTransitions) UnmarshalJSON(data []byte) error {
+	type invoiceStatusTransitions InvoiceStatusTransitions
+	v := struct {
+		FinalizedAt           int64 `json:"finalized_at"`
+		MarkedUncollectibleAt int64 `json:"marked_uncollectible_at"`
+		PaidAt                int64 `json:"paid_at"`
+		VoidedAt              int64 `json:"voided_at"`
+		*invoiceStatusTransitions
+	}{
+		invoiceStatusTransitions: (*invoiceStatusTransitions)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.FinalizedAt = time.Unix(v.FinalizedAt, 0)
+	i.MarkedUncollectibleAt = time.Unix(v.MarkedUncollectibleAt, 0)
+	i.PaidAt = time.Unix(v.PaidAt, 0)
+	i.VoidedAt = time.Unix(v.VoidedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an InvoiceSubscriptionDetailsPauseCollection.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *InvoiceSubscriptionDetailsPauseCollection) UnmarshalJSON(data []byte) error {
+	type invoiceSubscriptionDetailsPauseCollection InvoiceSubscriptionDetailsPauseCollection
+	v := struct {
+		ResumesAt int64 `json:"resumes_at"`
+		*invoiceSubscriptionDetailsPauseCollection
+	}{
+		invoiceSubscriptionDetailsPauseCollection: (*invoiceSubscriptionDetailsPauseCollection)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.ResumesAt = time.Unix(v.ResumesAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an InvoiceAmountsDue.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i InvoiceAmountsDue) MarshalJSON() ([]byte, error) {
+	type invoiceAmountsDue InvoiceAmountsDue
+	v := struct {
+		DueDate int64 `json:"due_date"`
+		PaidAt  int64 `json:"paid_at"`
+		invoiceAmountsDue
+	}{
+		invoiceAmountsDue: (invoiceAmountsDue)(i),
+		DueDate:           i.DueDate.Unix(),
+		PaidAt:            i.PaidAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an InvoiceStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i InvoiceStatusTransitions) MarshalJSON() ([]byte, error) {
+	type invoiceStatusTransitions InvoiceStatusTransitions
+	v := struct {
+		FinalizedAt           int64 `json:"finalized_at"`
+		MarkedUncollectibleAt int64 `json:"marked_uncollectible_at"`
+		PaidAt                int64 `json:"paid_at"`
+		VoidedAt              int64 `json:"voided_at"`
+		invoiceStatusTransitions
+	}{
+		invoiceStatusTransitions: (invoiceStatusTransitions)(i),
+		FinalizedAt:              i.FinalizedAt.Unix(),
+		MarkedUncollectibleAt:    i.MarkedUncollectibleAt.Unix(),
+		PaidAt:                   i.PaidAt.Unix(),
+		VoidedAt:                 i.VoidedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an InvoiceSubscriptionDetailsPauseCollection.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i InvoiceSubscriptionDetailsPauseCollection) MarshalJSON() ([]byte, error) {
+	type invoiceSubscriptionDetailsPauseCollection InvoiceSubscriptionDetailsPauseCollection
+	v := struct {
+		ResumesAt int64 `json:"resumes_at"`
+		invoiceSubscriptionDetailsPauseCollection
+	}{
+		invoiceSubscriptionDetailsPauseCollection: (invoiceSubscriptionDetailsPauseCollection)(i),
+		ResumesAt: i.ResumesAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an Invoice.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i Invoice) MarshalJSON() ([]byte, error) {
+	type invoice Invoice
+	v := struct {
+		AutomaticallyFinalizesAt  int64 `json:"automatically_finalizes_at"`
+		Created                   int64 `json:"created"`
+		DueDate                   int64 `json:"due_date"`
+		EffectiveAt               int64 `json:"effective_at"`
+		NextPaymentAttempt        int64 `json:"next_payment_attempt"`
+		PeriodEnd                 int64 `json:"period_end"`
+		PeriodStart               int64 `json:"period_start"`
+		SubscriptionProrationDate int64 `json:"subscription_proration_date"`
+		WebhooksDeliveredAt       int64 `json:"webhooks_delivered_at"`
+		invoice
+	}{
+		invoice:                   (invoice)(i),
+		AutomaticallyFinalizesAt:  i.AutomaticallyFinalizesAt.Unix(),
+		Created:                   i.Created.Unix(),
+		DueDate:                   i.DueDate.Unix(),
+		EffectiveAt:               i.EffectiveAt.Unix(),
+		NextPaymentAttempt:        i.NextPaymentAttempt.Unix(),
+		PeriodEnd:                 i.PeriodEnd.Unix(),
+		PeriodStart:               i.PeriodStart.Unix(),
+		SubscriptionProrationDate: i.SubscriptionProrationDate.Unix(),
+		WebhooksDeliveredAt:       i.WebhooksDeliveredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/invoiceitem.go
+++ b/invoiceitem.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they're not attached to invoices, or if it's attached to a draft invoice.
 type InvoiceItemParams struct {
@@ -80,7 +83,7 @@ type InvoiceItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -100,9 +103,9 @@ type InvoiceItemDiscountParams struct {
 // The period associated with this invoice item. When set to different values, the period will be rendered on the invoice. If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue. See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
 type InvoiceItemPeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start. This value is inclusive.
-	End *int64 `form:"end"`
+	End *time.Time `form:"end"`
 	// The start of the period. This value is inclusive.
-	Start *int64 `form:"start"`
+	Start *time.Time `form:"start"`
 }
 
 // Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline. One of `price` or `price_data` is required.
@@ -161,8 +164,8 @@ type InvoiceItem struct {
 	// The ID of the customer who will be billed when this invoice item is billed.
 	Customer *Customer `json:"customer"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Date    int64 `json:"date"`
-	Deleted bool  `json:"deleted"`
+	Date    time.Time `json:"date"`
+	Deleted bool      `json:"deleted"`
 	// An arbitrary string attached to the object. Often useful for displaying to users.
 	Description string `json:"description"`
 	// If true, discounts will apply to this invoice item. Always false for prorations.
@@ -221,11 +224,34 @@ func (i *InvoiceItem) UnmarshalJSON(data []byte) error {
 	}
 
 	type invoiceItem InvoiceItem
-	var v invoiceItem
+	v := struct {
+		Date int64 `json:"date"`
+		*invoiceItem
+	}{
+		invoiceItem: (*invoiceItem)(i),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*i = InvoiceItem(v)
+	i.Date = time.Unix(v.Date, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of an InvoiceItem.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i InvoiceItem) MarshalJSON() ([]byte, error) {
+	type invoiceItem InvoiceItem
+	v := struct {
+		Date int64 `json:"date"`
+		invoiceItem
+	}{
+		invoiceItem: (invoiceItem)(i),
+		Date:        i.Date.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/invoicelineitem.go
+++ b/invoicelineitem.go
@@ -6,6 +6,8 @@
 
 package stripe
 
+import "time"
+
 // Type of the pretax credit amount referenced.
 type InvoiceLineItemPretaxCreditAmountType string
 
@@ -38,7 +40,7 @@ type InvoiceLineItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *InvoiceLineItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -58,9 +60,9 @@ type InvoiceLineItemDiscountParams struct {
 // The period associated with this invoice item. When set to different values, the period will be rendered on the invoice. If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue. See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
 type InvoiceLineItemPeriodParams struct {
 	// The end of the period, which must be greater than or equal to the start. This value is inclusive.
-	End *int64 `form:"end"`
+	End *time.Time `form:"end"`
 	// The start of the period. This value is inclusive.
-	Start *int64 `form:"start"`
+	Start *time.Time `form:"start"`
 }
 
 // Data used to generate a new product object inline. One of `product` or `product_data` is required.

--- a/invoicepayment.go
+++ b/invoicepayment.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Type of payment object associated with this invoice payment.
 type InvoicePaymentPaymentType string
 
@@ -55,9 +60,9 @@ type InvoicePaymentPayment struct {
 }
 type InvoicePaymentStatusTransitions struct {
 	// The time that the payment was canceled.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// The time that the payment succeeded.
-	PaidAt int64 `json:"paid_at"`
+	PaidAt time.Time `json:"paid_at"`
 }
 
 // The invoice payment object
@@ -70,7 +75,7 @@ type InvoicePayment struct {
 	// Amount intended to be paid toward this invoice, in cents (or local equivalent)
 	AmountRequested int64 `json:"amount_requested"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// Unique identifier for the object.
@@ -94,4 +99,80 @@ type InvoicePaymentList struct {
 	APIResource
 	ListMeta
 	Data []*InvoicePayment `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of an InvoicePaymentStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *InvoicePaymentStatusTransitions) UnmarshalJSON(data []byte) error {
+	type invoicePaymentStatusTransitions InvoicePaymentStatusTransitions
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		PaidAt     int64 `json:"paid_at"`
+		*invoicePaymentStatusTransitions
+	}{
+		invoicePaymentStatusTransitions: (*invoicePaymentStatusTransitions)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.CanceledAt = time.Unix(v.CanceledAt, 0)
+	i.PaidAt = time.Unix(v.PaidAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an InvoicePayment.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *InvoicePayment) UnmarshalJSON(data []byte) error {
+	type invoicePayment InvoicePayment
+	v := struct {
+		Created int64 `json:"created"`
+		*invoicePayment
+	}{
+		invoicePayment: (*invoicePayment)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an InvoicePaymentStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i InvoicePaymentStatusTransitions) MarshalJSON() ([]byte, error) {
+	type invoicePaymentStatusTransitions InvoicePaymentStatusTransitions
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		PaidAt     int64 `json:"paid_at"`
+		invoicePaymentStatusTransitions
+	}{
+		invoicePaymentStatusTransitions: (invoicePaymentStatusTransitions)(i),
+		CanceledAt:                      i.CanceledAt.Unix(),
+		PaidAt:                          i.PaidAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an InvoicePayment.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i InvoicePayment) MarshalJSON() ([]byte, error) {
+	type invoicePayment InvoicePayment
+	v := struct {
+		Created int64 `json:"created"`
+		invoicePayment
+	}{
+		invoicePayment: (invoicePayment)(i),
+		Created:        i.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/issuing/dispute/client_test.go
+++ b/issuing/dispute/client_test.go
@@ -35,15 +35,15 @@ func TestIssuingDisputeNew(t *testing.T) {
 		Evidence: &stripe.IssuingDisputeEvidenceParams{
 			Canceled: &stripe.IssuingDisputeEvidenceCanceledParams{
 				AdditionalDocumentation:    stripe.String("file_123"),
-				CanceledAt:                 stripe.Int64(1577836800),
+				CanceledAt:                 stripe.UnixTime(1528573382),
 				CancellationPolicyProvided: stripe.Bool(true),
 				CancellationReason:         stripe.String("reason for cancellation"),
-				ExpectedAt:                 stripe.Int64(1577836800),
+				ExpectedAt:                 stripe.UnixTime(1528573382),
 				Explanation:                stripe.String("explanation"),
 				ProductDescription:         stripe.String("product description"),
 				ProductType:                stripe.String(string(stripe.IssuingDisputeEvidenceCanceledProductTypeMerchandise)),
 				ReturnStatus:               stripe.String(string(stripe.IssuingDisputeEvidenceCanceledReturnStatusMerchantRejected)),
-				ReturnedAt:                 stripe.Int64(1577836800),
+				ReturnedAt:                 stripe.UnixTime(1528573382),
 			},
 			Reason: stripe.String(string(stripe.IssuingDisputeEvidenceReasonCanceled)),
 		},

--- a/issuing_authorization.go
+++ b/issuing_authorization.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // How the card details were provided.
 type IssuingAuthorizationAuthorizationMethod string
@@ -432,7 +435,7 @@ type IssuingAuthorizationRequestHistory struct {
 	// A code created by Stripe which is shared with the merchant to validate the authorization. This field will be populated if the authorization message was approved. The code typically starts with the letter "S", followed by a six-digit number. For example, "S498162". Please note that the code is not guaranteed to be unique across authorizations.
 	AuthorizationCode string `json:"authorization_code"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// The `pending_request.merchant_amount` at the time of the request, presented in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
@@ -446,7 +449,7 @@ type IssuingAuthorizationRequestHistory struct {
 	// If the `request_history.reason` is `webhook_error` because the direct webhook response is invalid (for example, parsing errors or missing parameters), we surface a more detailed error message via this field.
 	ReasonMessage string `json:"reason_message"`
 	// Time when the card network received an authorization request from the acquirer in UTC. Referred to by networks as transmission time.
-	RequestedAt int64 `json:"requested_at"`
+	RequestedAt time.Time `json:"requested_at"`
 }
 
 // [Treasury](https://stripe.com/docs/api/treasury) details related to this authorization if it was created on a [FinancialAccount](https://stripe.com/docs/api/treasury/financial_accounts).
@@ -511,7 +514,7 @@ type IssuingAuthorization struct {
 	// The cardholder to whom this authorization belongs.
 	Cardholder *IssuingCardholder `json:"cardholder"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The currency of the cardholder. This currency can be different from the currency presented at authorization and the `merchant_currency` field on this authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// Fleet-specific information for authorizations using Fleet cards.
@@ -571,11 +574,74 @@ func (i *IssuingAuthorization) UnmarshalJSON(data []byte) error {
 	}
 
 	type issuingAuthorization IssuingAuthorization
-	var v issuingAuthorization
+	v := struct {
+		Created int64 `json:"created"`
+		*issuingAuthorization
+	}{
+		issuingAuthorization: (*issuingAuthorization)(i),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*i = IssuingAuthorization(v)
+	i.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of an IssuingAuthorizationRequestHistory.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *IssuingAuthorizationRequestHistory) UnmarshalJSON(data []byte) error {
+	type issuingAuthorizationRequestHistory IssuingAuthorizationRequestHistory
+	v := struct {
+		Created     int64 `json:"created"`
+		RequestedAt int64 `json:"requested_at"`
+		*issuingAuthorizationRequestHistory
+	}{
+		issuingAuthorizationRequestHistory: (*issuingAuthorizationRequestHistory)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.Created = time.Unix(v.Created, 0)
+	i.RequestedAt = time.Unix(v.RequestedAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an IssuingAuthorizationRequestHistory.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingAuthorizationRequestHistory) MarshalJSON() ([]byte, error) {
+	type issuingAuthorizationRequestHistory IssuingAuthorizationRequestHistory
+	v := struct {
+		Created     int64 `json:"created"`
+		RequestedAt int64 `json:"requested_at"`
+		issuingAuthorizationRequestHistory
+	}{
+		issuingAuthorizationRequestHistory: (issuingAuthorizationRequestHistory)(i),
+		Created:                            i.Created.Unix(),
+		RequestedAt:                        i.RequestedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an IssuingAuthorization.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingAuthorization) MarshalJSON() ([]byte, error) {
+	type issuingAuthorization IssuingAuthorization
+	v := struct {
+		Created int64 `json:"created"`
+		issuingAuthorization
+	}{
+		issuingAuthorization: (issuingAuthorization)(i),
+		Created:              i.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/issuing_creditunderwritingrecord.go
+++ b/issuing_creditunderwritingrecord.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The channel through which the applicant has submitted their application.
 type IssuingCreditUnderwritingRecordApplicationApplicationMethod string
 
@@ -320,7 +325,7 @@ type IssuingCreditUnderwritingRecordCorrectApplicationParams struct {
 	// Scope of demand made by the applicant.
 	Purpose *string `form:"purpose"`
 	// Date when the applicant submitted their application.
-	SubmittedAt *int64 `form:"submitted_at"`
+	SubmittedAt *time.Time `form:"submitted_at"`
 }
 
 // Information about the company or person applying or holding the account.
@@ -397,7 +402,7 @@ type IssuingCreditUnderwritingRecordCorrectParams struct {
 	// Information about the company or person applying or holding the account.
 	CreditUser *IssuingCreditUnderwritingRecordCorrectCreditUserParams `form:"credit_user"`
 	// Date when a decision was made.
-	DecidedAt *int64 `form:"decided_at"`
+	DecidedAt *time.Time `form:"decided_at"`
 	// Details about the decision.
 	Decision *IssuingCreditUnderwritingRecordCorrectDecisionParams `form:"decision"`
 	// Specifies which fields in the response should be expanded.
@@ -462,7 +467,7 @@ type IssuingCreditUnderwritingRecordReportDecisionUnderwritingExceptionParams st
 type IssuingCreditUnderwritingRecordReportDecisionParams struct {
 	Params `form:"*"`
 	// Date when a decision was made.
-	DecidedAt *int64 `form:"decided_at"`
+	DecidedAt *time.Time `form:"decided_at"`
 	// Details about the decision.
 	Decision *IssuingCreditUnderwritingRecordReportDecisionDecisionParams `form:"decision"`
 	// Specifies which fields in the response should be expanded.
@@ -496,7 +501,7 @@ type IssuingCreditUnderwritingRecordCreateFromApplicationApplicationParams struc
 	// Scope of demand made by the applicant.
 	Purpose *string `form:"purpose"`
 	// Date when the applicant submitted their application.
-	SubmittedAt *int64 `form:"submitted_at"`
+	SubmittedAt *time.Time `form:"submitted_at"`
 }
 
 // Information about the company or person applying or holding the account.
@@ -596,7 +601,7 @@ type IssuingCreditUnderwritingRecordCreateFromProactiveReviewParams struct {
 	// Information about the company or person applying or holding the account.
 	CreditUser *IssuingCreditUnderwritingRecordCreateFromProactiveReviewCreditUserParams `form:"credit_user"`
 	// Date when a decision was made.
-	DecidedAt *int64 `form:"decided_at"`
+	DecidedAt *time.Time `form:"decided_at"`
 	// Details about the decision.
 	Decision *IssuingCreditUnderwritingRecordCreateFromProactiveReviewDecisionParams `form:"decision"`
 	// Specifies which fields in the response should be expanded.
@@ -630,7 +635,7 @@ type IssuingCreditUnderwritingRecordApplication struct {
 	// Scope of demand made by the applicant.
 	Purpose IssuingCreditUnderwritingRecordApplicationPurpose `json:"purpose"`
 	// Date when the applicant submitted their application.
-	SubmittedAt int64 `json:"submitted_at"`
+	SubmittedAt time.Time `json:"submitted_at"`
 }
 type IssuingCreditUnderwritingRecordCreditUser struct {
 	// Email of the applicant or accountholder.
@@ -705,16 +710,16 @@ type IssuingCreditUnderwritingRecord struct {
 	// For decisions triggered by an application, details about the submission.
 	Application *IssuingCreditUnderwritingRecordApplication `json:"application"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The event that triggered the underwriting.
 	CreatedFrom IssuingCreditUnderwritingRecordCreatedFrom `json:"created_from"`
 	CreditUser  *IssuingCreditUnderwritingRecordCreditUser `json:"credit_user"`
 	// Date when a decision was made.
-	DecidedAt int64 `json:"decided_at"`
+	DecidedAt time.Time `json:"decided_at"`
 	// Details about the decision.
 	Decision *IssuingCreditUnderwritingRecordDecision `json:"decision"`
 	// For underwriting initiated by an application, a decision must be taken 30 days after the submission.
-	DecisionDeadline int64 `json:"decision_deadline"`
+	DecisionDeadline time.Time `json:"decision_deadline"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -734,4 +739,84 @@ type IssuingCreditUnderwritingRecordList struct {
 	APIResource
 	ListMeta
 	Data []*IssuingCreditUnderwritingRecord `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of an IssuingCreditUnderwritingRecordApplication.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *IssuingCreditUnderwritingRecordApplication) UnmarshalJSON(data []byte) error {
+	type issuingCreditUnderwritingRecordApplication IssuingCreditUnderwritingRecordApplication
+	v := struct {
+		SubmittedAt int64 `json:"submitted_at"`
+		*issuingCreditUnderwritingRecordApplication
+	}{
+		issuingCreditUnderwritingRecordApplication: (*issuingCreditUnderwritingRecordApplication)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.SubmittedAt = time.Unix(v.SubmittedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an IssuingCreditUnderwritingRecord.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *IssuingCreditUnderwritingRecord) UnmarshalJSON(data []byte) error {
+	type issuingCreditUnderwritingRecord IssuingCreditUnderwritingRecord
+	v := struct {
+		Created          int64 `json:"created"`
+		DecidedAt        int64 `json:"decided_at"`
+		DecisionDeadline int64 `json:"decision_deadline"`
+		*issuingCreditUnderwritingRecord
+	}{
+		issuingCreditUnderwritingRecord: (*issuingCreditUnderwritingRecord)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.Created = time.Unix(v.Created, 0)
+	i.DecidedAt = time.Unix(v.DecidedAt, 0)
+	i.DecisionDeadline = time.Unix(v.DecisionDeadline, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an IssuingCreditUnderwritingRecordApplication.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingCreditUnderwritingRecordApplication) MarshalJSON() ([]byte, error) {
+	type issuingCreditUnderwritingRecordApplication IssuingCreditUnderwritingRecordApplication
+	v := struct {
+		SubmittedAt int64 `json:"submitted_at"`
+		issuingCreditUnderwritingRecordApplication
+	}{
+		issuingCreditUnderwritingRecordApplication: (issuingCreditUnderwritingRecordApplication)(i),
+		SubmittedAt: i.SubmittedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an IssuingCreditUnderwritingRecord.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingCreditUnderwritingRecord) MarshalJSON() ([]byte, error) {
+	type issuingCreditUnderwritingRecord IssuingCreditUnderwritingRecord
+	v := struct {
+		Created          int64 `json:"created"`
+		DecidedAt        int64 `json:"decided_at"`
+		DecisionDeadline int64 `json:"decision_deadline"`
+		issuingCreditUnderwritingRecord
+	}{
+		issuingCreditUnderwritingRecord: (issuingCreditUnderwritingRecord)(i),
+		Created:                         i.Created.Unix(),
+		DecidedAt:                       i.DecidedAt.Unix(),
+		DecisionDeadline:                i.DecisionDeadline.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/issuing_dispute.go
+++ b/issuing_dispute.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Whether the product was a merchandise or service.
 type IssuingDisputeEvidenceCanceledProductType string
@@ -132,13 +135,13 @@ type IssuingDisputeEvidenceCanceledParams struct {
 	// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
 	AdditionalDocumentation *string `form:"additional_documentation"`
 	// Date when order was canceled.
-	CanceledAt *int64 `form:"canceled_at"`
+	CanceledAt *time.Time `form:"canceled_at"`
 	// Whether the cardholder was provided with a cancellation policy.
 	CancellationPolicyProvided *bool `form:"cancellation_policy_provided"`
 	// Reason for canceling the order.
 	CancellationReason *string `form:"cancellation_reason"`
 	// Date when the cardholder expected to receive the product.
-	ExpectedAt *int64 `form:"expected_at"`
+	ExpectedAt *time.Time `form:"expected_at"`
 	// Explanation of why the cardholder is disputing this transaction.
 	Explanation *string `form:"explanation"`
 	// Description of the merchandise or service that was purchased.
@@ -146,7 +149,7 @@ type IssuingDisputeEvidenceCanceledParams struct {
 	// Whether the product was a merchandise or service.
 	ProductType *string `form:"product_type"`
 	// Date when the product was returned or attempted to be returned.
-	ReturnedAt *int64 `form:"returned_at"`
+	ReturnedAt *time.Time `form:"returned_at"`
 	// Result of cardholder's attempt to return the product.
 	ReturnStatus *string `form:"return_status"`
 }
@@ -182,11 +185,11 @@ type IssuingDisputeEvidenceMerchandiseNotAsDescribedParams struct {
 	// Explanation of why the cardholder is disputing this transaction.
 	Explanation *string `form:"explanation"`
 	// Date when the product was received.
-	ReceivedAt *int64 `form:"received_at"`
+	ReceivedAt *time.Time `form:"received_at"`
 	// Description of the cardholder's attempt to return the product.
 	ReturnDescription *string `form:"return_description"`
 	// Date when the product was returned or attempted to be returned.
-	ReturnedAt *int64 `form:"returned_at"`
+	ReturnedAt *time.Time `form:"returned_at"`
 	// Result of cardholder's attempt to return the product.
 	ReturnStatus *string `form:"return_status"`
 }
@@ -204,7 +207,7 @@ type IssuingDisputeEvidenceNotReceivedParams struct {
 	// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
 	AdditionalDocumentation *string `form:"additional_documentation"`
 	// Date when the cardholder expected to receive the product.
-	ExpectedAt *int64 `form:"expected_at"`
+	ExpectedAt *time.Time `form:"expected_at"`
 	// Explanation of why the cardholder is disputing this transaction.
 	Explanation *string `form:"explanation"`
 	// Description of the merchandise or service that was purchased.
@@ -230,13 +233,13 @@ type IssuingDisputeEvidenceServiceNotAsDescribedParams struct {
 	// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
 	AdditionalDocumentation *string `form:"additional_documentation"`
 	// Date when order was canceled.
-	CanceledAt *int64 `form:"canceled_at"`
+	CanceledAt *time.Time `form:"canceled_at"`
 	// Reason for canceling the order.
 	CancellationReason *string `form:"cancellation_reason"`
 	// Explanation of why the cardholder is disputing this transaction.
 	Explanation *string `form:"explanation"`
 	// Date when the product was received.
-	ReceivedAt *int64 `form:"received_at"`
+	ReceivedAt *time.Time `form:"received_at"`
 }
 
 // Evidence provided for the dispute.
@@ -325,13 +328,13 @@ type IssuingDisputeEvidenceCanceled struct {
 	// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
 	AdditionalDocumentation *File `json:"additional_documentation"`
 	// Date when order was canceled.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// Whether the cardholder was provided with a cancellation policy.
 	CancellationPolicyProvided bool `json:"cancellation_policy_provided"`
 	// Reason for canceling the order.
 	CancellationReason string `json:"cancellation_reason"`
 	// Date when the cardholder expected to receive the product.
-	ExpectedAt int64 `json:"expected_at"`
+	ExpectedAt time.Time `json:"expected_at"`
 	// Explanation of why the cardholder is disputing this transaction.
 	Explanation string `json:"explanation"`
 	// Description of the merchandise or service that was purchased.
@@ -339,7 +342,7 @@ type IssuingDisputeEvidenceCanceled struct {
 	// Whether the product was a merchandise or service.
 	ProductType IssuingDisputeEvidenceCanceledProductType `json:"product_type"`
 	// Date when the product was returned or attempted to be returned.
-	ReturnedAt int64 `json:"returned_at"`
+	ReturnedAt time.Time `json:"returned_at"`
 	// Result of cardholder's attempt to return the product.
 	ReturnStatus IssuingDisputeEvidenceCanceledReturnStatus `json:"return_status"`
 }
@@ -369,11 +372,11 @@ type IssuingDisputeEvidenceMerchandiseNotAsDescribed struct {
 	// Explanation of why the cardholder is disputing this transaction.
 	Explanation string `json:"explanation"`
 	// Date when the product was received.
-	ReceivedAt int64 `json:"received_at"`
+	ReceivedAt time.Time `json:"received_at"`
 	// Description of the cardholder's attempt to return the product.
 	ReturnDescription string `json:"return_description"`
 	// Date when the product was returned or attempted to be returned.
-	ReturnedAt int64 `json:"returned_at"`
+	ReturnedAt time.Time `json:"returned_at"`
 	// Result of cardholder's attempt to return the product.
 	ReturnStatus IssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus `json:"return_status"`
 }
@@ -387,7 +390,7 @@ type IssuingDisputeEvidenceNotReceived struct {
 	// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
 	AdditionalDocumentation *File `json:"additional_documentation"`
 	// Date when the cardholder expected to receive the product.
-	ExpectedAt int64 `json:"expected_at"`
+	ExpectedAt time.Time `json:"expected_at"`
 	// Explanation of why the cardholder is disputing this transaction.
 	Explanation string `json:"explanation"`
 	// Description of the merchandise or service that was purchased.
@@ -409,13 +412,13 @@ type IssuingDisputeEvidenceServiceNotAsDescribed struct {
 	// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
 	AdditionalDocumentation *File `json:"additional_documentation"`
 	// Date when order was canceled.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// Reason for canceling the order.
 	CancellationReason string `json:"cancellation_reason"`
 	// Explanation of why the cardholder is disputing this transaction.
 	Explanation string `json:"explanation"`
 	// Date when the product was received.
-	ReceivedAt int64 `json:"received_at"`
+	ReceivedAt time.Time `json:"received_at"`
 }
 type IssuingDisputeEvidence struct {
 	Canceled                  *IssuingDisputeEvidenceCanceled                  `json:"canceled"`
@@ -448,7 +451,7 @@ type IssuingDispute struct {
 	// List of balance transactions associated with the dispute.
 	BalanceTransactions []*BalanceTransaction `json:"balance_transactions"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The currency the `transaction` was made in.
 	Currency Currency                `json:"currency"`
 	Evidence *IssuingDisputeEvidence `json:"evidence"`
@@ -487,11 +490,194 @@ func (i *IssuingDispute) UnmarshalJSON(data []byte) error {
 	}
 
 	type issuingDispute IssuingDispute
-	var v issuingDispute
+	v := struct {
+		Created int64 `json:"created"`
+		*issuingDispute
+	}{
+		issuingDispute: (*issuingDispute)(i),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*i = IssuingDispute(v)
+	i.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of an IssuingDisputeEvidenceCanceled.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *IssuingDisputeEvidenceCanceled) UnmarshalJSON(data []byte) error {
+	type issuingDisputeEvidenceCanceled IssuingDisputeEvidenceCanceled
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		ExpectedAt int64 `json:"expected_at"`
+		ReturnedAt int64 `json:"returned_at"`
+		*issuingDisputeEvidenceCanceled
+	}{
+		issuingDisputeEvidenceCanceled: (*issuingDisputeEvidenceCanceled)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.CanceledAt = time.Unix(v.CanceledAt, 0)
+	i.ExpectedAt = time.Unix(v.ExpectedAt, 0)
+	i.ReturnedAt = time.Unix(v.ReturnedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an IssuingDisputeEvidenceMerchandiseNotAsDescribed.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *IssuingDisputeEvidenceMerchandiseNotAsDescribed) UnmarshalJSON(data []byte) error {
+	type issuingDisputeEvidenceMerchandiseNotAsDescribed IssuingDisputeEvidenceMerchandiseNotAsDescribed
+	v := struct {
+		ReceivedAt int64 `json:"received_at"`
+		ReturnedAt int64 `json:"returned_at"`
+		*issuingDisputeEvidenceMerchandiseNotAsDescribed
+	}{
+		issuingDisputeEvidenceMerchandiseNotAsDescribed: (*issuingDisputeEvidenceMerchandiseNotAsDescribed)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.ReceivedAt = time.Unix(v.ReceivedAt, 0)
+	i.ReturnedAt = time.Unix(v.ReturnedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an IssuingDisputeEvidenceNotReceived.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *IssuingDisputeEvidenceNotReceived) UnmarshalJSON(data []byte) error {
+	type issuingDisputeEvidenceNotReceived IssuingDisputeEvidenceNotReceived
+	v := struct {
+		ExpectedAt int64 `json:"expected_at"`
+		*issuingDisputeEvidenceNotReceived
+	}{
+		issuingDisputeEvidenceNotReceived: (*issuingDisputeEvidenceNotReceived)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.ExpectedAt = time.Unix(v.ExpectedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of an IssuingDisputeEvidenceServiceNotAsDescribed.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *IssuingDisputeEvidenceServiceNotAsDescribed) UnmarshalJSON(data []byte) error {
+	type issuingDisputeEvidenceServiceNotAsDescribed IssuingDisputeEvidenceServiceNotAsDescribed
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		ReceivedAt int64 `json:"received_at"`
+		*issuingDisputeEvidenceServiceNotAsDescribed
+	}{
+		issuingDisputeEvidenceServiceNotAsDescribed: (*issuingDisputeEvidenceServiceNotAsDescribed)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.CanceledAt = time.Unix(v.CanceledAt, 0)
+	i.ReceivedAt = time.Unix(v.ReceivedAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an IssuingDisputeEvidenceCanceled.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingDisputeEvidenceCanceled) MarshalJSON() ([]byte, error) {
+	type issuingDisputeEvidenceCanceled IssuingDisputeEvidenceCanceled
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		ExpectedAt int64 `json:"expected_at"`
+		ReturnedAt int64 `json:"returned_at"`
+		issuingDisputeEvidenceCanceled
+	}{
+		issuingDisputeEvidenceCanceled: (issuingDisputeEvidenceCanceled)(i),
+		CanceledAt:                     i.CanceledAt.Unix(),
+		ExpectedAt:                     i.ExpectedAt.Unix(),
+		ReturnedAt:                     i.ReturnedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an IssuingDisputeEvidenceMerchandiseNotAsDescribed.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingDisputeEvidenceMerchandiseNotAsDescribed) MarshalJSON() ([]byte, error) {
+	type issuingDisputeEvidenceMerchandiseNotAsDescribed IssuingDisputeEvidenceMerchandiseNotAsDescribed
+	v := struct {
+		ReceivedAt int64 `json:"received_at"`
+		ReturnedAt int64 `json:"returned_at"`
+		issuingDisputeEvidenceMerchandiseNotAsDescribed
+	}{
+		issuingDisputeEvidenceMerchandiseNotAsDescribed: (issuingDisputeEvidenceMerchandiseNotAsDescribed)(i),
+		ReceivedAt: i.ReceivedAt.Unix(),
+		ReturnedAt: i.ReturnedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an IssuingDisputeEvidenceNotReceived.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingDisputeEvidenceNotReceived) MarshalJSON() ([]byte, error) {
+	type issuingDisputeEvidenceNotReceived IssuingDisputeEvidenceNotReceived
+	v := struct {
+		ExpectedAt int64 `json:"expected_at"`
+		issuingDisputeEvidenceNotReceived
+	}{
+		issuingDisputeEvidenceNotReceived: (issuingDisputeEvidenceNotReceived)(i),
+		ExpectedAt:                        i.ExpectedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an IssuingDisputeEvidenceServiceNotAsDescribed.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingDisputeEvidenceServiceNotAsDescribed) MarshalJSON() ([]byte, error) {
+	type issuingDisputeEvidenceServiceNotAsDescribed IssuingDisputeEvidenceServiceNotAsDescribed
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		ReceivedAt int64 `json:"received_at"`
+		issuingDisputeEvidenceServiceNotAsDescribed
+	}{
+		issuingDisputeEvidenceServiceNotAsDescribed: (issuingDisputeEvidenceServiceNotAsDescribed)(i),
+		CanceledAt: i.CanceledAt.Unix(),
+		ReceivedAt: i.ReceivedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of an IssuingDispute.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingDispute) MarshalJSON() ([]byte, error) {
+	type issuingDispute IssuingDispute
+	v := struct {
+		Created int64 `json:"created"`
+		issuingDispute
+	}{
+		issuingDispute: (issuingDispute)(i),
+		Created:        i.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/issuing_fraudliabilitydebit.go
+++ b/issuing_fraudliabilitydebit.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Returns a list of Issuing FraudLiabilityDebit objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 type IssuingFraudLiabilityDebitListParams struct {
 	ListParams `form:"*"`
@@ -42,7 +47,7 @@ type IssuingFraudLiabilityDebit struct {
 	// ID of the [balance transaction](https://stripe.com/docs/api/balance_transactions) associated with this debit.
 	BalanceTransaction *BalanceTransaction `json:"balance_transaction"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The currency of the debit. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// The ID of the linked dispute.
@@ -60,4 +65,40 @@ type IssuingFraudLiabilityDebitList struct {
 	APIResource
 	ListMeta
 	Data []*IssuingFraudLiabilityDebit `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of an IssuingFraudLiabilityDebit.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (i *IssuingFraudLiabilityDebit) UnmarshalJSON(data []byte) error {
+	type issuingFraudLiabilityDebit IssuingFraudLiabilityDebit
+	v := struct {
+		Created int64 `json:"created"`
+		*issuingFraudLiabilityDebit
+	}{
+		issuingFraudLiabilityDebit: (*issuingFraudLiabilityDebit)(i),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	i.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an IssuingFraudLiabilityDebit.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingFraudLiabilityDebit) MarshalJSON() ([]byte, error) {
+	type issuingFraudLiabilityDebit IssuingFraudLiabilityDebit
+	v := struct {
+		Created int64 `json:"created"`
+		issuingFraudLiabilityDebit
+	}{
+		issuingFraudLiabilityDebit: (issuingFraudLiabilityDebit)(i),
+		Created:                    i.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/issuing_personalizationdesign.go
+++ b/issuing_personalizationdesign.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // The reason(s) the card logo was rejected.
 type IssuingPersonalizationDesignRejectionReasonsCardLogo string
@@ -161,7 +164,7 @@ type IssuingPersonalizationDesign struct {
 	// Hash containing carrier text, for use with physical bundles that support carrier text.
 	CarrierText *IssuingPersonalizationDesignCarrierText `json:"carrier_text"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -199,11 +202,34 @@ func (i *IssuingPersonalizationDesign) UnmarshalJSON(data []byte) error {
 	}
 
 	type issuingPersonalizationDesign IssuingPersonalizationDesign
-	var v issuingPersonalizationDesign
+	v := struct {
+		Created int64 `json:"created"`
+		*issuingPersonalizationDesign
+	}{
+		issuingPersonalizationDesign: (*issuingPersonalizationDesign)(i),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*i = IssuingPersonalizationDesign(v)
+	i.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of an IssuingPersonalizationDesign.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingPersonalizationDesign) MarshalJSON() ([]byte, error) {
+	type issuingPersonalizationDesign IssuingPersonalizationDesign
+	v := struct {
+		Created int64 `json:"created"`
+		issuingPersonalizationDesign
+	}{
+		issuingPersonalizationDesign: (issuingPersonalizationDesign)(i),
+		Created:                      i.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/issuing_token.go
+++ b/issuing_token.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // The token service provider / card network associated with the token.
 type IssuingTokenNetwork string
@@ -223,7 +226,7 @@ type IssuingToken struct {
 	// Card associated with this token.
 	Card *IssuingCard `json:"card"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The hashed ID derived from the device ID from the card network associated with the token.
 	DeviceFingerprint string `json:"device_fingerprint"`
 	// Unique identifier for the object.
@@ -236,7 +239,7 @@ type IssuingToken struct {
 	Network     IssuingTokenNetwork      `json:"network"`
 	NetworkData *IssuingTokenNetworkData `json:"network_data"`
 	// Time at which the token was last updated by the card network. Measured in seconds since the Unix epoch.
-	NetworkUpdatedAt int64 `json:"network_updated_at"`
+	NetworkUpdatedAt time.Time `json:"network_updated_at"`
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// The usage state of the token.
@@ -262,11 +265,38 @@ func (i *IssuingToken) UnmarshalJSON(data []byte) error {
 	}
 
 	type issuingToken IssuingToken
-	var v issuingToken
+	v := struct {
+		Created          int64 `json:"created"`
+		NetworkUpdatedAt int64 `json:"network_updated_at"`
+		*issuingToken
+	}{
+		issuingToken: (*issuingToken)(i),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*i = IssuingToken(v)
+	i.Created = time.Unix(v.Created, 0)
+	i.NetworkUpdatedAt = time.Unix(v.NetworkUpdatedAt, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of an IssuingToken.
+// This custom marshaling is needed to handle the time fields correctly.
+func (i IssuingToken) MarshalJSON() ([]byte, error) {
+	type issuingToken IssuingToken
+	v := struct {
+		Created          int64 `json:"created"`
+		NetworkUpdatedAt int64 `json:"network_updated_at"`
+		issuingToken
+	}{
+		issuingToken:     (issuingToken)(i),
+		Created:          i.Created.Unix(),
+		NetworkUpdatedAt: i.NetworkUpdatedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/loginlink.go
+++ b/loginlink.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Creates a login link for a connected account to access the Express Dashboard.
 //
 // You can only create login links for accounts that use the [Express Dashboard](https://stripe.com/connect/express-dashboard) and are connected to your platform.
@@ -25,9 +30,45 @@ func (p *LoginLinkParams) AddExpand(f string) {
 type LoginLink struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// The URL for the login link.
 	URL string `json:"url"`
+}
+
+// UnmarshalJSON handles deserialization of a LoginLink.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (l *LoginLink) UnmarshalJSON(data []byte) error {
+	type loginLink LoginLink
+	v := struct {
+		Created int64 `json:"created"`
+		*loginLink
+	}{
+		loginLink: (*loginLink)(l),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	l.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a LoginLink.
+// This custom marshaling is needed to handle the time fields correctly.
+func (l LoginLink) MarshalJSON() ([]byte, error) {
+	type loginLink LoginLink
+	v := struct {
+		Created int64 `json:"created"`
+		loginLink
+	}{
+		loginLink: (loginLink)(l),
+		Created:   l.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/margin.go
+++ b/margin.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Retrieve a list of your margins.
 type MarginListParams struct {
@@ -58,7 +61,7 @@ type Margin struct {
 	// Whether the margin can be applied to invoices, invoice items, or invoice line items. Defaults to `true`.
 	Active bool `json:"active"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -72,7 +75,7 @@ type Margin struct {
 	// Percent that will be taken off the subtotal before tax (after all other discounts and promotions) of any invoice to which the margin is applied.
 	PercentOff float64 `json:"percent_off"`
 	// Time at which the object was last updated. Measured in seconds since the Unix epoch.
-	Updated int64 `json:"updated"`
+	Updated time.Time `json:"updated"`
 }
 
 // MarginList is a list of Margins as retrieved from a list endpoint.
@@ -92,11 +95,38 @@ func (m *Margin) UnmarshalJSON(data []byte) error {
 	}
 
 	type margin Margin
-	var v margin
+	v := struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+		*margin
+	}{
+		margin: (*margin)(m),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*m = Margin(v)
+	m.Created = time.Unix(v.Created, 0)
+	m.Updated = time.Unix(v.Updated, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a Margin.
+// This custom marshaling is needed to handle the time fields correctly.
+func (m Margin) MarshalJSON() ([]byte, error) {
+	type margin Margin
+	v := struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+		margin
+	}{
+		margin:  (margin)(m),
+		Created: m.Created.Unix(),
+		Updated: m.Updated.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/order.go
+++ b/order.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The status of the most recent automated tax calculation for this Order.
 type OrderAutomaticTaxStatus string
 
@@ -1865,7 +1870,7 @@ type Order struct {
 	// Refer to our docs for [creating and processing an order](https://stripe.com/docs/orders-beta/create-and-process) to learn about how client_secret should be handled.
 	ClientSecret string `json:"client_secret"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The credits applied to the Order. At most 10 credits can be applied to an Order.
 	Credits []*OrderCredit `json:"credits"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -1904,4 +1909,40 @@ type OrderList struct {
 	APIResource
 	ListMeta
 	Data []*Order `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of an Order.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (o *Order) UnmarshalJSON(data []byte) error {
+	type order Order
+	v := struct {
+		Created int64 `json:"created"`
+		*order
+	}{
+		order: (*order)(o),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	o.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an Order.
+// This custom marshaling is needed to handle the time fields correctly.
+func (o Order) MarshalJSON() ([]byte, error) {
+	type order Order
+	v := struct {
+		Created int64 `json:"created"`
+		order
+	}{
+		order:   (order)(o),
+		Created: o.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/paymentintent.go
+++ b/paymentintent.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Controls whether this PaymentIntent will accept redirect-based payment methods.
 //
@@ -1401,7 +1404,7 @@ type PaymentIntentMandateDataCustomerAcceptanceOnlineParams struct {
 // This hash contains details about the customer acceptance of the Mandate.
 type PaymentIntentMandateDataCustomerAcceptanceParams struct {
 	// The time at which the customer accepted the Mandate.
-	AcceptedAt *int64 `form:"accepted_at"`
+	AcceptedAt *time.Time `form:"accepted_at"`
 	// If this is a Mandate accepted offline, this hash contains details about the offline acceptance.
 	Offline *PaymentIntentMandateDataCustomerAcceptanceOfflineParams `form:"offline"`
 	// If this is a Mandate accepted online, this hash contains details about the online acceptance.
@@ -1475,7 +1478,7 @@ type PaymentIntentPaymentDetailsCarRentalParams struct {
 	// Car pick-up address.
 	PickupAddress *AddressParams `form:"pickup_address"`
 	// Car pick-up time. Measured in seconds since the Unix epoch.
-	PickupAt *int64 `form:"pickup_at"`
+	PickupAt *time.Time `form:"pickup_at"`
 	// Rental rate.
 	RateAmount *int64 `form:"rate_amount"`
 	// The frequency at which the rate amount is applied. One of `day`, `week` or `month`
@@ -1485,7 +1488,7 @@ type PaymentIntentPaymentDetailsCarRentalParams struct {
 	// Car return address.
 	ReturnAddress *AddressParams `form:"return_address"`
 	// Car return time. Measured in seconds since the Unix epoch.
-	ReturnAt *int64 `form:"return_at"`
+	ReturnAt *time.Time `form:"return_at"`
 	// Indicates whether the goods or services are tax-exempt or tax is not collected.
 	TaxExempt *bool `form:"tax_exempt"`
 }
@@ -1527,13 +1530,13 @@ type PaymentIntentPaymentDetailsEventDetailsParams struct {
 	// Delivery details for this purchase.
 	Delivery *PaymentIntentPaymentDetailsEventDetailsDeliveryParams `form:"delivery"`
 	// Event end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Type of the event entertainment (concert, sports event etc)
 	Genre *string `form:"genre"`
 	// The name of the event.
 	Name *string `form:"name"`
 	// Event start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Affiliate details for this purchase.
@@ -1573,11 +1576,11 @@ type PaymentIntentPaymentDetailsFlightSegmentParams struct {
 	// The International Air Transport Association (IATA) airport code for the arrival airport.
 	ArrivalAirport *string `form:"arrival_airport"`
 	// The arrival time for the flight segment. Measured in seconds since the Unix epoch.
-	ArrivesAt *int64 `form:"arrives_at"`
+	ArrivesAt *time.Time `form:"arrives_at"`
 	// The International Air Transport Association (IATA) carrier code of the carrier operating the flight segment.
 	Carrier *string `form:"carrier"`
 	// The departure time for the flight segment. Measured in seconds since the Unix epoch.
-	DepartsAt *int64 `form:"departs_at"`
+	DepartsAt *time.Time `form:"departs_at"`
 	// The International Air Transport Association (IATA) airport code for the departure airport.
 	DepartureAirport *string `form:"departure_airport"`
 	// The flight number associated with the segment
@@ -1649,9 +1652,9 @@ type PaymentIntentPaymentDetailsLodgingParams struct {
 	// The lodging category
 	Category *string `form:"category"`
 	// Loding check-in time. Measured in seconds since the Unix epoch.
-	CheckinAt *int64 `form:"checkin_at"`
+	CheckinAt *time.Time `form:"checkin_at"`
 	// Lodging check-out time. Measured in seconds since the Unix epoch.
-	CheckoutAt *int64 `form:"checkout_at"`
+	CheckoutAt *time.Time `form:"checkout_at"`
 	// The customer service phone number of the lodging company.
 	CustomerServicePhoneNumber *string `form:"customer_service_phone_number"`
 	// The daily lodging room rate.
@@ -1705,11 +1708,11 @@ type PaymentIntentPaymentDetailsSubscriptionParams struct {
 	// Subscription billing details for this purchase.
 	BillingInterval *PaymentIntentPaymentDetailsSubscriptionBillingIntervalParams `form:"billing_interval"`
 	// Subscription end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Name of the product on subscription. e.g. Apple Music Subscription
 	Name *string `form:"name"`
 	// Subscription start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Provides industry-specific information about the charge.
@@ -2108,7 +2111,7 @@ type PaymentIntentPaymentMethodOptionsCardMandateOptionsParams struct {
 	// A description of the mandate or subscription that is meant to be displayed to the customer.
 	Description *string `form:"description"`
 	// End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
-	EndDate *int64 `form:"end_date"`
+	EndDate *time.Time `form:"end_date"`
 	// Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
 	Interval *string `form:"interval"`
 	// The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
@@ -2116,7 +2119,7 @@ type PaymentIntentPaymentMethodOptionsCardMandateOptionsParams struct {
 	// Unique identifier for the mandate or subscription.
 	Reference *string `form:"reference"`
 	// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
-	StartDate *int64 `form:"start_date"`
+	StartDate *time.Time `form:"start_date"`
 	// Specifies the type of mandates supported. Possible values are `india`.
 	SupportedTypes []*string `form:"supported_types"`
 }
@@ -2388,7 +2391,7 @@ type PaymentIntentPaymentMethodOptionsIDBankTransferParams struct {
 	// The UNIX timestamp until which the virtual bank account is valid. Permitted range is from 5 minutes from now until 31 days from now. If unset, it defaults to 3 days from now.
 	ExpiresAfter *int64 `form:"expires_after"`
 	// The UNIX timestamp until which the virtual bank account is valid. Permitted range is from now until 30 days from now. If unset, it defaults to 1 days from now.
-	ExpiresAt *int64 `form:"expires_at"`
+	ExpiresAt *time.Time `form:"expires_at"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
 	//
 	// If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
@@ -2465,7 +2468,7 @@ type PaymentIntentPaymentMethodOptionsKonbiniParams struct {
 	// The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST. Defaults to 3 days.
 	ExpiresAfterDays *int64 `form:"expires_after_days"`
 	// The timestamp at which the Konbini payment instructions will expire. Only one of `expires_after_days` or `expires_at` may be set.
-	ExpiresAt *int64 `form:"expires_at"`
+	ExpiresAt *time.Time `form:"expires_at"`
 	// A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
 	ProductDescription *string `form:"product_description"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -2731,7 +2734,7 @@ type PaymentIntentPaymentMethodOptionsPixParams struct {
 	// The number of seconds (between 10 and 1209600) after which Pix payment will expire. Defaults to 86400 seconds.
 	ExpiresAfterSeconds *int64 `form:"expires_after_seconds"`
 	// The timestamp at which the Pix expires (between 10 and 1209600 seconds in the future). Defaults to 1 day in the future.
-	ExpiresAt *int64 `form:"expires_at"`
+	ExpiresAt *time.Time `form:"expires_at"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
 	//
 	// If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
@@ -3368,7 +3371,7 @@ type PaymentIntentCapturePaymentDetailsCarRentalParams struct {
 	// Car pick-up address.
 	PickupAddress *AddressParams `form:"pickup_address"`
 	// Car pick-up time. Measured in seconds since the Unix epoch.
-	PickupAt *int64 `form:"pickup_at"`
+	PickupAt *time.Time `form:"pickup_at"`
 	// Rental rate.
 	RateAmount *int64 `form:"rate_amount"`
 	// The frequency at which the rate amount is applied. One of `day`, `week` or `month`
@@ -3378,7 +3381,7 @@ type PaymentIntentCapturePaymentDetailsCarRentalParams struct {
 	// Car return address.
 	ReturnAddress *AddressParams `form:"return_address"`
 	// Car return time. Measured in seconds since the Unix epoch.
-	ReturnAt *int64 `form:"return_at"`
+	ReturnAt *time.Time `form:"return_at"`
 	// Indicates whether the goods or services are tax-exempt or tax is not collected.
 	TaxExempt *bool `form:"tax_exempt"`
 }
@@ -3420,13 +3423,13 @@ type PaymentIntentCapturePaymentDetailsEventDetailsParams struct {
 	// Delivery details for this purchase.
 	Delivery *PaymentIntentCapturePaymentDetailsEventDetailsDeliveryParams `form:"delivery"`
 	// Event end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Type of the event entertainment (concert, sports event etc)
 	Genre *string `form:"genre"`
 	// The name of the event.
 	Name *string `form:"name"`
 	// Event start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Affiliate details for this purchase.
@@ -3466,11 +3469,11 @@ type PaymentIntentCapturePaymentDetailsFlightSegmentParams struct {
 	// The International Air Transport Association (IATA) airport code for the arrival airport.
 	ArrivalAirport *string `form:"arrival_airport"`
 	// The arrival time for the flight segment. Measured in seconds since the Unix epoch.
-	ArrivesAt *int64 `form:"arrives_at"`
+	ArrivesAt *time.Time `form:"arrives_at"`
 	// The International Air Transport Association (IATA) carrier code of the carrier operating the flight segment.
 	Carrier *string `form:"carrier"`
 	// The departure time for the flight segment. Measured in seconds since the Unix epoch.
-	DepartsAt *int64 `form:"departs_at"`
+	DepartsAt *time.Time `form:"departs_at"`
 	// The International Air Transport Association (IATA) airport code for the departure airport.
 	DepartureAirport *string `form:"departure_airport"`
 	// The flight number associated with the segment
@@ -3542,9 +3545,9 @@ type PaymentIntentCapturePaymentDetailsLodgingParams struct {
 	// The lodging category
 	Category *string `form:"category"`
 	// Loding check-in time. Measured in seconds since the Unix epoch.
-	CheckinAt *int64 `form:"checkin_at"`
+	CheckinAt *time.Time `form:"checkin_at"`
 	// Lodging check-out time. Measured in seconds since the Unix epoch.
-	CheckoutAt *int64 `form:"checkout_at"`
+	CheckoutAt *time.Time `form:"checkout_at"`
 	// The customer service phone number of the lodging company.
 	CustomerServicePhoneNumber *string `form:"customer_service_phone_number"`
 	// The daily lodging room rate.
@@ -3598,11 +3601,11 @@ type PaymentIntentCapturePaymentDetailsSubscriptionParams struct {
 	// Subscription billing details for this purchase.
 	BillingInterval *PaymentIntentCapturePaymentDetailsSubscriptionBillingIntervalParams `form:"billing_interval"`
 	// Subscription end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Name of the product on subscription. e.g. Apple Music Subscription
 	Name *string `form:"name"`
 	// Subscription start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Provides industry-specific information about the charge.
@@ -3742,7 +3745,7 @@ type PaymentIntentConfirmPaymentDetailsCarRentalParams struct {
 	// Car pick-up address.
 	PickupAddress *AddressParams `form:"pickup_address"`
 	// Car pick-up time. Measured in seconds since the Unix epoch.
-	PickupAt *int64 `form:"pickup_at"`
+	PickupAt *time.Time `form:"pickup_at"`
 	// Rental rate.
 	RateAmount *int64 `form:"rate_amount"`
 	// The frequency at which the rate amount is applied. One of `day`, `week` or `month`
@@ -3752,7 +3755,7 @@ type PaymentIntentConfirmPaymentDetailsCarRentalParams struct {
 	// Car return address.
 	ReturnAddress *AddressParams `form:"return_address"`
 	// Car return time. Measured in seconds since the Unix epoch.
-	ReturnAt *int64 `form:"return_at"`
+	ReturnAt *time.Time `form:"return_at"`
 	// Indicates whether the goods or services are tax-exempt or tax is not collected.
 	TaxExempt *bool `form:"tax_exempt"`
 }
@@ -3794,13 +3797,13 @@ type PaymentIntentConfirmPaymentDetailsEventDetailsParams struct {
 	// Delivery details for this purchase.
 	Delivery *PaymentIntentConfirmPaymentDetailsEventDetailsDeliveryParams `form:"delivery"`
 	// Event end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Type of the event entertainment (concert, sports event etc)
 	Genre *string `form:"genre"`
 	// The name of the event.
 	Name *string `form:"name"`
 	// Event start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Affiliate details for this purchase.
@@ -3840,11 +3843,11 @@ type PaymentIntentConfirmPaymentDetailsFlightSegmentParams struct {
 	// The International Air Transport Association (IATA) airport code for the arrival airport.
 	ArrivalAirport *string `form:"arrival_airport"`
 	// The arrival time for the flight segment. Measured in seconds since the Unix epoch.
-	ArrivesAt *int64 `form:"arrives_at"`
+	ArrivesAt *time.Time `form:"arrives_at"`
 	// The International Air Transport Association (IATA) carrier code of the carrier operating the flight segment.
 	Carrier *string `form:"carrier"`
 	// The departure time for the flight segment. Measured in seconds since the Unix epoch.
-	DepartsAt *int64 `form:"departs_at"`
+	DepartsAt *time.Time `form:"departs_at"`
 	// The International Air Transport Association (IATA) airport code for the departure airport.
 	DepartureAirport *string `form:"departure_airport"`
 	// The flight number associated with the segment
@@ -3916,9 +3919,9 @@ type PaymentIntentConfirmPaymentDetailsLodgingParams struct {
 	// The lodging category
 	Category *string `form:"category"`
 	// Loding check-in time. Measured in seconds since the Unix epoch.
-	CheckinAt *int64 `form:"checkin_at"`
+	CheckinAt *time.Time `form:"checkin_at"`
 	// Lodging check-out time. Measured in seconds since the Unix epoch.
-	CheckoutAt *int64 `form:"checkout_at"`
+	CheckoutAt *time.Time `form:"checkout_at"`
 	// The customer service phone number of the lodging company.
 	CustomerServicePhoneNumber *string `form:"customer_service_phone_number"`
 	// The daily lodging room rate.
@@ -3972,11 +3975,11 @@ type PaymentIntentConfirmPaymentDetailsSubscriptionParams struct {
 	// Subscription billing details for this purchase.
 	BillingInterval *PaymentIntentConfirmPaymentDetailsSubscriptionBillingIntervalParams `form:"billing_interval"`
 	// Subscription end time. Measured in seconds since the Unix epoch.
-	EndsAt *int64 `form:"ends_at"`
+	EndsAt *time.Time `form:"ends_at"`
 	// Name of the product on subscription. e.g. Apple Music Subscription
 	Name *string `form:"name"`
 	// Subscription start time. Measured in seconds since the Unix epoch.
-	StartsAt *int64 `form:"starts_at"`
+	StartsAt *time.Time `form:"starts_at"`
 }
 
 // Provides industry-specific information about the charge.
@@ -4335,7 +4338,7 @@ type PaymentIntentNextActionAlipayHandleRedirect struct {
 }
 type PaymentIntentNextActionBoletoDisplayDetails struct {
 	// The timestamp after which the boleto expires.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The URL to the hosted boleto voucher page, which allows customers to view the boleto voucher.
 	HostedVoucherURL string `json:"hosted_voucher_url"`
 	// The boleto number.
@@ -4345,13 +4348,13 @@ type PaymentIntentNextActionBoletoDisplayDetails struct {
 }
 type PaymentIntentNextActionCardAwaitNotification struct {
 	// The time that payment will be attempted. If customer approval is required, they need to provide approval before this time.
-	ChargeAttemptAt int64 `json:"charge_attempt_at"`
+	ChargeAttemptAt time.Time `json:"charge_attempt_at"`
 	// For payments greater than INR 15000, the customer must provide explicit approval of the payment with their bank. For payments of lower amount, no customer action is required.
 	CustomerApprovalRequired bool `json:"customer_approval_required"`
 }
 type PaymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode struct {
 	// The date (unix timestamp) when the QR code expires.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The image_url_png string used to render QR code
 	ImageURLPNG string `json:"image_url_png"`
 	// The image_url_svg string used to render QR code
@@ -4534,7 +4537,7 @@ type PaymentIntentNextActionKonbiniDisplayDetailsStores struct {
 }
 type PaymentIntentNextActionKonbiniDisplayDetails struct {
 	// The timestamp at which the pending Konbini payment expires.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The URL for the Konbini payment instructions page, which allows customers to view and print a Konbini voucher.
 	HostedVoucherURL string                                              `json:"hosted_voucher_url"`
 	Stores           *PaymentIntentNextActionKonbiniDisplayDetailsStores `json:"stores"`
@@ -4543,7 +4546,7 @@ type PaymentIntentNextActionMultibancoDisplayDetails struct {
 	// Entity number associated with this Multibanco payment.
 	Entity string `json:"entity"`
 	// The timestamp at which the Multibanco voucher expires.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The URL for the hosted Multibanco voucher page, which allows customers to view a Multibanco voucher.
 	HostedVoucherURL string `json:"hosted_voucher_url"`
 	// Reference number associated with this Multibanco payment.
@@ -4551,7 +4554,7 @@ type PaymentIntentNextActionMultibancoDisplayDetails struct {
 }
 type PaymentIntentNextActionOXXODisplayDetails struct {
 	// The timestamp after which the OXXO voucher expires.
-	ExpiresAfter int64 `json:"expires_after"`
+	ExpiresAfter time.Time `json:"expires_after"`
 	// The URL for the hosted OXXO voucher page, which allows customers to view and print an OXXO voucher.
 	HostedVoucherURL string `json:"hosted_voucher_url"`
 	// OXXO reference number.
@@ -4571,7 +4574,7 @@ type PaymentIntentNextActionPixDisplayQRCode struct {
 	// The raw data string used to generate QR code, it should be used together with QR code library.
 	Data string `json:"data"`
 	// The date (unix timestamp) when the PIX expires.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The URL to the hosted pix instructions page, which allows customers to view the pix QR code.
 	HostedInstructionsURL string `json:"hosted_instructions_url"`
 	// The image_url_png string used to render png QR code
@@ -4615,7 +4618,7 @@ type PaymentIntentNextActionSwishHandleRedirectOrDisplayQRCode struct {
 type PaymentIntentNextActionUseStripeSDK struct{}
 type PaymentIntentNextActionVerifyWithMicrodeposits struct {
 	// The timestamp when the microdeposits are expected to land.
-	ArrivalDate int64 `json:"arrival_date"`
+	ArrivalDate time.Time `json:"arrival_date"`
 	// The URL for the hosted verification page, which allows customers to verify their bank account.
 	HostedVerificationURL string `json:"hosted_verification_url"`
 	// The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
@@ -4726,7 +4729,7 @@ type PaymentIntentPaymentDetailsCarRental struct {
 	NoShow        bool     `json:"no_show"`
 	PickupAddress *Address `json:"pickup_address"`
 	// Car pick-up time. Measured in seconds since the Unix epoch.
-	PickupAt int64 `json:"pickup_at"`
+	PickupAt time.Time `json:"pickup_at"`
 	// Rental rate.
 	RateAmount int64 `json:"rate_amount"`
 	// The frequency at which the rate amount is applied. One of `day`, `week` or `month`
@@ -4735,7 +4738,7 @@ type PaymentIntentPaymentDetailsCarRental struct {
 	RenterName    string   `json:"renter_name"`
 	ReturnAddress *Address `json:"return_address"`
 	// Car return time. Measured in seconds since the Unix epoch.
-	ReturnAt int64 `json:"return_at"`
+	ReturnAt time.Time `json:"return_at"`
 	// Indicates whether the goods or services are tax-exempt or tax is not collected.
 	TaxExempt bool `json:"tax_exempt"`
 }
@@ -4765,13 +4768,13 @@ type PaymentIntentPaymentDetailsEventDetails struct {
 	Company  string                                           `json:"company"`
 	Delivery *PaymentIntentPaymentDetailsEventDetailsDelivery `json:"delivery"`
 	// Event end time. Measured in seconds since the Unix epoch.
-	EndsAt int64 `json:"ends_at"`
+	EndsAt time.Time `json:"ends_at"`
 	// Type of the event entertainment (concert, sports event etc)
 	Genre string `json:"genre"`
 	// The name of the event.
 	Name string `json:"name"`
 	// Event start time. Measured in seconds since the Unix epoch.
-	StartsAt int64 `json:"starts_at"`
+	StartsAt time.Time `json:"starts_at"`
 }
 type PaymentIntentPaymentDetailsSubscriptionAffiliate struct {
 	// The name of the affiliate that originated the purchase.
@@ -4789,11 +4792,11 @@ type PaymentIntentPaymentDetailsSubscription struct {
 	AutoRenewal     bool                                                    `json:"auto_renewal"`
 	BillingInterval *PaymentIntentPaymentDetailsSubscriptionBillingInterval `json:"billing_interval"`
 	// Subscription end time. Measured in seconds since the Unix epoch.
-	EndsAt int64 `json:"ends_at"`
+	EndsAt time.Time `json:"ends_at"`
 	// Name of the product on subscription. e.g. Apple Music Subscription.
 	Name string `json:"name"`
 	// Subscription start time. Measured in seconds since the Unix epoch.
-	StartsAt int64 `json:"starts_at"`
+	StartsAt time.Time `json:"starts_at"`
 }
 type PaymentIntentPaymentDetails struct {
 	CarRental    *PaymentIntentPaymentDetailsCarRental    `json:"car_rental"`
@@ -4978,7 +4981,7 @@ type PaymentIntentPaymentMethodOptionsCardMandateOptions struct {
 	// A description of the mandate or subscription that is meant to be displayed to the customer.
 	Description string `json:"description"`
 	// End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
-	EndDate int64 `json:"end_date"`
+	EndDate time.Time `json:"end_date"`
 	// Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
 	Interval PaymentIntentPaymentMethodOptionsCardMandateOptionsInterval `json:"interval"`
 	// The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
@@ -4986,7 +4989,7 @@ type PaymentIntentPaymentMethodOptionsCardMandateOptions struct {
 	// Unique identifier for the mandate or subscription.
 	Reference string `json:"reference"`
 	// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
-	StartDate int64 `json:"start_date"`
+	StartDate time.Time `json:"start_date"`
 	// Specifies the type of mandates supported. Possible values are `india`.
 	SupportedTypes []PaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedType `json:"supported_types"`
 }
@@ -5139,7 +5142,7 @@ type PaymentIntentPaymentMethodOptionsIDBankTransfer struct {
 	// The UNIX timestamp until which the virtual bank account is valid. Permitted range is from now till 2678400 seconds (31 days) from now.
 	ExpiresAfter int64 `json:"expires_after"`
 	// The UNIX timestamp until which the virtual bank account is valid. Permitted range is from now until 30 days from now. If unset, it defaults to 1 days from now.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
 	//
 	// If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
@@ -5192,7 +5195,7 @@ type PaymentIntentPaymentMethodOptionsKonbini struct {
 	// The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST.
 	ExpiresAfterDays int64 `json:"expires_after_days"`
 	// The timestamp at which the Konbini payment instructions will expire. Only one of `expires_after_days` or `expires_at` may be set.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
 	ProductDescription string `json:"product_description"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -5380,7 +5383,7 @@ type PaymentIntentPaymentMethodOptionsPix struct {
 	// The number of seconds (between 10 and 1209600) after which Pix payment will expire.
 	ExpiresAfterSeconds int64 `json:"expires_after_seconds"`
 	// The timestamp at which the Pix expires.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// Indicates that you intend to make future payments with this PaymentIntent's payment method.
 	//
 	// If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
@@ -5611,7 +5614,7 @@ type PaymentIntentProcessingCardCustomerNotification struct {
 	// Whether customer approval has been requested for this payment. For payments greater than INR 15000 or mandate amount, the customer must provide explicit approval of the payment with their bank.
 	ApprovalRequested bool `json:"approval_requested"`
 	// If customer approval is required, they need to provide approval before this time.
-	CompletesAt int64 `json:"completes_at"`
+	CompletesAt time.Time `json:"completes_at"`
 }
 type PaymentIntentProcessingCard struct {
 	CustomerNotification *PaymentIntentProcessingCardCustomerNotification `json:"customer_notification"`
@@ -5662,7 +5665,7 @@ type PaymentIntent struct {
 	// Settings to configure compatible payment methods from the [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods)
 	AutomaticPaymentMethods *PaymentIntentAutomaticPaymentMethods `json:"automatic_payment_methods"`
 	// Populated when `status` is `canceled`, this is the time at which the PaymentIntent was canceled. Measured in seconds since the Unix epoch.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// Reason for cancellation of this PaymentIntent, either user-provided (`duplicate`, `fraudulent`, `requested_by_customer`, or `abandoned`) or generated by Stripe internally (`failed_invoice`, `void_invoice`, or `automatic`).
 	CancellationReason PaymentIntentCancellationReason `json:"cancellation_reason"`
 	// Controls when the funds will be captured from the customer's account.
@@ -5676,7 +5679,7 @@ type PaymentIntent struct {
 	// Describes whether we can confirm this PaymentIntent automatically, or if it requires customer action to confirm the payment.
 	ConfirmationMethod PaymentIntentConfirmationMethod `json:"confirmation_method"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// ID of the Customer this PaymentIntent belongs to, if one exists.
@@ -5772,11 +5775,630 @@ func (p *PaymentIntent) UnmarshalJSON(data []byte) error {
 	}
 
 	type paymentIntent PaymentIntent
-	var v paymentIntent
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		Created    int64 `json:"created"`
+		*paymentIntent
+	}{
+		paymentIntent: (*paymentIntent)(p),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*p = PaymentIntent(v)
+	p.CanceledAt = time.Unix(v.CanceledAt, 0)
+	p.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentNextActionBoletoDisplayDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentNextActionBoletoDisplayDetails) UnmarshalJSON(data []byte) error {
+	type paymentIntentNextActionBoletoDisplayDetails PaymentIntentNextActionBoletoDisplayDetails
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*paymentIntentNextActionBoletoDisplayDetails
+	}{
+		paymentIntentNextActionBoletoDisplayDetails: (*paymentIntentNextActionBoletoDisplayDetails)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentNextActionCardAwaitNotification.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentNextActionCardAwaitNotification) UnmarshalJSON(data []byte) error {
+	type paymentIntentNextActionCardAwaitNotification PaymentIntentNextActionCardAwaitNotification
+	v := struct {
+		ChargeAttemptAt int64 `json:"charge_attempt_at"`
+		*paymentIntentNextActionCardAwaitNotification
+	}{
+		paymentIntentNextActionCardAwaitNotification: (*paymentIntentNextActionCardAwaitNotification)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ChargeAttemptAt = time.Unix(v.ChargeAttemptAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode) UnmarshalJSON(data []byte) error {
+	type paymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode PaymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*paymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode
+	}{
+		paymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode: (*paymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentNextActionKonbiniDisplayDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentNextActionKonbiniDisplayDetails) UnmarshalJSON(data []byte) error {
+	type paymentIntentNextActionKonbiniDisplayDetails PaymentIntentNextActionKonbiniDisplayDetails
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*paymentIntentNextActionKonbiniDisplayDetails
+	}{
+		paymentIntentNextActionKonbiniDisplayDetails: (*paymentIntentNextActionKonbiniDisplayDetails)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentNextActionMultibancoDisplayDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentNextActionMultibancoDisplayDetails) UnmarshalJSON(data []byte) error {
+	type paymentIntentNextActionMultibancoDisplayDetails PaymentIntentNextActionMultibancoDisplayDetails
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*paymentIntentNextActionMultibancoDisplayDetails
+	}{
+		paymentIntentNextActionMultibancoDisplayDetails: (*paymentIntentNextActionMultibancoDisplayDetails)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentNextActionOXXODisplayDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentNextActionOXXODisplayDetails) UnmarshalJSON(data []byte) error {
+	type paymentIntentNextActionOXXODisplayDetails PaymentIntentNextActionOXXODisplayDetails
+	v := struct {
+		ExpiresAfter int64 `json:"expires_after"`
+		*paymentIntentNextActionOXXODisplayDetails
+	}{
+		paymentIntentNextActionOXXODisplayDetails: (*paymentIntentNextActionOXXODisplayDetails)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAfter = time.Unix(v.ExpiresAfter, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentNextActionPixDisplayQRCode.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentNextActionPixDisplayQRCode) UnmarshalJSON(data []byte) error {
+	type paymentIntentNextActionPixDisplayQRCode PaymentIntentNextActionPixDisplayQRCode
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*paymentIntentNextActionPixDisplayQRCode
+	}{
+		paymentIntentNextActionPixDisplayQRCode: (*paymentIntentNextActionPixDisplayQRCode)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentNextActionVerifyWithMicrodeposits.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentNextActionVerifyWithMicrodeposits) UnmarshalJSON(data []byte) error {
+	type paymentIntentNextActionVerifyWithMicrodeposits PaymentIntentNextActionVerifyWithMicrodeposits
+	v := struct {
+		ArrivalDate int64 `json:"arrival_date"`
+		*paymentIntentNextActionVerifyWithMicrodeposits
+	}{
+		paymentIntentNextActionVerifyWithMicrodeposits: (*paymentIntentNextActionVerifyWithMicrodeposits)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ArrivalDate = time.Unix(v.ArrivalDate, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentPaymentDetailsCarRental.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentPaymentDetailsCarRental) UnmarshalJSON(data []byte) error {
+	type paymentIntentPaymentDetailsCarRental PaymentIntentPaymentDetailsCarRental
+	v := struct {
+		PickupAt int64 `json:"pickup_at"`
+		ReturnAt int64 `json:"return_at"`
+		*paymentIntentPaymentDetailsCarRental
+	}{
+		paymentIntentPaymentDetailsCarRental: (*paymentIntentPaymentDetailsCarRental)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.PickupAt = time.Unix(v.PickupAt, 0)
+	p.ReturnAt = time.Unix(v.ReturnAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentPaymentDetailsEventDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentPaymentDetailsEventDetails) UnmarshalJSON(data []byte) error {
+	type paymentIntentPaymentDetailsEventDetails PaymentIntentPaymentDetailsEventDetails
+	v := struct {
+		EndsAt   int64 `json:"ends_at"`
+		StartsAt int64 `json:"starts_at"`
+		*paymentIntentPaymentDetailsEventDetails
+	}{
+		paymentIntentPaymentDetailsEventDetails: (*paymentIntentPaymentDetailsEventDetails)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.EndsAt = time.Unix(v.EndsAt, 0)
+	p.StartsAt = time.Unix(v.StartsAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentPaymentDetailsSubscription.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentPaymentDetailsSubscription) UnmarshalJSON(data []byte) error {
+	type paymentIntentPaymentDetailsSubscription PaymentIntentPaymentDetailsSubscription
+	v := struct {
+		EndsAt   int64 `json:"ends_at"`
+		StartsAt int64 `json:"starts_at"`
+		*paymentIntentPaymentDetailsSubscription
+	}{
+		paymentIntentPaymentDetailsSubscription: (*paymentIntentPaymentDetailsSubscription)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.EndsAt = time.Unix(v.EndsAt, 0)
+	p.StartsAt = time.Unix(v.StartsAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentPaymentMethodOptionsCardMandateOptions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentPaymentMethodOptionsCardMandateOptions) UnmarshalJSON(data []byte) error {
+	type paymentIntentPaymentMethodOptionsCardMandateOptions PaymentIntentPaymentMethodOptionsCardMandateOptions
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		*paymentIntentPaymentMethodOptionsCardMandateOptions
+	}{
+		paymentIntentPaymentMethodOptionsCardMandateOptions: (*paymentIntentPaymentMethodOptionsCardMandateOptions)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.EndDate = time.Unix(v.EndDate, 0)
+	p.StartDate = time.Unix(v.StartDate, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentPaymentMethodOptionsIDBankTransfer.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentPaymentMethodOptionsIDBankTransfer) UnmarshalJSON(data []byte) error {
+	type paymentIntentPaymentMethodOptionsIDBankTransfer PaymentIntentPaymentMethodOptionsIDBankTransfer
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*paymentIntentPaymentMethodOptionsIDBankTransfer
+	}{
+		paymentIntentPaymentMethodOptionsIDBankTransfer: (*paymentIntentPaymentMethodOptionsIDBankTransfer)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentPaymentMethodOptionsKonbini.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentPaymentMethodOptionsKonbini) UnmarshalJSON(data []byte) error {
+	type paymentIntentPaymentMethodOptionsKonbini PaymentIntentPaymentMethodOptionsKonbini
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*paymentIntentPaymentMethodOptionsKonbini
+	}{
+		paymentIntentPaymentMethodOptionsKonbini: (*paymentIntentPaymentMethodOptionsKonbini)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentPaymentMethodOptionsPix.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentPaymentMethodOptionsPix) UnmarshalJSON(data []byte) error {
+	type paymentIntentPaymentMethodOptionsPix PaymentIntentPaymentMethodOptionsPix
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*paymentIntentPaymentMethodOptionsPix
+	}{
+		paymentIntentPaymentMethodOptionsPix: (*paymentIntentPaymentMethodOptionsPix)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentIntentProcessingCardCustomerNotification.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentIntentProcessingCardCustomerNotification) UnmarshalJSON(data []byte) error {
+	type paymentIntentProcessingCardCustomerNotification PaymentIntentProcessingCardCustomerNotification
+	v := struct {
+		CompletesAt int64 `json:"completes_at"`
+		*paymentIntentProcessingCardCustomerNotification
+	}{
+		paymentIntentProcessingCardCustomerNotification: (*paymentIntentProcessingCardCustomerNotification)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.CompletesAt = time.Unix(v.CompletesAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a PaymentIntentNextActionBoletoDisplayDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentNextActionBoletoDisplayDetails) MarshalJSON() ([]byte, error) {
+	type paymentIntentNextActionBoletoDisplayDetails PaymentIntentNextActionBoletoDisplayDetails
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		paymentIntentNextActionBoletoDisplayDetails
+	}{
+		paymentIntentNextActionBoletoDisplayDetails: (paymentIntentNextActionBoletoDisplayDetails)(p),
+		ExpiresAt: p.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentNextActionCardAwaitNotification.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentNextActionCardAwaitNotification) MarshalJSON() ([]byte, error) {
+	type paymentIntentNextActionCardAwaitNotification PaymentIntentNextActionCardAwaitNotification
+	v := struct {
+		ChargeAttemptAt int64 `json:"charge_attempt_at"`
+		paymentIntentNextActionCardAwaitNotification
+	}{
+		paymentIntentNextActionCardAwaitNotification: (paymentIntentNextActionCardAwaitNotification)(p),
+		ChargeAttemptAt: p.ChargeAttemptAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode) MarshalJSON() ([]byte, error) {
+	type paymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode PaymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		paymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode
+	}{
+		paymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode: (paymentIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode)(p),
+		ExpiresAt: p.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentNextActionKonbiniDisplayDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentNextActionKonbiniDisplayDetails) MarshalJSON() ([]byte, error) {
+	type paymentIntentNextActionKonbiniDisplayDetails PaymentIntentNextActionKonbiniDisplayDetails
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		paymentIntentNextActionKonbiniDisplayDetails
+	}{
+		paymentIntentNextActionKonbiniDisplayDetails: (paymentIntentNextActionKonbiniDisplayDetails)(p),
+		ExpiresAt: p.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentNextActionMultibancoDisplayDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentNextActionMultibancoDisplayDetails) MarshalJSON() ([]byte, error) {
+	type paymentIntentNextActionMultibancoDisplayDetails PaymentIntentNextActionMultibancoDisplayDetails
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		paymentIntentNextActionMultibancoDisplayDetails
+	}{
+		paymentIntentNextActionMultibancoDisplayDetails: (paymentIntentNextActionMultibancoDisplayDetails)(p),
+		ExpiresAt: p.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentNextActionOXXODisplayDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentNextActionOXXODisplayDetails) MarshalJSON() ([]byte, error) {
+	type paymentIntentNextActionOXXODisplayDetails PaymentIntentNextActionOXXODisplayDetails
+	v := struct {
+		ExpiresAfter int64 `json:"expires_after"`
+		paymentIntentNextActionOXXODisplayDetails
+	}{
+		paymentIntentNextActionOXXODisplayDetails: (paymentIntentNextActionOXXODisplayDetails)(p),
+		ExpiresAfter: p.ExpiresAfter.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentNextActionPixDisplayQRCode.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentNextActionPixDisplayQRCode) MarshalJSON() ([]byte, error) {
+	type paymentIntentNextActionPixDisplayQRCode PaymentIntentNextActionPixDisplayQRCode
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		paymentIntentNextActionPixDisplayQRCode
+	}{
+		paymentIntentNextActionPixDisplayQRCode: (paymentIntentNextActionPixDisplayQRCode)(p),
+		ExpiresAt:                               p.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentNextActionVerifyWithMicrodeposits.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentNextActionVerifyWithMicrodeposits) MarshalJSON() ([]byte, error) {
+	type paymentIntentNextActionVerifyWithMicrodeposits PaymentIntentNextActionVerifyWithMicrodeposits
+	v := struct {
+		ArrivalDate int64 `json:"arrival_date"`
+		paymentIntentNextActionVerifyWithMicrodeposits
+	}{
+		paymentIntentNextActionVerifyWithMicrodeposits: (paymentIntentNextActionVerifyWithMicrodeposits)(p),
+		ArrivalDate: p.ArrivalDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentPaymentDetailsCarRental.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentPaymentDetailsCarRental) MarshalJSON() ([]byte, error) {
+	type paymentIntentPaymentDetailsCarRental PaymentIntentPaymentDetailsCarRental
+	v := struct {
+		PickupAt int64 `json:"pickup_at"`
+		ReturnAt int64 `json:"return_at"`
+		paymentIntentPaymentDetailsCarRental
+	}{
+		paymentIntentPaymentDetailsCarRental: (paymentIntentPaymentDetailsCarRental)(p),
+		PickupAt:                             p.PickupAt.Unix(),
+		ReturnAt:                             p.ReturnAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentPaymentDetailsEventDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentPaymentDetailsEventDetails) MarshalJSON() ([]byte, error) {
+	type paymentIntentPaymentDetailsEventDetails PaymentIntentPaymentDetailsEventDetails
+	v := struct {
+		EndsAt   int64 `json:"ends_at"`
+		StartsAt int64 `json:"starts_at"`
+		paymentIntentPaymentDetailsEventDetails
+	}{
+		paymentIntentPaymentDetailsEventDetails: (paymentIntentPaymentDetailsEventDetails)(p),
+		EndsAt:                                  p.EndsAt.Unix(),
+		StartsAt:                                p.StartsAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentPaymentDetailsSubscription.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentPaymentDetailsSubscription) MarshalJSON() ([]byte, error) {
+	type paymentIntentPaymentDetailsSubscription PaymentIntentPaymentDetailsSubscription
+	v := struct {
+		EndsAt   int64 `json:"ends_at"`
+		StartsAt int64 `json:"starts_at"`
+		paymentIntentPaymentDetailsSubscription
+	}{
+		paymentIntentPaymentDetailsSubscription: (paymentIntentPaymentDetailsSubscription)(p),
+		EndsAt:                                  p.EndsAt.Unix(),
+		StartsAt:                                p.StartsAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentPaymentMethodOptionsCardMandateOptions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentPaymentMethodOptionsCardMandateOptions) MarshalJSON() ([]byte, error) {
+	type paymentIntentPaymentMethodOptionsCardMandateOptions PaymentIntentPaymentMethodOptionsCardMandateOptions
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		paymentIntentPaymentMethodOptionsCardMandateOptions
+	}{
+		paymentIntentPaymentMethodOptionsCardMandateOptions: (paymentIntentPaymentMethodOptionsCardMandateOptions)(p),
+		EndDate:   p.EndDate.Unix(),
+		StartDate: p.StartDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentPaymentMethodOptionsIDBankTransfer.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentPaymentMethodOptionsIDBankTransfer) MarshalJSON() ([]byte, error) {
+	type paymentIntentPaymentMethodOptionsIDBankTransfer PaymentIntentPaymentMethodOptionsIDBankTransfer
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		paymentIntentPaymentMethodOptionsIDBankTransfer
+	}{
+		paymentIntentPaymentMethodOptionsIDBankTransfer: (paymentIntentPaymentMethodOptionsIDBankTransfer)(p),
+		ExpiresAt: p.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentPaymentMethodOptionsKonbini.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentPaymentMethodOptionsKonbini) MarshalJSON() ([]byte, error) {
+	type paymentIntentPaymentMethodOptionsKonbini PaymentIntentPaymentMethodOptionsKonbini
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		paymentIntentPaymentMethodOptionsKonbini
+	}{
+		paymentIntentPaymentMethodOptionsKonbini: (paymentIntentPaymentMethodOptionsKonbini)(p),
+		ExpiresAt:                                p.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentPaymentMethodOptionsPix.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentPaymentMethodOptionsPix) MarshalJSON() ([]byte, error) {
+	type paymentIntentPaymentMethodOptionsPix PaymentIntentPaymentMethodOptionsPix
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		paymentIntentPaymentMethodOptionsPix
+	}{
+		paymentIntentPaymentMethodOptionsPix: (paymentIntentPaymentMethodOptionsPix)(p),
+		ExpiresAt:                            p.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntentProcessingCardCustomerNotification.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntentProcessingCardCustomerNotification) MarshalJSON() ([]byte, error) {
+	type paymentIntentProcessingCardCustomerNotification PaymentIntentProcessingCardCustomerNotification
+	v := struct {
+		CompletesAt int64 `json:"completes_at"`
+		paymentIntentProcessingCardCustomerNotification
+	}{
+		paymentIntentProcessingCardCustomerNotification: (paymentIntentProcessingCardCustomerNotification)(p),
+		CompletesAt: p.CompletesAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentIntent.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentIntent) MarshalJSON() ([]byte, error) {
+	type paymentIntent PaymentIntent
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		Created    int64 `json:"created"`
+		paymentIntent
+	}{
+		paymentIntent: (paymentIntent)(p),
+		CanceledAt:    p.CanceledAt.Unix(),
+		Created:       p.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/paymentmethod.go
+++ b/paymentmethod.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // This field indicates whether this payment method can be shown again to its customer in a checkout flow. Stripe products such as Checkout and Elements use this field to determine whether a payment method can be shown as a saved payment method in a checkout flow. The field defaults to “unspecified”.
 type PaymentMethodAllowRedisplay string
@@ -927,7 +930,7 @@ type PaymentMethodCardChecks struct {
 // Details about payments collected offline.
 type PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline struct {
 	// Time at which the payment was collected while offline
-	StoredAt int64 `json:"stored_at"`
+	StoredAt time.Time `json:"stored_at"`
 	// The method used to process this payment method offline. Only deferred is allowed.
 	Type PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOfflineType `json:"type"`
 }
@@ -965,7 +968,7 @@ type PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent struct {
 	// The [product code](https://stripe.com/docs/card-product-codes) that identifies the specific program or product associated with a card.
 	BrandProduct string `json:"brand_product"`
 	// When using manual capture, a future timestamp after which the charge will be automatically refunded if uncaptured.
-	CaptureBefore int64 `json:"capture_before"`
+	CaptureBefore time.Time `json:"capture_before"`
 	// The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`). In some cases, the cardholder name may not be available depending on how the issuer has configured the card. Cardholder name is typically not available on swipe or contactless payments, such as those made with Apple Pay and Google Pay.
 	CardholderName string `json:"cardholder_name"`
 	// Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
@@ -1133,7 +1136,7 @@ type PaymentMethodCardPresentNetworks struct {
 // Details about payment methods collected offline.
 type PaymentMethodCardPresentOffline struct {
 	// Time at which the payment was collected while offline
-	StoredAt int64 `json:"stored_at"`
+	StoredAt time.Time `json:"stored_at"`
 	// The method used to process this payment method offline. Only deferred is allowed.
 	Type PaymentMethodCardPresentOfflineType `json:"type"`
 }
@@ -1436,7 +1439,7 @@ type PaymentMethod struct {
 	CardPresent    *PaymentMethodCardPresent    `json:"card_present"`
 	CashApp        *PaymentMethodCashApp        `json:"cashapp"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The ID of the Customer to which this PaymentMethod is saved. This will not be set when the PaymentMethod has not been saved to a Customer.
 	Customer        *Customer                     `json:"customer"`
 	CustomerBalance *PaymentMethodCustomerBalance `json:"customer_balance"`
@@ -1509,11 +1512,142 @@ func (p *PaymentMethod) UnmarshalJSON(data []byte) error {
 	}
 
 	type paymentMethod PaymentMethod
-	var v paymentMethod
+	v := struct {
+		Created int64 `json:"created"`
+		*paymentMethod
+	}{
+		paymentMethod: (*paymentMethod)(p),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*p = PaymentMethod(v)
+	p.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline) UnmarshalJSON(data []byte) error {
+	type paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		*paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline
+	}{
+		paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline: (*paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.StoredAt = time.Unix(v.StoredAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent) UnmarshalJSON(data []byte) error {
+	type paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent
+	v := struct {
+		CaptureBefore int64 `json:"capture_before"`
+		*paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent
+	}{
+		paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent: (*paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.CaptureBefore = time.Unix(v.CaptureBefore, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PaymentMethodCardPresentOffline.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentMethodCardPresentOffline) UnmarshalJSON(data []byte) error {
+	type paymentMethodCardPresentOffline PaymentMethodCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		*paymentMethodCardPresentOffline
+	}{
+		paymentMethodCardPresentOffline: (*paymentMethodCardPresentOffline)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.StoredAt = time.Unix(v.StoredAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline) MarshalJSON() ([]byte, error) {
+	type paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline
+	}{
+		paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline: (paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresentOffline)(p),
+		StoredAt: p.StoredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent) MarshalJSON() ([]byte, error) {
+	type paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent PaymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent
+	v := struct {
+		CaptureBefore int64 `json:"capture_before"`
+		paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent
+	}{
+		paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent: (paymentMethodCardGeneratedFromPaymentMethodDetailsCardPresent)(p),
+		CaptureBefore: p.CaptureBefore.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentMethodCardPresentOffline.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentMethodCardPresentOffline) MarshalJSON() ([]byte, error) {
+	type paymentMethodCardPresentOffline PaymentMethodCardPresentOffline
+	v := struct {
+		StoredAt int64 `json:"stored_at"`
+		paymentMethodCardPresentOffline
+	}{
+		paymentMethodCardPresentOffline: (paymentMethodCardPresentOffline)(p),
+		StoredAt:                        p.StoredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a PaymentMethod.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentMethod) MarshalJSON() ([]byte, error) {
+	type paymentMethod PaymentMethod
+	v := struct {
+		Created int64 `json:"created"`
+		paymentMethod
+	}{
+		paymentMethod: (paymentMethod)(p),
+		Created:       p.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/paymentmethoddomain.go
+++ b/paymentmethoddomain.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The status of the payment method on the domain.
 type PaymentMethodDomainAmazonPayStatus string
 
@@ -181,7 +186,7 @@ type PaymentMethodDomain struct {
 	// Indicates the status of a specific payment method on a payment method domain.
 	ApplePay *PaymentMethodDomainApplePay `json:"apple_pay"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The domain name that this payment method domain object represents.
 	DomainName string `json:"domain_name"`
 	// Whether this payment method domain is enabled. If the domain is not enabled, payment methods that require a payment method domain will not appear in Elements.
@@ -205,4 +210,40 @@ type PaymentMethodDomainList struct {
 	APIResource
 	ListMeta
 	Data []*PaymentMethodDomain `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a PaymentMethodDomain.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PaymentMethodDomain) UnmarshalJSON(data []byte) error {
+	type paymentMethodDomain PaymentMethodDomain
+	v := struct {
+		Created int64 `json:"created"`
+		*paymentMethodDomain
+	}{
+		paymentMethodDomain: (*paymentMethodDomain)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a PaymentMethodDomain.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentMethodDomain) MarshalJSON() ([]byte, error) {
+	type paymentMethodDomain PaymentMethodDomain
+	v := struct {
+		Created int64 `json:"created"`
+		paymentMethodDomain
+	}{
+		paymentMethodDomain: (paymentMethodDomain)(p),
+		Created:             p.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/paymentrecord.go
+++ b/paymentrecord.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Indicates whether the customer was present in your checkout flow during this payment.
 type PaymentRecordCustomerPresence string
@@ -43,7 +46,7 @@ type PaymentRecordReportPaymentAttemptFailedParams struct {
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// When the reported payment failed. Measured in seconds since the Unix epoch.
-	FailedAt *int64            `form:"failed_at"`
+	FailedAt *time.Time        `form:"failed_at"`
 	Metadata map[string]string `form:"metadata"`
 }
 
@@ -67,7 +70,7 @@ type PaymentRecordReportPaymentAttemptGuaranteedParams struct {
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// When the reported payment was guaranteed. Measured in seconds since the Unix epoch.
-	GuaranteedAt *int64            `form:"guaranteed_at"`
+	GuaranteedAt *time.Time        `form:"guaranteed_at"`
 	Metadata     map[string]string `form:"metadata"`
 }
 
@@ -141,7 +144,7 @@ type PaymentRecordReportPaymentAttemptParams struct {
 	// Information about the payment attempt guarantee.
 	Guaranteed *PaymentRecordReportPaymentAttemptGuaranteedParams `form:"guaranteed"`
 	// When the reported payment was initiated. Measured in seconds since the Unix epoch.
-	InitiatedAt *int64 `form:"initiated_at"`
+	InitiatedAt *time.Time `form:"initiated_at"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
 	Metadata map[string]string `form:"metadata"`
 	// The outcome of the reported payment.
@@ -172,7 +175,7 @@ func (p *PaymentRecordReportPaymentAttemptParams) AddMetadata(key string, value 
 type PaymentRecordReportPaymentAttemptCanceledParams struct {
 	Params `form:"*"`
 	// When the reported payment was canceled. Measured in seconds since the Unix epoch.
-	CanceledAt *int64 `form:"canceled_at"`
+	CanceledAt *time.Time `form:"canceled_at"`
 	// Specifies which fields in the response should be expanded.
 	Expand   []*string         `form:"expand"`
 	Metadata map[string]string `form:"metadata"`
@@ -215,13 +218,13 @@ type PaymentRecordReportPaymentCustomerDetailsParams struct {
 // Information about the payment attempt failure.
 type PaymentRecordReportPaymentFailedParams struct {
 	// When the reported payment failed. Measured in seconds since the Unix epoch.
-	FailedAt *int64 `form:"failed_at"`
+	FailedAt *time.Time `form:"failed_at"`
 }
 
 // Information about the payment attempt guarantee.
 type PaymentRecordReportPaymentGuaranteedParams struct {
 	// When the reported payment was guaranteed. Measured in seconds since the Unix epoch.
-	GuaranteedAt *int64 `form:"guaranteed_at"`
+	GuaranteedAt *time.Time `form:"guaranteed_at"`
 }
 
 // The billing details associated with the method of payment.
@@ -287,7 +290,7 @@ type PaymentRecordReportPaymentParams struct {
 	// Information about the payment attempt guarantee.
 	Guaranteed *PaymentRecordReportPaymentGuaranteedParams `form:"guaranteed"`
 	// When the reported payment was initiated. Measured in seconds since the Unix epoch.
-	InitiatedAt *int64 `form:"initiated_at"`
+	InitiatedAt *time.Time `form:"initiated_at"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
 	Metadata map[string]string `form:"metadata"`
 	// The outcome of the reported payment.
@@ -415,7 +418,7 @@ type PaymentRecord struct {
 	// A representation of an amount of money, consisting of an amount and a currency.
 	AmountRequested *PaymentRecordAmountRequested `json:"amount_requested"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Customer information for this payment.
 	CustomerDetails *PaymentRecordCustomerDetails `json:"customer_details"`
 	// Indicates whether the customer was present in your checkout flow during this payment.
@@ -450,11 +453,34 @@ func (p *PaymentRecord) UnmarshalJSON(data []byte) error {
 	}
 
 	type paymentRecord PaymentRecord
-	var v paymentRecord
+	v := struct {
+		Created int64 `json:"created"`
+		*paymentRecord
+	}{
+		paymentRecord: (*paymentRecord)(p),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*p = PaymentRecord(v)
+	p.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a PaymentRecord.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PaymentRecord) MarshalJSON() ([]byte, error) {
+	type paymentRecord PaymentRecord
+	v := struct {
+		Created int64 `json:"created"`
+		paymentRecord
+	}{
+		paymentRecord: (paymentRecord)(p),
+		Created:       p.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/person.go
+++ b/person.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
 type PersonPoliticalExposure string
 
@@ -147,7 +152,7 @@ func (p *PersonParams) AddMetadata(key string, value string) {
 // Details on the legal guardian's acceptance of the main Stripe service agreement.
 type PersonAdditionalTOSAcceptancesAccountParams struct {
 	// The Unix timestamp marking when the account representative accepted the service agreement.
-	Date *int64 `form:"date"`
+	Date *time.Time `form:"date"`
 	// The IP address from which the account representative accepted the service agreement.
 	IP *string `form:"ip"`
 	// The user agent of the browser from which the account representative accepted the service agreement.
@@ -304,7 +309,7 @@ func (p *PersonListParams) AddExpand(f string) {
 // Details on the legal guardian's acceptance of the main Stripe service agreement.
 type PersonAdditionalTOSAcceptancesAccount struct {
 	// The Unix timestamp marking when the legal guardian accepted the service agreement.
-	Date int64 `json:"date"`
+	Date time.Time `json:"date"`
 	// The IP address from which the legal guardian accepted the service agreement.
 	IP string `json:"ip"`
 	// The user agent of the browser from which the legal guardian accepted the service agreement.
@@ -474,7 +479,7 @@ type Person struct {
 	// The Kanji variation of the person's address (Japan only).
 	AddressKanji *PersonAddressKanji `json:"address_kanji"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64      `json:"created"`
+	Created time.Time  `json:"created"`
 	Deleted bool       `json:"deleted"`
 	DOB     *PersonDOB `json:"dob"`
 	// The person's email address.
@@ -529,4 +534,76 @@ type PersonList struct {
 	APIResource
 	ListMeta
 	Data []*Person `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a PersonAdditionalTOSAcceptancesAccount.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PersonAdditionalTOSAcceptancesAccount) UnmarshalJSON(data []byte) error {
+	type personAdditionalTOSAcceptancesAccount PersonAdditionalTOSAcceptancesAccount
+	v := struct {
+		Date int64 `json:"date"`
+		*personAdditionalTOSAcceptancesAccount
+	}{
+		personAdditionalTOSAcceptancesAccount: (*personAdditionalTOSAcceptancesAccount)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.Date = time.Unix(v.Date, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a Person.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *Person) UnmarshalJSON(data []byte) error {
+	type person Person
+	v := struct {
+		Created int64 `json:"created"`
+		*person
+	}{
+		person: (*person)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a PersonAdditionalTOSAcceptancesAccount.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PersonAdditionalTOSAcceptancesAccount) MarshalJSON() ([]byte, error) {
+	type personAdditionalTOSAcceptancesAccount PersonAdditionalTOSAcceptancesAccount
+	v := struct {
+		Date int64 `json:"date"`
+		personAdditionalTOSAcceptancesAccount
+	}{
+		personAdditionalTOSAcceptancesAccount: (personAdditionalTOSAcceptancesAccount)(p),
+		Date:                                  p.Date.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a Person.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p Person) MarshalJSON() ([]byte, error) {
+	type person Person
+	v := struct {
+		Created int64 `json:"created"`
+		person
+	}{
+		person:  (person)(p),
+		Created: p.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/price.go
+++ b/price.go
@@ -9,6 +9,7 @@ package stripe
 import (
 	"encoding/json"
 	"github.com/stripe/stripe-go/v81/form"
+	"time"
 )
 
 // Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `unit_amount` or `unit_amount_decimal`) will be charged per unit in `quantity` (for prices with `usage_type=licensed`), or per unit of total usage (for prices with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
@@ -343,7 +344,7 @@ type PriceMigrateToParams struct {
 	// The behavior controlling the point in the subscription lifecycle after which to migrate the price. Currently must be `at_cycle_end`.
 	Behavior *string `form:"behavior"`
 	// The time after which subscriptions should start using the new price.
-	EffectiveAfter *int64 `form:"effective_after"`
+	EffectiveAfter *time.Time `form:"effective_after"`
 	// The ID of the price object.
 	Price *string `form:"price"`
 }
@@ -418,7 +419,7 @@ type PriceMigrateTo struct {
 	// The behavior controlling at what point in the subscription lifecycle to migrate the price
 	Behavior PriceMigrateToBehavior `json:"behavior"`
 	// The unix timestamp after at which subscriptions will start to migrate to the new price.
-	EffectiveAfter int64 `json:"effective_after"`
+	EffectiveAfter time.Time `json:"effective_after"`
 	// The id of the price being migrated to
 	Price string `json:"price"`
 }
@@ -474,7 +475,7 @@ type Price struct {
 	// Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `unit_amount` or `unit_amount_decimal`) will be charged per unit in `quantity` (for prices with `usage_type=licensed`), or per unit of total usage (for prices with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
 	BillingScheme PriceBillingScheme `json:"billing_scheme"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// Prices defined in each available currency option. Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
@@ -540,11 +541,70 @@ func (p *Price) UnmarshalJSON(data []byte) error {
 	}
 
 	type price Price
-	var v price
+	v := struct {
+		Created int64 `json:"created"`
+		*price
+	}{
+		price: (*price)(p),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*p = Price(v)
+	p.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a PriceMigrateTo.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (p *PriceMigrateTo) UnmarshalJSON(data []byte) error {
+	type priceMigrateTo PriceMigrateTo
+	v := struct {
+		EffectiveAfter int64 `json:"effective_after"`
+		*priceMigrateTo
+	}{
+		priceMigrateTo: (*priceMigrateTo)(p),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	p.EffectiveAfter = time.Unix(v.EffectiveAfter, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a PriceMigrateTo.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p PriceMigrateTo) MarshalJSON() ([]byte, error) {
+	type priceMigrateTo PriceMigrateTo
+	v := struct {
+		EffectiveAfter int64 `json:"effective_after"`
+		priceMigrateTo
+	}{
+		priceMigrateTo: (priceMigrateTo)(p),
+		EffectiveAfter: p.EffectiveAfter.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a Price.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p Price) MarshalJSON() ([]byte, error) {
+	type price Price
+	v := struct {
+		Created int64 `json:"created"`
+		price
+	}{
+		price:   (price)(p),
+		Created: p.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/product.go
+++ b/product.go
@@ -9,6 +9,7 @@ package stripe
 import (
 	"encoding/json"
 	"github.com/stripe/stripe-go/v81/form"
+	"time"
 )
 
 // The specific type of gift_card provisioning, only `fixed_amount` currently supported.
@@ -307,7 +308,7 @@ type Product struct {
 	// Whether the product is currently available for purchase.
 	Active bool `json:"active"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The ID of the [Price](https://stripe.com/docs/api/prices) object that is the default price for this product.
 	DefaultPrice *Price `json:"default_price"`
 	Deleted      bool   `json:"deleted"`
@@ -342,7 +343,7 @@ type Product struct {
 	// A label that represents units of this product. When set, this will be included in customers' receipts, invoices, Checkout, and the customer portal.
 	UnitLabel string `json:"unit_label"`
 	// Time at which the object was last updated. Measured in seconds since the Unix epoch.
-	Updated int64 `json:"updated"`
+	Updated time.Time `json:"updated"`
 	// A URL of a publicly-accessible webpage for this product.
 	URL string `json:"url"`
 }
@@ -371,11 +372,38 @@ func (p *Product) UnmarshalJSON(data []byte) error {
 	}
 
 	type product Product
-	var v product
+	v := struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+		*product
+	}{
+		product: (*product)(p),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*p = Product(v)
+	p.Created = time.Unix(v.Created, 0)
+	p.Updated = time.Unix(v.Updated, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a Product.
+// This custom marshaling is needed to handle the time fields correctly.
+func (p Product) MarshalJSON() ([]byte, error) {
+	type product Product
+	v := struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+		product
+	}{
+		product: (product)(p),
+		Created: p.Created.Unix(),
+		Updated: p.Updated.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/quote.go
+++ b/quote.go
@@ -9,6 +9,7 @@ package stripe
 import (
 	"encoding/json"
 	"github.com/stripe/stripe-go/v81/form"
+	"time"
 )
 
 // Type of the account referenced.
@@ -388,7 +389,7 @@ type QuoteDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *QuoteDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -442,7 +443,7 @@ type QuoteLineItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *QuoteLineItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -532,7 +533,7 @@ type QuoteLineActionAddItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *QuoteLineActionAddItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -621,7 +622,7 @@ type QuoteLineActionSetItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *QuoteLineActionSetItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -736,7 +737,7 @@ type QuoteLineEndsAtParams struct {
 	// Time span for the quote line starting from the `starts_at` date.
 	Duration *QuoteLineEndsAtDurationParams `form:"duration"`
 	// A precise Unix timestamp.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select a way to pass in `ends_at`.
 	Type *string `form:"type"`
 }
@@ -776,7 +777,7 @@ type QuoteLineStartsAtParams struct {
 	// The timestamp the given line ends at.
 	LineEndsAt *QuoteLineStartsAtLineEndsAtParams `form:"line_ends_at"`
 	// A precise Unix timestamp.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select a way to pass in `starts_at`.
 	Type *string `form:"type"`
 }
@@ -832,7 +833,7 @@ type QuoteSubscriptionDataBillOnAcceptanceBillFromParams struct {
 	// Details of a Quote line to start the bill period from.
 	LineStartsAt *QuoteSubscriptionDataBillOnAcceptanceBillFromLineStartsAtParams `form:"line_starts_at"`
 	// A precise Unix timestamp.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of method to specify the `bill_from` time.
 	Type *string `form:"type"`
 }
@@ -860,7 +861,7 @@ type QuoteSubscriptionDataBillOnAcceptanceBillUntilParams struct {
 	// Details of a Quote line item from which to bill until.
 	LineEndsAt *QuoteSubscriptionDataBillOnAcceptanceBillUntilLineEndsAtParams `form:"line_ends_at"`
 	// A precise Unix timestamp.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of method to specify the `bill_until` time.
 	Type *string `form:"type"`
 }
@@ -890,8 +891,8 @@ type QuoteSubscriptionDataParams struct {
 	// The subscription's description, meant to be displayable to the customer. Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
 	Description *string `form:"description"`
 	// When creating a new subscription, the date of which the subscription schedule will start after the quote is accepted. When updating a subscription, the date of which the subscription will be updated using a subscription schedule. The special value `current_period_end` can be provided to update a subscription at the end of its current period. The `effective_date` is ignored if it is in the past when the quote is accepted.
-	EffectiveDate                 *int64 `form:"effective_date"`
-	EffectiveDateCurrentPeriodEnd *bool  `form:"-"` // See custom AppendTo
+	EffectiveDate                 *time.Time `form:"effective_date"`
+	EffectiveDateCurrentPeriodEnd *bool      `form:"-"` // See custom AppendTo
 	// Behavior of the subscription schedule and underlying subscription when it ends.
 	EndBehavior *string `form:"end_behavior"`
 	// The id of a subscription that the quote will update. By default, the quote will contain the state of the subscription (such as line items, collection method and billing thresholds) unless overridden.
@@ -951,7 +952,7 @@ type QuoteSubscriptionDataOverrideBillOnAcceptanceBillFromParams struct {
 	// Details of a Quote line to start the bill period from.
 	LineStartsAt *QuoteSubscriptionDataOverrideBillOnAcceptanceBillFromLineStartsAtParams `form:"line_starts_at"`
 	// A precise Unix timestamp.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of method to specify the `bill_from` time.
 	Type *string `form:"type"`
 }
@@ -979,7 +980,7 @@ type QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntilParams struct {
 	// Details of a Quote line item from which to bill until.
 	LineEndsAt *QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntilLineEndsAtParams `form:"line_ends_at"`
 	// A precise Unix timestamp.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of method to specify the `bill_until` time.
 	Type *string `form:"type"`
 }
@@ -1050,7 +1051,7 @@ type QuoteParams struct {
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// A future timestamp on which the quote will be canceled if in `open` or `draft` status. Measured in seconds since the Unix epoch. If no value is passed, the default expiration date configured in your [quote template settings](https://dashboard.stripe.com/settings/billing/quote) will be used.
-	ExpiresAt *int64 `form:"expires_at"`
+	ExpiresAt *time.Time `form:"expires_at"`
 	// A footer that will be displayed on the quote PDF. If no value is passed, the default footer configured in your [quote template settings](https://dashboard.stripe.com/settings/billing/quote) will be used.
 	Footer *string `form:"footer"`
 	// Clone an existing quote. The new quote will be created in `status=draft`. When using this parameter, you cannot specify any other parameters except for `expires_at`.
@@ -1160,7 +1161,7 @@ type QuoteFinalizeQuoteParams struct {
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// A future timestamp on which the quote will be canceled if in `open` or `draft` status. Measured in seconds since the Unix epoch.
-	ExpiresAt *int64 `form:"expires_at"`
+	ExpiresAt *time.Time `form:"expires_at"`
 }
 
 // AddExpand appends a new field to expand.
@@ -1373,7 +1374,7 @@ type QuoteComputed struct {
 	// The definitive totals and line items the customer will be charged on a recurring basis. Takes into account the line items with recurring prices and discounts with `duration=forever` coupons only. Defaults to `null` if no inputted line items with recurring prices.
 	Recurring *QuoteComputedRecurring `json:"recurring"`
 	// The time at which the quote's estimated schedules and upcoming invoices were generated.
-	UpdatedAt int64                 `json:"updated_at"`
+	UpdatedAt time.Time             `json:"updated_at"`
 	Upfront   *QuoteComputedUpfront `json:"upfront"`
 }
 
@@ -1399,13 +1400,13 @@ type QuoteStatusDetailsCanceled struct {
 	// The reason this quote was marked as canceled.
 	Reason QuoteStatusDetailsCanceledReason `json:"reason"`
 	// Time at which the quote was marked as canceled. Measured in seconds since the Unix epoch.
-	TransitionedAt int64 `json:"transitioned_at"`
+	TransitionedAt time.Time `json:"transitioned_at"`
 }
 
 // The IDs of the lines that are invalid if the stale reason type is `lines_invalid`.
 type QuoteStatusDetailsStaleLastReasonLinesInvalid struct {
 	// The timestamp at which the lines were marked as invalid.
-	InvalidAt int64 `json:"invalid_at"`
+	InvalidAt time.Time `json:"invalid_at"`
 	// The list of lines that became invalid at the given timestamp.
 	Lines []string `json:"lines"`
 }
@@ -1441,13 +1442,13 @@ type QuoteStatusDetailsStaleLastReason struct {
 }
 type QuoteStatusDetailsStale struct {
 	// Time at which the quote expires. Measured in seconds since the Unix epoch.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The most recent reason this quote was marked as stale.
 	LastReason *QuoteStatusDetailsStaleLastReason `json:"last_reason"`
 	// Time at which the stale reason was updated. Measured in seconds since the Unix epoch.
-	LastUpdatedAt int64 `json:"last_updated_at"`
+	LastUpdatedAt time.Time `json:"last_updated_at"`
 	// Time at which the quote was marked as stale. Measured in seconds since the Unix epoch.
-	TransitionedAt int64 `json:"transitioned_at"`
+	TransitionedAt time.Time `json:"transitioned_at"`
 }
 
 // Details on when and why a quote has been marked as stale or canceled.
@@ -1457,11 +1458,11 @@ type QuoteStatusDetails struct {
 }
 type QuoteStatusTransitions struct {
 	// The time that the quote was accepted. Measured in seconds since Unix epoch.
-	AcceptedAt int64 `json:"accepted_at"`
+	AcceptedAt time.Time `json:"accepted_at"`
 	// The time that the quote was canceled. Measured in seconds since Unix epoch.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// The time that the quote was finalized. Measured in seconds since Unix epoch.
-	FinalizedAt int64 `json:"finalized_at"`
+	FinalizedAt time.Time `json:"finalized_at"`
 }
 
 // The timestamp the given line starts at.
@@ -1473,11 +1474,11 @@ type QuoteSubscriptionDataBillOnAcceptanceBillFromLineStartsAt struct {
 // The start of the period to bill from when the Quote is accepted.
 type QuoteSubscriptionDataBillOnAcceptanceBillFrom struct {
 	// The materialized time.
-	Computed int64 `json:"computed"`
+	Computed time.Time `json:"computed"`
 	// The timestamp the given line starts at.
 	LineStartsAt *QuoteSubscriptionDataBillOnAcceptanceBillFromLineStartsAt `json:"line_starts_at"`
 	// A precise Unix timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The type of method to specify the `bill_from` time.
 	Type QuoteSubscriptionDataBillOnAcceptanceBillFromType `json:"type"`
 }
@@ -1499,13 +1500,13 @@ type QuoteSubscriptionDataBillOnAcceptanceBillUntilLineEndsAt struct {
 // The end of the period to bill until when the Quote is accepted.
 type QuoteSubscriptionDataBillOnAcceptanceBillUntil struct {
 	// The materialized time.
-	Computed int64 `json:"computed"`
+	Computed time.Time `json:"computed"`
 	// Time span for the quote line starting from the `starts_at` date.
 	Duration *QuoteSubscriptionDataBillOnAcceptanceBillUntilDuration `json:"duration"`
 	// The timestamp the given line ends at.
 	LineEndsAt *QuoteSubscriptionDataBillOnAcceptanceBillUntilLineEndsAt `json:"line_ends_at"`
 	// A precise Unix timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The type of method to specify the `bill_until` time.
 	Type QuoteSubscriptionDataBillOnAcceptanceBillUntilType `json:"type"`
 }
@@ -1532,7 +1533,7 @@ type QuoteSubscriptionData struct {
 	// The subscription's description, meant to be displayable to the customer. Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
 	Description string `json:"description"`
 	// When creating a new subscription, the date of which the subscription schedule will start after the quote is accepted. This date is ignored if it is in the past when the quote is accepted. Measured in seconds since the Unix epoch.
-	EffectiveDate int64 `json:"effective_date"`
+	EffectiveDate time.Time `json:"effective_date"`
 	// Behavior of the subscription schedule and underlying subscription when it ends.
 	EndBehavior QuoteSubscriptionDataEndBehavior `json:"end_behavior"`
 	// The id of the subscription that will be updated when the quote is accepted.
@@ -1564,11 +1565,11 @@ type QuoteSubscriptionDataOverrideBillOnAcceptanceBillFromLineStartsAt struct {
 // The start of the period to bill from when the Quote is accepted.
 type QuoteSubscriptionDataOverrideBillOnAcceptanceBillFrom struct {
 	// The materialized time.
-	Computed int64 `json:"computed"`
+	Computed time.Time `json:"computed"`
 	// The timestamp the given line starts at.
 	LineStartsAt *QuoteSubscriptionDataOverrideBillOnAcceptanceBillFromLineStartsAt `json:"line_starts_at"`
 	// A precise Unix timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The type of method to specify the `bill_from` time.
 	Type QuoteSubscriptionDataOverrideBillOnAcceptanceBillFromType `json:"type"`
 }
@@ -1590,13 +1591,13 @@ type QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntilLineEndsAt struct {
 // The end of the period to bill until when the Quote is accepted.
 type QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntil struct {
 	// The materialized time.
-	Computed int64 `json:"computed"`
+	Computed time.Time `json:"computed"`
 	// Time span for the quote line starting from the `starts_at` date.
 	Duration *QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntilDuration `json:"duration"`
 	// The timestamp the given line ends at.
 	LineEndsAt *QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntilLineEndsAt `json:"line_ends_at"`
 	// A precise Unix timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The type of method to specify the `bill_until` time.
 	Type QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntilType `json:"type"`
 }
@@ -1712,7 +1713,7 @@ type Quote struct {
 	CollectionMethod QuoteCollectionMethod `json:"collection_method"`
 	Computed         *QuoteComputed        `json:"computed"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// The customer which this quote belongs to. A customer is required before finalizing the quote. Once specified, it cannot be changed.
@@ -1724,7 +1725,7 @@ type Quote struct {
 	// The discounts applied to this quote.
 	Discounts []*Discount `json:"discounts"`
 	// The date on which the quote will be canceled if in `open` or `draft` status. Measured in seconds since the Unix epoch.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// A footer that will be displayed on the quote PDF.
 	Footer string `json:"footer"`
 	// Details of the quote that was cloned. See the [cloning documentation](https://stripe.com/docs/quotes/clone) for more details.
@@ -1788,11 +1789,430 @@ func (q *Quote) UnmarshalJSON(data []byte) error {
 	}
 
 	type quote Quote
-	var v quote
+	v := struct {
+		Created   int64 `json:"created"`
+		ExpiresAt int64 `json:"expires_at"`
+		*quote
+	}{
+		quote: (*quote)(q),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*q = Quote(v)
+	q.Created = time.Unix(v.Created, 0)
+	q.ExpiresAt = time.Unix(v.ExpiresAt, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteComputed.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteComputed) UnmarshalJSON(data []byte) error {
+	type quoteComputed QuoteComputed
+	v := struct {
+		UpdatedAt int64 `json:"updated_at"`
+		*quoteComputed
+	}{
+		quoteComputed: (*quoteComputed)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.UpdatedAt = time.Unix(v.UpdatedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteStatusDetailsCanceled.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteStatusDetailsCanceled) UnmarshalJSON(data []byte) error {
+	type quoteStatusDetailsCanceled QuoteStatusDetailsCanceled
+	v := struct {
+		TransitionedAt int64 `json:"transitioned_at"`
+		*quoteStatusDetailsCanceled
+	}{
+		quoteStatusDetailsCanceled: (*quoteStatusDetailsCanceled)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.TransitionedAt = time.Unix(v.TransitionedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteStatusDetailsStaleLastReasonLinesInvalid.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteStatusDetailsStaleLastReasonLinesInvalid) UnmarshalJSON(data []byte) error {
+	type quoteStatusDetailsStaleLastReasonLinesInvalid QuoteStatusDetailsStaleLastReasonLinesInvalid
+	v := struct {
+		InvalidAt int64 `json:"invalid_at"`
+		*quoteStatusDetailsStaleLastReasonLinesInvalid
+	}{
+		quoteStatusDetailsStaleLastReasonLinesInvalid: (*quoteStatusDetailsStaleLastReasonLinesInvalid)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.InvalidAt = time.Unix(v.InvalidAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteStatusDetailsStale.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteStatusDetailsStale) UnmarshalJSON(data []byte) error {
+	type quoteStatusDetailsStale QuoteStatusDetailsStale
+	v := struct {
+		ExpiresAt      int64 `json:"expires_at"`
+		LastUpdatedAt  int64 `json:"last_updated_at"`
+		TransitionedAt int64 `json:"transitioned_at"`
+		*quoteStatusDetailsStale
+	}{
+		quoteStatusDetailsStale: (*quoteStatusDetailsStale)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	q.LastUpdatedAt = time.Unix(v.LastUpdatedAt, 0)
+	q.TransitionedAt = time.Unix(v.TransitionedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteStatusTransitions) UnmarshalJSON(data []byte) error {
+	type quoteStatusTransitions QuoteStatusTransitions
+	v := struct {
+		AcceptedAt  int64 `json:"accepted_at"`
+		CanceledAt  int64 `json:"canceled_at"`
+		FinalizedAt int64 `json:"finalized_at"`
+		*quoteStatusTransitions
+	}{
+		quoteStatusTransitions: (*quoteStatusTransitions)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.AcceptedAt = time.Unix(v.AcceptedAt, 0)
+	q.CanceledAt = time.Unix(v.CanceledAt, 0)
+	q.FinalizedAt = time.Unix(v.FinalizedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteSubscriptionDataBillOnAcceptanceBillFrom.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteSubscriptionDataBillOnAcceptanceBillFrom) UnmarshalJSON(data []byte) error {
+	type quoteSubscriptionDataBillOnAcceptanceBillFrom QuoteSubscriptionDataBillOnAcceptanceBillFrom
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		*quoteSubscriptionDataBillOnAcceptanceBillFrom
+	}{
+		quoteSubscriptionDataBillOnAcceptanceBillFrom: (*quoteSubscriptionDataBillOnAcceptanceBillFrom)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Computed = time.Unix(v.Computed, 0)
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteSubscriptionDataBillOnAcceptanceBillUntil.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteSubscriptionDataBillOnAcceptanceBillUntil) UnmarshalJSON(data []byte) error {
+	type quoteSubscriptionDataBillOnAcceptanceBillUntil QuoteSubscriptionDataBillOnAcceptanceBillUntil
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		*quoteSubscriptionDataBillOnAcceptanceBillUntil
+	}{
+		quoteSubscriptionDataBillOnAcceptanceBillUntil: (*quoteSubscriptionDataBillOnAcceptanceBillUntil)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Computed = time.Unix(v.Computed, 0)
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteSubscriptionData.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteSubscriptionData) UnmarshalJSON(data []byte) error {
+	type quoteSubscriptionData QuoteSubscriptionData
+	v := struct {
+		EffectiveDate int64 `json:"effective_date"`
+		*quoteSubscriptionData
+	}{
+		quoteSubscriptionData: (*quoteSubscriptionData)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.EffectiveDate = time.Unix(v.EffectiveDate, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteSubscriptionDataOverrideBillOnAcceptanceBillFrom.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteSubscriptionDataOverrideBillOnAcceptanceBillFrom) UnmarshalJSON(data []byte) error {
+	type quoteSubscriptionDataOverrideBillOnAcceptanceBillFrom QuoteSubscriptionDataOverrideBillOnAcceptanceBillFrom
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		*quoteSubscriptionDataOverrideBillOnAcceptanceBillFrom
+	}{
+		quoteSubscriptionDataOverrideBillOnAcceptanceBillFrom: (*quoteSubscriptionDataOverrideBillOnAcceptanceBillFrom)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Computed = time.Unix(v.Computed, 0)
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntil.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntil) UnmarshalJSON(data []byte) error {
+	type quoteSubscriptionDataOverrideBillOnAcceptanceBillUntil QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntil
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		*quoteSubscriptionDataOverrideBillOnAcceptanceBillUntil
+	}{
+		quoteSubscriptionDataOverrideBillOnAcceptanceBillUntil: (*quoteSubscriptionDataOverrideBillOnAcceptanceBillUntil)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Computed = time.Unix(v.Computed, 0)
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a QuoteComputed.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteComputed) MarshalJSON() ([]byte, error) {
+	type quoteComputed QuoteComputed
+	v := struct {
+		UpdatedAt int64 `json:"updated_at"`
+		quoteComputed
+	}{
+		quoteComputed: (quoteComputed)(q),
+		UpdatedAt:     q.UpdatedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteStatusDetailsCanceled.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteStatusDetailsCanceled) MarshalJSON() ([]byte, error) {
+	type quoteStatusDetailsCanceled QuoteStatusDetailsCanceled
+	v := struct {
+		TransitionedAt int64 `json:"transitioned_at"`
+		quoteStatusDetailsCanceled
+	}{
+		quoteStatusDetailsCanceled: (quoteStatusDetailsCanceled)(q),
+		TransitionedAt:             q.TransitionedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteStatusDetailsStaleLastReasonLinesInvalid.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteStatusDetailsStaleLastReasonLinesInvalid) MarshalJSON() ([]byte, error) {
+	type quoteStatusDetailsStaleLastReasonLinesInvalid QuoteStatusDetailsStaleLastReasonLinesInvalid
+	v := struct {
+		InvalidAt int64 `json:"invalid_at"`
+		quoteStatusDetailsStaleLastReasonLinesInvalid
+	}{
+		quoteStatusDetailsStaleLastReasonLinesInvalid: (quoteStatusDetailsStaleLastReasonLinesInvalid)(q),
+		InvalidAt: q.InvalidAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteStatusDetailsStale.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteStatusDetailsStale) MarshalJSON() ([]byte, error) {
+	type quoteStatusDetailsStale QuoteStatusDetailsStale
+	v := struct {
+		ExpiresAt      int64 `json:"expires_at"`
+		LastUpdatedAt  int64 `json:"last_updated_at"`
+		TransitionedAt int64 `json:"transitioned_at"`
+		quoteStatusDetailsStale
+	}{
+		quoteStatusDetailsStale: (quoteStatusDetailsStale)(q),
+		ExpiresAt:               q.ExpiresAt.Unix(),
+		LastUpdatedAt:           q.LastUpdatedAt.Unix(),
+		TransitionedAt:          q.TransitionedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteStatusTransitions) MarshalJSON() ([]byte, error) {
+	type quoteStatusTransitions QuoteStatusTransitions
+	v := struct {
+		AcceptedAt  int64 `json:"accepted_at"`
+		CanceledAt  int64 `json:"canceled_at"`
+		FinalizedAt int64 `json:"finalized_at"`
+		quoteStatusTransitions
+	}{
+		quoteStatusTransitions: (quoteStatusTransitions)(q),
+		AcceptedAt:             q.AcceptedAt.Unix(),
+		CanceledAt:             q.CanceledAt.Unix(),
+		FinalizedAt:            q.FinalizedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteSubscriptionDataBillOnAcceptanceBillFrom.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteSubscriptionDataBillOnAcceptanceBillFrom) MarshalJSON() ([]byte, error) {
+	type quoteSubscriptionDataBillOnAcceptanceBillFrom QuoteSubscriptionDataBillOnAcceptanceBillFrom
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		quoteSubscriptionDataBillOnAcceptanceBillFrom
+	}{
+		quoteSubscriptionDataBillOnAcceptanceBillFrom: (quoteSubscriptionDataBillOnAcceptanceBillFrom)(q),
+		Computed:  q.Computed.Unix(),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteSubscriptionDataBillOnAcceptanceBillUntil.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteSubscriptionDataBillOnAcceptanceBillUntil) MarshalJSON() ([]byte, error) {
+	type quoteSubscriptionDataBillOnAcceptanceBillUntil QuoteSubscriptionDataBillOnAcceptanceBillUntil
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		quoteSubscriptionDataBillOnAcceptanceBillUntil
+	}{
+		quoteSubscriptionDataBillOnAcceptanceBillUntil: (quoteSubscriptionDataBillOnAcceptanceBillUntil)(q),
+		Computed:  q.Computed.Unix(),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteSubscriptionData.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteSubscriptionData) MarshalJSON() ([]byte, error) {
+	type quoteSubscriptionData QuoteSubscriptionData
+	v := struct {
+		EffectiveDate int64 `json:"effective_date"`
+		quoteSubscriptionData
+	}{
+		quoteSubscriptionData: (quoteSubscriptionData)(q),
+		EffectiveDate:         q.EffectiveDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteSubscriptionDataOverrideBillOnAcceptanceBillFrom.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteSubscriptionDataOverrideBillOnAcceptanceBillFrom) MarshalJSON() ([]byte, error) {
+	type quoteSubscriptionDataOverrideBillOnAcceptanceBillFrom QuoteSubscriptionDataOverrideBillOnAcceptanceBillFrom
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		quoteSubscriptionDataOverrideBillOnAcceptanceBillFrom
+	}{
+		quoteSubscriptionDataOverrideBillOnAcceptanceBillFrom: (quoteSubscriptionDataOverrideBillOnAcceptanceBillFrom)(q),
+		Computed:  q.Computed.Unix(),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntil.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntil) MarshalJSON() ([]byte, error) {
+	type quoteSubscriptionDataOverrideBillOnAcceptanceBillUntil QuoteSubscriptionDataOverrideBillOnAcceptanceBillUntil
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		quoteSubscriptionDataOverrideBillOnAcceptanceBillUntil
+	}{
+		quoteSubscriptionDataOverrideBillOnAcceptanceBillUntil: (quoteSubscriptionDataOverrideBillOnAcceptanceBillUntil)(q),
+		Computed:  q.Computed.Unix(),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a Quote.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q Quote) MarshalJSON() ([]byte, error) {
+	type quote Quote
+	v := struct {
+		Created   int64 `json:"created"`
+		ExpiresAt int64 `json:"expires_at"`
+		quote
+	}{
+		quote:     (quote)(q),
+		Created:   q.Created.Unix(),
+		ExpiresAt: q.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/quoteline.go
+++ b/quoteline.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The discount end type.
 type QuoteLineActionAddDiscountDiscountEndType string
 
@@ -217,7 +222,7 @@ type QuoteLineActionAddDiscount struct {
 // Details to determine how long the discount should be applied for.
 type QuoteLineActionAddItemDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type QuoteLineActionAddItemDiscountDiscountEndType `json:"type"`
 }
@@ -261,7 +266,7 @@ type QuoteLineActionAddItem struct {
 // Details to determine how long the discount should be applied for.
 type QuoteLineActionRemoveDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type QuoteLineActionRemoveDiscountDiscountEndType `json:"type"`
 }
@@ -287,7 +292,7 @@ type QuoteLineActionRemoveItem struct {
 // Details to determine how long the discount should be applied for.
 type QuoteLineActionSetDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type QuoteLineActionSetDiscountDiscountEndType `json:"type"`
 }
@@ -307,7 +312,7 @@ type QuoteLineActionSetDiscount struct {
 // Details to determine how long the discount should be applied for.
 type QuoteLineActionSetItemDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type QuoteLineActionSetItemDiscountDiscountEndType `json:"type"`
 }
@@ -409,13 +414,13 @@ type QuoteLineEndsAtDuration struct {
 // Details to identify the end of the time range modified by the proposed change. If not supplied, the quote line is considered a point-in-time operation that only affects the exact timestamp at `starts_at`, and a restricted set of attributes is supported on the quote line.
 type QuoteLineEndsAt struct {
 	// The timestamp value that will be used to determine when to make changes to the subscription schedule, as computed from the `ends_at` field. For example, if `ends_at[type]=upcoming_invoice`, the upcoming invoice date will be computed at the time the `ends_at` field was specified and saved. This field will not be recomputed upon future requests to update or finalize the quote unless `ends_at` is respecified. This field is guaranteed to be populated after quote acceptance.
-	Computed int64 `json:"computed"`
+	Computed time.Time `json:"computed"`
 	// Use the `end` time of a given discount.
 	DiscountEnd *QuoteLineEndsAtDiscountEnd `json:"discount_end"`
 	// Time span for the quote line starting from the `starts_at` date.
 	Duration *QuoteLineEndsAtDuration `json:"duration"`
 	// A precise Unix timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// Select a way to pass in `ends_at`.
 	Type QuoteLineEndsAtType `json:"type"`
 }
@@ -449,13 +454,13 @@ type QuoteLineStartsAtLineEndsAt struct {
 // Details to identify the earliest timestamp where the proposed change should take effect.
 type QuoteLineStartsAt struct {
 	// The timestamp value that will be used to determine when to make changes to the subscription schedule, as computed from the `starts_at` field. For example, if `starts_at[type]=upcoming_invoice`, the upcoming invoice date will be computed at the time the `starts_at` field was specified and saved. This field will not be recomputed upon future requests to update or finalize the quote unless `starts_at` is respecified. This field is guaranteed to be populated after quote acceptance.
-	Computed int64 `json:"computed"`
+	Computed time.Time `json:"computed"`
 	// Use the `end` time of a given discount.
 	DiscountEnd *QuoteLineStartsAtDiscountEnd `json:"discount_end"`
 	// The timestamp the given line ends at.
 	LineEndsAt *QuoteLineStartsAtLineEndsAt `json:"line_ends_at"`
 	// A precise Unix timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// Select a way to pass in `starts_at`.
 	Type QuoteLineStartsAtType `json:"type"`
 }
@@ -505,4 +510,228 @@ type QuoteLineList struct {
 	APIResource
 	ListMeta
 	Data []*QuoteLine `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a QuoteLineActionAddItemDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteLineActionAddItemDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type quoteLineActionAddItemDiscountDiscountEnd QuoteLineActionAddItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*quoteLineActionAddItemDiscountDiscountEnd
+	}{
+		quoteLineActionAddItemDiscountDiscountEnd: (*quoteLineActionAddItemDiscountDiscountEnd)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteLineActionRemoveDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteLineActionRemoveDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type quoteLineActionRemoveDiscountDiscountEnd QuoteLineActionRemoveDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*quoteLineActionRemoveDiscountDiscountEnd
+	}{
+		quoteLineActionRemoveDiscountDiscountEnd: (*quoteLineActionRemoveDiscountDiscountEnd)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteLineActionSetDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteLineActionSetDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type quoteLineActionSetDiscountDiscountEnd QuoteLineActionSetDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*quoteLineActionSetDiscountDiscountEnd
+	}{
+		quoteLineActionSetDiscountDiscountEnd: (*quoteLineActionSetDiscountDiscountEnd)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteLineActionSetItemDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteLineActionSetItemDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type quoteLineActionSetItemDiscountDiscountEnd QuoteLineActionSetItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*quoteLineActionSetItemDiscountDiscountEnd
+	}{
+		quoteLineActionSetItemDiscountDiscountEnd: (*quoteLineActionSetItemDiscountDiscountEnd)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteLineEndsAt.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteLineEndsAt) UnmarshalJSON(data []byte) error {
+	type quoteLineEndsAt QuoteLineEndsAt
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		*quoteLineEndsAt
+	}{
+		quoteLineEndsAt: (*quoteLineEndsAt)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Computed = time.Unix(v.Computed, 0)
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuoteLineStartsAt.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuoteLineStartsAt) UnmarshalJSON(data []byte) error {
+	type quoteLineStartsAt QuoteLineStartsAt
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		*quoteLineStartsAt
+	}{
+		quoteLineStartsAt: (*quoteLineStartsAt)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Computed = time.Unix(v.Computed, 0)
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a QuoteLineActionAddItemDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteLineActionAddItemDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type quoteLineActionAddItemDiscountDiscountEnd QuoteLineActionAddItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		quoteLineActionAddItemDiscountDiscountEnd
+	}{
+		quoteLineActionAddItemDiscountDiscountEnd: (quoteLineActionAddItemDiscountDiscountEnd)(q),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteLineActionRemoveDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteLineActionRemoveDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type quoteLineActionRemoveDiscountDiscountEnd QuoteLineActionRemoveDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		quoteLineActionRemoveDiscountDiscountEnd
+	}{
+		quoteLineActionRemoveDiscountDiscountEnd: (quoteLineActionRemoveDiscountDiscountEnd)(q),
+		Timestamp:                                q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteLineActionSetDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteLineActionSetDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type quoteLineActionSetDiscountDiscountEnd QuoteLineActionSetDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		quoteLineActionSetDiscountDiscountEnd
+	}{
+		quoteLineActionSetDiscountDiscountEnd: (quoteLineActionSetDiscountDiscountEnd)(q),
+		Timestamp:                             q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteLineActionSetItemDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteLineActionSetItemDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type quoteLineActionSetItemDiscountDiscountEnd QuoteLineActionSetItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		quoteLineActionSetItemDiscountDiscountEnd
+	}{
+		quoteLineActionSetItemDiscountDiscountEnd: (quoteLineActionSetItemDiscountDiscountEnd)(q),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteLineEndsAt.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteLineEndsAt) MarshalJSON() ([]byte, error) {
+	type quoteLineEndsAt QuoteLineEndsAt
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		quoteLineEndsAt
+	}{
+		quoteLineEndsAt: (quoteLineEndsAt)(q),
+		Computed:        q.Computed.Unix(),
+		Timestamp:       q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuoteLineStartsAt.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuoteLineStartsAt) MarshalJSON() ([]byte, error) {
+	type quoteLineStartsAt QuoteLineStartsAt
+	v := struct {
+		Computed  int64 `json:"computed"`
+		Timestamp int64 `json:"timestamp"`
+		quoteLineStartsAt
+	}{
+		quoteLineStartsAt: (quoteLineStartsAt)(q),
+		Computed:          q.Computed.Unix(),
+		Timestamp:         q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/quotepreviewinvoice.go
+++ b/quotepreviewinvoice.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The status of the payment, one of `open`, `paid`, or `past_due`
 type QuotePreviewInvoiceAmountsDueStatus string
 
@@ -471,9 +476,9 @@ type QuotePreviewInvoiceAmountsDue struct {
 	// An arbitrary string attached to the object. Often useful for displaying to users.
 	Description string `json:"description"`
 	// Date on which a payment plan's payment is due.
-	DueDate int64 `json:"due_date"`
+	DueDate time.Time `json:"due_date"`
 	// Timestamp when the payment was paid.
-	PaidAt int64 `json:"paid_at"`
+	PaidAt time.Time `json:"paid_at"`
 	// The status of the payment, one of `open`, `paid`, or `past_due`
 	Status QuotePreviewInvoiceAmountsDueStatus `json:"status"`
 }
@@ -682,13 +687,13 @@ type QuotePreviewInvoiceShippingCost struct {
 }
 type QuotePreviewInvoiceStatusTransitions struct {
 	// The time that the invoice draft was finalized.
-	FinalizedAt int64 `json:"finalized_at"`
+	FinalizedAt time.Time `json:"finalized_at"`
 	// The time that the invoice was marked uncollectible.
-	MarkedUncollectibleAt int64 `json:"marked_uncollectible_at"`
+	MarkedUncollectibleAt time.Time `json:"marked_uncollectible_at"`
 	// The time that the invoice was paid.
-	PaidAt int64 `json:"paid_at"`
+	PaidAt time.Time `json:"paid_at"`
 	// The time that the invoice was voided.
-	VoidedAt int64 `json:"voided_at"`
+	VoidedAt time.Time `json:"voided_at"`
 }
 
 // If specified, payment collection for this subscription will be paused. Note that the subscription status will be unchanged and will not be updated to `paused`. Learn more about [pausing collection](https://stripe.com/docs/billing/subscriptions/pause-payment).
@@ -696,7 +701,7 @@ type QuotePreviewInvoiceSubscriptionDetailsPauseCollection struct {
 	// The payment collection behavior for this subscription while paused. One of `keep_as_draft`, `mark_uncollectible`, or `void`.
 	Behavior QuotePreviewInvoiceSubscriptionDetailsPauseCollectionBehavior `json:"behavior"`
 	// The time after which the subscription will resume collecting payments.
-	ResumesAt int64 `json:"resumes_at"`
+	ResumesAt time.Time `json:"resumes_at"`
 }
 
 // Details about the subscription that created this invoice.
@@ -835,7 +840,7 @@ type QuotePreviewInvoice struct {
 	// Whether an attempt has been made to pay the invoice. An invoice is not attempted until 1 hour after the `invoice.created` webhook, for example, so you might not want to display that invoice as unpaid to your users.
 	Attempted bool `json:"attempted"`
 	// The time when this invoice is currently scheduled to be automatically finalized. The field will be `null` if the invoice is not scheduled to finalize in the future. If the invoice is not in the draft state, this field will always be `null` - see `finalized_at` for the time when an already-finalized invoice was finalized.
-	AutomaticallyFinalizesAt int64                            `json:"automatically_finalizes_at"`
+	AutomaticallyFinalizesAt time.Time                        `json:"automatically_finalizes_at"`
 	AutomaticTax             *QuotePreviewInvoiceAutomaticTax `json:"automatic_tax"`
 	// Indicates the reason why the invoice was created.
 	//
@@ -850,7 +855,7 @@ type QuotePreviewInvoice struct {
 	// Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions.
 	CollectionMethod QuotePreviewInvoiceCollectionMethod `json:"collection_method"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// The customer's address. Until the invoice is finalized, this field will equal `customer.address`. Once the invoice is finalized, this field will no longer be updated.
@@ -884,9 +889,9 @@ type QuotePreviewInvoice struct {
 	// The discounts applied to the invoice. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
 	Discounts []*Discount `json:"discounts"`
 	// The date on which payment for this invoice is due. This value will be `null` for invoices where `collection_method=charge_automatically`.
-	DueDate int64 `json:"due_date"`
+	DueDate time.Time `json:"due_date"`
 	// The date when this invoice is in effect. Same as `finalized_at` unless overwritten. When defined, this value replaces the system-generated 'Date of issue' printed on the invoice PDF and receipt.
-	EffectiveAt int64 `json:"effective_at"`
+	EffectiveAt time.Time `json:"effective_at"`
 	// Ending customer balance after the invoice is finalized. Invoices are finalized approximately an hour after successful webhook delivery or when payment collection is attempted for the invoice. If the invoice has not been finalized yet, this will be null.
 	EndingBalance int64 `json:"ending_balance"`
 	// Footer displayed on the invoice.
@@ -907,7 +912,7 @@ type QuotePreviewInvoice struct {
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
 	Metadata map[string]string `json:"metadata"`
 	// The time at which payment will next be attempted. This value will be `null` for invoices where `collection_method=send_invoice`.
-	NextPaymentAttempt int64 `json:"next_payment_attempt"`
+	NextPaymentAttempt time.Time `json:"next_payment_attempt"`
 	// A unique, identifying string that appears on emails sent to the customer for this invoice. This starts with the customer's unique invoice_prefix if it is specified.
 	Number string `json:"number"`
 	// String representing the object's type. Objects of the same type share the same value.
@@ -924,9 +929,9 @@ type QuotePreviewInvoice struct {
 	Payments        *InvoicePaymentList                 `json:"payments"`
 	PaymentSettings *QuotePreviewInvoicePaymentSettings `json:"payment_settings"`
 	// End of the usage period during which invoice items were added to this invoice. This looks back one period for a subscription invoice. Use the [line item period](https://stripe.com/api/invoices/line_item#invoice_line_item_object-period) to get the service period for each price.
-	PeriodEnd int64 `json:"period_end"`
+	PeriodEnd time.Time `json:"period_end"`
 	// Start of the usage period during which invoice items were added to this invoice. This looks back one period for a subscription invoice. Use the [line item period](https://stripe.com/api/invoices/line_item#invoice_line_item_object-period) to get the service period for each price.
-	PeriodStart int64 `json:"period_start"`
+	PeriodStart time.Time `json:"period_start"`
 	// Total amount of all post-payment credit notes issued for this invoice.
 	PostPaymentCreditNotesAmount int64 `json:"post_payment_credit_notes_amount"`
 	// Total amount of all pre-payment credit notes issued for this invoice.
@@ -952,7 +957,7 @@ type QuotePreviewInvoice struct {
 	// Details about the subscription that created this invoice.
 	SubscriptionDetails *QuotePreviewInvoiceSubscriptionDetails `json:"subscription_details"`
 	// Only set for upcoming invoices that preview prorations. The time used to calculate prorations.
-	SubscriptionProrationDate int64 `json:"subscription_proration_date"`
+	SubscriptionProrationDate time.Time `json:"subscription_proration_date"`
 	// Total of all subscriptions, invoice items, and prorations on the invoice before any invoice level discount or exclusive tax is applied. Item discounts are already incorporated
 	Subtotal int64 `json:"subtotal"`
 	// The integer amount in cents (or local equivalent) representing the subtotal of the invoice before any invoice level discount or tax is applied. Item discounts are already incorporated
@@ -977,7 +982,7 @@ type QuotePreviewInvoice struct {
 	// The account (if any) the payment will be attributed to for tax reporting, and where funds from the payment will be transferred to for the invoice.
 	TransferData *QuotePreviewInvoiceTransferData `json:"transfer_data"`
 	// Invoices are automatically paid or sent 1 hour after webhooks are delivered, or until all webhook delivery attempts have [been exhausted](https://stripe.com/docs/billing/webhooks#understand). This field tracks the time when webhooks for this invoice were successfully delivered. If the invoice had no webhooks to deliver, this will be set while the invoice is being created.
-	WebhooksDeliveredAt int64 `json:"webhooks_delivered_at"`
+	WebhooksDeliveredAt time.Time `json:"webhooks_delivered_at"`
 }
 
 // QuotePreviewInvoiceList is a list of QuotePreviewInvoices as retrieved from a list endpoint.
@@ -985,4 +990,196 @@ type QuotePreviewInvoiceList struct {
 	APIResource
 	ListMeta
 	Data []*QuotePreviewInvoice `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewInvoiceAmountsDue.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewInvoiceAmountsDue) UnmarshalJSON(data []byte) error {
+	type quotePreviewInvoiceAmountsDue QuotePreviewInvoiceAmountsDue
+	v := struct {
+		DueDate int64 `json:"due_date"`
+		PaidAt  int64 `json:"paid_at"`
+		*quotePreviewInvoiceAmountsDue
+	}{
+		quotePreviewInvoiceAmountsDue: (*quotePreviewInvoiceAmountsDue)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.DueDate = time.Unix(v.DueDate, 0)
+	q.PaidAt = time.Unix(v.PaidAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewInvoiceStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewInvoiceStatusTransitions) UnmarshalJSON(data []byte) error {
+	type quotePreviewInvoiceStatusTransitions QuotePreviewInvoiceStatusTransitions
+	v := struct {
+		FinalizedAt           int64 `json:"finalized_at"`
+		MarkedUncollectibleAt int64 `json:"marked_uncollectible_at"`
+		PaidAt                int64 `json:"paid_at"`
+		VoidedAt              int64 `json:"voided_at"`
+		*quotePreviewInvoiceStatusTransitions
+	}{
+		quotePreviewInvoiceStatusTransitions: (*quotePreviewInvoiceStatusTransitions)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.FinalizedAt = time.Unix(v.FinalizedAt, 0)
+	q.MarkedUncollectibleAt = time.Unix(v.MarkedUncollectibleAt, 0)
+	q.PaidAt = time.Unix(v.PaidAt, 0)
+	q.VoidedAt = time.Unix(v.VoidedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewInvoiceSubscriptionDetailsPauseCollection.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewInvoiceSubscriptionDetailsPauseCollection) UnmarshalJSON(data []byte) error {
+	type quotePreviewInvoiceSubscriptionDetailsPauseCollection QuotePreviewInvoiceSubscriptionDetailsPauseCollection
+	v := struct {
+		ResumesAt int64 `json:"resumes_at"`
+		*quotePreviewInvoiceSubscriptionDetailsPauseCollection
+	}{
+		quotePreviewInvoiceSubscriptionDetailsPauseCollection: (*quotePreviewInvoiceSubscriptionDetailsPauseCollection)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.ResumesAt = time.Unix(v.ResumesAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewInvoice.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewInvoice) UnmarshalJSON(data []byte) error {
+	type quotePreviewInvoice QuotePreviewInvoice
+	v := struct {
+		AutomaticallyFinalizesAt  int64 `json:"automatically_finalizes_at"`
+		Created                   int64 `json:"created"`
+		DueDate                   int64 `json:"due_date"`
+		EffectiveAt               int64 `json:"effective_at"`
+		NextPaymentAttempt        int64 `json:"next_payment_attempt"`
+		PeriodEnd                 int64 `json:"period_end"`
+		PeriodStart               int64 `json:"period_start"`
+		SubscriptionProrationDate int64 `json:"subscription_proration_date"`
+		WebhooksDeliveredAt       int64 `json:"webhooks_delivered_at"`
+		*quotePreviewInvoice
+	}{
+		quotePreviewInvoice: (*quotePreviewInvoice)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.AutomaticallyFinalizesAt = time.Unix(v.AutomaticallyFinalizesAt, 0)
+	q.Created = time.Unix(v.Created, 0)
+	q.DueDate = time.Unix(v.DueDate, 0)
+	q.EffectiveAt = time.Unix(v.EffectiveAt, 0)
+	q.NextPaymentAttempt = time.Unix(v.NextPaymentAttempt, 0)
+	q.PeriodEnd = time.Unix(v.PeriodEnd, 0)
+	q.PeriodStart = time.Unix(v.PeriodStart, 0)
+	q.SubscriptionProrationDate = time.Unix(v.SubscriptionProrationDate, 0)
+	q.WebhooksDeliveredAt = time.Unix(v.WebhooksDeliveredAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a QuotePreviewInvoiceAmountsDue.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewInvoiceAmountsDue) MarshalJSON() ([]byte, error) {
+	type quotePreviewInvoiceAmountsDue QuotePreviewInvoiceAmountsDue
+	v := struct {
+		DueDate int64 `json:"due_date"`
+		PaidAt  int64 `json:"paid_at"`
+		quotePreviewInvoiceAmountsDue
+	}{
+		quotePreviewInvoiceAmountsDue: (quotePreviewInvoiceAmountsDue)(q),
+		DueDate:                       q.DueDate.Unix(),
+		PaidAt:                        q.PaidAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewInvoiceStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewInvoiceStatusTransitions) MarshalJSON() ([]byte, error) {
+	type quotePreviewInvoiceStatusTransitions QuotePreviewInvoiceStatusTransitions
+	v := struct {
+		FinalizedAt           int64 `json:"finalized_at"`
+		MarkedUncollectibleAt int64 `json:"marked_uncollectible_at"`
+		PaidAt                int64 `json:"paid_at"`
+		VoidedAt              int64 `json:"voided_at"`
+		quotePreviewInvoiceStatusTransitions
+	}{
+		quotePreviewInvoiceStatusTransitions: (quotePreviewInvoiceStatusTransitions)(q),
+		FinalizedAt:                          q.FinalizedAt.Unix(),
+		MarkedUncollectibleAt:                q.MarkedUncollectibleAt.Unix(),
+		PaidAt:                               q.PaidAt.Unix(),
+		VoidedAt:                             q.VoidedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewInvoiceSubscriptionDetailsPauseCollection.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewInvoiceSubscriptionDetailsPauseCollection) MarshalJSON() ([]byte, error) {
+	type quotePreviewInvoiceSubscriptionDetailsPauseCollection QuotePreviewInvoiceSubscriptionDetailsPauseCollection
+	v := struct {
+		ResumesAt int64 `json:"resumes_at"`
+		quotePreviewInvoiceSubscriptionDetailsPauseCollection
+	}{
+		quotePreviewInvoiceSubscriptionDetailsPauseCollection: (quotePreviewInvoiceSubscriptionDetailsPauseCollection)(q),
+		ResumesAt: q.ResumesAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewInvoice.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewInvoice) MarshalJSON() ([]byte, error) {
+	type quotePreviewInvoice QuotePreviewInvoice
+	v := struct {
+		AutomaticallyFinalizesAt  int64 `json:"automatically_finalizes_at"`
+		Created                   int64 `json:"created"`
+		DueDate                   int64 `json:"due_date"`
+		EffectiveAt               int64 `json:"effective_at"`
+		NextPaymentAttempt        int64 `json:"next_payment_attempt"`
+		PeriodEnd                 int64 `json:"period_end"`
+		PeriodStart               int64 `json:"period_start"`
+		SubscriptionProrationDate int64 `json:"subscription_proration_date"`
+		WebhooksDeliveredAt       int64 `json:"webhooks_delivered_at"`
+		quotePreviewInvoice
+	}{
+		quotePreviewInvoice:       (quotePreviewInvoice)(q),
+		AutomaticallyFinalizesAt:  q.AutomaticallyFinalizesAt.Unix(),
+		Created:                   q.Created.Unix(),
+		DueDate:                   q.DueDate.Unix(),
+		EffectiveAt:               q.EffectiveAt.Unix(),
+		NextPaymentAttempt:        q.NextPaymentAttempt.Unix(),
+		PeriodEnd:                 q.PeriodEnd.Unix(),
+		PeriodStart:               q.PeriodStart.Unix(),
+		SubscriptionProrationDate: q.SubscriptionProrationDate.Unix(),
+		WebhooksDeliveredAt:       q.WebhooksDeliveredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/quotepreviewsubscriptionschedule.go
+++ b/quotepreviewsubscriptionschedule.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Describes whether the quote line is affecting a new schedule or an existing schedule.
 type QuotePreviewSubscriptionScheduleAppliesToType string
 
@@ -248,9 +253,9 @@ type QuotePreviewSubscriptionScheduleAppliesTo struct {
 // Object representing the start and end dates for the current phase of the subscription schedule, if it is `active`.
 type QuotePreviewSubscriptionScheduleCurrentPhase struct {
 	// The end of this phase of the subscription schedule.
-	EndDate int64 `json:"end_date"`
+	EndDate time.Time `json:"end_date"`
 	// The start of this phase of the subscription schedule.
-	StartDate int64 `json:"start_date"`
+	StartDate time.Time `json:"start_date"`
 }
 
 // The account that's liable for tax. If set, the business address and tax registrations required to perform the tax calculation are loaded from this account. The tax transaction is returned in the report of the connected account.
@@ -329,7 +334,7 @@ type QuotePreviewSubscriptionScheduleLastPriceMigrationErrorFailedTransition str
 // Details of the most recent price migration that failed for the subscription schedule.
 type QuotePreviewSubscriptionScheduleLastPriceMigrationError struct {
 	// The time at which the price migration encountered an error.
-	ErroredAt int64 `json:"errored_at"`
+	ErroredAt time.Time `json:"errored_at"`
 	// The involved price pairs in each failed transition.
 	FailedTransitions []*QuotePreviewSubscriptionScheduleLastPriceMigrationErrorFailedTransition `json:"failed_transitions"`
 	// The type of error encountered by the price migration.
@@ -339,7 +344,7 @@ type QuotePreviewSubscriptionScheduleLastPriceMigrationError struct {
 // Details to determine how long the discount should be applied for.
 type QuotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type QuotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEndType `json:"type"`
 }
@@ -395,7 +400,7 @@ type QuotePreviewSubscriptionSchedulePhaseBillingThresholds struct {
 // Details to determine how long the discount should be applied for.
 type QuotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type QuotePreviewSubscriptionSchedulePhaseDiscountDiscountEndType `json:"type"`
 }
@@ -439,7 +444,7 @@ type QuotePreviewSubscriptionSchedulePhaseItemBillingThresholds struct {
 // Details to determine how long the discount should be applied for.
 type QuotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type QuotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEndType `json:"type"`
 }
@@ -536,7 +541,7 @@ type QuotePreviewSubscriptionSchedulePhase struct {
 	// The stackable discounts that will be applied to the subscription on this phase. Subscription item discounts are applied before subscription discounts.
 	Discounts []*QuotePreviewSubscriptionSchedulePhaseDiscount `json:"discounts"`
 	// The end of this phase of the subscription schedule.
-	EndDate int64 `json:"end_date"`
+	EndDate time.Time `json:"end_date"`
 	// The invoice settings applicable during this phase.
 	InvoiceSettings *QuotePreviewSubscriptionSchedulePhaseInvoiceSettings `json:"invoice_settings"`
 	// Subscription items to configure the subscription to during this phase of the subscription schedule.
@@ -550,13 +555,13 @@ type QuotePreviewSubscriptionSchedulePhase struct {
 	// If the subscription schedule will prorate when transitioning to this phase. Possible values are `create_prorations` and `none`.
 	ProrationBehavior QuotePreviewSubscriptionSchedulePhaseProrationBehavior `json:"proration_behavior"`
 	// The start of this phase of the subscription schedule.
-	StartDate int64 `json:"start_date"`
+	StartDate time.Time `json:"start_date"`
 	// The account (if any) the associated subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
 	TransferData *QuotePreviewSubscriptionSchedulePhaseTransferData `json:"transfer_data"`
 	// Specify behavior of the trial when crossing schedule phase boundaries
 	TrialContinuation QuotePreviewSubscriptionSchedulePhaseTrialContinuation `json:"trial_continuation"`
 	// When the trial ends within the phase.
-	TrialEnd int64 `json:"trial_end"`
+	TrialEnd time.Time `json:"trial_end"`
 	// Settings related to any trials on the subscription during this phase.
 	TrialSettings *QuotePreviewSubscriptionSchedulePhaseTrialSettings `json:"trial_settings"`
 }
@@ -566,9 +571,9 @@ type QuotePreviewSubscriptionSchedulePrebilling struct {
 	// ID of the prebilling invoice.
 	Invoice *Invoice `json:"invoice"`
 	// The end of the last period for which the invoice pre-bills.
-	PeriodEnd int64 `json:"period_end"`
+	PeriodEnd time.Time `json:"period_end"`
 	// The start of the first period for which the invoice pre-bills.
-	PeriodStart int64 `json:"period_start"`
+	PeriodStart time.Time `json:"period_start"`
 	// Whether to cancel or preserve `prebilling` if the subscription is updated during the prebilled period.
 	UpdateBehavior QuotePreviewSubscriptionSchedulePrebillingUpdateBehavior `json:"update_behavior"`
 }
@@ -579,11 +584,11 @@ type QuotePreviewSubscriptionSchedule struct {
 	// Configures when the subscription schedule generates prorations for phase transitions. Possible values are `prorate_on_next_phase` or `prorate_up_front` with the default being `prorate_on_next_phase`. `prorate_on_next_phase` will apply phase changes and generate prorations at transition time. `prorate_up_front` will bill for all phases within the current billing cycle up front.
 	BillingBehavior QuotePreviewSubscriptionScheduleBillingBehavior `json:"billing_behavior"`
 	// Time at which the subscription schedule was canceled. Measured in seconds since the Unix epoch.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// Time at which the subscription schedule was completed. Measured in seconds since the Unix epoch.
-	CompletedAt int64 `json:"completed_at"`
+	CompletedAt time.Time `json:"completed_at"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Object representing the start and end dates for the current phase of the subscription schedule, if it is `active`.
 	CurrentPhase *QuotePreviewSubscriptionScheduleCurrentPhase `json:"current_phase"`
 	// ID of the customer who owns the subscription schedule.
@@ -606,7 +611,7 @@ type QuotePreviewSubscriptionSchedule struct {
 	// Time period and invoice for a Subscription billed in advance.
 	Prebilling *QuotePreviewSubscriptionSchedulePrebilling `json:"prebilling"`
 	// Time at which the subscription schedule was released. Measured in seconds since the Unix epoch.
-	ReleasedAt int64 `json:"released_at"`
+	ReleasedAt time.Time `json:"released_at"`
 	// ID of the subscription once managed by the subscription schedule (if it is released).
 	ReleasedSubscription string `json:"released_subscription"`
 	// The present status of the subscription schedule. Possible values are `not_started`, `active`, `completed`, `released`, and `canceled`. You can read more about the different states in our [behavior guide](https://stripe.com/docs/billing/subscriptions/subscription-schedules).
@@ -622,4 +627,320 @@ type QuotePreviewSubscriptionScheduleList struct {
 	APIResource
 	ListMeta
 	Data []*QuotePreviewSubscriptionSchedule `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewSubscriptionScheduleCurrentPhase.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewSubscriptionScheduleCurrentPhase) UnmarshalJSON(data []byte) error {
+	type quotePreviewSubscriptionScheduleCurrentPhase QuotePreviewSubscriptionScheduleCurrentPhase
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		*quotePreviewSubscriptionScheduleCurrentPhase
+	}{
+		quotePreviewSubscriptionScheduleCurrentPhase: (*quotePreviewSubscriptionScheduleCurrentPhase)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.EndDate = time.Unix(v.EndDate, 0)
+	q.StartDate = time.Unix(v.StartDate, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewSubscriptionScheduleLastPriceMigrationError.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewSubscriptionScheduleLastPriceMigrationError) UnmarshalJSON(data []byte) error {
+	type quotePreviewSubscriptionScheduleLastPriceMigrationError QuotePreviewSubscriptionScheduleLastPriceMigrationError
+	v := struct {
+		ErroredAt int64 `json:"errored_at"`
+		*quotePreviewSubscriptionScheduleLastPriceMigrationError
+	}{
+		quotePreviewSubscriptionScheduleLastPriceMigrationError: (*quotePreviewSubscriptionScheduleLastPriceMigrationError)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.ErroredAt = time.Unix(v.ErroredAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type quotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd QuotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*quotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd
+	}{
+		quotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd: (*quotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type quotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd QuotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*quotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd
+	}{
+		quotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd: (*quotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type quotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd QuotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*quotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd
+	}{
+		quotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd: (*quotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewSubscriptionSchedulePhase.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewSubscriptionSchedulePhase) UnmarshalJSON(data []byte) error {
+	type quotePreviewSubscriptionSchedulePhase QuotePreviewSubscriptionSchedulePhase
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		TrialEnd  int64 `json:"trial_end"`
+		*quotePreviewSubscriptionSchedulePhase
+	}{
+		quotePreviewSubscriptionSchedulePhase: (*quotePreviewSubscriptionSchedulePhase)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.EndDate = time.Unix(v.EndDate, 0)
+	q.StartDate = time.Unix(v.StartDate, 0)
+	q.TrialEnd = time.Unix(v.TrialEnd, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewSubscriptionSchedulePrebilling.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewSubscriptionSchedulePrebilling) UnmarshalJSON(data []byte) error {
+	type quotePreviewSubscriptionSchedulePrebilling QuotePreviewSubscriptionSchedulePrebilling
+	v := struct {
+		PeriodEnd   int64 `json:"period_end"`
+		PeriodStart int64 `json:"period_start"`
+		*quotePreviewSubscriptionSchedulePrebilling
+	}{
+		quotePreviewSubscriptionSchedulePrebilling: (*quotePreviewSubscriptionSchedulePrebilling)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.PeriodEnd = time.Unix(v.PeriodEnd, 0)
+	q.PeriodStart = time.Unix(v.PeriodStart, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a QuotePreviewSubscriptionSchedule.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (q *QuotePreviewSubscriptionSchedule) UnmarshalJSON(data []byte) error {
+	type quotePreviewSubscriptionSchedule QuotePreviewSubscriptionSchedule
+	v := struct {
+		CanceledAt  int64 `json:"canceled_at"`
+		CompletedAt int64 `json:"completed_at"`
+		Created     int64 `json:"created"`
+		ReleasedAt  int64 `json:"released_at"`
+		*quotePreviewSubscriptionSchedule
+	}{
+		quotePreviewSubscriptionSchedule: (*quotePreviewSubscriptionSchedule)(q),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	q.CanceledAt = time.Unix(v.CanceledAt, 0)
+	q.CompletedAt = time.Unix(v.CompletedAt, 0)
+	q.Created = time.Unix(v.Created, 0)
+	q.ReleasedAt = time.Unix(v.ReleasedAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a QuotePreviewSubscriptionScheduleCurrentPhase.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewSubscriptionScheduleCurrentPhase) MarshalJSON() ([]byte, error) {
+	type quotePreviewSubscriptionScheduleCurrentPhase QuotePreviewSubscriptionScheduleCurrentPhase
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		quotePreviewSubscriptionScheduleCurrentPhase
+	}{
+		quotePreviewSubscriptionScheduleCurrentPhase: (quotePreviewSubscriptionScheduleCurrentPhase)(q),
+		EndDate:   q.EndDate.Unix(),
+		StartDate: q.StartDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewSubscriptionScheduleLastPriceMigrationError.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewSubscriptionScheduleLastPriceMigrationError) MarshalJSON() ([]byte, error) {
+	type quotePreviewSubscriptionScheduleLastPriceMigrationError QuotePreviewSubscriptionScheduleLastPriceMigrationError
+	v := struct {
+		ErroredAt int64 `json:"errored_at"`
+		quotePreviewSubscriptionScheduleLastPriceMigrationError
+	}{
+		quotePreviewSubscriptionScheduleLastPriceMigrationError: (quotePreviewSubscriptionScheduleLastPriceMigrationError)(q),
+		ErroredAt: q.ErroredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type quotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd QuotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		quotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd
+	}{
+		quotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd: (quotePreviewSubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd)(q),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type quotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd QuotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		quotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd
+	}{
+		quotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd: (quotePreviewSubscriptionSchedulePhaseDiscountDiscountEnd)(q),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type quotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd QuotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		quotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd
+	}{
+		quotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd: (quotePreviewSubscriptionSchedulePhaseItemDiscountDiscountEnd)(q),
+		Timestamp: q.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewSubscriptionSchedulePhase.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewSubscriptionSchedulePhase) MarshalJSON() ([]byte, error) {
+	type quotePreviewSubscriptionSchedulePhase QuotePreviewSubscriptionSchedulePhase
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		TrialEnd  int64 `json:"trial_end"`
+		quotePreviewSubscriptionSchedulePhase
+	}{
+		quotePreviewSubscriptionSchedulePhase: (quotePreviewSubscriptionSchedulePhase)(q),
+		EndDate:                               q.EndDate.Unix(),
+		StartDate:                             q.StartDate.Unix(),
+		TrialEnd:                              q.TrialEnd.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewSubscriptionSchedulePrebilling.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewSubscriptionSchedulePrebilling) MarshalJSON() ([]byte, error) {
+	type quotePreviewSubscriptionSchedulePrebilling QuotePreviewSubscriptionSchedulePrebilling
+	v := struct {
+		PeriodEnd   int64 `json:"period_end"`
+		PeriodStart int64 `json:"period_start"`
+		quotePreviewSubscriptionSchedulePrebilling
+	}{
+		quotePreviewSubscriptionSchedulePrebilling: (quotePreviewSubscriptionSchedulePrebilling)(q),
+		PeriodEnd:   q.PeriodEnd.Unix(),
+		PeriodStart: q.PeriodStart.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a QuotePreviewSubscriptionSchedule.
+// This custom marshaling is needed to handle the time fields correctly.
+func (q QuotePreviewSubscriptionSchedule) MarshalJSON() ([]byte, error) {
+	type quotePreviewSubscriptionSchedule QuotePreviewSubscriptionSchedule
+	v := struct {
+		CanceledAt  int64 `json:"canceled_at"`
+		CompletedAt int64 `json:"completed_at"`
+		Created     int64 `json:"created"`
+		ReleasedAt  int64 `json:"released_at"`
+		quotePreviewSubscriptionSchedule
+	}{
+		quotePreviewSubscriptionSchedule: (quotePreviewSubscriptionSchedule)(q),
+		CanceledAt:                       q.CanceledAt.Unix(),
+		CompletedAt:                      q.CompletedAt.Unix(),
+		Created:                          q.Created.Unix(),
+		ReleasedAt:                       q.ReleasedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/radar_earlyfraudwarning.go
+++ b/radar_earlyfraudwarning.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The type of fraud labelled by the issuer. One of `card_never_received`, `fraudulent_card_application`, `made_with_counterfeit_card`, `made_with_lost_card`, `made_with_stolen_card`, `misc`, `unauthorized_use_of_card`.
 type RadarEarlyFraudWarningFraudType string
 
@@ -65,7 +70,7 @@ type RadarEarlyFraudWarning struct {
 	// ID of the charge this early fraud warning is for, optionally expanded.
 	Charge *Charge `json:"charge"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The type of fraud labelled by the issuer. One of `card_never_received`, `fraudulent_card_application`, `made_with_counterfeit_card`, `made_with_lost_card`, `made_with_stolen_card`, `misc`, `unauthorized_use_of_card`.
 	FraudType RadarEarlyFraudWarningFraudType `json:"fraud_type"`
 	// Unique identifier for the object.
@@ -83,4 +88,40 @@ type RadarEarlyFraudWarningList struct {
 	APIResource
 	ListMeta
 	Data []*RadarEarlyFraudWarning `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a RadarEarlyFraudWarning.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (r *RadarEarlyFraudWarning) UnmarshalJSON(data []byte) error {
+	type radarEarlyFraudWarning RadarEarlyFraudWarning
+	v := struct {
+		Created int64 `json:"created"`
+		*radarEarlyFraudWarning
+	}{
+		radarEarlyFraudWarning: (*radarEarlyFraudWarning)(r),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	r.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a RadarEarlyFraudWarning.
+// This custom marshaling is needed to handle the time fields correctly.
+func (r RadarEarlyFraudWarning) MarshalJSON() ([]byte, error) {
+	type radarEarlyFraudWarning RadarEarlyFraudWarning
+	v := struct {
+		Created int64 `json:"created"`
+		radarEarlyFraudWarning
+	}{
+		radarEarlyFraudWarning: (radarEarlyFraudWarning)(r),
+		Created:                r.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/radar_valuelist.go
+++ b/radar_valuelist.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The type of items in the value list. One of `card_fingerprint`, `us_bank_account_fingerprint`, `sepa_debit_fingerprint`, `card_bin`, `email`, `ip_address`, `country`, `string`, `case_sensitive_string`, or `customer_id`.
 type RadarValueListItemType string
 
@@ -80,7 +85,7 @@ type RadarValueList struct {
 	// The name of the value list for use in rules.
 	Alias string `json:"alias"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The name or email address of the user who created this value list.
 	CreatedBy string `json:"created_by"`
 	Deleted   bool   `json:"deleted"`
@@ -105,4 +110,40 @@ type RadarValueListList struct {
 	APIResource
 	ListMeta
 	Data []*RadarValueList `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a RadarValueList.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (r *RadarValueList) UnmarshalJSON(data []byte) error {
+	type radarValueList RadarValueList
+	v := struct {
+		Created int64 `json:"created"`
+		*radarValueList
+	}{
+		radarValueList: (*radarValueList)(r),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	r.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a RadarValueList.
+// This custom marshaling is needed to handle the time fields correctly.
+func (r RadarValueList) MarshalJSON() ([]byte, error) {
+	type radarValueList RadarValueList
+	v := struct {
+		Created int64 `json:"created"`
+		radarValueList
+	}{
+		radarValueList: (radarValueList)(r),
+		Created:        r.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/refund.go
+++ b/refund.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // The type of refund. This can be `refund`, `reversal`, or `pending`.
 type RefundDestinationDetailsCardType string
@@ -282,14 +285,14 @@ type RefundDestinationDetails struct {
 }
 type RefundNextActionDisplayDetailsEmailSent struct {
 	// The timestamp when the email was sent.
-	EmailSentAt int64 `json:"email_sent_at"`
+	EmailSentAt time.Time `json:"email_sent_at"`
 	// The recipient's email address.
 	EmailSentTo string `json:"email_sent_to"`
 }
 type RefundNextActionDisplayDetails struct {
 	EmailSent *RefundNextActionDisplayDetailsEmailSent `json:"email_sent"`
 	// The expiry timestamp.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 }
 type RefundNextAction struct {
 	DisplayDetails *RefundNextActionDisplayDetails `json:"display_details"`
@@ -311,7 +314,7 @@ type Refund struct {
 	// ID of the charge that's refunded.
 	Charge *Charge `json:"charge"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// An arbitrary string attached to the object. You can use this for displaying to users (available on non-card refunds only).
@@ -361,11 +364,106 @@ func (r *Refund) UnmarshalJSON(data []byte) error {
 	}
 
 	type refund Refund
-	var v refund
+	v := struct {
+		Created int64 `json:"created"`
+		*refund
+	}{
+		refund: (*refund)(r),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*r = Refund(v)
+	r.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a RefundNextActionDisplayDetailsEmailSent.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (r *RefundNextActionDisplayDetailsEmailSent) UnmarshalJSON(data []byte) error {
+	type refundNextActionDisplayDetailsEmailSent RefundNextActionDisplayDetailsEmailSent
+	v := struct {
+		EmailSentAt int64 `json:"email_sent_at"`
+		*refundNextActionDisplayDetailsEmailSent
+	}{
+		refundNextActionDisplayDetailsEmailSent: (*refundNextActionDisplayDetailsEmailSent)(r),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	r.EmailSentAt = time.Unix(v.EmailSentAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a RefundNextActionDisplayDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (r *RefundNextActionDisplayDetails) UnmarshalJSON(data []byte) error {
+	type refundNextActionDisplayDetails RefundNextActionDisplayDetails
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*refundNextActionDisplayDetails
+	}{
+		refundNextActionDisplayDetails: (*refundNextActionDisplayDetails)(r),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	r.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a RefundNextActionDisplayDetailsEmailSent.
+// This custom marshaling is needed to handle the time fields correctly.
+func (r RefundNextActionDisplayDetailsEmailSent) MarshalJSON() ([]byte, error) {
+	type refundNextActionDisplayDetailsEmailSent RefundNextActionDisplayDetailsEmailSent
+	v := struct {
+		EmailSentAt int64 `json:"email_sent_at"`
+		refundNextActionDisplayDetailsEmailSent
+	}{
+		refundNextActionDisplayDetailsEmailSent: (refundNextActionDisplayDetailsEmailSent)(r),
+		EmailSentAt:                             r.EmailSentAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a RefundNextActionDisplayDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (r RefundNextActionDisplayDetails) MarshalJSON() ([]byte, error) {
+	type refundNextActionDisplayDetails RefundNextActionDisplayDetails
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		refundNextActionDisplayDetails
+	}{
+		refundNextActionDisplayDetails: (refundNextActionDisplayDetails)(r),
+		ExpiresAt:                      r.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a Refund.
+// This custom marshaling is needed to handle the time fields correctly.
+func (r Refund) MarshalJSON() ([]byte, error) {
+	type refund Refund
+	v := struct {
+		Created int64 `json:"created"`
+		refund
+	}{
+		refund:  (refund)(r),
+		Created: r.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/reporting_reportrun.go
+++ b/reporting_reportrun.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Status of this report run. This will be `pending` when the run is initially created.
 //
 //	When the run finishes, this will be set to `succeeded` and the `result` field will be populated.
@@ -44,9 +49,9 @@ type ReportingReportRunParametersParams struct {
 	// Currency of objects to be included in the report run.
 	Currency *string `form:"currency"`
 	// Ending timestamp of data to be included in the report run (exclusive).
-	IntervalEnd *int64 `form:"interval_end"`
+	IntervalEnd *time.Time `form:"interval_end"`
 	// Starting timestamp of data to be included in the report run.
-	IntervalStart *int64 `form:"interval_start"`
+	IntervalStart *time.Time `form:"interval_start"`
 	// Payout ID by which to filter the report run.
 	Payout *string `form:"payout"`
 	// Category of balance transactions to be included in the report run.
@@ -79,9 +84,9 @@ type ReportingReportRunParameters struct {
 	// Currency of objects to be included in the report run.
 	Currency Currency `json:"currency"`
 	// Ending timestamp of data to be included in the report run. Can be any UTC timestamp between 1 second after the user specified `interval_start` and 1 second before this report's last `data_available_end` value.
-	IntervalEnd int64 `json:"interval_end"`
+	IntervalEnd time.Time `json:"interval_end"`
 	// Starting timestamp of data to be included in the report run. Can be any UTC timestamp between 1 second after this report's `data_available_start` and 1 second before the user specified `interval_end` value.
-	IntervalStart int64 `json:"interval_start"`
+	IntervalStart time.Time `json:"interval_start"`
 	// Payout ID by which to filter the report run.
 	Payout string `json:"payout"`
 	// Category of balance transactions to be included in the report run.
@@ -101,7 +106,7 @@ type ReportingReportRunParameters struct {
 type ReportingReportRun struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// If something should go wrong during the run, a message about the failure (populated when
 	//  `status=failed`).
 	Error string `json:"error"`
@@ -123,7 +128,7 @@ type ReportingReportRun struct {
 	Status ReportingReportRunStatus `json:"status"`
 	// Timestamp at which this run successfully finished (populated when
 	//  `status=succeeded`). Measured in seconds since the Unix epoch.
-	SucceededAt int64 `json:"succeeded_at"`
+	SucceededAt time.Time `json:"succeeded_at"`
 }
 
 // ReportingReportRunList is a list of ReportRuns as retrieved from a list endpoint.
@@ -131,4 +136,84 @@ type ReportingReportRunList struct {
 	APIResource
 	ListMeta
 	Data []*ReportingReportRun `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a ReportingReportRunParameters.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (r *ReportingReportRunParameters) UnmarshalJSON(data []byte) error {
+	type reportingReportRunParameters ReportingReportRunParameters
+	v := struct {
+		IntervalEnd   int64 `json:"interval_end"`
+		IntervalStart int64 `json:"interval_start"`
+		*reportingReportRunParameters
+	}{
+		reportingReportRunParameters: (*reportingReportRunParameters)(r),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	r.IntervalEnd = time.Unix(v.IntervalEnd, 0)
+	r.IntervalStart = time.Unix(v.IntervalStart, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a ReportingReportRun.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (r *ReportingReportRun) UnmarshalJSON(data []byte) error {
+	type reportingReportRun ReportingReportRun
+	v := struct {
+		Created     int64 `json:"created"`
+		SucceededAt int64 `json:"succeeded_at"`
+		*reportingReportRun
+	}{
+		reportingReportRun: (*reportingReportRun)(r),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	r.Created = time.Unix(v.Created, 0)
+	r.SucceededAt = time.Unix(v.SucceededAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a ReportingReportRunParameters.
+// This custom marshaling is needed to handle the time fields correctly.
+func (r ReportingReportRunParameters) MarshalJSON() ([]byte, error) {
+	type reportingReportRunParameters ReportingReportRunParameters
+	v := struct {
+		IntervalEnd   int64 `json:"interval_end"`
+		IntervalStart int64 `json:"interval_start"`
+		reportingReportRunParameters
+	}{
+		reportingReportRunParameters: (reportingReportRunParameters)(r),
+		IntervalEnd:                  r.IntervalEnd.Unix(),
+		IntervalStart:                r.IntervalStart.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a ReportingReportRun.
+// This custom marshaling is needed to handle the time fields correctly.
+func (r ReportingReportRun) MarshalJSON() ([]byte, error) {
+	type reportingReportRun ReportingReportRun
+	v := struct {
+		Created     int64 `json:"created"`
+		SucceededAt int64 `json:"succeeded_at"`
+		reportingReportRun
+	}{
+		reportingReportRun: (reportingReportRun)(r),
+		Created:            r.Created.Unix(),
+		SucceededAt:        r.SucceededAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/reporting_reporttype.go
+++ b/reporting_reporttype.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Returns a full list of Report Types.
 type ReportingReportTypeListParams struct {
 	ListParams `form:"*"`
@@ -41,9 +46,9 @@ func (p *ReportingReportTypeParams) AddExpand(f string) {
 type ReportingReportType struct {
 	APIResource
 	// Most recent time for which this Report Type is available. Measured in seconds since the Unix epoch.
-	DataAvailableEnd int64 `json:"data_available_end"`
+	DataAvailableEnd time.Time `json:"data_available_end"`
 	// Earliest time for which this Report Type is available. Measured in seconds since the Unix epoch.
-	DataAvailableStart int64 `json:"data_available_start"`
+	DataAvailableStart time.Time `json:"data_available_start"`
 	// List of column names that are included by default when this Report Type gets run. (If the Report Type doesn't support the `columns` parameter, this will be null.)
 	DefaultColumns []string `json:"default_columns"`
 	// The [ID of the Report Type](https://stripe.com/docs/reporting/statements/api#available-report-types), such as `balance.summary.1`.
@@ -55,7 +60,7 @@ type ReportingReportType struct {
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// When this Report Type was latest updated. Measured in seconds since the Unix epoch.
-	Updated int64 `json:"updated"`
+	Updated time.Time `json:"updated"`
 	// Version of the Report Type. Different versions report with the same ID will have the same purpose, but may take different run parameters or have different result schemas.
 	Version int64 `json:"version"`
 }
@@ -65,4 +70,48 @@ type ReportingReportTypeList struct {
 	APIResource
 	ListMeta
 	Data []*ReportingReportType `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a ReportingReportType.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (r *ReportingReportType) UnmarshalJSON(data []byte) error {
+	type reportingReportType ReportingReportType
+	v := struct {
+		DataAvailableEnd   int64 `json:"data_available_end"`
+		DataAvailableStart int64 `json:"data_available_start"`
+		Updated            int64 `json:"updated"`
+		*reportingReportType
+	}{
+		reportingReportType: (*reportingReportType)(r),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	r.DataAvailableEnd = time.Unix(v.DataAvailableEnd, 0)
+	r.DataAvailableStart = time.Unix(v.DataAvailableStart, 0)
+	r.Updated = time.Unix(v.Updated, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a ReportingReportType.
+// This custom marshaling is needed to handle the time fields correctly.
+func (r ReportingReportType) MarshalJSON() ([]byte, error) {
+	type reportingReportType ReportingReportType
+	v := struct {
+		DataAvailableEnd   int64 `json:"data_available_end"`
+		DataAvailableStart int64 `json:"data_available_start"`
+		Updated            int64 `json:"updated"`
+		reportingReportType
+	}{
+		reportingReportType: (reportingReportType)(r),
+		DataAvailableEnd:    r.DataAvailableEnd.Unix(),
+		DataAvailableStart:  r.DataAvailableStart.Unix(),
+		Updated:             r.Updated.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/setupintent.go
+++ b/setupintent.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Controls whether this SetupIntent will accept redirect-based payment methods.
 //
@@ -339,7 +342,7 @@ type SetupIntentMandateDataCustomerAcceptanceOnlineParams struct {
 // This hash contains details about the customer acceptance of the Mandate.
 type SetupIntentMandateDataCustomerAcceptanceParams struct {
 	// The time at which the customer accepted the Mandate.
-	AcceptedAt *int64 `form:"accepted_at"`
+	AcceptedAt *time.Time `form:"accepted_at"`
 	// If this is a Mandate accepted offline, this hash contains details about the offline acceptance.
 	Offline *SetupIntentMandateDataCustomerAcceptanceOfflineParams `form:"offline"`
 	// If this is a Mandate accepted online, this hash contains details about the online acceptance.
@@ -793,7 +796,7 @@ type SetupIntentPaymentMethodOptionsCardMandateOptionsParams struct {
 	// A description of the mandate or subscription that is meant to be displayed to the customer.
 	Description *string `form:"description"`
 	// End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
-	EndDate *int64 `form:"end_date"`
+	EndDate *time.Time `form:"end_date"`
 	// Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
 	Interval *string `form:"interval"`
 	// The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
@@ -801,7 +804,7 @@ type SetupIntentPaymentMethodOptionsCardMandateOptionsParams struct {
 	// Unique identifier for the mandate or subscription.
 	Reference *string `form:"reference"`
 	// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
-	StartDate *int64 `form:"start_date"`
+	StartDate *time.Time `form:"start_date"`
 	// Specifies the type of mandates supported. Possible values are `india`.
 	SupportedTypes []*string `form:"supported_types"`
 }
@@ -1559,7 +1562,7 @@ type SetupIntentAutomaticPaymentMethods struct {
 }
 type SetupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode struct {
 	// The date (unix timestamp) when the QR code expires.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The image_url_png string used to render QR code
 	ImageURLPNG string `json:"image_url_png"`
 	// The image_url_svg string used to render QR code
@@ -1583,7 +1586,7 @@ type SetupIntentNextActionRedirectToURL struct {
 type SetupIntentNextActionUseStripeSDK struct{}
 type SetupIntentNextActionVerifyWithMicrodeposits struct {
 	// The timestamp when the microdeposits are expected to land.
-	ArrivalDate int64 `json:"arrival_date"`
+	ArrivalDate time.Time `json:"arrival_date"`
 	// The URL for the hosted verification page, which allows customers to verify their bank account.
 	HostedVerificationURL string `json:"hosted_verification_url"`
 	// The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
@@ -1647,7 +1650,7 @@ type SetupIntentPaymentMethodOptionsCardMandateOptions struct {
 	// A description of the mandate or subscription that is meant to be displayed to the customer.
 	Description string `json:"description"`
 	// End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
-	EndDate int64 `json:"end_date"`
+	EndDate time.Time `json:"end_date"`
 	// Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
 	Interval SetupIntentPaymentMethodOptionsCardMandateOptionsInterval `json:"interval"`
 	// The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
@@ -1655,7 +1658,7 @@ type SetupIntentPaymentMethodOptionsCardMandateOptions struct {
 	// Unique identifier for the mandate or subscription.
 	Reference string `json:"reference"`
 	// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
-	StartDate int64 `json:"start_date"`
+	StartDate time.Time `json:"start_date"`
 	// Specifies the type of mandates supported. Possible values are `india`.
 	SupportedTypes []SetupIntentPaymentMethodOptionsCardMandateOptionsSupportedType `json:"supported_types"`
 }
@@ -1790,7 +1793,7 @@ type SetupIntent struct {
 	// The client secret can be used to complete payment setup from your frontend. It should not be stored, logged, or exposed to anyone other than the customer. Make sure that you have TLS enabled on any page that includes the client secret.
 	ClientSecret string `json:"client_secret"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// ID of the Customer this SetupIntent belongs to, if one exists.
 	//
 	// If present, the SetupIntent's payment method will be attached to the Customer on successful setup. Payment methods attached to other Customers cannot be used with this SetupIntent.
@@ -1854,11 +1857,146 @@ func (s *SetupIntent) UnmarshalJSON(data []byte) error {
 	}
 
 	type setupIntent SetupIntent
-	var v setupIntent
+	v := struct {
+		Created int64 `json:"created"`
+		*setupIntent
+	}{
+		setupIntent: (*setupIntent)(s),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*s = SetupIntent(v)
+	s.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SetupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SetupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode) UnmarshalJSON(data []byte) error {
+	type setupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode SetupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		*setupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode
+	}{
+		setupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode: (*setupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SetupIntentNextActionVerifyWithMicrodeposits.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SetupIntentNextActionVerifyWithMicrodeposits) UnmarshalJSON(data []byte) error {
+	type setupIntentNextActionVerifyWithMicrodeposits SetupIntentNextActionVerifyWithMicrodeposits
+	v := struct {
+		ArrivalDate int64 `json:"arrival_date"`
+		*setupIntentNextActionVerifyWithMicrodeposits
+	}{
+		setupIntentNextActionVerifyWithMicrodeposits: (*setupIntentNextActionVerifyWithMicrodeposits)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.ArrivalDate = time.Unix(v.ArrivalDate, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SetupIntentPaymentMethodOptionsCardMandateOptions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SetupIntentPaymentMethodOptionsCardMandateOptions) UnmarshalJSON(data []byte) error {
+	type setupIntentPaymentMethodOptionsCardMandateOptions SetupIntentPaymentMethodOptionsCardMandateOptions
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		*setupIntentPaymentMethodOptionsCardMandateOptions
+	}{
+		setupIntentPaymentMethodOptionsCardMandateOptions: (*setupIntentPaymentMethodOptionsCardMandateOptions)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.EndDate = time.Unix(v.EndDate, 0)
+	s.StartDate = time.Unix(v.StartDate, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a SetupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SetupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode) MarshalJSON() ([]byte, error) {
+	type setupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode SetupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode
+	v := struct {
+		ExpiresAt int64 `json:"expires_at"`
+		setupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode
+	}{
+		setupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode: (setupIntentNextActionCashAppHandleRedirectOrDisplayQRCodeQRCode)(s),
+		ExpiresAt: s.ExpiresAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SetupIntentNextActionVerifyWithMicrodeposits.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SetupIntentNextActionVerifyWithMicrodeposits) MarshalJSON() ([]byte, error) {
+	type setupIntentNextActionVerifyWithMicrodeposits SetupIntentNextActionVerifyWithMicrodeposits
+	v := struct {
+		ArrivalDate int64 `json:"arrival_date"`
+		setupIntentNextActionVerifyWithMicrodeposits
+	}{
+		setupIntentNextActionVerifyWithMicrodeposits: (setupIntentNextActionVerifyWithMicrodeposits)(s),
+		ArrivalDate: s.ArrivalDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SetupIntentPaymentMethodOptionsCardMandateOptions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SetupIntentPaymentMethodOptionsCardMandateOptions) MarshalJSON() ([]byte, error) {
+	type setupIntentPaymentMethodOptionsCardMandateOptions SetupIntentPaymentMethodOptionsCardMandateOptions
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		setupIntentPaymentMethodOptionsCardMandateOptions
+	}{
+		setupIntentPaymentMethodOptionsCardMandateOptions: (setupIntentPaymentMethodOptionsCardMandateOptions)(s),
+		EndDate:   s.EndDate.Unix(),
+		StartDate: s.StartDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SetupIntent.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SetupIntent) MarshalJSON() ([]byte, error) {
+	type setupIntent SetupIntent
+	v := struct {
+		Created int64 `json:"created"`
+		setupIntent
+	}{
+		setupIntent: (setupIntent)(s),
+		Created:     s.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/sigma_scheduledqueryrun.go
+++ b/sigma_scheduledqueryrun.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The query's execution status, which will be `completed` for successful runs, and `canceled`, `failed`, or `timed_out` otherwise.
 type SigmaScheduledQueryRunStatus string
 
@@ -53,9 +58,9 @@ type SigmaScheduledQueryRunError struct {
 type SigmaScheduledQueryRun struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// When the query was run, Sigma contained a snapshot of your Stripe data at this time.
-	DataLoadTime int64                        `json:"data_load_time"`
+	DataLoadTime time.Time                    `json:"data_load_time"`
 	Error        *SigmaScheduledQueryRunError `json:"error"`
 	// The file object representing the results of the query.
 	File *File `json:"file"`
@@ -66,7 +71,7 @@ type SigmaScheduledQueryRun struct {
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// Time at which the result expires and is no longer available for download.
-	ResultAvailableUntil int64 `json:"result_available_until"`
+	ResultAvailableUntil time.Time `json:"result_available_until"`
 	// SQL for the query.
 	SQL string `json:"sql"`
 	// The query's execution status, which will be `completed` for successful runs, and `canceled`, `failed`, or `timed_out` otherwise.
@@ -80,4 +85,48 @@ type SigmaScheduledQueryRunList struct {
 	APIResource
 	ListMeta
 	Data []*SigmaScheduledQueryRun `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a SigmaScheduledQueryRun.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SigmaScheduledQueryRun) UnmarshalJSON(data []byte) error {
+	type sigmaScheduledQueryRun SigmaScheduledQueryRun
+	v := struct {
+		Created              int64 `json:"created"`
+		DataLoadTime         int64 `json:"data_load_time"`
+		ResultAvailableUntil int64 `json:"result_available_until"`
+		*sigmaScheduledQueryRun
+	}{
+		sigmaScheduledQueryRun: (*sigmaScheduledQueryRun)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.Created = time.Unix(v.Created, 0)
+	s.DataLoadTime = time.Unix(v.DataLoadTime, 0)
+	s.ResultAvailableUntil = time.Unix(v.ResultAvailableUntil, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a SigmaScheduledQueryRun.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SigmaScheduledQueryRun) MarshalJSON() ([]byte, error) {
+	type sigmaScheduledQueryRun SigmaScheduledQueryRun
+	v := struct {
+		Created              int64 `json:"created"`
+		DataLoadTime         int64 `json:"data_load_time"`
+		ResultAvailableUntil int64 `json:"result_available_until"`
+		sigmaScheduledQueryRun
+	}{
+		sigmaScheduledQueryRun: (sigmaScheduledQueryRun)(s),
+		Created:                s.Created.Unix(),
+		DataLoadTime:           s.DataLoadTime.Unix(),
+		ResultAvailableUntil:   s.ResultAvailableUntil.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/source.go
+++ b/source.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // This field indicates whether this payment method can be shown again to its customer in a checkout flow. Stripe products such as Checkout and Elements use this field to determine whether a payment method can be shown as a saved payment method in a checkout flow. The field defaults to “unspecified”.
 type SourceAllowRedisplay string
 
@@ -184,7 +189,7 @@ type SourceMandateAcceptanceOfflineParams struct {
 // The parameters required to store a mandate accepted online. Should only be set if `mandate[type]` is `online`
 type SourceMandateAcceptanceOnlineParams struct {
 	// The Unix timestamp (in seconds) when the mandate was accepted or refused by the customer.
-	Date *int64 `form:"date"`
+	Date *time.Time `form:"date"`
 	// The IP address from which the mandate was accepted or refused by the customer.
 	IP *string `form:"ip"`
 	// The user agent of the browser from which the mandate was accepted or refused by the customer.
@@ -194,7 +199,7 @@ type SourceMandateAcceptanceOnlineParams struct {
 // The parameters required to notify Stripe of a mandate acceptance or refusal by the customer.
 type SourceMandateAcceptanceParams struct {
 	// The Unix timestamp (in seconds) when the mandate was accepted or refused by the customer.
-	Date *int64 `form:"date"`
+	Date *time.Time `form:"date"`
 	// The IP address from which the mandate was accepted or refused by the customer.
 	IP *string `form:"ip"`
 	// The parameters required to store a mandate accepted offline. Should only be set if `mandate[type]` is `offline`
@@ -598,7 +603,7 @@ type Source struct {
 	ClientSecret     string                  `json:"client_secret"`
 	CodeVerification *SourceCodeVerification `json:"code_verification"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) associated with the source. This is the currency for which the source will be chargeable once ready. Required for `single_use` sources.
 	Currency Currency `json:"currency"`
 	// The ID of the customer to which this source is attached. This will not be present when the source has not been attached to a customer.
@@ -638,4 +643,40 @@ type Source struct {
 	// Either `reusable` or `single_use`. Whether this source should be reusable or not. Some source types may or may not be reusable by construction, while others may leave the option at creation. If an incompatible value is passed, an error will be returned.
 	Usage  SourceUsage   `json:"usage"`
 	WeChat *SourceWeChat `json:"wechat"`
+}
+
+// UnmarshalJSON handles deserialization of a Source.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *Source) UnmarshalJSON(data []byte) error {
+	type source Source
+	v := struct {
+		Created int64 `json:"created"`
+		*source
+	}{
+		source: (*source)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a Source.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s Source) MarshalJSON() ([]byte, error) {
+	type source Source
+	v := struct {
+		Created int64 `json:"created"`
+		source
+	}{
+		source:  (source)(s),
+		Created: s.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/source/client_test.go
+++ b/source/client_test.go
@@ -23,10 +23,10 @@ func TestSourceNew(t *testing.T) {
 		Mandate: &stripe.SourceMandateParams{
 			Amount: stripe.Int64(1000),
 			Acceptance: &stripe.SourceMandateAcceptanceParams{
-				Date: stripe.Int64(1528573382),
+				Date: stripe.UnixTime(1528573382),
 				IP:   stripe.String("127.0.0.1"),
 				Online: &stripe.SourceMandateAcceptanceOnlineParams{
-					Date:      stripe.Int64(1528573382),
+					Date:      stripe.UnixTime(1528573382),
 					IP:        stripe.String("127.0.0.1"),
 					UserAgent: stripe.String("User-Agent"),
 				},

--- a/stripe.go
+++ b/stripe.go
@@ -1389,6 +1389,32 @@ func AddBetaVersion(betaName string, betaVersion string) error {
 	return nil
 }
 
+// Time returns a pointer to the time.Time value passed in.
+func Time(v time.Time) *time.Time {
+	return &v
+}
+
+// TimeValue returns the value of the time.Time pointer passed in or
+// time.Time{} if the pointer is nil.
+func TimeValue(v *time.Time) time.Time {
+	if v != nil {
+		return *v
+	}
+	return time.Time{}
+}
+
+// UnixTime returns a pointer to the time.Time value associated to the
+// Unix epoch timestamp passed in.
+func UnixTime(v int64) *time.Time {
+	return Time(time.Unix(v, 0))
+}
+
+// UnixTimeValue returns the Unix epoch timestamp value of the time.Time
+// pointer passed in or 0 if the pointer is nil.
+func UnixTimeValue(v *time.Time) int64 {
+	return TimeValue(v).Unix()
+}
+
 //
 // Private constants
 //

--- a/subscription.go
+++ b/subscription.go
@@ -9,6 +9,7 @@ package stripe
 import (
 	"encoding/json"
 	"github.com/stripe/stripe-go/v81/form"
+	"time"
 )
 
 // If Stripe disabled automatic tax, this enum describes why.
@@ -344,7 +345,7 @@ type SubscriptionParams struct {
 	// Automatic tax settings for this subscription. We recommend you only include this parameter when the existing value is being changed.
 	AutomaticTax *SubscriptionAutomaticTaxParams `form:"automatic_tax"`
 	// For new subscriptions, a past timestamp to backdate the subscription's start date to. If set, the first invoice will contain a proration for the timespan between the start date and the current time. Can be combined with trials and the billing cycle anchor.
-	BackdateStartDate *int64 `form:"backdate_start_date"`
+	BackdateStartDate *time.Time `form:"backdate_start_date"`
 	// A future timestamp in UTC format to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). The anchor is the reference point that aligns future billing cycle dates. It sets the day of week for `week` intervals, the day of month for `month` and `year` intervals, and the month of year for `year` intervals.
 	BillingCycleAnchor *int64 `form:"billing_cycle_anchor"`
 	// Mutually exclusive with billing_cycle_anchor and only valid with monthly and yearly price intervals. When provided, the billing_cycle_anchor is set to the next occurence of the day_of_month at the hour, minute, and second UTC.
@@ -354,7 +355,7 @@ type SubscriptionParams struct {
 	// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
 	BillingThresholds *SubscriptionBillingThresholdsParams `form:"billing_thresholds"`
 	// A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
-	CancelAt *int64 `form:"cancel_at"`
+	CancelAt *time.Time `form:"cancel_at"`
 	// Indicate whether this subscription should cancel at the end of the current period (`current_period_end`). Defaults to `false`.
 	CancelAtPeriodEnd *bool `form:"cancel_at_period_end"`
 	// Details about why this subscription was cancelled
@@ -416,12 +417,12 @@ type SubscriptionParams struct {
 	// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. The default value is `create_prorations`.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#upcoming_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations.
-	ProrationDate *int64 `form:"proration_date"`
+	ProrationDate *time.Time `form:"proration_date"`
 	// If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges. This will be unset if you POST an empty value.
 	TransferData *SubscriptionTransferDataParams `form:"transfer_data"`
 	// Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
-	TrialEnd    *int64 `form:"trial_end"`
-	TrialEndNow *bool  `form:"-"` // See custom AppendTo
+	TrialEnd    *time.Time `form:"trial_end"`
+	TrialEndNow *bool      `form:"-"` // See custom AppendTo
 	// Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
 	TrialFromPlan *bool `form:"trial_from_plan"`
 	// Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
@@ -470,7 +471,7 @@ type SubscriptionAddInvoiceItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *SubscriptionAddInvoiceItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -546,7 +547,7 @@ type SubscriptionDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *SubscriptionDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -622,7 +623,7 @@ type SubscriptionPauseCollectionParams struct {
 	// The payment collection behavior for this subscription while paused. One of `keep_as_draft`, `mark_uncollectible`, or `void`.
 	Behavior *string `form:"behavior"`
 	// The time after which the subscription will resume collecting payments.
-	ResumesAt *int64 `form:"resumes_at"`
+	ResumesAt *time.Time `form:"resumes_at"`
 }
 
 // Additional fields for Mandate creation
@@ -878,7 +879,7 @@ type SubscriptionResumeParams struct {
 	// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. The default value is `create_prorations`.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// If set, the proration will be calculated as though the subscription was resumed at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint.
-	ProrationDate *int64 `form:"proration_date"`
+	ProrationDate *time.Time `form:"proration_date"`
 }
 
 // AddExpand appends a new field to expand.
@@ -956,7 +957,7 @@ type SubscriptionLastPriceMigrationErrorFailedTransition struct {
 // Details of the most recent price migration that failed for the subscription.
 type SubscriptionLastPriceMigrationError struct {
 	// The time at which the price migration encountered an error.
-	ErroredAt int64 `json:"errored_at"`
+	ErroredAt time.Time `json:"errored_at"`
 	// The involved price pairs in each failed transition.
 	FailedTransitions []*SubscriptionLastPriceMigrationErrorFailedTransition `json:"failed_transitions"`
 	// The type of error encountered by the price migration.
@@ -968,7 +969,7 @@ type SubscriptionPauseCollection struct {
 	// The payment collection behavior for this subscription while paused. One of `keep_as_draft`, `mark_uncollectible`, or `void`.
 	Behavior SubscriptionPauseCollectionBehavior `json:"behavior"`
 	// The time after which the subscription will resume collecting payments.
-	ResumesAt int64 `json:"resumes_at"`
+	ResumesAt time.Time `json:"resumes_at"`
 }
 type SubscriptionPaymentSettingsPaymentMethodOptionsACSSDebitMandateOptions struct {
 	// Transaction type of the mandate.
@@ -1091,15 +1092,15 @@ type SubscriptionPendingInvoiceItemInterval struct {
 // If specified, [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates) that will be applied to the subscription once the `latest_invoice` has been paid.
 type SubscriptionPendingUpdate struct {
 	// If the update is applied, determines the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. The timestamp is in UTC format.
-	BillingCycleAnchor int64 `json:"billing_cycle_anchor"`
+	BillingCycleAnchor time.Time `json:"billing_cycle_anchor"`
 	// The point after which the changes reflected by this update will be discarded and no longer applied.
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 	// The number of iterations of prebilling to apply.
 	PrebillingIterations int64 `json:"prebilling_iterations"`
 	// List of subscription items, each with an attached plan, that will be set if the update is applied.
 	SubscriptionItems []*SubscriptionItem `json:"subscription_items"`
 	// Unix timestamp representing the end of the trial period the customer will get before being charged for the first time, if the update is applied.
-	TrialEnd int64 `json:"trial_end"`
+	TrialEnd time.Time `json:"trial_end"`
 	// Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
 	TrialFromPlan bool `json:"trial_from_plan"`
 }
@@ -1109,9 +1110,9 @@ type SubscriptionPrebilling struct {
 	// ID of the prebilling invoice.
 	Invoice *Invoice `json:"invoice"`
 	// The end of the last period for which the invoice pre-bills.
-	PeriodEnd int64 `json:"period_end"`
+	PeriodEnd time.Time `json:"period_end"`
 	// The start of the first period for which the invoice pre-bills.
-	PeriodStart int64 `json:"period_start"`
+	PeriodStart time.Time `json:"period_start"`
 	// Whether to cancel or preserve `prebilling` if the subscription is updated during the prebilled period.
 	UpdateBehavior SubscriptionPrebillingUpdateBehavior `json:"update_behavior"`
 }
@@ -1147,29 +1148,29 @@ type Subscription struct {
 	ApplicationFeePercent float64                   `json:"application_fee_percent"`
 	AutomaticTax          *SubscriptionAutomaticTax `json:"automatic_tax"`
 	// The reference point that aligns future [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle) dates. It sets the day of week for `week` intervals, the day of month for `month` and `year` intervals, and the month of year for `year` intervals. The timestamp is in UTC format.
-	BillingCycleAnchor int64 `json:"billing_cycle_anchor"`
+	BillingCycleAnchor time.Time `json:"billing_cycle_anchor"`
 	// The fixed values used to calculate the `billing_cycle_anchor`.
 	BillingCycleAnchorConfig *SubscriptionBillingCycleAnchorConfig `json:"billing_cycle_anchor_config"`
 	// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period
 	BillingThresholds *SubscriptionBillingThresholds `json:"billing_thresholds"`
 	// A date in the future at which the subscription will automatically get canceled
-	CancelAt int64 `json:"cancel_at"`
+	CancelAt time.Time `json:"cancel_at"`
 	// Whether this subscription will (if `status=active`) or did (if `status=canceled`) cancel at the end of the current billing period.
 	CancelAtPeriodEnd bool `json:"cancel_at_period_end"`
 	// If the subscription has been canceled, the date of that cancellation. If the subscription was canceled with `cancel_at_period_end`, `canceled_at` will reflect the time of the most recent update request, not the end of the subscription period when the subscription is automatically moved to a canceled state.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// Details about why this subscription was cancelled
 	CancellationDetails *SubscriptionCancellationDetails `json:"cancellation_details"`
 	// Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions and mark the subscription as `active`.
 	CollectionMethod SubscriptionCollectionMethod `json:"collection_method"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// End of the current period that the subscription has been invoiced for. At the end of this period, a new invoice will be created.
-	CurrentPeriodEnd int64 `json:"current_period_end"`
+	CurrentPeriodEnd time.Time `json:"current_period_end"`
 	// Start of the current period that the subscription has been invoiced for.
-	CurrentPeriodStart int64 `json:"current_period_start"`
+	CurrentPeriodStart time.Time `json:"current_period_start"`
 	// ID of the customer who owns the subscription.
 	Customer *Customer `json:"customer"`
 	// Number of days a customer has to pay invoices generated by this subscription. This value will be `null` for subscriptions where `collection_method=charge_automatically`.
@@ -1187,7 +1188,7 @@ type Subscription struct {
 	// The discounts applied to the subscription. Subscription item discounts are applied before subscription discounts. Use `expand[]=discounts` to expand each discount.
 	Discounts []*Discount `json:"discounts"`
 	// If the subscription has ended, the date the subscription ended.
-	EndedAt int64 `json:"ended_at"`
+	EndedAt time.Time `json:"ended_at"`
 	// Unique identifier for the object.
 	ID              string                       `json:"id"`
 	InvoiceSettings *SubscriptionInvoiceSettings `json:"invoice_settings"`
@@ -1202,7 +1203,7 @@ type Subscription struct {
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
 	Metadata map[string]string `json:"metadata"`
 	// Specifies the approximate timestamp on which any pending invoice items will be billed according to the schedule provided at `pending_invoice_item_interval`.
-	NextPendingInvoiceItemInvoice int64 `json:"next_pending_invoice_item_invoice"`
+	NextPendingInvoiceItemInvoice time.Time `json:"next_pending_invoice_item_invoice"`
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// The account (if any) the charge was made on behalf of for charges associated with this subscription. See the Connect documentation for details.
@@ -1222,7 +1223,7 @@ type Subscription struct {
 	// The schedule attached to the subscription
 	Schedule *SubscriptionSchedule `json:"schedule"`
 	// Date when the subscription was first created. The date might differ from the `created` date due to backdating.
-	StartDate int64 `json:"start_date"`
+	StartDate time.Time `json:"start_date"`
 	// Possible values are `incomplete`, `incomplete_expired`, `trialing`, `active`, `past_due`, `canceled`, `unpaid`, or `paused`.
 	//
 	// For `collection_method=charge_automatically` a subscription moves into `incomplete` if the initial payment attempt fails. A subscription in this status can only have metadata and default_source updated. Once the first invoice is paid, the subscription moves into an `active` status. If the first invoice is not paid within 23 hours, the subscription transitions to `incomplete_expired`. This is a terminal status, the open invoice will be voided and no further invoices will be generated.
@@ -1240,11 +1241,11 @@ type Subscription struct {
 	// The account (if any) the subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
 	TransferData *SubscriptionTransferData `json:"transfer_data"`
 	// If the subscription has a trial, the end of that trial.
-	TrialEnd int64 `json:"trial_end"`
+	TrialEnd time.Time `json:"trial_end"`
 	// Settings related to subscription trials.
 	TrialSettings *SubscriptionTrialSettings `json:"trial_settings"`
 	// If the subscription has a trial, the beginning of that trial.
-	TrialStart int64 `json:"trial_start"`
+	TrialStart time.Time `json:"trial_start"`
 }
 
 // SubscriptionList is a list of Subscriptions as retrieved from a list endpoint.
@@ -1271,11 +1272,230 @@ func (s *Subscription) UnmarshalJSON(data []byte) error {
 	}
 
 	type subscription Subscription
-	var v subscription
+	v := struct {
+		BillingCycleAnchor            int64 `json:"billing_cycle_anchor"`
+		CancelAt                      int64 `json:"cancel_at"`
+		CanceledAt                    int64 `json:"canceled_at"`
+		Created                       int64 `json:"created"`
+		CurrentPeriodEnd              int64 `json:"current_period_end"`
+		CurrentPeriodStart            int64 `json:"current_period_start"`
+		EndedAt                       int64 `json:"ended_at"`
+		NextPendingInvoiceItemInvoice int64 `json:"next_pending_invoice_item_invoice"`
+		StartDate                     int64 `json:"start_date"`
+		TrialEnd                      int64 `json:"trial_end"`
+		TrialStart                    int64 `json:"trial_start"`
+		*subscription
+	}{
+		subscription: (*subscription)(s),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*s = Subscription(v)
+	s.BillingCycleAnchor = time.Unix(v.BillingCycleAnchor, 0)
+	s.CancelAt = time.Unix(v.CancelAt, 0)
+	s.CanceledAt = time.Unix(v.CanceledAt, 0)
+	s.Created = time.Unix(v.Created, 0)
+	s.CurrentPeriodEnd = time.Unix(v.CurrentPeriodEnd, 0)
+	s.CurrentPeriodStart = time.Unix(v.CurrentPeriodStart, 0)
+	s.EndedAt = time.Unix(v.EndedAt, 0)
+	s.NextPendingInvoiceItemInvoice = time.Unix(v.NextPendingInvoiceItemInvoice, 0)
+	s.StartDate = time.Unix(v.StartDate, 0)
+	s.TrialEnd = time.Unix(v.TrialEnd, 0)
+	s.TrialStart = time.Unix(v.TrialStart, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionLastPriceMigrationError.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionLastPriceMigrationError) UnmarshalJSON(data []byte) error {
+	type subscriptionLastPriceMigrationError SubscriptionLastPriceMigrationError
+	v := struct {
+		ErroredAt int64 `json:"errored_at"`
+		*subscriptionLastPriceMigrationError
+	}{
+		subscriptionLastPriceMigrationError: (*subscriptionLastPriceMigrationError)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.ErroredAt = time.Unix(v.ErroredAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionPauseCollection.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionPauseCollection) UnmarshalJSON(data []byte) error {
+	type subscriptionPauseCollection SubscriptionPauseCollection
+	v := struct {
+		ResumesAt int64 `json:"resumes_at"`
+		*subscriptionPauseCollection
+	}{
+		subscriptionPauseCollection: (*subscriptionPauseCollection)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.ResumesAt = time.Unix(v.ResumesAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionPendingUpdate.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionPendingUpdate) UnmarshalJSON(data []byte) error {
+	type subscriptionPendingUpdate SubscriptionPendingUpdate
+	v := struct {
+		BillingCycleAnchor int64 `json:"billing_cycle_anchor"`
+		ExpiresAt          int64 `json:"expires_at"`
+		TrialEnd           int64 `json:"trial_end"`
+		*subscriptionPendingUpdate
+	}{
+		subscriptionPendingUpdate: (*subscriptionPendingUpdate)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.BillingCycleAnchor = time.Unix(v.BillingCycleAnchor, 0)
+	s.ExpiresAt = time.Unix(v.ExpiresAt, 0)
+	s.TrialEnd = time.Unix(v.TrialEnd, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionPrebilling.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionPrebilling) UnmarshalJSON(data []byte) error {
+	type subscriptionPrebilling SubscriptionPrebilling
+	v := struct {
+		PeriodEnd   int64 `json:"period_end"`
+		PeriodStart int64 `json:"period_start"`
+		*subscriptionPrebilling
+	}{
+		subscriptionPrebilling: (*subscriptionPrebilling)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.PeriodEnd = time.Unix(v.PeriodEnd, 0)
+	s.PeriodStart = time.Unix(v.PeriodStart, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a SubscriptionLastPriceMigrationError.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionLastPriceMigrationError) MarshalJSON() ([]byte, error) {
+	type subscriptionLastPriceMigrationError SubscriptionLastPriceMigrationError
+	v := struct {
+		ErroredAt int64 `json:"errored_at"`
+		subscriptionLastPriceMigrationError
+	}{
+		subscriptionLastPriceMigrationError: (subscriptionLastPriceMigrationError)(s),
+		ErroredAt:                           s.ErroredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionPauseCollection.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionPauseCollection) MarshalJSON() ([]byte, error) {
+	type subscriptionPauseCollection SubscriptionPauseCollection
+	v := struct {
+		ResumesAt int64 `json:"resumes_at"`
+		subscriptionPauseCollection
+	}{
+		subscriptionPauseCollection: (subscriptionPauseCollection)(s),
+		ResumesAt:                   s.ResumesAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionPendingUpdate.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionPendingUpdate) MarshalJSON() ([]byte, error) {
+	type subscriptionPendingUpdate SubscriptionPendingUpdate
+	v := struct {
+		BillingCycleAnchor int64 `json:"billing_cycle_anchor"`
+		ExpiresAt          int64 `json:"expires_at"`
+		TrialEnd           int64 `json:"trial_end"`
+		subscriptionPendingUpdate
+	}{
+		subscriptionPendingUpdate: (subscriptionPendingUpdate)(s),
+		BillingCycleAnchor:        s.BillingCycleAnchor.Unix(),
+		ExpiresAt:                 s.ExpiresAt.Unix(),
+		TrialEnd:                  s.TrialEnd.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionPrebilling.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionPrebilling) MarshalJSON() ([]byte, error) {
+	type subscriptionPrebilling SubscriptionPrebilling
+	v := struct {
+		PeriodEnd   int64 `json:"period_end"`
+		PeriodStart int64 `json:"period_start"`
+		subscriptionPrebilling
+	}{
+		subscriptionPrebilling: (subscriptionPrebilling)(s),
+		PeriodEnd:              s.PeriodEnd.Unix(),
+		PeriodStart:            s.PeriodStart.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a Subscription.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s Subscription) MarshalJSON() ([]byte, error) {
+	type subscription Subscription
+	v := struct {
+		BillingCycleAnchor            int64 `json:"billing_cycle_anchor"`
+		CancelAt                      int64 `json:"cancel_at"`
+		CanceledAt                    int64 `json:"canceled_at"`
+		Created                       int64 `json:"created"`
+		CurrentPeriodEnd              int64 `json:"current_period_end"`
+		CurrentPeriodStart            int64 `json:"current_period_start"`
+		EndedAt                       int64 `json:"ended_at"`
+		NextPendingInvoiceItemInvoice int64 `json:"next_pending_invoice_item_invoice"`
+		StartDate                     int64 `json:"start_date"`
+		TrialEnd                      int64 `json:"trial_end"`
+		TrialStart                    int64 `json:"trial_start"`
+		subscription
+	}{
+		subscription:                  (subscription)(s),
+		BillingCycleAnchor:            s.BillingCycleAnchor.Unix(),
+		CancelAt:                      s.CancelAt.Unix(),
+		CanceledAt:                    s.CanceledAt.Unix(),
+		Created:                       s.Created.Unix(),
+		CurrentPeriodEnd:              s.CurrentPeriodEnd.Unix(),
+		CurrentPeriodStart:            s.CurrentPeriodStart.Unix(),
+		EndedAt:                       s.EndedAt.Unix(),
+		NextPendingInvoiceItemInvoice: s.NextPendingInvoiceItemInvoice.Unix(),
+		StartDate:                     s.StartDate.Unix(),
+		TrialEnd:                      s.TrialEnd.Unix(),
+		TrialStart:                    s.TrialStart.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/subscriptionitem.go
+++ b/subscriptionitem.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Determines the type of trial for this item.
 type SubscriptionItemTrialType string
@@ -50,7 +53,7 @@ type SubscriptionItemParams struct {
 	// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. The default value is `create_prorations`.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint.
-	ProrationDate *int64 `form:"proration_date"`
+	ProrationDate *time.Time `form:"proration_date"`
 	// The quantity you'd like to apply to the subscription item you're creating.
 	Quantity *int64 `form:"quantity"`
 	// The identifier of the subscription to modify.
@@ -94,7 +97,7 @@ type SubscriptionItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *SubscriptionItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -193,8 +196,8 @@ type SubscriptionItem struct {
 	// Define thresholds at which an invoice will be sent, and the related subscription advanced to a new billing period
 	BillingThresholds *SubscriptionItemBillingThresholds `json:"billing_thresholds"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
-	Deleted bool  `json:"deleted"`
+	Created time.Time `json:"created"`
+	Deleted bool      `json:"deleted"`
 	// The discounts applied to the subscription item. Subscription item discounts are applied before subscription discounts. Use `expand[]=discounts` to expand each discount.
 	Discounts []*Discount `json:"discounts"`
 	// Unique identifier for the object.
@@ -246,11 +249,34 @@ func (s *SubscriptionItem) UnmarshalJSON(data []byte) error {
 	}
 
 	type subscriptionItem SubscriptionItem
-	var v subscriptionItem
+	v := struct {
+		Created int64 `json:"created"`
+		*subscriptionItem
+	}{
+		subscriptionItem: (*subscriptionItem)(s),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*s = SubscriptionItem(v)
+	s.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a SubscriptionItem.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionItem) MarshalJSON() ([]byte, error) {
+	type subscriptionItem SubscriptionItem
+	v := struct {
+		Created int64 `json:"created"`
+		subscriptionItem
+	}{
+		subscriptionItem: (subscriptionItem)(s),
+		Created:          s.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/subscriptionschedule.go
+++ b/subscriptionschedule.go
@@ -9,6 +9,7 @@ package stripe
 import (
 	"encoding/json"
 	"github.com/stripe/stripe-go/v81/form"
+	"time"
 )
 
 // Configures when the subscription schedule generates prorations for phase transitions. Possible values are `prorate_on_next_phase` or `prorate_up_front` with the default being `prorate_on_next_phase`. `prorate_on_next_phase` will apply phase changes and generate prorations at transition time. `prorate_up_front` will bill for all phases within the current billing cycle up front.
@@ -255,7 +256,7 @@ type SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -315,7 +316,7 @@ type SubscriptionSchedulePhaseDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *SubscriptionSchedulePhaseDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -363,7 +364,7 @@ type SubscriptionSchedulePhaseItemDiscountDiscountEndParams struct {
 	// Time span for the redeemed discount.
 	Duration *SubscriptionSchedulePhaseItemDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -464,8 +465,8 @@ type SubscriptionSchedulePhaseParams struct {
 	// The coupons to redeem into discounts for the schedule phase. If not specified, inherits the discount from the subscription's customer. Pass an empty string to avoid inheriting any discounts.
 	Discounts []*SubscriptionSchedulePhaseDiscountParams `form:"discounts"`
 	// The date at which this phase of the subscription schedule ends. If set, `iterations` must not be set.
-	EndDate    *int64 `form:"end_date"`
-	EndDateNow *bool  `form:"-"` // See custom AppendTo
+	EndDate    *time.Time `form:"end_date"`
+	EndDateNow *bool      `form:"-"` // See custom AppendTo
 	// All invoices will be billed using the specified settings.
 	InvoiceSettings *SubscriptionSchedulePhaseInvoiceSettingsParams `form:"invoice_settings"`
 	// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
@@ -481,8 +482,8 @@ type SubscriptionSchedulePhaseParams struct {
 	// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase. The default value is `create_prorations`. This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase. It's different from the request-level [proration_behavior](https://stripe.com/docs/api/subscription_schedules/update#update_subscription_schedule-proration_behavior) parameter which controls what happens if the update request affects the billing configuration of the current phase.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// The date at which this phase of the subscription schedule starts or `now`. Must be set on the first phase.
-	StartDate    *int64 `form:"start_date"`
-	StartDateNow *bool  `form:"-"` // See custom AppendTo
+	StartDate    *time.Time `form:"start_date"`
+	StartDateNow *bool      `form:"-"` // See custom AppendTo
 	// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
 	TransferData *SubscriptionTransferDataParams `form:"transfer_data"`
 	// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
@@ -490,8 +491,8 @@ type SubscriptionSchedulePhaseParams struct {
 	// Specify trial behavior when crossing phase boundaries
 	TrialContinuation *string `form:"trial_continuation"`
 	// Sets the phase to trialing from the start date to this date. Must be before the phase end date, can not be combined with `trial`
-	TrialEnd    *int64 `form:"trial_end"`
-	TrialEndNow *bool  `form:"-"` // See custom AppendTo
+	TrialEnd    *time.Time `form:"trial_end"`
+	TrialEndNow *bool      `form:"-"` // See custom AppendTo
 	// Settings related to subscription trials.
 	TrialSettings *SubscriptionSchedulePhaseTrialSettingsParams `form:"trial_settings"`
 }
@@ -550,8 +551,8 @@ type SubscriptionScheduleParams struct {
 	// If the update changes the current phase, indicates whether the changes should be prorated. The default value is `create_prorations`.
 	ProrationBehavior *string `form:"proration_behavior"`
 	// When the subscription schedule starts. We recommend using `now` so that it starts the subscription immediately. You can also use a Unix timestamp to backdate the subscription so that it starts on a past date, or set a future date for the subscription to start on.
-	StartDate    *int64 `form:"start_date"`
-	StartDateNow *bool  `form:"-"` // See custom AppendTo
+	StartDate    *time.Time `form:"start_date"`
+	StartDateNow *bool      `form:"-"` // See custom AppendTo
 }
 
 // AddExpand appends a new field to expand.
@@ -596,7 +597,7 @@ type SubscriptionScheduleAmendAmendmentAmendmentEndParams struct {
 	// Time span for the amendment starting from the `amendment_start`.
 	Duration *SubscriptionScheduleAmendAmendmentAmendmentEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the amendment to end. Must be after the `amendment_start`.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of three ways to pass the `amendment_end`.
 	Type *string `form:"type"`
 }
@@ -620,7 +621,7 @@ type SubscriptionScheduleAmendAmendmentAmendmentStartParams struct {
 	// Use the `end` time of a given discount.
 	DiscountEnd *SubscriptionScheduleAmendAmendmentAmendmentStartDiscountEndParams `form:"discount_end"`
 	// A precise Unix timestamp for the amendment to start.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of three ways to pass the `amendment_start`.
 	Type *string `form:"type"`
 }
@@ -690,7 +691,7 @@ type SubscriptionScheduleAmendAmendmentItemActionAddDiscountDiscountEndParams st
 	// Time span for the redeemed discount.
 	Duration *SubscriptionScheduleAmendAmendmentItemActionAddDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -759,7 +760,7 @@ type SubscriptionScheduleAmendAmendmentItemActionSetDiscountDiscountEndParams st
 	// Time span for the redeemed discount.
 	Duration *SubscriptionScheduleAmendAmendmentItemActionSetDiscountDiscountEndDurationParams `form:"duration"`
 	// A precise Unix timestamp for the discount to end. Must be in the future.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// The type of calculation made to determine when the discount ends.
 	Type *string `form:"type"`
 }
@@ -894,7 +895,7 @@ type SubscriptionScheduleAmendPrebillingBillFromParams struct {
 	// Start the prebilled period when a specified amendment begins.
 	AmendmentStart *SubscriptionScheduleAmendPrebillingBillFromAmendmentStartParams `form:"amendment_start"`
 	// Start the prebilled period at a precise integer timestamp, starting from the Unix epoch.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of several ways to pass the `bill_from` value.
 	Type *string `form:"type"`
 }
@@ -920,7 +921,7 @@ type SubscriptionScheduleAmendPrebillingBillUntilParams struct {
 	// Time span for prebilling, starting from `bill_from`.
 	Duration *SubscriptionScheduleAmendPrebillingBillUntilDurationParams `form:"duration"`
 	// End the prebilled period at a precise integer timestamp, starting from the Unix epoch.
-	Timestamp *int64 `form:"timestamp"`
+	Timestamp *time.Time `form:"timestamp"`
 	// Select one of several ways to pass the `bill_until` value.
 	Type *string `form:"type"`
 }
@@ -997,9 +998,9 @@ func (p *SubscriptionScheduleReleaseParams) AddExpand(f string) {
 // Object representing the start and end dates for the current phase of the subscription schedule, if it is `active`.
 type SubscriptionScheduleCurrentPhase struct {
 	// The end of this phase of the subscription schedule.
-	EndDate int64 `json:"end_date"`
+	EndDate time.Time `json:"end_date"`
 	// The start of this phase of the subscription schedule.
-	StartDate int64 `json:"start_date"`
+	StartDate time.Time `json:"start_date"`
 }
 type SubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer struct {
 	// The connected account being referenced when `type` is `account`.
@@ -1046,7 +1047,7 @@ type SubscriptionScheduleLastPriceMigrationErrorFailedTransition struct {
 // Details of the most recent price migration that failed for the subscription schedule.
 type SubscriptionScheduleLastPriceMigrationError struct {
 	// The time at which the price migration encountered an error.
-	ErroredAt int64 `json:"errored_at"`
+	ErroredAt time.Time `json:"errored_at"`
 	// The involved price pairs in each failed transition.
 	FailedTransitions []*SubscriptionScheduleLastPriceMigrationErrorFailedTransition `json:"failed_transitions"`
 	// The type of error encountered by the price migration.
@@ -1056,7 +1057,7 @@ type SubscriptionScheduleLastPriceMigrationError struct {
 // Details to determine how long the discount should be applied for.
 type SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEndType `json:"type"`
 }
@@ -1088,7 +1089,7 @@ type SubscriptionSchedulePhaseAddInvoiceItem struct {
 // Details to determine how long the discount should be applied for.
 type SubscriptionSchedulePhaseDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type SubscriptionSchedulePhaseDiscountDiscountEndType `json:"type"`
 }
@@ -1126,7 +1127,7 @@ type SubscriptionSchedulePhaseInvoiceSettings struct {
 // Details to determine how long the discount should be applied for.
 type SubscriptionSchedulePhaseItemDiscountDiscountEnd struct {
 	// The discount end timestamp.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
 	// The discount end type.
 	Type SubscriptionSchedulePhaseItemDiscountDiscountEndType `json:"type"`
 }
@@ -1215,7 +1216,7 @@ type SubscriptionSchedulePhase struct {
 	// The stackable discounts that will be applied to the subscription on this phase. Subscription item discounts are applied before subscription discounts.
 	Discounts []*SubscriptionSchedulePhaseDiscount `json:"discounts"`
 	// The end of this phase of the subscription schedule.
-	EndDate int64 `json:"end_date"`
+	EndDate time.Time `json:"end_date"`
 	// The invoice settings applicable during this phase.
 	InvoiceSettings *SubscriptionSchedulePhaseInvoiceSettings `json:"invoice_settings"`
 	// Subscription items to configure the subscription to during this phase of the subscription schedule.
@@ -1229,13 +1230,13 @@ type SubscriptionSchedulePhase struct {
 	// If the subscription schedule will prorate when transitioning to this phase. Possible values are `create_prorations` and `none`.
 	ProrationBehavior SubscriptionSchedulePhaseProrationBehavior `json:"proration_behavior"`
 	// The start of this phase of the subscription schedule.
-	StartDate int64 `json:"start_date"`
+	StartDate time.Time `json:"start_date"`
 	// The account (if any) the associated subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
 	TransferData *SubscriptionTransferData `json:"transfer_data"`
 	// Specify behavior of the trial when crossing schedule phase boundaries
 	TrialContinuation SubscriptionSchedulePhaseTrialContinuation `json:"trial_continuation"`
 	// When the trial ends within the phase.
-	TrialEnd int64 `json:"trial_end"`
+	TrialEnd time.Time `json:"trial_end"`
 	// Settings related to any trials on the subscription during this phase.
 	TrialSettings *SubscriptionSchedulePhaseTrialSettings `json:"trial_settings"`
 }
@@ -1245,9 +1246,9 @@ type SubscriptionSchedulePrebilling struct {
 	// ID of the prebilling invoice.
 	Invoice *Invoice `json:"invoice"`
 	// The end of the last period for which the invoice pre-bills.
-	PeriodEnd int64 `json:"period_end"`
+	PeriodEnd time.Time `json:"period_end"`
 	// The start of the first period for which the invoice pre-bills.
-	PeriodStart int64 `json:"period_start"`
+	PeriodStart time.Time `json:"period_start"`
 	// Whether to cancel or preserve `prebilling` if the subscription is updated during the prebilled period.
 	UpdateBehavior SubscriptionSchedulePrebillingUpdateBehavior `json:"update_behavior"`
 }
@@ -1262,11 +1263,11 @@ type SubscriptionSchedule struct {
 	// Configures when the subscription schedule generates prorations for phase transitions. Possible values are `prorate_on_next_phase` or `prorate_up_front` with the default being `prorate_on_next_phase`. `prorate_on_next_phase` will apply phase changes and generate prorations at transition time. `prorate_up_front` will bill for all phases within the current billing cycle up front.
 	BillingBehavior SubscriptionScheduleBillingBehavior `json:"billing_behavior"`
 	// Time at which the subscription schedule was canceled. Measured in seconds since the Unix epoch.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// Time at which the subscription schedule was completed. Measured in seconds since the Unix epoch.
-	CompletedAt int64 `json:"completed_at"`
+	CompletedAt time.Time `json:"completed_at"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Object representing the start and end dates for the current phase of the subscription schedule, if it is `active`.
 	CurrentPhase *SubscriptionScheduleCurrentPhase `json:"current_phase"`
 	// ID of the customer who owns the subscription schedule.
@@ -1289,7 +1290,7 @@ type SubscriptionSchedule struct {
 	// Time period and invoice for a Subscription billed in advance.
 	Prebilling *SubscriptionSchedulePrebilling `json:"prebilling"`
 	// Time at which the subscription schedule was released. Measured in seconds since the Unix epoch.
-	ReleasedAt int64 `json:"released_at"`
+	ReleasedAt time.Time `json:"released_at"`
 	// ID of the subscription once managed by the subscription schedule (if it is released).
 	ReleasedSubscription *Subscription `json:"released_subscription"`
 	// The present status of the subscription schedule. Possible values are `not_started`, `active`, `completed`, `released`, and `canceled`. You can read more about the different states in our [behavior guide](https://stripe.com/docs/billing/subscriptions/subscription-schedules).
@@ -1317,11 +1318,314 @@ func (s *SubscriptionSchedule) UnmarshalJSON(data []byte) error {
 	}
 
 	type subscriptionSchedule SubscriptionSchedule
-	var v subscriptionSchedule
+	v := struct {
+		CanceledAt  int64 `json:"canceled_at"`
+		CompletedAt int64 `json:"completed_at"`
+		Created     int64 `json:"created"`
+		ReleasedAt  int64 `json:"released_at"`
+		*subscriptionSchedule
+	}{
+		subscriptionSchedule: (*subscriptionSchedule)(s),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*s = SubscriptionSchedule(v)
+	s.CanceledAt = time.Unix(v.CanceledAt, 0)
+	s.CompletedAt = time.Unix(v.CompletedAt, 0)
+	s.Created = time.Unix(v.Created, 0)
+	s.ReleasedAt = time.Unix(v.ReleasedAt, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionScheduleCurrentPhase.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionScheduleCurrentPhase) UnmarshalJSON(data []byte) error {
+	type subscriptionScheduleCurrentPhase SubscriptionScheduleCurrentPhase
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		*subscriptionScheduleCurrentPhase
+	}{
+		subscriptionScheduleCurrentPhase: (*subscriptionScheduleCurrentPhase)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.EndDate = time.Unix(v.EndDate, 0)
+	s.StartDate = time.Unix(v.StartDate, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionScheduleLastPriceMigrationError.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionScheduleLastPriceMigrationError) UnmarshalJSON(data []byte) error {
+	type subscriptionScheduleLastPriceMigrationError SubscriptionScheduleLastPriceMigrationError
+	v := struct {
+		ErroredAt int64 `json:"errored_at"`
+		*subscriptionScheduleLastPriceMigrationError
+	}{
+		subscriptionScheduleLastPriceMigrationError: (*subscriptionScheduleLastPriceMigrationError)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.ErroredAt = time.Unix(v.ErroredAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type subscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*subscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd
+	}{
+		subscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd: (*subscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionSchedulePhaseDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionSchedulePhaseDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type subscriptionSchedulePhaseDiscountDiscountEnd SubscriptionSchedulePhaseDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*subscriptionSchedulePhaseDiscountDiscountEnd
+	}{
+		subscriptionSchedulePhaseDiscountDiscountEnd: (*subscriptionSchedulePhaseDiscountDiscountEnd)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionSchedulePhaseItemDiscountDiscountEnd.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionSchedulePhaseItemDiscountDiscountEnd) UnmarshalJSON(data []byte) error {
+	type subscriptionSchedulePhaseItemDiscountDiscountEnd SubscriptionSchedulePhaseItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*subscriptionSchedulePhaseItemDiscountDiscountEnd
+	}{
+		subscriptionSchedulePhaseItemDiscountDiscountEnd: (*subscriptionSchedulePhaseItemDiscountDiscountEnd)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionSchedulePhase.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionSchedulePhase) UnmarshalJSON(data []byte) error {
+	type subscriptionSchedulePhase SubscriptionSchedulePhase
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		TrialEnd  int64 `json:"trial_end"`
+		*subscriptionSchedulePhase
+	}{
+		subscriptionSchedulePhase: (*subscriptionSchedulePhase)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.EndDate = time.Unix(v.EndDate, 0)
+	s.StartDate = time.Unix(v.StartDate, 0)
+	s.TrialEnd = time.Unix(v.TrialEnd, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a SubscriptionSchedulePrebilling.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (s *SubscriptionSchedulePrebilling) UnmarshalJSON(data []byte) error {
+	type subscriptionSchedulePrebilling SubscriptionSchedulePrebilling
+	v := struct {
+		PeriodEnd   int64 `json:"period_end"`
+		PeriodStart int64 `json:"period_start"`
+		*subscriptionSchedulePrebilling
+	}{
+		subscriptionSchedulePrebilling: (*subscriptionSchedulePrebilling)(s),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.PeriodEnd = time.Unix(v.PeriodEnd, 0)
+	s.PeriodStart = time.Unix(v.PeriodStart, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a SubscriptionScheduleCurrentPhase.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionScheduleCurrentPhase) MarshalJSON() ([]byte, error) {
+	type subscriptionScheduleCurrentPhase SubscriptionScheduleCurrentPhase
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		subscriptionScheduleCurrentPhase
+	}{
+		subscriptionScheduleCurrentPhase: (subscriptionScheduleCurrentPhase)(s),
+		EndDate:                          s.EndDate.Unix(),
+		StartDate:                        s.StartDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionScheduleLastPriceMigrationError.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionScheduleLastPriceMigrationError) MarshalJSON() ([]byte, error) {
+	type subscriptionScheduleLastPriceMigrationError SubscriptionScheduleLastPriceMigrationError
+	v := struct {
+		ErroredAt int64 `json:"errored_at"`
+		subscriptionScheduleLastPriceMigrationError
+	}{
+		subscriptionScheduleLastPriceMigrationError: (subscriptionScheduleLastPriceMigrationError)(s),
+		ErroredAt: s.ErroredAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type subscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd SubscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		subscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd
+	}{
+		subscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd: (subscriptionSchedulePhaseAddInvoiceItemDiscountDiscountEnd)(s),
+		Timestamp: s.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionSchedulePhaseDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionSchedulePhaseDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type subscriptionSchedulePhaseDiscountDiscountEnd SubscriptionSchedulePhaseDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		subscriptionSchedulePhaseDiscountDiscountEnd
+	}{
+		subscriptionSchedulePhaseDiscountDiscountEnd: (subscriptionSchedulePhaseDiscountDiscountEnd)(s),
+		Timestamp: s.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionSchedulePhaseItemDiscountDiscountEnd.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionSchedulePhaseItemDiscountDiscountEnd) MarshalJSON() ([]byte, error) {
+	type subscriptionSchedulePhaseItemDiscountDiscountEnd SubscriptionSchedulePhaseItemDiscountDiscountEnd
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		subscriptionSchedulePhaseItemDiscountDiscountEnd
+	}{
+		subscriptionSchedulePhaseItemDiscountDiscountEnd: (subscriptionSchedulePhaseItemDiscountDiscountEnd)(s),
+		Timestamp: s.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionSchedulePhase.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionSchedulePhase) MarshalJSON() ([]byte, error) {
+	type subscriptionSchedulePhase SubscriptionSchedulePhase
+	v := struct {
+		EndDate   int64 `json:"end_date"`
+		StartDate int64 `json:"start_date"`
+		TrialEnd  int64 `json:"trial_end"`
+		subscriptionSchedulePhase
+	}{
+		subscriptionSchedulePhase: (subscriptionSchedulePhase)(s),
+		EndDate:                   s.EndDate.Unix(),
+		StartDate:                 s.StartDate.Unix(),
+		TrialEnd:                  s.TrialEnd.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionSchedulePrebilling.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionSchedulePrebilling) MarshalJSON() ([]byte, error) {
+	type subscriptionSchedulePrebilling SubscriptionSchedulePrebilling
+	v := struct {
+		PeriodEnd   int64 `json:"period_end"`
+		PeriodStart int64 `json:"period_start"`
+		subscriptionSchedulePrebilling
+	}{
+		subscriptionSchedulePrebilling: (subscriptionSchedulePrebilling)(s),
+		PeriodEnd:                      s.PeriodEnd.Unix(),
+		PeriodStart:                    s.PeriodStart.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a SubscriptionSchedule.
+// This custom marshaling is needed to handle the time fields correctly.
+func (s SubscriptionSchedule) MarshalJSON() ([]byte, error) {
+	type subscriptionSchedule SubscriptionSchedule
+	v := struct {
+		CanceledAt  int64 `json:"canceled_at"`
+		CompletedAt int64 `json:"completed_at"`
+		Created     int64 `json:"created"`
+		ReleasedAt  int64 `json:"released_at"`
+		subscriptionSchedule
+	}{
+		subscriptionSchedule: (subscriptionSchedule)(s),
+		CanceledAt:           s.CanceledAt.Unix(),
+		CompletedAt:          s.CompletedAt.Unix(),
+		Created:              s.Created.Unix(),
+		ReleasedAt:           s.ReleasedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/tax_form.go
+++ b/tax_form.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Indicates the level of the jurisdiction where the form was filed.
 type TaxFormFilingStatusJurisdictionLevel string
@@ -131,7 +134,7 @@ type TaxFormFilingStatusJurisdiction struct {
 // A list of tax filing statuses. Note that a filing status will only be included if the form has been filed directly with the jurisdiction's tax authority.
 type TaxFormFilingStatus struct {
 	// Time when the filing status was updated.
-	EffectiveAt  int64                            `json:"effective_at"`
+	EffectiveAt  time.Time                        `json:"effective_at"`
 	Jurisdiction *TaxFormFilingStatusJurisdiction `json:"jurisdiction"`
 	// The current status of the filed form.
 	Value TaxFormFilingStatusValue `json:"value"`
@@ -179,7 +182,7 @@ type TaxForm struct {
 	// The form that corrects this form, if any.
 	CorrectedBy *TaxForm `json:"corrected_by"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64          `json:"created"`
+	Created time.Time      `json:"created"`
 	EUDac7  *TaxFormEUDac7 `json:"eu_dac7"`
 	// A list of tax filing statuses. Note that a filing status will only be included if the form has been filed directly with the jurisdiction's tax authority.
 	FilingStatuses []*TaxFormFilingStatus `json:"filing_statuses"`
@@ -216,11 +219,70 @@ func (t *TaxForm) UnmarshalJSON(data []byte) error {
 	}
 
 	type taxForm TaxForm
-	var v taxForm
+	v := struct {
+		Created int64 `json:"created"`
+		*taxForm
+	}{
+		taxForm: (*taxForm)(t),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*t = TaxForm(v)
+	t.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TaxFormFilingStatus.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TaxFormFilingStatus) UnmarshalJSON(data []byte) error {
+	type taxFormFilingStatus TaxFormFilingStatus
+	v := struct {
+		EffectiveAt int64 `json:"effective_at"`
+		*taxFormFilingStatus
+	}{
+		taxFormFilingStatus: (*taxFormFilingStatus)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.EffectiveAt = time.Unix(v.EffectiveAt, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TaxFormFilingStatus.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TaxFormFilingStatus) MarshalJSON() ([]byte, error) {
+	type taxFormFilingStatus TaxFormFilingStatus
+	v := struct {
+		EffectiveAt int64 `json:"effective_at"`
+		taxFormFilingStatus
+	}{
+		taxFormFilingStatus: (taxFormFilingStatus)(t),
+		EffectiveAt:         t.EffectiveAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a TaxForm.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TaxForm) MarshalJSON() ([]byte, error) {
+	type taxForm TaxForm
+	v := struct {
+		Created int64 `json:"created"`
+		taxForm
+	}{
+		taxForm: (taxForm)(t),
+		Created: t.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/tax_transaction.go
+++ b/tax_transaction.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The type of customer address provided.
 type TaxTransactionCustomerDetailsAddressSource string
 
@@ -250,7 +255,7 @@ type TaxTransactionCreateFromCalculationParams struct {
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
 	Metadata map[string]string `form:"metadata"`
 	// The Unix timestamp representing when the tax liability is assumed or reduced, which determines the liability posting period and handling in tax liability reports. The timestamp must fall within the `tax_date` and the current time, unless the `tax_date` is scheduled in advance. Defaults to the current time.
-	PostedAt *int64 `form:"posted_at"`
+	PostedAt *time.Time `form:"posted_at"`
 	// A custom order or sale identifier, such as 'myOrder_123'. Must be unique across all transactions, including reversals.
 	Reference *string `form:"reference"`
 }
@@ -425,7 +430,7 @@ type TaxTransactionShippingCost struct {
 type TaxTransaction struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// The ID of an existing [Customer](https://stripe.com/docs/api/customers/object) used for the resource.
@@ -442,7 +447,7 @@ type TaxTransaction struct {
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// The Unix timestamp representing when the tax liability is assumed or reduced.
-	PostedAt int64 `json:"posted_at"`
+	PostedAt time.Time `json:"posted_at"`
 	// A custom unique identifier, such as 'myOrder_123'.
 	Reference string `json:"reference"`
 	// If `type=reversal`, contains information about what was reversed.
@@ -452,7 +457,51 @@ type TaxTransaction struct {
 	// The shipping cost details for the transaction.
 	ShippingCost *TaxTransactionShippingCost `json:"shipping_cost"`
 	// Timestamp of date at which the tax rules and rates in effect applies for the calculation.
-	TaxDate int64 `json:"tax_date"`
+	TaxDate time.Time `json:"tax_date"`
 	// If `reversal`, this transaction reverses an earlier transaction.
 	Type TaxTransactionType `json:"type"`
+}
+
+// UnmarshalJSON handles deserialization of a TaxTransaction.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TaxTransaction) UnmarshalJSON(data []byte) error {
+	type taxTransaction TaxTransaction
+	v := struct {
+		Created  int64 `json:"created"`
+		PostedAt int64 `json:"posted_at"`
+		TaxDate  int64 `json:"tax_date"`
+		*taxTransaction
+	}{
+		taxTransaction: (*taxTransaction)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Created = time.Unix(v.Created, 0)
+	t.PostedAt = time.Unix(v.PostedAt, 0)
+	t.TaxDate = time.Unix(v.TaxDate, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TaxTransaction.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TaxTransaction) MarshalJSON() ([]byte, error) {
+	type taxTransaction TaxTransaction
+	v := struct {
+		Created  int64 `json:"created"`
+		PostedAt int64 `json:"posted_at"`
+		TaxDate  int64 `json:"tax_date"`
+		taxTransaction
+	}{
+		taxTransaction: (taxTransaction)(t),
+		Created:        t.Created.Unix(),
+		PostedAt:       t.PostedAt.Unix(),
+		TaxDate:        t.TaxDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/taxdeductedatsource.go
+++ b/taxdeductedatsource.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 type TaxDeductedAtSource struct {
 	// Unique identifier for the object.
@@ -14,9 +17,9 @@ type TaxDeductedAtSource struct {
 	// String representing the object's type. Objects of the same type share the same value.
 	Object string `json:"object"`
 	// The end of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period.
-	PeriodEnd int64 `json:"period_end"`
+	PeriodEnd time.Time `json:"period_end"`
 	// The start of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period.
-	PeriodStart int64 `json:"period_start"`
+	PeriodStart time.Time `json:"period_start"`
 	// The TAN that was supplied to Stripe when TDS was assessed
 	TaxDeductionAccountNumber string `json:"tax_deduction_account_number"`
 }
@@ -31,11 +34,38 @@ func (t *TaxDeductedAtSource) UnmarshalJSON(data []byte) error {
 	}
 
 	type taxDeductedAtSource TaxDeductedAtSource
-	var v taxDeductedAtSource
+	v := struct {
+		PeriodEnd   int64 `json:"period_end"`
+		PeriodStart int64 `json:"period_start"`
+		*taxDeductedAtSource
+	}{
+		taxDeductedAtSource: (*taxDeductedAtSource)(t),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*t = TaxDeductedAtSource(v)
+	t.PeriodEnd = time.Unix(v.PeriodEnd, 0)
+	t.PeriodStart = time.Unix(v.PeriodStart, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a TaxDeductedAtSource.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TaxDeductedAtSource) MarshalJSON() ([]byte, error) {
+	type taxDeductedAtSource TaxDeductedAtSource
+	v := struct {
+		PeriodEnd   int64 `json:"period_end"`
+		PeriodStart int64 `json:"period_start"`
+		taxDeductedAtSource
+	}{
+		taxDeductedAtSource: (taxDeductedAtSource)(t),
+		PeriodEnd:           t.PeriodEnd.Unix(),
+		PeriodStart:         t.PeriodStart.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/taxrate.go
+++ b/taxrate.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // The level of the jurisdiction that imposes this tax rate. Will be `null` for manually defined tax rates.
 type TaxRateJurisdictionLevel string
@@ -130,7 +133,7 @@ type TaxRate struct {
 	// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
 	Country string `json:"country"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// An arbitrary string attached to the tax rate for your internal use only. It will not be visible to your customers.
 	Description string `json:"description"`
 	// The display name of the tax rates as it will appear to your customer on their receipt email, PDF, and the hosted invoice page.
@@ -182,11 +185,34 @@ func (t *TaxRate) UnmarshalJSON(data []byte) error {
 	}
 
 	type taxRate TaxRate
-	var v taxRate
+	v := struct {
+		Created int64 `json:"created"`
+		*taxRate
+	}{
+		taxRate: (*taxRate)(t),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*t = TaxRate(v)
+	t.Created = time.Unix(v.Created, 0)
 	return nil
+}
+
+// MarshalJSON handles serialization of a TaxRate.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TaxRate) MarshalJSON() ([]byte, error) {
+	type taxRate TaxRate
+	v := struct {
+		Created int64 `json:"created"`
+		taxRate
+	}{
+		taxRate: (taxRate)(t),
+		Created: t.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/testhelpers_testclock.go
+++ b/testhelpers_testclock.go
@@ -6,7 +6,10 @@
 
 package stripe
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // The status of the Test Clock.
 type TestHelpersTestClockStatus string
@@ -24,7 +27,7 @@ type TestHelpersTestClockParams struct {
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// The initial frozen time for this test clock.
-	FrozenTime *int64 `form:"frozen_time"`
+	FrozenTime *time.Time `form:"frozen_time"`
 	// The name for this test clock.
 	Name *string `form:"name"`
 }
@@ -52,7 +55,7 @@ type TestHelpersTestClockAdvanceParams struct {
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
 	// The time to advance the test clock. Must be after the test clock's current frozen time. Cannot be more than two intervals in the future from the shortest subscription in this test clock. If there are no subscriptions in this test clock, it cannot be more than two years in the future.
-	FrozenTime *int64 `form:"frozen_time"`
+	FrozenTime *time.Time `form:"frozen_time"`
 }
 
 // AddExpand appends a new field to expand.
@@ -62,7 +65,7 @@ func (p *TestHelpersTestClockAdvanceParams) AddExpand(f string) {
 
 type TestHelpersTestClockStatusDetailsAdvancing struct {
 	// The `frozen_time` that the Test Clock is advancing towards.
-	TargetFrozenTime int64 `json:"target_frozen_time"`
+	TargetFrozenTime time.Time `json:"target_frozen_time"`
 }
 type TestHelpersTestClockStatusDetails struct {
 	Advancing *TestHelpersTestClockStatusDetailsAdvancing `json:"advancing"`
@@ -74,12 +77,12 @@ type TestHelpersTestClockStatusDetails struct {
 type TestHelpersTestClock struct {
 	APIResource
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
-	Deleted bool  `json:"deleted"`
+	Created time.Time `json:"created"`
+	Deleted bool      `json:"deleted"`
 	// Time at which this clock is scheduled to auto delete.
-	DeletesAfter int64 `json:"deletes_after"`
+	DeletesAfter time.Time `json:"deletes_after"`
 	// Time at which all objects belonging to this clock are frozen.
-	FrozenTime int64 `json:"frozen_time"`
+	FrozenTime time.Time `json:"frozen_time"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -110,11 +113,78 @@ func (t *TestHelpersTestClock) UnmarshalJSON(data []byte) error {
 	}
 
 	type testHelpersTestClock TestHelpersTestClock
-	var v testHelpersTestClock
+	v := struct {
+		Created      int64 `json:"created"`
+		DeletesAfter int64 `json:"deletes_after"`
+		FrozenTime   int64 `json:"frozen_time"`
+		*testHelpersTestClock
+	}{
+		testHelpersTestClock: (*testHelpersTestClock)(t),
+	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
-	*t = TestHelpersTestClock(v)
+	t.Created = time.Unix(v.Created, 0)
+	t.DeletesAfter = time.Unix(v.DeletesAfter, 0)
+	t.FrozenTime = time.Unix(v.FrozenTime, 0)
 	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TestHelpersTestClockStatusDetailsAdvancing.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TestHelpersTestClockStatusDetailsAdvancing) UnmarshalJSON(data []byte) error {
+	type testHelpersTestClockStatusDetailsAdvancing TestHelpersTestClockStatusDetailsAdvancing
+	v := struct {
+		TargetFrozenTime int64 `json:"target_frozen_time"`
+		*testHelpersTestClockStatusDetailsAdvancing
+	}{
+		testHelpersTestClockStatusDetailsAdvancing: (*testHelpersTestClockStatusDetailsAdvancing)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.TargetFrozenTime = time.Unix(v.TargetFrozenTime, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TestHelpersTestClockStatusDetailsAdvancing.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TestHelpersTestClockStatusDetailsAdvancing) MarshalJSON() ([]byte, error) {
+	type testHelpersTestClockStatusDetailsAdvancing TestHelpersTestClockStatusDetailsAdvancing
+	v := struct {
+		TargetFrozenTime int64 `json:"target_frozen_time"`
+		testHelpersTestClockStatusDetailsAdvancing
+	}{
+		testHelpersTestClockStatusDetailsAdvancing: (testHelpersTestClockStatusDetailsAdvancing)(t),
+		TargetFrozenTime: t.TargetFrozenTime.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a TestHelpersTestClock.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TestHelpersTestClock) MarshalJSON() ([]byte, error) {
+	type testHelpersTestClock TestHelpersTestClock
+	v := struct {
+		Created      int64 `json:"created"`
+		DeletesAfter int64 `json:"deletes_after"`
+		FrozenTime   int64 `json:"frozen_time"`
+		testHelpersTestClock
+	}{
+		testHelpersTestClock: (testHelpersTestClock)(t),
+		Created:              t.Created.Unix(),
+		DeletesAfter:         t.DeletesAfter.Unix(),
+		FrozenTime:           t.FrozenTime.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/testhelpersissuing_authorization.go
+++ b/testhelpersissuing_authorization.go
@@ -6,6 +6,8 @@
 
 package stripe
 
+import "time"
+
 // Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
 type TestHelpersIssuingAuthorizationAmountDetailsParams struct {
 	// The ATM withdrawal fee.
@@ -257,7 +259,7 @@ type TestHelpersIssuingAuthorizationCapturePurchaseDetailsFlightSegmentParams st
 // Information about the flight that was purchased with this transaction.
 type TestHelpersIssuingAuthorizationCapturePurchaseDetailsFlightParams struct {
 	// The time that the flight departed.
-	DepartureAt *int64 `form:"departure_at"`
+	DepartureAt *time.Time `form:"departure_at"`
 	// The name of the passenger.
 	PassengerName *string `form:"passenger_name"`
 	// Whether the ticket is refundable.
@@ -285,7 +287,7 @@ type TestHelpersIssuingAuthorizationCapturePurchaseDetailsFuelParams struct {
 // Information about lodging that was purchased with this transaction.
 type TestHelpersIssuingAuthorizationCapturePurchaseDetailsLodgingParams struct {
 	// The time of checking into the lodging.
-	CheckInAt *int64 `form:"check_in_at"`
+	CheckInAt *time.Time `form:"check_in_at"`
 	// The number of nights stayed at the lodging.
 	Nights *int64 `form:"nights"`
 }

--- a/testhelpersissuing_transaction.go
+++ b/testhelpersissuing_transaction.go
@@ -6,6 +6,8 @@
 
 package stripe
 
+import "time"
+
 // Refund a test-mode Transaction.
 type TestHelpersIssuingTransactionRefundParams struct {
 	Params `form:"*"`
@@ -117,7 +119,7 @@ type TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsFlightSegment
 // Information about the flight that was purchased with this transaction.
 type TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsFlightParams struct {
 	// The time that the flight departed.
-	DepartureAt *int64 `form:"departure_at"`
+	DepartureAt *time.Time `form:"departure_at"`
 	// The name of the passenger.
 	PassengerName *string `form:"passenger_name"`
 	// Whether the ticket is refundable.
@@ -145,7 +147,7 @@ type TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsFuelParams st
 // Information about lodging that was purchased with this transaction.
 type TestHelpersIssuingTransactionCreateForceCapturePurchaseDetailsLodgingParams struct {
 	// The time of checking into the lodging.
-	CheckInAt *int64 `form:"check_in_at"`
+	CheckInAt *time.Time `form:"check_in_at"`
 	// The number of nights stayed at the lodging.
 	Nights *int64 `form:"nights"`
 }
@@ -293,7 +295,7 @@ type TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsFlightSegme
 // Information about the flight that was purchased with this transaction.
 type TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsFlightParams struct {
 	// The time that the flight departed.
-	DepartureAt *int64 `form:"departure_at"`
+	DepartureAt *time.Time `form:"departure_at"`
 	// The name of the passenger.
 	PassengerName *string `form:"passenger_name"`
 	// Whether the ticket is refundable.
@@ -321,7 +323,7 @@ type TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsFuelParams 
 // Information about lodging that was purchased with this transaction.
 type TestHelpersIssuingTransactionCreateUnlinkedRefundPurchaseDetailsLodgingParams struct {
 	// The time of checking into the lodging.
-	CheckInAt *int64 `form:"check_in_at"`
+	CheckInAt *time.Time `form:"check_in_at"`
 	// The number of nights stayed at the lodging.
 	Nights *int64 `form:"nights"`
 }

--- a/treasury_creditreversal.go
+++ b/treasury_creditreversal.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The rails used to reverse the funds.
 type TreasuryCreditReversalNetwork string
 
@@ -70,7 +75,7 @@ func (p *TreasuryCreditReversalParams) AddMetadata(key string, value string) {
 
 type TreasuryCreditReversalStatusTransitions struct {
 	// Timestamp describing when the CreditReversal changed status to `posted`
-	PostedAt int64 `json:"posted_at"`
+	PostedAt time.Time `json:"posted_at"`
 }
 
 // You can reverse some [ReceivedCredits](https://stripe.com/docs/api#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
@@ -79,7 +84,7 @@ type TreasuryCreditReversal struct {
 	// Amount (in cents) transferred.
 	Amount int64 `json:"amount"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// The FinancialAccount to reverse funds from.
@@ -110,4 +115,76 @@ type TreasuryCreditReversalList struct {
 	APIResource
 	ListMeta
 	Data []*TreasuryCreditReversal `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryCreditReversalStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryCreditReversalStatusTransitions) UnmarshalJSON(data []byte) error {
+	type treasuryCreditReversalStatusTransitions TreasuryCreditReversalStatusTransitions
+	v := struct {
+		PostedAt int64 `json:"posted_at"`
+		*treasuryCreditReversalStatusTransitions
+	}{
+		treasuryCreditReversalStatusTransitions: (*treasuryCreditReversalStatusTransitions)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.PostedAt = time.Unix(v.PostedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryCreditReversal.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryCreditReversal) UnmarshalJSON(data []byte) error {
+	type treasuryCreditReversal TreasuryCreditReversal
+	v := struct {
+		Created int64 `json:"created"`
+		*treasuryCreditReversal
+	}{
+		treasuryCreditReversal: (*treasuryCreditReversal)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TreasuryCreditReversalStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryCreditReversalStatusTransitions) MarshalJSON() ([]byte, error) {
+	type treasuryCreditReversalStatusTransitions TreasuryCreditReversalStatusTransitions
+	v := struct {
+		PostedAt int64 `json:"posted_at"`
+		treasuryCreditReversalStatusTransitions
+	}{
+		treasuryCreditReversalStatusTransitions: (treasuryCreditReversalStatusTransitions)(t),
+		PostedAt:                                t.PostedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a TreasuryCreditReversal.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryCreditReversal) MarshalJSON() ([]byte, error) {
+	type treasuryCreditReversal TreasuryCreditReversal
+	v := struct {
+		Created int64 `json:"created"`
+		treasuryCreditReversal
+	}{
+		treasuryCreditReversal: (treasuryCreditReversal)(t),
+		Created:                t.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/treasury_debitreversal.go
+++ b/treasury_debitreversal.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The rails used to reverse the funds.
 type TreasuryDebitReversalNetwork string
 
@@ -77,7 +82,7 @@ type TreasuryDebitReversalLinkedFlows struct {
 }
 type TreasuryDebitReversalStatusTransitions struct {
 	// Timestamp describing when the DebitReversal changed status to `completed`.
-	CompletedAt int64 `json:"completed_at"`
+	CompletedAt time.Time `json:"completed_at"`
 }
 
 // You can reverse some [ReceivedDebits](https://stripe.com/docs/api#received_debits) depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of a new object known as a DebitReversal.
@@ -86,7 +91,7 @@ type TreasuryDebitReversal struct {
 	// Amount (in cents) transferred.
 	Amount int64 `json:"amount"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// The FinancialAccount to reverse funds from.
@@ -119,4 +124,76 @@ type TreasuryDebitReversalList struct {
 	APIResource
 	ListMeta
 	Data []*TreasuryDebitReversal `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryDebitReversalStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryDebitReversalStatusTransitions) UnmarshalJSON(data []byte) error {
+	type treasuryDebitReversalStatusTransitions TreasuryDebitReversalStatusTransitions
+	v := struct {
+		CompletedAt int64 `json:"completed_at"`
+		*treasuryDebitReversalStatusTransitions
+	}{
+		treasuryDebitReversalStatusTransitions: (*treasuryDebitReversalStatusTransitions)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.CompletedAt = time.Unix(v.CompletedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryDebitReversal.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryDebitReversal) UnmarshalJSON(data []byte) error {
+	type treasuryDebitReversal TreasuryDebitReversal
+	v := struct {
+		Created int64 `json:"created"`
+		*treasuryDebitReversal
+	}{
+		treasuryDebitReversal: (*treasuryDebitReversal)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TreasuryDebitReversalStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryDebitReversalStatusTransitions) MarshalJSON() ([]byte, error) {
+	type treasuryDebitReversalStatusTransitions TreasuryDebitReversalStatusTransitions
+	v := struct {
+		CompletedAt int64 `json:"completed_at"`
+		treasuryDebitReversalStatusTransitions
+	}{
+		treasuryDebitReversalStatusTransitions: (treasuryDebitReversalStatusTransitions)(t),
+		CompletedAt:                            t.CompletedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a TreasuryDebitReversal.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryDebitReversal) MarshalJSON() ([]byte, error) {
+	type treasuryDebitReversal TreasuryDebitReversal
+	v := struct {
+		Created int64 `json:"created"`
+		treasuryDebitReversal
+	}{
+		treasuryDebitReversal: (treasuryDebitReversal)(t),
+		Created:               t.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/treasury_financialaccount.go
+++ b/treasury_financialaccount.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The array of paths to active Features in the Features hash.
 type TreasuryFinancialAccountActiveFeature string
 
@@ -494,7 +499,7 @@ type TreasuryFinancialAccount struct {
 	// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
 	Country string `json:"country"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// The display name for the FinancialAccount. Use this field to customize the names of the FinancialAccounts for your connected accounts. Unlike the `nickname` field, `display_name` is not internal metadata and will be exposed to connected accounts.
 	DisplayName string `json:"display_name"`
 	// Encodes whether a FinancialAccount has access to a particular Feature, with a `status` enum and associated `status_details`.
@@ -531,4 +536,40 @@ type TreasuryFinancialAccountList struct {
 	APIResource
 	ListMeta
 	Data []*TreasuryFinancialAccount `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryFinancialAccount.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryFinancialAccount) UnmarshalJSON(data []byte) error {
+	type treasuryFinancialAccount TreasuryFinancialAccount
+	v := struct {
+		Created int64 `json:"created"`
+		*treasuryFinancialAccount
+	}{
+		treasuryFinancialAccount: (*treasuryFinancialAccount)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TreasuryFinancialAccount.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryFinancialAccount) MarshalJSON() ([]byte, error) {
+	type treasuryFinancialAccount TreasuryFinancialAccount
+	v := struct {
+		Created int64 `json:"created"`
+		treasuryFinancialAccount
+	}{
+		treasuryFinancialAccount: (treasuryFinancialAccount)(t),
+		Created:                  t.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/treasury_inboundtransfer.go
+++ b/treasury_inboundtransfer.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Reason for the failure.
 type TreasuryInboundTransferFailureDetailsCode string
 
@@ -178,11 +183,11 @@ type TreasuryInboundTransferOriginPaymentMethodDetails struct {
 }
 type TreasuryInboundTransferStatusTransitions struct {
 	// Timestamp describing when an InboundTransfer changed status to `canceled`.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// Timestamp describing when an InboundTransfer changed status to `failed`.
-	FailedAt int64 `json:"failed_at"`
+	FailedAt time.Time `json:"failed_at"`
 	// Timestamp describing when an InboundTransfer changed status to `succeeded`.
-	SucceededAt int64 `json:"succeeded_at"`
+	SucceededAt time.Time `json:"succeeded_at"`
 }
 
 // Use [InboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://stripe.com/docs/api#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
@@ -195,7 +200,7 @@ type TreasuryInboundTransfer struct {
 	// Returns `true` if the InboundTransfer is able to be canceled.
 	Cancelable bool `json:"cancelable"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// An arbitrary string attached to the object. Often useful for displaying to users.
@@ -235,4 +240,84 @@ type TreasuryInboundTransferList struct {
 	APIResource
 	ListMeta
 	Data []*TreasuryInboundTransfer `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryInboundTransferStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryInboundTransferStatusTransitions) UnmarshalJSON(data []byte) error {
+	type treasuryInboundTransferStatusTransitions TreasuryInboundTransferStatusTransitions
+	v := struct {
+		CanceledAt  int64 `json:"canceled_at"`
+		FailedAt    int64 `json:"failed_at"`
+		SucceededAt int64 `json:"succeeded_at"`
+		*treasuryInboundTransferStatusTransitions
+	}{
+		treasuryInboundTransferStatusTransitions: (*treasuryInboundTransferStatusTransitions)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.CanceledAt = time.Unix(v.CanceledAt, 0)
+	t.FailedAt = time.Unix(v.FailedAt, 0)
+	t.SucceededAt = time.Unix(v.SucceededAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryInboundTransfer.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryInboundTransfer) UnmarshalJSON(data []byte) error {
+	type treasuryInboundTransfer TreasuryInboundTransfer
+	v := struct {
+		Created int64 `json:"created"`
+		*treasuryInboundTransfer
+	}{
+		treasuryInboundTransfer: (*treasuryInboundTransfer)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TreasuryInboundTransferStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryInboundTransferStatusTransitions) MarshalJSON() ([]byte, error) {
+	type treasuryInboundTransferStatusTransitions TreasuryInboundTransferStatusTransitions
+	v := struct {
+		CanceledAt  int64 `json:"canceled_at"`
+		FailedAt    int64 `json:"failed_at"`
+		SucceededAt int64 `json:"succeeded_at"`
+		treasuryInboundTransferStatusTransitions
+	}{
+		treasuryInboundTransferStatusTransitions: (treasuryInboundTransferStatusTransitions)(t),
+		CanceledAt:                               t.CanceledAt.Unix(),
+		FailedAt:                                 t.FailedAt.Unix(),
+		SucceededAt:                              t.SucceededAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a TreasuryInboundTransfer.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryInboundTransfer) MarshalJSON() ([]byte, error) {
+	type treasuryInboundTransfer TreasuryInboundTransfer
+	v := struct {
+		Created int64 `json:"created"`
+		treasuryInboundTransfer
+	}{
+		treasuryInboundTransfer: (treasuryInboundTransfer)(t),
+		Created:                 t.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/treasury_outboundpayment.go
+++ b/treasury_outboundpayment.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // The rails used to send funds.
 type TreasuryOutboundPaymentDestinationPaymentMethodDetailsFinancialAccountNetwork string
 
@@ -292,13 +297,13 @@ type TreasuryOutboundPaymentReturnedDetails struct {
 }
 type TreasuryOutboundPaymentStatusTransitions struct {
 	// Timestamp describing when an OutboundPayment changed status to `canceled`.
-	CanceledAt int64 `json:"canceled_at"`
+	CanceledAt time.Time `json:"canceled_at"`
 	// Timestamp describing when an OutboundPayment changed status to `failed`.
-	FailedAt int64 `json:"failed_at"`
+	FailedAt time.Time `json:"failed_at"`
 	// Timestamp describing when an OutboundPayment changed status to `posted`.
-	PostedAt int64 `json:"posted_at"`
+	PostedAt time.Time `json:"posted_at"`
 	// Timestamp describing when an OutboundPayment changed status to `returned`.
-	ReturnedAt int64 `json:"returned_at"`
+	ReturnedAt time.Time `json:"returned_at"`
 }
 type TreasuryOutboundPaymentTrackingDetailsACH struct {
 	// ACH trace ID of the OutboundPayment for payments sent over the `ach` network.
@@ -333,7 +338,7 @@ type TreasuryOutboundPayment struct {
 	// Returns `true` if the object can be canceled, and `false` otherwise.
 	Cancelable bool `json:"cancelable"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// ID of the [customer](https://stripe.com/docs/api/customers) to whom an OutboundPayment is sent.
@@ -347,7 +352,7 @@ type TreasuryOutboundPayment struct {
 	// Details about the end user.
 	EndUserDetails *TreasuryOutboundPaymentEndUserDetails `json:"end_user_details"`
 	// The date when funds are expected to arrive in the destination account.
-	ExpectedArrivalDate int64 `json:"expected_arrival_date"`
+	ExpectedArrivalDate time.Time `json:"expected_arrival_date"`
 	// The FinancialAccount that funds were pulled from.
 	FinancialAccount string `json:"financial_account"`
 	// A [hosted transaction receipt](https://stripe.com/docs/treasury/moving-money/regulatory-receipts) URL that is provided when money movement is considered regulated under Stripe's money transmission licenses.
@@ -378,4 +383,92 @@ type TreasuryOutboundPaymentList struct {
 	APIResource
 	ListMeta
 	Data []*TreasuryOutboundPayment `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryOutboundPaymentStatusTransitions.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryOutboundPaymentStatusTransitions) UnmarshalJSON(data []byte) error {
+	type treasuryOutboundPaymentStatusTransitions TreasuryOutboundPaymentStatusTransitions
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		FailedAt   int64 `json:"failed_at"`
+		PostedAt   int64 `json:"posted_at"`
+		ReturnedAt int64 `json:"returned_at"`
+		*treasuryOutboundPaymentStatusTransitions
+	}{
+		treasuryOutboundPaymentStatusTransitions: (*treasuryOutboundPaymentStatusTransitions)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.CanceledAt = time.Unix(v.CanceledAt, 0)
+	t.FailedAt = time.Unix(v.FailedAt, 0)
+	t.PostedAt = time.Unix(v.PostedAt, 0)
+	t.ReturnedAt = time.Unix(v.ReturnedAt, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryOutboundPayment.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryOutboundPayment) UnmarshalJSON(data []byte) error {
+	type treasuryOutboundPayment TreasuryOutboundPayment
+	v := struct {
+		Created             int64 `json:"created"`
+		ExpectedArrivalDate int64 `json:"expected_arrival_date"`
+		*treasuryOutboundPayment
+	}{
+		treasuryOutboundPayment: (*treasuryOutboundPayment)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Created = time.Unix(v.Created, 0)
+	t.ExpectedArrivalDate = time.Unix(v.ExpectedArrivalDate, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TreasuryOutboundPaymentStatusTransitions.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryOutboundPaymentStatusTransitions) MarshalJSON() ([]byte, error) {
+	type treasuryOutboundPaymentStatusTransitions TreasuryOutboundPaymentStatusTransitions
+	v := struct {
+		CanceledAt int64 `json:"canceled_at"`
+		FailedAt   int64 `json:"failed_at"`
+		PostedAt   int64 `json:"posted_at"`
+		ReturnedAt int64 `json:"returned_at"`
+		treasuryOutboundPaymentStatusTransitions
+	}{
+		treasuryOutboundPaymentStatusTransitions: (treasuryOutboundPaymentStatusTransitions)(t),
+		CanceledAt:                               t.CanceledAt.Unix(),
+		FailedAt:                                 t.FailedAt.Unix(),
+		PostedAt:                                 t.PostedAt.Unix(),
+		ReturnedAt:                               t.ReturnedAt.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a TreasuryOutboundPayment.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryOutboundPayment) MarshalJSON() ([]byte, error) {
+	type treasuryOutboundPayment TreasuryOutboundPayment
+	v := struct {
+		Created             int64 `json:"created"`
+		ExpectedArrivalDate int64 `json:"expected_arrival_date"`
+		treasuryOutboundPayment
+	}{
+		treasuryOutboundPayment: (treasuryOutboundPayment)(t),
+		Created:                 t.Created.Unix(),
+		ExpectedArrivalDate:     t.ExpectedArrivalDate.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/treasury_receivedcredit.go
+++ b/treasury_receivedcredit.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Reason for the failure. A ReceivedCredit might fail because the receiving FinancialAccount is closed or frozen.
 type TreasuryReceivedCreditFailureCode string
 
@@ -226,7 +231,7 @@ type TreasuryReceivedCreditNetworkDetails struct {
 // Details describing when a ReceivedCredit may be reversed.
 type TreasuryReceivedCreditReversalDetails struct {
 	// Time before which a ReceivedCredit can be reversed.
-	Deadline int64 `json:"deadline"`
+	Deadline time.Time `json:"deadline"`
 	// Set if a ReceivedCredit cannot be reversed.
 	RestrictedReason TreasuryReceivedCreditReversalDetailsRestrictedReason `json:"restricted_reason"`
 }
@@ -237,7 +242,7 @@ type TreasuryReceivedCredit struct {
 	// Amount (in cents) transferred.
 	Amount int64 `json:"amount"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// An arbitrary string attached to the object. Often useful for displaying to users.
@@ -273,4 +278,76 @@ type TreasuryReceivedCreditList struct {
 	APIResource
 	ListMeta
 	Data []*TreasuryReceivedCredit `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryReceivedCreditReversalDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryReceivedCreditReversalDetails) UnmarshalJSON(data []byte) error {
+	type treasuryReceivedCreditReversalDetails TreasuryReceivedCreditReversalDetails
+	v := struct {
+		Deadline int64 `json:"deadline"`
+		*treasuryReceivedCreditReversalDetails
+	}{
+		treasuryReceivedCreditReversalDetails: (*treasuryReceivedCreditReversalDetails)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Deadline = time.Unix(v.Deadline, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryReceivedCredit.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryReceivedCredit) UnmarshalJSON(data []byte) error {
+	type treasuryReceivedCredit TreasuryReceivedCredit
+	v := struct {
+		Created int64 `json:"created"`
+		*treasuryReceivedCredit
+	}{
+		treasuryReceivedCredit: (*treasuryReceivedCredit)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TreasuryReceivedCreditReversalDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryReceivedCreditReversalDetails) MarshalJSON() ([]byte, error) {
+	type treasuryReceivedCreditReversalDetails TreasuryReceivedCreditReversalDetails
+	v := struct {
+		Deadline int64 `json:"deadline"`
+		treasuryReceivedCreditReversalDetails
+	}{
+		treasuryReceivedCreditReversalDetails: (treasuryReceivedCreditReversalDetails)(t),
+		Deadline:                              t.Deadline.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a TreasuryReceivedCredit.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryReceivedCredit) MarshalJSON() ([]byte, error) {
+	type treasuryReceivedCredit TreasuryReceivedCredit
+	v := struct {
+		Created int64 `json:"created"`
+		treasuryReceivedCredit
+	}{
+		treasuryReceivedCredit: (treasuryReceivedCredit)(t),
+		Created:                t.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/treasury_receiveddebit.go
+++ b/treasury_receiveddebit.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // Reason for the failure. A ReceivedDebit might fail because the FinancialAccount doesn't have sufficient funds, is closed, or is frozen.
 type TreasuryReceivedDebitFailureCode string
 
@@ -177,7 +182,7 @@ type TreasuryReceivedDebitNetworkDetails struct {
 // Details describing when a ReceivedDebit might be reversed.
 type TreasuryReceivedDebitReversalDetails struct {
 	// Time before which a ReceivedDebit can be reversed.
-	Deadline int64 `json:"deadline"`
+	Deadline time.Time `json:"deadline"`
 	// Set if a ReceivedDebit can't be reversed.
 	RestrictedReason TreasuryReceivedDebitReversalDetailsRestrictedReason `json:"restricted_reason"`
 }
@@ -188,7 +193,7 @@ type TreasuryReceivedDebit struct {
 	// Amount (in cents) transferred.
 	Amount int64 `json:"amount"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
+	Created time.Time `json:"created"`
 	// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
 	Currency Currency `json:"currency"`
 	// An arbitrary string attached to the object. Often useful for displaying to users.
@@ -224,4 +229,76 @@ type TreasuryReceivedDebitList struct {
 	APIResource
 	ListMeta
 	Data []*TreasuryReceivedDebit `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryReceivedDebitReversalDetails.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryReceivedDebitReversalDetails) UnmarshalJSON(data []byte) error {
+	type treasuryReceivedDebitReversalDetails TreasuryReceivedDebitReversalDetails
+	v := struct {
+		Deadline int64 `json:"deadline"`
+		*treasuryReceivedDebitReversalDetails
+	}{
+		treasuryReceivedDebitReversalDetails: (*treasuryReceivedDebitReversalDetails)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Deadline = time.Unix(v.Deadline, 0)
+	return nil
+}
+
+// UnmarshalJSON handles deserialization of a TreasuryReceivedDebit.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (t *TreasuryReceivedDebit) UnmarshalJSON(data []byte) error {
+	type treasuryReceivedDebit TreasuryReceivedDebit
+	v := struct {
+		Created int64 `json:"created"`
+		*treasuryReceivedDebit
+	}{
+		treasuryReceivedDebit: (*treasuryReceivedDebit)(t),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	t.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a TreasuryReceivedDebitReversalDetails.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryReceivedDebitReversalDetails) MarshalJSON() ([]byte, error) {
+	type treasuryReceivedDebitReversalDetails TreasuryReceivedDebitReversalDetails
+	v := struct {
+		Deadline int64 `json:"deadline"`
+		treasuryReceivedDebitReversalDetails
+	}{
+		treasuryReceivedDebitReversalDetails: (treasuryReceivedDebitReversalDetails)(t),
+		Deadline:                             t.Deadline.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// MarshalJSON handles serialization of a TreasuryReceivedDebit.
+// This custom marshaling is needed to handle the time fields correctly.
+func (t TreasuryReceivedDebit) MarshalJSON() ([]byte, error) {
+	type treasuryReceivedDebit TreasuryReceivedDebit
+	v := struct {
+		Created int64 `json:"created"`
+		treasuryReceivedDebit
+	}{
+		treasuryReceivedDebit: (treasuryReceivedDebit)(t),
+		Created:               t.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/usagerecord.go
+++ b/usagerecord.go
@@ -6,7 +6,11 @@
 
 package stripe
 
-import "github.com/stripe/stripe-go/v81/form"
+import (
+	"encoding/json"
+	"github.com/stripe/stripe-go/v81/form"
+	"time"
+)
 
 // Possible values for the action parameter on usage record creation.
 const (
@@ -31,8 +35,8 @@ type UsageRecordParams struct {
 	// The usage quantity for the specified timestamp.
 	Quantity *int64 `form:"quantity"`
 	// The timestamp for the usage event. This timestamp must be within the current billing period of the subscription of the provided `subscription_item`, and must not be in the future. When passing `"now"`, Stripe records usage for the current time. Default is `"now"` if a value is not provided.
-	Timestamp    *int64 `form:"timestamp"`
-	TimestampNow *bool  `form:"-"` // See custom AppendTo
+	Timestamp    *time.Time `form:"timestamp"`
+	TimestampNow *bool      `form:"-"` // See custom AppendTo
 }
 
 // AddExpand appends a new field to expand.
@@ -66,5 +70,41 @@ type UsageRecord struct {
 	// The ID of the subscription item this usage record contains data for.
 	SubscriptionItem string `json:"subscription_item"`
 	// The timestamp when this usage occurred.
-	Timestamp int64 `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// UnmarshalJSON handles deserialization of an UsageRecord.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (u *UsageRecord) UnmarshalJSON(data []byte) error {
+	type usageRecord UsageRecord
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		*usageRecord
+	}{
+		usageRecord: (*usageRecord)(u),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	u.Timestamp = time.Unix(v.Timestamp, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of an UsageRecord.
+// This custom marshaling is needed to handle the time fields correctly.
+func (u UsageRecord) MarshalJSON() ([]byte, error) {
+	type usageRecord UsageRecord
+	v := struct {
+		Timestamp int64 `json:"timestamp"`
+		usageRecord
+	}{
+		usageRecord: (usageRecord)(u),
+		Timestamp:   u.Timestamp.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }

--- a/usagerecord/client_test.go
+++ b/usagerecord/client_test.go
@@ -10,10 +10,9 @@ import (
 )
 
 func TestUsageRecordNew(t *testing.T) {
-	now := int64(time.Now().Unix())
 	usageRecord, err := New(&stripe.UsageRecordParams{
 		Quantity:         stripe.Int64(123),
-		Timestamp:        stripe.Int64(now),
+		Timestamp:        stripe.Time(time.Now()),
 		Action:           stripe.String(stripe.UsageRecordActionIncrement),
 		SubscriptionItem: stripe.String("si_123"),
 	})

--- a/usagerecord_test.go
+++ b/usagerecord_test.go
@@ -17,7 +17,7 @@ func TestUsageRecordParams_AppendTo(t *testing.T) {
 		{"action", &UsageRecordParams{Action: String("increment")}, "increment"},
 		{"quantity", &UsageRecordParams{Quantity: Int64(2000)}, strconv.FormatUint(2000, 10)},
 		{"quantity", &UsageRecordParams{Quantity: Int64(0)}, strconv.FormatUint(0, 10)},
-		{"timestamp", &UsageRecordParams{Timestamp: Int64(123123123)}, strconv.FormatUint(123123123, 10)},
+		{"timestamp", &UsageRecordParams{Timestamp: UnixTime(123123123)}, strconv.FormatUint(123123123, 10)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.field, func(t *testing.T) {

--- a/webhookendpoint.go
+++ b/webhookendpoint.go
@@ -6,6 +6,11 @@
 
 package stripe
 
+import (
+	"encoding/json"
+	"time"
+)
+
 // You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.
 type WebhookEndpointParams struct {
 	Params `form:"*"`
@@ -69,8 +74,8 @@ type WebhookEndpoint struct {
 	// The ID of the associated Connect application.
 	Application string `json:"application"`
 	// Time at which the object was created. Measured in seconds since the Unix epoch.
-	Created int64 `json:"created"`
-	Deleted bool  `json:"deleted"`
+	Created time.Time `json:"created"`
+	Deleted bool      `json:"deleted"`
 	// An optional description of what the webhook is used for.
 	Description string `json:"description"`
 	// The list of events to enable for this endpoint. `['*']` indicates that all events are enabled, except those that require explicit selection.
@@ -96,4 +101,40 @@ type WebhookEndpointList struct {
 	APIResource
 	ListMeta
 	Data []*WebhookEndpoint `json:"data"`
+}
+
+// UnmarshalJSON handles deserialization of a WebhookEndpoint.
+// This custom unmarshaling is needed to handle the time fields correctly.
+func (w *WebhookEndpoint) UnmarshalJSON(data []byte) error {
+	type webhookEndpoint WebhookEndpoint
+	v := struct {
+		Created int64 `json:"created"`
+		*webhookEndpoint
+	}{
+		webhookEndpoint: (*webhookEndpoint)(w),
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	w.Created = time.Unix(v.Created, 0)
+	return nil
+}
+
+// MarshalJSON handles serialization of a WebhookEndpoint.
+// This custom marshaling is needed to handle the time fields correctly.
+func (w WebhookEndpoint) MarshalJSON() ([]byte, error) {
+	type webhookEndpoint WebhookEndpoint
+	v := struct {
+		Created int64 `json:"created"`
+		webhookEndpoint
+	}{
+		webhookEndpoint: (webhookEndpoint)(w),
+		Created:         w.Created.Unix(),
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
This change supports codegen changes that converts datetime fields from `int64` to `time.Time` as brought up in this issue:  https://github.com/stripe/stripe-go/issues/1205.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
* The main change is in the form serialization in `form.go` for `time.Time` fields. Serialization is performed by reflection, and we do not want the default behavior of inspecting into a `time.Time` type, rather just convert it to an `int64`
* While I was in there, I also created convenience method `Time`, `TimeValue`, `UnixTime` and `UnixValue` to help in creating `time.Time` and `*time.Time` parameter fields
* I also updated unit tests expecting an `int64` type

### See Also
<!-- Include any links or additional information that help explain this change. -->
*  https://github.com/stripe/stripe-go/issues/1205