### PR TITLE
Update behavior of AddBetaHeader

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -1425,7 +1425,7 @@ func AddBetaVersion(betaName string, betaVersion string) error {
 		return errors.New("beta version should start with 'v' followed by a number")
 	}
 
-	parts := strings.Split(apiVersionWithBetaHeaders, ";")
+	parts := strings.Split(apiVersionWithBetaHeaders, "; ")
 	updated := false
 
 	for i, part := range parts {
@@ -1448,7 +1448,7 @@ func AddBetaVersion(betaName string, betaVersion string) error {
 	}
 
 	// Join the parts back together
-	apiVersionWithBetaHeaders = strings.Join(parts, ";")
+	apiVersionWithBetaHeaders = strings.Join(parts, "; ")
 	return nil
 }
 

--- a/stripe.go
+++ b/stripe.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1413,11 +1414,41 @@ func StringSlice(v []string) []*string {
 	return out
 }
 
+// AddBetaVersion adds or updates a beta version for a given beta feature in the API version string.
+// It ensures the beta version starts with 'v' followed by a number (e.g. "v2") and updates the API version string
+// with the highest version number for the given beta feature if there's a conflict.
 func AddBetaVersion(betaName string, betaVersion string) error {
-	if strings.Contains(apiVersionWithBetaHeaders, "; "+betaName+"=") {
-		return fmt.Errorf("Stripe version header %s already contains entry for beta %s", apiVersionWithBetaHeaders, betaName)
+	if !strings.HasPrefix(betaVersion, "v") {
+		return errors.New("beta version should start with 'v'")
 	}
-	apiVersionWithBetaHeaders = fmt.Sprintf("%s; %s=%s", apiVersionWithBetaHeaders, betaName, betaVersion)
+	if _, err := strconv.Atoi(betaVersion[1:]); err != nil {
+		return errors.New("beta version should start with 'v' followed by a number")
+	}
+
+	parts := strings.Split(apiVersionWithBetaHeaders, ";")
+	updated := false
+
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, betaName+"=") {
+			// Extract the existing version
+			existingVersion := strings.TrimPrefix(part, betaName+"=")
+			if betaVersion > existingVersion {
+				// Overwrite with the bigger version number
+				parts[i] = fmt.Sprintf("%s=%s", betaName, betaVersion)
+			}
+			updated = true
+			break
+		}
+	}
+
+	if !updated {
+		// Append the new betaName and betaVersion if not found
+		parts = append(parts, fmt.Sprintf("%s=%s", betaName, betaVersion))
+	}
+
+	// Join the parts back together
+	apiVersionWithBetaHeaders = strings.Join(parts, ";")
 	return nil
 }
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -58,6 +58,7 @@ func TestApiVersion(t *testing.T) {
 }
 
 func TestCanSetBetaHeaders(t *testing.T) {
+	defer cleanupBetaHeaders()
 	AddBetaVersion("feature_in_beta", "v3")
 
 	c := GetBackend(APIBackend).(*BackendImplementation)
@@ -66,25 +67,61 @@ func TestCanSetBetaHeaders(t *testing.T) {
 	req, err := c.NewRequest("", "", key, "", nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, APIVersion+"; feature_in_beta=v3", req.Header.Get("Stripe-Version"))
+	assert.Equal(t, APIVersion+";feature_in_beta=v3", req.Header.Get("Stripe-Version"))
+}
+
+func TestSetBetaVersionTwiceAsc(t *testing.T) {
+	defer cleanupBetaHeaders()
+	err := AddBetaVersion("feature_in_beta", "v3")
+	assert.Nil(t, err)
+	err = AddBetaVersion("feature_in_beta", "v5")
+	assert.Nil(t, err)
+
+	c := GetBackend(APIBackend).(*BackendImplementation)
+	key := "apiKey"
+
+	req, err := c.NewRequest("", "", key, "", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, APIVersion+";feature_in_beta=v5", req.Header.Get("Stripe-Version"))
 
 	// clean up
 	apiVersionWithBetaHeaders = APIVersion
 }
 
-func TestCannotSetSameBetaHeaderTwice(t *testing.T) {
-	err := AddBetaVersion("feature_in_beta", "v3")
+func TestSetBetaVersionTwiceDesc(t *testing.T) {
+	defer cleanupBetaHeaders()
+	err := AddBetaVersion("feature_in_beta", "v5")
+	assert.Nil(t, err)
+	err = AddBetaVersion("feature_in_beta", "v3")
 	assert.Nil(t, err)
 
-	err = AddBetaVersion("feature_in_beta", "v3")
+	c := GetBackend(APIBackend).(*BackendImplementation)
+	key := "apiKey"
 
-	assert.Contains(t, err.Error(), "already contains entry for beta feature_in_beta")
+	req, err := c.NewRequest("", "", key, "", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, APIVersion+";feature_in_beta=v5", req.Header.Get("Stripe-Version"))
+
+	// clean up
+	apiVersionWithBetaHeaders = APIVersion
+}
+
+func TestCannotSetSameBetaHeaderWithInvalidString(t *testing.T) {
+	defer cleanupBetaHeaders()
+	err := AddBetaVersion("feature_in_beta", "f3")
+	assert.Equal(t, err.Error(), "beta version should start with 'v'")
+
+	err = AddBetaVersion("feature_in_beta", "v3a")
+	assert.Equal(t, err.Error(), "beta version should start with 'v' followed by a number")
 
 	// clean up
 	apiVersionWithBetaHeaders = APIVersion
 }
 
 func TestCanSetSecondBetaHeaders(t *testing.T) {
+	defer cleanupBetaHeaders()
 	AddBetaVersion("feature_in_beta", "v3")
 	AddBetaVersion("second_feature_in_beta", "v2")
 
@@ -94,7 +131,7 @@ func TestCanSetSecondBetaHeaders(t *testing.T) {
 	req, err := c.NewRequest("", "", key, "", nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, APIVersion+"; feature_in_beta=v3; second_feature_in_beta=v2", req.Header.Get("Stripe-Version"))
+	assert.Equal(t, APIVersion+";feature_in_beta=v3;second_feature_in_beta=v2", req.Header.Get("Stripe-Version"))
 
 	// clean up
 	apiVersionWithBetaHeaders = APIVersion
@@ -1724,11 +1761,12 @@ func TestRawRequestTelemetry(t *testing.T) {
 }
 
 func TestAddBetaVersion(t *testing.T) {
+	defer cleanupBetaHeaders()
 	AddBetaVersion("feature_beta", "v3")
-	expectedAPIVersion := APIVersion + "; feature_beta=v3"
+	expectedAPIVersion := APIVersion + ";feature_beta=v3"
 	assert.Equal(t, expectedAPIVersion, apiVersionWithBetaHeaders)
 	err := AddBetaVersion("feature_beta", "v3")
-	assert.Equal(t, "Stripe version header "+expectedAPIVersion+" already contains entry for beta feature_beta", err.Error())
+	assert.Nil(t, err)
 }
 
 //
@@ -1739,4 +1777,8 @@ func TestAddBetaVersion(t *testing.T) {
 // which comes wrapper in a JSON object with a single field of "error".
 func wrapError(serialized []byte) []byte {
 	return []byte(`{"error":` + string(serialized) + `}`)
+}
+
+func cleanupBetaHeaders() {
+	apiVersionWithBetaHeaders = APIVersion
 }

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -67,7 +67,7 @@ func TestCanSetBetaHeaders(t *testing.T) {
 	req, err := c.NewRequest("", "", key, "", nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, APIVersion+";feature_in_beta=v3", req.Header.Get("Stripe-Version"))
+	assert.Equal(t, APIVersion+"; feature_in_beta=v3", req.Header.Get("Stripe-Version"))
 }
 
 func TestSetBetaVersionTwiceAsc(t *testing.T) {
@@ -83,7 +83,7 @@ func TestSetBetaVersionTwiceAsc(t *testing.T) {
 	req, err := c.NewRequest("", "", key, "", nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, APIVersion+";feature_in_beta=v5", req.Header.Get("Stripe-Version"))
+	assert.Equal(t, APIVersion+"; feature_in_beta=v5", req.Header.Get("Stripe-Version"))
 
 	// clean up
 	apiVersionWithBetaHeaders = APIVersion
@@ -102,7 +102,7 @@ func TestSetBetaVersionTwiceDesc(t *testing.T) {
 	req, err := c.NewRequest("", "", key, "", nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, APIVersion+";feature_in_beta=v5", req.Header.Get("Stripe-Version"))
+	assert.Equal(t, APIVersion+"; feature_in_beta=v5", req.Header.Get("Stripe-Version"))
 
 	// clean up
 	apiVersionWithBetaHeaders = APIVersion
@@ -131,7 +131,7 @@ func TestCanSetSecondBetaHeaders(t *testing.T) {
 	req, err := c.NewRequest("", "", key, "", nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, APIVersion+";feature_in_beta=v3;second_feature_in_beta=v2", req.Header.Get("Stripe-Version"))
+	assert.Equal(t, APIVersion+"; feature_in_beta=v3; second_feature_in_beta=v2", req.Header.Get("Stripe-Version"))
 
 	// clean up
 	apiVersionWithBetaHeaders = APIVersion
@@ -1763,7 +1763,7 @@ func TestRawRequestTelemetry(t *testing.T) {
 func TestAddBetaVersion(t *testing.T) {
 	defer cleanupBetaHeaders()
 	AddBetaVersion("feature_beta", "v3")
-	expectedAPIVersion := APIVersion + ";feature_beta=v3"
+	expectedAPIVersion := APIVersion + "; feature_beta=v3"
 	assert.Equal(t, expectedAPIVersion, apiVersionWithBetaHeaders)
 	err := AddBetaVersion("feature_beta", "v3")
 	assert.Nil(t, err)


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
We decided to let users pass in the same beta header multiple times.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- AddBetaVersion will use the highest version number used for a beta feature instead of return an `error` on a conflict as it had done previously.

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
- AddBetaVersion will use the highest version number used for a beta feature instead of return an `error` on a conflict as it had done previously.

