### PR TITLE
Handle top-level External Account service

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -54,6 +54,7 @@ import (
 	entitlementsfeature "github.com/stripe/stripe-go/v82/entitlements/feature"
 	"github.com/stripe/stripe-go/v82/ephemeralkey"
 	"github.com/stripe/stripe-go/v82/event"
+	"github.com/stripe/stripe-go/v82/externalaccount"
 	"github.com/stripe/stripe-go/v82/feerefund"
 	"github.com/stripe/stripe-go/v82/file"
 	"github.com/stripe/stripe-go/v82/filelink"
@@ -285,6 +286,8 @@ type API struct {
 	EphemeralKeys *ephemeralkey.Client
 	// Events is the client used to invoke /v1/events APIs.
 	Events *event.Client
+	// ExternalAccounts is the client used to invoke /v1/external_accounts APIs.
+	ExternalAccounts *externalaccount.Client
 	// FeeRefunds is the client used to invoke /v1/application_fees/{id}/refunds APIs.
 	FeeRefunds *feerefund.Client
 	// FileLinks is the client used to invoke /v1/file_links APIs.
@@ -617,6 +620,7 @@ func (a *API) Init(key string, backends *stripe.Backends) {
 	a.EntitlementsFeatures = &entitlementsfeature.Client{B: backends.API, Key: key}
 	a.EphemeralKeys = &ephemeralkey.Client{B: backends.API, Key: key}
 	a.Events = &event.Client{B: backends.API, Key: key}
+	a.ExternalAccounts = &externalaccount.Client{B: backends.API, Key: key}
 	a.FeeRefunds = &feerefund.Client{B: backends.API, Key: key}
 	a.FileLinks = &filelink.Client{B: backends.API, Key: key}
 	a.Files = &file.Client{B: backends.API, BUploads: backends.Uploads, Key: key}

--- a/externalaccount/client.go
+++ b/externalaccount/client.go
@@ -10,8 +10,8 @@ package externalaccount
 import (
 	"net/http"
 
-	stripe "github.com/stripe/stripe-go/v81"
-	"github.com/stripe/stripe-go/v81/form"
+	stripe "github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/form"
 )
 
 // Client is used to invoke /v1/external_accounts APIs.
@@ -79,9 +79,10 @@ func NewBankAccount(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 
 // Create an external account for a given connected account.
 func (c Client) NewBankAccount(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	body := &form.Values{}
+	params.AppendToAsSourceOrExternalAccount(body)
 	bankaccount := &stripe.BankAccount{}
-	err := c.B.Call(
-		http.MethodPost, "/v1/external_accounts", c.Key, params, bankaccount)
+	err := c.B.CallRaw(http.MethodPost, "/v1/external_accounts", c.Key, []byte(body.Encode()), &params.Params, bankaccount)
 	return bankaccount, err
 }
 
@@ -92,8 +93,10 @@ func NewCard(params *stripe.CardParams) (*stripe.Card, error) {
 
 // Create an external account for a given connected account.
 func (c Client) NewCard(params *stripe.CardParams) (*stripe.Card, error) {
+	body := &form.Values{}
+	params.AppendToAsCardSourceOrExternalAccount(body, nil)
 	card := &stripe.Card{}
-	err := c.B.Call(http.MethodPost, "/v1/external_accounts", c.Key, params, card)
+	err := c.B.CallRaw(http.MethodPost, "/v1/external_accounts", c.Key, []byte(body.Encode()), &params.Params, card)
 	return card, err
 }
 

--- a/externalaccount/client.go
+++ b/externalaccount/client.go
@@ -1,0 +1,225 @@
+//
+//
+// File generated from our OpenAPI spec
+//
+//
+
+// Package externalaccount provides the /v1/external_accounts APIs
+package externalaccount
+
+import (
+	"net/http"
+
+	stripe "github.com/stripe/stripe-go/v81"
+	"github.com/stripe/stripe-go/v81/form"
+)
+
+// Client is used to invoke /v1/external_accounts APIs.
+type Client struct {
+	B   stripe.Backend
+	Key string
+}
+
+// Delete a specified external account for a given account.
+func DeleteBankAccount(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	return getC().DeleteBankAccount(id, params)
+}
+
+// Delete a specified external account for a given account.
+func (c Client) DeleteBankAccount(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	path := stripe.FormatURLPath("/v1/external_accounts/%s", id)
+	bankaccount := &stripe.BankAccount{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, bankaccount)
+	return bankaccount, err
+}
+
+// Delete a specified external account for a given account.
+func DeleteCard(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	return getC().DeleteCard(id, params)
+}
+
+// Delete a specified external account for a given account.
+func (c Client) DeleteCard(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	path := stripe.FormatURLPath("/v1/external_accounts/%s", id)
+	card := &stripe.Card{}
+	err := c.B.Call(http.MethodDelete, path, c.Key, params, card)
+	return card, err
+}
+
+// Retrieve a specified external account for a given account.
+func GetBankAccount(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	return getC().GetBankAccount(id, params)
+}
+
+// Retrieve a specified external account for a given account.
+func (c Client) GetBankAccount(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	path := stripe.FormatURLPath("/v1/external_accounts/%s", id)
+	bankaccount := &stripe.BankAccount{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, bankaccount)
+	return bankaccount, err
+}
+
+// Retrieve a specified external account for a given account.
+func GetCard(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	return getC().GetCard(id, params)
+}
+
+// Retrieve a specified external account for a given account.
+func (c Client) GetCard(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	path := stripe.FormatURLPath("/v1/external_accounts/%s", id)
+	card := &stripe.Card{}
+	err := c.B.Call(http.MethodGet, path, c.Key, params, card)
+	return card, err
+}
+
+// Create an external account for a given connected account.
+func NewBankAccount(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	return getC().NewBankAccount(params)
+}
+
+// Create an external account for a given connected account.
+func (c Client) NewBankAccount(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	bankaccount := &stripe.BankAccount{}
+	err := c.B.Call(
+		http.MethodPost, "/v1/external_accounts", c.Key, params, bankaccount)
+	return bankaccount, err
+}
+
+// Create an external account for a given connected account.
+func NewCard(params *stripe.CardParams) (*stripe.Card, error) {
+	return getC().NewCard(params)
+}
+
+// Create an external account for a given connected account.
+func (c Client) NewCard(params *stripe.CardParams) (*stripe.Card, error) {
+	card := &stripe.Card{}
+	err := c.B.Call(http.MethodPost, "/v1/external_accounts", c.Key, params, card)
+	return card, err
+}
+
+// Updates the metadata, account holder name, account holder type of a bank account belonging to
+// a connected account and optionally sets it as the default for its currency. Other bank account
+// details are not editable by design.
+//
+// You can only update bank accounts when [account.controller.requirement_collection is application, which includes <a href="/connect/custom-accounts">Custom accounts](https://stripe.com/api/accounts/object#account_object-controller-requirement_collection).
+//
+// You can re-enable a disabled bank account by performing an update call without providing any
+// arguments or changes.
+func UpdateBankAccount(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	return getC().UpdateBankAccount(id, params)
+}
+
+// Updates the metadata, account holder name, account holder type of a bank account belonging to
+// a connected account and optionally sets it as the default for its currency. Other bank account
+// details are not editable by design.
+//
+// You can only update bank accounts when [account.controller.requirement_collection is application, which includes <a href="/connect/custom-accounts">Custom accounts](https://stripe.com/api/accounts/object#account_object-controller-requirement_collection).
+//
+// You can re-enable a disabled bank account by performing an update call without providing any
+// arguments or changes.
+func (c Client) UpdateBankAccount(id string, params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
+	path := stripe.FormatURLPath("/v1/external_accounts/%s", id)
+	bankaccount := &stripe.BankAccount{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, bankaccount)
+	return bankaccount, err
+}
+
+// Updates the metadata, account holder name, account holder type of a bank account belonging to
+// a connected account and optionally sets it as the default for its currency. Other bank account
+// details are not editable by design.
+//
+// You can only update bank accounts when [account.controller.requirement_collection is application, which includes <a href="/connect/custom-accounts">Custom accounts](https://stripe.com/api/accounts/object#account_object-controller-requirement_collection).
+//
+// You can re-enable a disabled bank account by performing an update call without providing any
+// arguments or changes.
+func UpdateCard(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	return getC().UpdateCard(id, params)
+}
+
+// Updates the metadata, account holder name, account holder type of a bank account belonging to
+// a connected account and optionally sets it as the default for its currency. Other bank account
+// details are not editable by design.
+//
+// You can only update bank accounts when [account.controller.requirement_collection is application, which includes <a href="/connect/custom-accounts">Custom accounts](https://stripe.com/api/accounts/object#account_object-controller-requirement_collection).
+//
+// You can re-enable a disabled bank account by performing an update call without providing any
+// arguments or changes.
+func (c Client) UpdateCard(id string, params *stripe.CardParams) (*stripe.Card, error) {
+	path := stripe.FormatURLPath("/v1/external_accounts/%s", id)
+	card := &stripe.Card{}
+	err := c.B.Call(http.MethodPost, path, c.Key, params, card)
+	return card, err
+}
+
+// List external accounts for an account.
+func ListBankAccount(params *stripe.BankAccountListParams) *Iter {
+	return getC().ListBankAccount(params)
+}
+
+// List external accounts for an account.
+func (c Client) ListBankAccount(listParams *stripe.BankAccountListParams) *Iter {
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.BankAccountList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/external_accounts", c.Key, []byte(b.Encode()), p, list)
+
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
+
+			return ret, list, err
+		}),
+	}
+}
+
+// Iter is an iterator for external accounts.
+type Iter struct {
+	*stripe.Iter
+}
+
+// Card returns the external account which the iterator is currently pointing to.
+func (i *Iter) Card() *stripe.Card {
+	return i.Current().(*stripe.Card)
+}
+
+// BankAccount returns the external account which the iterator is currently pointing to.
+func (i *Iter) BankAccount() *stripe.BankAccount {
+	return i.Current().(*stripe.BankAccount)
+}
+
+// CardList returns the current list object which the iterator is currently using. List objects will change as new API calls are made to continue pagination.
+func (i *Iter) CardList() *stripe.CardList {
+	return i.List().(*stripe.CardList)
+}
+
+// BankAccountList returns the current list object which the iterator is currently using. List objects will change as new API calls are made to continue pagination.
+func (i *Iter) BankAccountList() *stripe.BankAccountList {
+	return i.List().(*stripe.BankAccountList)
+}
+
+// List external accounts for an account.
+func ListCard(params *stripe.CardListParams) *Iter {
+	return getC().ListCard(params)
+}
+
+// List external accounts for an account.
+func (c Client) ListCard(listParams *stripe.CardListParams) *Iter {
+	return &Iter{
+		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+			list := &stripe.CardList{}
+			err := c.B.CallRaw(http.MethodGet, "/v1/external_accounts", c.Key, []byte(b.Encode()), p, list)
+
+			ret := make([]interface{}, len(list.Data))
+			for i, v := range list.Data {
+				ret[i] = v
+			}
+
+			return ret, list, err
+		}),
+	}
+}
+
+func getC() Client {
+	return Client{stripe.GetBackend(stripe.APIBackend), stripe.Key}
+}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Stripe recently added a `/v1/external_accounts` endpoint that used to be under `/v1/account/%s/external_accounts`. The endpoint returns a union type of either `Card` or `BankAccount`. Go does not have a great way to deal with union types, so in the past for the child endpoints, we created separate `Card` and `BankAccount` services. For the top-level External Account service, we decided to have a single service with mirrored methods (e.g. both `GetCard` and `GetBankAccount`).

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds `externalaccount/client.go` with separate CRUDL operations for each of Card and BankAccount.

## Changelog
- Add support for top-level External Account CRUDL calls by adding separate `GetCard`/`GetBankAccount`, `NewCard`/`NewBankAccount`, etc. calls.
