### PR TITLE
Add usage data for stripe client usage

### DIFF
--- a/account/client_test.go
+++ b/account/client_test.go
@@ -10,28 +10,28 @@ import (
 )
 
 func TestAccountDel(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	account, err := sc.Accounts.Del("acct_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, account)
 }
 
 func TestAccountGet(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	account, err := sc.Accounts.Get()
 	assert.Nil(t, err)
 	assert.NotNil(t, account)
 }
 
 func TestAccountGetByID(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	account, err := sc.Accounts.GetByID("acct_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, account)
 }
 
 func TestAccountList(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	i := sc.Accounts.List(&stripe.AccountListParams{})
 
 	// Verify that we can get at least one account
@@ -42,7 +42,7 @@ func TestAccountList(t *testing.T) {
 }
 
 func TestAccountNew(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	account, err := sc.Accounts.New(&stripe.AccountParams{
 		BusinessProfile: &stripe.AccountBusinessProfileParams{
 			Name:         stripe.String("name"),
@@ -109,7 +109,7 @@ func TestAccountNew(t *testing.T) {
 }
 
 func TestAccountReject(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	account, err := sc.Accounts.Reject("acct_123", &stripe.AccountRejectParams{
 		Reason: stripe.String("fraud"),
 	})
@@ -118,7 +118,7 @@ func TestAccountReject(t *testing.T) {
 }
 
 func TestAccountUpdate(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	account, err := sc.Accounts.Update("acct_123", &stripe.AccountParams{
 		Company: &stripe.AccountCompanyParams{
 			Address: &stripe.AddressParams{

--- a/account/client_test.go
+++ b/account/client_test.go
@@ -1,33 +1,38 @@
-package account
+package account_test
 
 import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go/v81"
-	_ "github.com/stripe/stripe-go/v81/testing"
+	"github.com/stripe/stripe-go/v81/client"
+	. "github.com/stripe/stripe-go/v81/testing"
 )
 
 func TestAccountDel(t *testing.T) {
-	account, err := Del("acct_123", nil)
+	sc := client.New(TestApiKey, nil)
+	account, err := sc.Accounts.Del("acct_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, account)
 }
 
 func TestAccountGet(t *testing.T) {
-	account, err := Get()
+	sc := client.New(TestApiKey, nil)
+	account, err := sc.Accounts.Get()
 	assert.Nil(t, err)
 	assert.NotNil(t, account)
 }
 
 func TestAccountGetByID(t *testing.T) {
-	account, err := GetByID("acct_123", nil)
+	sc := client.New(TestApiKey, nil)
+	account, err := sc.Accounts.GetByID("acct_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, account)
 }
 
 func TestAccountList(t *testing.T) {
-	i := List(&stripe.AccountListParams{})
+	sc := client.New(TestApiKey, nil)
+	i := sc.Accounts.List(&stripe.AccountListParams{})
 
 	// Verify that we can get at least one account
 	assert.True(t, i.Next())
@@ -37,7 +42,8 @@ func TestAccountList(t *testing.T) {
 }
 
 func TestAccountNew(t *testing.T) {
-	account, err := New(&stripe.AccountParams{
+	sc := client.New(TestApiKey, nil)
+	account, err := sc.Accounts.New(&stripe.AccountParams{
 		BusinessProfile: &stripe.AccountBusinessProfileParams{
 			Name:         stripe.String("name"),
 			SupportEmail: stripe.String("foo@bar.com"),
@@ -103,7 +109,8 @@ func TestAccountNew(t *testing.T) {
 }
 
 func TestAccountReject(t *testing.T) {
-	account, err := Reject("acct_123", &stripe.AccountRejectParams{
+	sc := client.New(TestApiKey, nil)
+	account, err := sc.Accounts.Reject("acct_123", &stripe.AccountRejectParams{
 		Reason: stripe.String("fraud"),
 	})
 	assert.Nil(t, err)
@@ -111,7 +118,8 @@ func TestAccountReject(t *testing.T) {
 }
 
 func TestAccountUpdate(t *testing.T) {
-	account, err := Update("acct_123", &stripe.AccountParams{
+	sc := client.New(TestApiKey, nil)
+	account, err := sc.Accounts.Update("acct_123", &stripe.AccountParams{
 		Company: &stripe.AccountCompanyParams{
 			Address: &stripe.AddressParams{
 				Country:    stripe.String("CA"),

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestChargeCapture(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	charge, err := sc.Charges.Capture("ch_123", &stripe.ChargeCaptureParams{
 		Amount: stripe.Int64(123),
 	})
@@ -19,14 +19,14 @@ func TestChargeCapture(t *testing.T) {
 }
 
 func TestChargeGet(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	charge, err := sc.Charges.Get("ch_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)
 }
 
 func TestChargeList(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	i := sc.Charges.List(&stripe.ChargeListParams{})
 
 	// Verify that we can get at least one charge
@@ -37,7 +37,7 @@ func TestChargeList(t *testing.T) {
 }
 
 func TestChargeSearch(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	i := sc.Charges.Search(&stripe.ChargeSearchParams{SearchParams: stripe.SearchParams{
 		Query: "currency:\"USD\"",
 	}})
@@ -51,7 +51,7 @@ func TestChargeSearch(t *testing.T) {
 }
 
 func TestChargeNew(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	charge, err := sc.Charges.New(&stripe.ChargeParams{
 		Amount:   stripe.Int64(11700),
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
@@ -70,7 +70,7 @@ func TestChargeNew(t *testing.T) {
 }
 
 func TestChargeUpdate(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	charge, err := sc.Charges.Update("ch_123", &stripe.ChargeParams{
 		Description: stripe.String("Updated description"),
 	})

--- a/charge/client_test.go
+++ b/charge/client_test.go
@@ -1,15 +1,17 @@
-package charge
+package charge_test
 
 import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go/v81"
-	_ "github.com/stripe/stripe-go/v81/testing"
+	"github.com/stripe/stripe-go/v81/client"
+	. "github.com/stripe/stripe-go/v81/testing"
 )
 
 func TestChargeCapture(t *testing.T) {
-	charge, err := Capture("ch_123", &stripe.ChargeCaptureParams{
+	sc := client.New(TestApiKey, nil)
+	charge, err := sc.Charges.Capture("ch_123", &stripe.ChargeCaptureParams{
 		Amount: stripe.Int64(123),
 	})
 	assert.Nil(t, err)
@@ -17,13 +19,15 @@ func TestChargeCapture(t *testing.T) {
 }
 
 func TestChargeGet(t *testing.T) {
-	charge, err := Get("ch_123", nil)
+	sc := client.New(TestApiKey, nil)
+	charge, err := sc.Charges.Get("ch_123", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, charge)
 }
 
 func TestChargeList(t *testing.T) {
-	i := List(&stripe.ChargeListParams{})
+	sc := client.New(TestApiKey, nil)
+	i := sc.Charges.List(&stripe.ChargeListParams{})
 
 	// Verify that we can get at least one charge
 	assert.True(t, i.Next())
@@ -33,7 +37,8 @@ func TestChargeList(t *testing.T) {
 }
 
 func TestChargeSearch(t *testing.T) {
-	i := Search(&stripe.ChargeSearchParams{SearchParams: stripe.SearchParams{
+	sc := client.New(TestApiKey, nil)
+	i := sc.Charges.Search(&stripe.ChargeSearchParams{SearchParams: stripe.SearchParams{
 		Query: "currency:\"USD\"",
 	}})
 
@@ -46,7 +51,8 @@ func TestChargeSearch(t *testing.T) {
 }
 
 func TestChargeNew(t *testing.T) {
-	charge, err := New(&stripe.ChargeParams{
+	sc := client.New(TestApiKey, nil)
+	charge, err := sc.Charges.New(&stripe.ChargeParams{
 		Amount:   stripe.Int64(11700),
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
 		Source:   &stripe.PaymentSourceSourceParams{Token: stripe.String("src_123")},
@@ -64,7 +70,8 @@ func TestChargeNew(t *testing.T) {
 }
 
 func TestChargeUpdate(t *testing.T) {
-	charge, err := Update("ch_123", &stripe.ChargeParams{
+	sc := client.New(TestApiKey, nil)
+	charge, err := sc.Charges.Update("ch_123", &stripe.ChargeParams{
 		Description: stripe.String("Updated description"),
 	})
 	assert.Nil(t, err)

--- a/client/api.go
+++ b/client/api.go
@@ -425,7 +425,7 @@ type API struct {
 
 func (a *API) Init(key string, backends *stripe.Backends) {
 
-	usage := []string{"stripe_go_client"}
+	usage := []string{"stripe_client"}
 	if backends == nil {
 		backends = &stripe.Backends{
 			API:     &stripe.UsageBackend{B: stripe.GetBackend(stripe.APIBackend), Usage: usage},

--- a/client/api.go
+++ b/client/api.go
@@ -8,9 +8,6 @@
 package client
 
 import (
-	"bytes"
-	"reflect"
-
 	stripe "github.com/stripe/stripe-go/v81"
 	"github.com/stripe/stripe-go/v81/account"
 	"github.com/stripe/stripe-go/v81/accountlink"
@@ -58,7 +55,6 @@ import (
 	financialconnectionsaccount "github.com/stripe/stripe-go/v81/financialconnections/account"
 	financialconnectionssession "github.com/stripe/stripe-go/v81/financialconnections/session"
 	financialconnectionstransaction "github.com/stripe/stripe-go/v81/financialconnections/transaction"
-	"github.com/stripe/stripe-go/v81/form"
 	forwardingrequest "github.com/stripe/stripe-go/v81/forwarding/request"
 	identityverificationreport "github.com/stripe/stripe-go/v81/identity/verificationreport"
 	identityverificationsession "github.com/stripe/stripe-go/v81/identity/verificationsession"
@@ -432,9 +428,9 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	usage := []string{"stripe_go_client"}
 	if backends == nil {
 		backends = &stripe.Backends{
-			API:     &usageBackend{b: stripe.GetBackend(stripe.APIBackend), usage: usage},
-			Connect: &usageBackend{b: stripe.GetBackend(stripe.ConnectBackend), usage: usage},
-			Uploads: &usageBackend{b: stripe.GetBackend(stripe.UploadsBackend), usage: usage},
+			API:     &stripe.UsageBackend{B: stripe.GetBackend(stripe.APIBackend), Usage: usage},
+			Connect: &stripe.UsageBackend{B: stripe.GetBackend(stripe.ConnectBackend), Usage: usage},
+			Uploads: &stripe.UsageBackend{B: stripe.GetBackend(stripe.UploadsBackend), Usage: usage},
 		}
 	}
 
@@ -582,38 +578,4 @@ func New(key string, backends *stripe.Backends) *API {
 	api := API{}
 	api.Init(key, backends)
 	return &api
-}
-
-// usageBackend is a wrapper for stripe.Backend that sets the usage parameter
-type usageBackend struct {
-	b     stripe.Backend
-	usage []string
-}
-
-func (u *usageBackend) Call(method, path, key string, params stripe.ParamsContainer, v stripe.LastResponseSetter) error {
-	if r := reflect.ValueOf(params); r.Kind() == reflect.Ptr && !r.IsNil() {
-		params.GetParams().InternalSetUsage(u.usage)
-	}
-	return u.b.Call(method, path, key, params, v)
-}
-
-func (u *usageBackend) CallRaw(method, path, key string, body *form.Values, params *stripe.Params, v stripe.LastResponseSetter) error {
-	params.GetParams().InternalSetUsage(u.usage)
-	return u.b.CallRaw(method, path, key, body, params, v)
-}
-
-func (u *usageBackend) CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *stripe.Params, v stripe.LastResponseSetter) error {
-	params.GetParams().InternalSetUsage(u.usage)
-	return u.b.CallMultipart(method, path, key, boundary, body, params, v)
-}
-
-func (u *usageBackend) CallStreaming(method, path, key string, params stripe.ParamsContainer, v stripe.StreamingLastResponseSetter) error {
-	if r := reflect.ValueOf(params); r.Kind() == reflect.Ptr && !r.IsNil() {
-		params.GetParams().InternalSetUsage(u.usage)
-	}
-	return u.b.CallStreaming(method, path, key, params, v)
-}
-
-func (u *usageBackend) SetMaxNetworkRetries(maxNetworkRetries int64) {
-	u.b.SetMaxNetworkRetries(maxNetworkRetries)
 }

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -1,27 +1,31 @@
-package coupon
+package coupon_test
 
 import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go/v81"
-	_ "github.com/stripe/stripe-go/v81/testing"
+	"github.com/stripe/stripe-go/v81/client"
+	. "github.com/stripe/stripe-go/v81/testing"
 )
 
 func TestCouponDel(t *testing.T) {
-	coupon, err := Del("25OFF", nil)
+	sc := client.New(TestApiKey, nil)
+	coupon, err := sc.Coupons.Del("25OFF", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)
 }
 
 func TestCouponGet(t *testing.T) {
-	coupon, err := Get("25OFF", nil)
+	sc := client.New(TestApiKey, nil)
+	coupon, err := sc.Coupons.Get("25OFF", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)
 }
 
 func TestCouponList(t *testing.T) {
-	i := List(&stripe.CouponListParams{})
+	sc := client.New(TestApiKey, nil)
+	i := sc.Coupons.List(&stripe.CouponListParams{})
 
 	// Verify that we can get at least one coupon
 	assert.True(t, i.Next())
@@ -31,7 +35,8 @@ func TestCouponList(t *testing.T) {
 }
 
 func TestCouponNew(t *testing.T) {
-	coupon, err := New(&stripe.CouponParams{
+	sc := client.New(TestApiKey, nil)
+	coupon, err := sc.Coupons.New(&stripe.CouponParams{
 		AppliesTo: &stripe.CouponAppliesToParams{
 			Products: stripe.StringSlice([]string{
 				"prod_123",
@@ -49,7 +54,8 @@ func TestCouponNew(t *testing.T) {
 }
 
 func TestCouponUpdate(t *testing.T) {
-	coupon, err := Update("25OFF", &stripe.CouponParams{
+	sc := client.New(TestApiKey, nil)
+	coupon, err := sc.Coupons.Update("25OFF", &stripe.CouponParams{
 		Params: stripe.Params{
 			Metadata: map[string]string{
 				"foo": "bar",

--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -10,21 +10,21 @@ import (
 )
 
 func TestCouponDel(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	coupon, err := sc.Coupons.Del("25OFF", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)
 }
 
 func TestCouponGet(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	coupon, err := sc.Coupons.Get("25OFF", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)
 }
 
 func TestCouponList(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	i := sc.Coupons.List(&stripe.CouponListParams{})
 
 	// Verify that we can get at least one coupon
@@ -35,7 +35,7 @@ func TestCouponList(t *testing.T) {
 }
 
 func TestCouponNew(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	coupon, err := sc.Coupons.New(&stripe.CouponParams{
 		AppliesTo: &stripe.CouponAppliesToParams{
 			Products: stripe.StringSlice([]string{
@@ -54,7 +54,7 @@ func TestCouponNew(t *testing.T) {
 }
 
 func TestCouponUpdate(t *testing.T) {
-	sc := client.New(TestApiKey, nil)
+	sc := client.New(TestAPIKey, nil)
 	coupon, err := sc.Coupons.Update("25OFF", &stripe.CouponParams{
 		Params: stripe.Params{
 			Metadata: map[string]string{

--- a/params.go
+++ b/params.go
@@ -220,7 +220,7 @@ func (p *Params) AddExpand(f string) {
 // InternalSetUsage sets the usage field on the Params struct.
 // Unstable: for internal stripe-go usage only.
 func (p *Params) InternalSetUsage(usage []string) {
-	p.usage = usage
+	p.usage = append(p.usage, usage...)
 }
 
 // AddExtra adds a new arbitrary key-value pair to the request data

--- a/stripe.go
+++ b/stripe.go
@@ -1608,3 +1608,37 @@ func RawRequest(method, path string, content string, params *RawParams) (*APIRes
 	}
 	return nil, fmt.Errorf("Error: cannot call RawRequest if backends.API is initialized with a backend that doesn't implement RawRequestBackend")
 }
+
+// UsageBackend is a wrapper for stripe.Backend that sets the usage parameter
+type UsageBackend struct {
+	B     Backend
+	Usage []string
+}
+
+func (u *UsageBackend) Call(method, path, key string, params ParamsContainer, v LastResponseSetter) error {
+	if r := reflect.ValueOf(params); r.Kind() == reflect.Ptr && !r.IsNil() {
+		params.GetParams().InternalSetUsage(u.Usage)
+	}
+	return u.B.Call(method, path, key, params, v)
+}
+
+func (u *UsageBackend) CallRaw(method, path, key string, body *form.Values, params *Params, v LastResponseSetter) error {
+	params.GetParams().InternalSetUsage(u.Usage)
+	return u.B.CallRaw(method, path, key, body, params, v)
+}
+
+func (u *UsageBackend) CallMultipart(method, path, key, boundary string, body *bytes.Buffer, params *Params, v LastResponseSetter) error {
+	params.GetParams().InternalSetUsage(u.Usage)
+	return u.B.CallMultipart(method, path, key, boundary, body, params, v)
+}
+
+func (u *UsageBackend) CallStreaming(method, path, key string, params ParamsContainer, v StreamingLastResponseSetter) error {
+	if r := reflect.ValueOf(params); r.Kind() == reflect.Ptr && !r.IsNil() {
+		params.GetParams().InternalSetUsage(u.Usage)
+	}
+	return u.B.CallStreaming(method, path, key, params, v)
+}
+
+func (u *UsageBackend) SetMaxNetworkRetries(maxNetworkRetries int64) {
+	u.B.SetMaxNetworkRetries(maxNetworkRetries)
+}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -30,6 +30,9 @@ const (
 	// TestMerchantID is a token that can be used to represent a merchant ID in
 	// simple tests.
 	TestMerchantID = "acct_123"
+
+	// TestAPIKey is an API key that can be used against stripe-mock in tests.
+	TestAPIKey = "sk_test_myTestKey"
 )
 
 func init() {
@@ -82,7 +85,7 @@ func init() {
 		os.Exit(1)
 	}
 
-	stripe.Key = "sk_test_myTestKey"
+	stripe.Key = TestAPIKey
 
 	// Configure a backend for stripe-mock and set it for both the API and
 	// Uploads (unlike the real Stripe API, stripe-mock supports both these


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
We would like to get a better sense of how many users are using Stripe Clients (aka. `client.API`) vs the global client. This will help us better inform how to update documentation and consider possible changes to the Stripe Client going forward.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
This sends the string `stripe_client` to telemetry statistics when they are enabled when a Stripe Client was used for that request. It does this by wrapping the existing `Backend`s with a `usageBackend` that sets the string `stripe_client` on requests. This string is not sent on the global client, so we can distinguish the two.

I also updated a few random tests to use the Stripe Client to add some additional test coverage for this change.

## Changelog
* Add telemetry for usage of the Stripe Client
