### PR TITLE
require beta SDKs match event versions exactly when deserializing

### DIFF
--- a/webhook/client_test.go
+++ b/webhook/client_test.go
@@ -297,3 +297,25 @@ func TestConstructEventWithOptions_UsesDefaultToleranceWhenNoneProvided(t *testi
 		t.Errorf("Expected error due to being too old, but got %v.", err)
 	}
 }
+
+func TestApiVersionCompatibility(t *testing.T) {
+	tests := []struct {
+		sdkApiVersion   string
+		eventApiVersion string
+		expected        bool
+	}{
+		{"2024-02-31.acacia", "1999-03-31", false},
+		{"2024-02-31.acacia", "2025-03-31.basil", false},
+		{"2024-04-31.basil", "2025-03-31.basil", true},
+		{"2024-01-01.preview", "2025-03-31.basil", false},
+		{"2024-01-01.preview", "2025-03-31.preview", false},
+		{"2024-01-01.preview", "2024-01-01.preview", true},
+	}
+
+	for _, test := range tests {
+		result := isCompatibleAPIVersion(test.sdkApiVersion, test.eventApiVersion)
+		if result != test.expected {
+			t.Errorf("Expected %v for API version %s <> %s, got %v", test.expected, test.sdkApiVersion, test.eventApiVersion, result)
+		}
+	}
+}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We decided that beta SDKs should exactly match the API version for events they're deserializing to minimize the chances of accidental breaking changes. This PR tweaks the version matching function to accommodate that change

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- updated `isCompatibleAPIVersion` signature and implementation
- added tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-1556](https://go/j/RUN_DEVSDK-1556)

## Changelog

- ⚠️ Public Preview SDKs now require an exact API version match when deserializing webhooks