### PR TITLE
Fix coupon test for field that was removed

### DIFF
--- a/coupon/client_test.go
+++ b/coupon/client_test.go
@@ -43,11 +43,10 @@ func TestCouponNew(t *testing.T) {
 				"prod_abc",
 			}),
 		},
-		Currency:         stripe.String(string(stripe.CurrencyUSD)),
-		Duration:         stripe.String(string(stripe.CouponDurationOnce)),
-		DurationInMonths: stripe.Int64(3),
-		ID:               stripe.String("25OFF"),
-		PercentOff:       stripe.Float64(12.5),
+		Currency:   stripe.String(string(stripe.CurrencyUSD)),
+		Duration:   stripe.String(string(stripe.CouponDurationOnce)),
+		ID:         stripe.String("25OFF"),
+		PercentOff: stripe.Float64(12.5),
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, coupon)


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The coupon change made in https://github.com/stripe/stripe-go/commit/89f7daa9e504eee8e51bade30637545d77917f24#diff-a7914a23e2b39d1496fef46a29de8797daf070921d3f80fee80cd230ad15d73d but for master

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
