### PR TITLE
Support cleaner pagination for V1 in stripe.Client

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -190,8 +190,9 @@ func (it *v1List[T]) getPage() {
 // Query is the function used to get a page listing.
 type v1Query[T any] func(*Params, *form.Values) ([]*T, ListContainer, error)
 
-// getV1List returns a new v1List for a given query and its options.
-func getV1List[T any](container ListParamsContainer, query v1Query[T]) *v1List[T] {
+// newV1List returns a new v1List for a given query and its options, and initializes
+// it by fetching the first page of items.
+func newV1List[T any](container ListParamsContainer, query v1Query[T]) *v1List[T] {
 	var listParams *ListParams
 	formValues := &form.Values{}
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -145,7 +145,7 @@ func TestIterListAndMeta(t *testing.T) {
 
 func TestV1ListEmpty(t *testing.T) {
 	tq := testV1Query[*int]{{nil, &ListMeta{}, nil}}
-	g, gerr := collectList(getV1List(nil, tq.query))
+	g, gerr := collectList(newV1List(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, 0, len(g))
 	assert.NoError(t, gerr)
@@ -153,7 +153,7 @@ func TestV1ListEmpty(t *testing.T) {
 
 func TestV1ListEmptyErr(t *testing.T) {
 	tq := testV1Query[*int]{{nil, &ListMeta{}, errTest}}
-	g, gerr := collectList(getV1List(nil, tq.query))
+	g, gerr := collectList(newV1List(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, 0, len(g))
 	assert.Equal(t, errTest, gerr)
@@ -162,7 +162,7 @@ func TestV1ListEmptyErr(t *testing.T) {
 func TestV1ListOne(t *testing.T) {
 	tq := testV1Query[*int]{{[]*int{intPtr(1)}, &ListMeta{}, nil}}
 	want := []*int{intPtr(1)}
-	g, gerr := collectList(getV1List(nil, tq.query))
+	g, gerr := collectList(newV1List(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -171,7 +171,7 @@ func TestV1ListOne(t *testing.T) {
 func TestV1ListOneErr(t *testing.T) {
 	tq := testV1Query[*int]{{[]*int{intPtr(1)}, &ListMeta{}, errTest}}
 	want := []*int{intPtr(1)}
-	g, gerr := collectList(getV1List(nil, tq.query))
+	g, gerr := collectList(newV1List(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.Equal(t, errTest, gerr)
@@ -183,7 +183,7 @@ func TestV1ListPage2EmptyErr(t *testing.T) {
 		{nil, &ListMeta{}, errTest},
 	}
 	want := []*item{{"x"}}
-	g, gerr := collectList(getV1List(nil, tq.query))
+	g, gerr := collectList(newV1List(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.Equal(t, errTest, gerr)
@@ -195,7 +195,7 @@ func TestV1ListTwoPages(t *testing.T) {
 		{[]*item{{"y"}}, &ListMeta{}, nil},
 	}
 	want := []*item{{"x"}, {"y"}}
-	g, gerr := collectList(getV1List(nil, tq.query))
+	g, gerr := collectList(newV1List(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -207,7 +207,7 @@ func TestV1ListTwoPagesErr(t *testing.T) {
 		{[]*item{{"y"}}, &ListMeta{}, errTest},
 	}
 	want := []*item{{"x"}, {"y"}}
-	g, gerr := collectList(getV1List(nil, tq.query))
+	g, gerr := collectList(newV1List(nil, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.Equal(t, errTest, gerr)
@@ -216,7 +216,7 @@ func TestV1ListTwoPagesErr(t *testing.T) {
 func TestV1ListReversed(t *testing.T) {
 	tq := testV1Query[*int]{{[]*int{intPtr(1), intPtr(2)}, &ListMeta{}, nil}}
 	want := []*int{intPtr(2), intPtr(1)}
-	g, gerr := collectList(getV1List(&ListParams{EndingBefore: String("x")}, tq.query))
+	g, gerr := collectList(newV1List(&ListParams{EndingBefore: String("x")}, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)
@@ -228,7 +228,7 @@ func TestV1ListReversedTwoPages(t *testing.T) {
 		{[]*item{{"1"}, {"2"}}, &ListMeta{}, nil},
 	}
 	want := []*item{{"4"}, {"3"}, {"2"}, {"1"}}
-	g, gerr := collectList(getV1List(&ListParams{EndingBefore: String("x")}, tq.query))
+	g, gerr := collectList(newV1List(&ListParams{EndingBefore: String("x")}, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)
 	assert.NoError(t, gerr)

--- a/iter_test.go
+++ b/iter_test.go
@@ -143,6 +143,97 @@ func TestIterListAndMeta(t *testing.T) {
 	assert.Equal(t, listMeta, it.Meta())
 }
 
+func TestV1ListEmpty(t *testing.T) {
+	tq := testV1Query[*int]{{nil, &ListMeta{}, nil}}
+	g, gerr := collectList(getV1List(nil, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, 0, len(g))
+	assert.NoError(t, gerr)
+}
+
+func TestV1ListEmptyErr(t *testing.T) {
+	tq := testV1Query[*int]{{nil, &ListMeta{}, errTest}}
+	g, gerr := collectList(getV1List(nil, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, 0, len(g))
+	assert.Equal(t, errTest, gerr)
+}
+
+func TestV1ListOne(t *testing.T) {
+	tq := testV1Query[*int]{{[]*int{intPtr(1)}, &ListMeta{}, nil}}
+	want := []*int{intPtr(1)}
+	g, gerr := collectList(getV1List(nil, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, want, g)
+	assert.NoError(t, gerr)
+}
+
+func TestV1ListOneErr(t *testing.T) {
+	tq := testV1Query[*int]{{[]*int{intPtr(1)}, &ListMeta{}, errTest}}
+	want := []*int{intPtr(1)}
+	g, gerr := collectList(getV1List(nil, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, want, g)
+	assert.Equal(t, errTest, gerr)
+}
+
+func TestV1ListPage2EmptyErr(t *testing.T) {
+	tq := testV1Query[*item]{
+		{[]*item{{"x"}}, &ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{nil, &ListMeta{}, errTest},
+	}
+	want := []*item{{"x"}}
+	g, gerr := collectList(getV1List(nil, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, want, g)
+	assert.Equal(t, errTest, gerr)
+}
+
+func TestV1ListTwoPages(t *testing.T) {
+	tq := testV1Query[*item]{
+		{[]*item{{"x"}}, &ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{[]*item{{"y"}}, &ListMeta{}, nil},
+	}
+	want := []*item{{"x"}, {"y"}}
+	g, gerr := collectList(getV1List(nil, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, want, g)
+	assert.NoError(t, gerr)
+}
+
+func TestV1ListTwoPagesErr(t *testing.T) {
+	tq := testV1Query[*item]{
+		{[]*item{{"x"}}, &ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{[]*item{{"y"}}, &ListMeta{}, errTest},
+	}
+	want := []*item{{"x"}, {"y"}}
+	g, gerr := collectList(getV1List(nil, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, want, g)
+	assert.Equal(t, errTest, gerr)
+}
+
+func TestV1ListReversed(t *testing.T) {
+	tq := testV1Query[*int]{{[]*int{intPtr(1), intPtr(2)}, &ListMeta{}, nil}}
+	want := []*int{intPtr(2), intPtr(1)}
+	g, gerr := collectList(getV1List(&ListParams{EndingBefore: String("x")}, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, want, g)
+	assert.NoError(t, gerr)
+}
+
+func TestV1ListReversedTwoPages(t *testing.T) {
+	tq := testV1Query[*item]{
+		{[]*item{&item{"3"}, &item{"4"}}, &ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{[]*item{&item{"1"}, &item{"2"}}, &ListMeta{}, nil},
+	}
+	want := []*item{&item{"4"}, &item{"3"}, &item{"2"}, &item{"1"}}
+	g, gerr := collectList(getV1List(&ListParams{EndingBefore: String("x")}, tq.query))
+	assert.Equal(t, 0, len(tq))
+	assert.Equal(t, want, g)
+	assert.NoError(t, gerr)
+}
+
 //
 // ---
 //
@@ -163,6 +254,38 @@ func (tq *testQuery) query(*Params, *form.Values) ([]interface{}, ListContainer,
 	x := (*tq)[0]
 	*tq = (*tq)[1:]
 	return x.v, x.m, x.e
+}
+
+type testV1Query[T any] []struct {
+	v []T
+	m ListContainer
+	e error
+}
+
+func (tq *testV1Query[T]) query(*Params, *form.Values) ([]T, ListContainer, error) {
+	x := (*tq)[0]
+	*tq = (*tq)[1:]
+	return x.v, x.m, x.e
+}
+
+func collectList[T any](it *v1List[*T]) ([]*T, error) {
+	var tt []*T
+	var err error
+	it.All()(func(t *T, e error) bool {
+		if e != nil {
+			err = e
+			return false
+		}
+		tt = append(tt, t)
+		return true
+	})
+	return tt, err
+}
+
+func intPtr(i int) *int {
+	intPtr := new(int)
+	*intPtr = i
+	return intPtr
 }
 
 type collectable interface {

--- a/iter_test.go
+++ b/iter_test.go
@@ -268,7 +268,7 @@ func (tq *testV1Query[T]) query(*Params, *form.Values) ([]T, ListContainer, erro
 	return x.v, x.m, x.e
 }
 
-func collectList[T any](it *v1List[*T]) ([]*T, error) {
+func collectList[T any](it *v1List[T]) ([]*T, error) {
 	var tt []*T
 	var err error
 	it.All()(func(t *T, e error) bool {

--- a/iter_test.go
+++ b/iter_test.go
@@ -224,10 +224,10 @@ func TestV1ListReversed(t *testing.T) {
 
 func TestV1ListReversedTwoPages(t *testing.T) {
 	tq := testV1Query[*item]{
-		{[]*item{&item{"3"}, &item{"4"}}, &ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
-		{[]*item{&item{"1"}, &item{"2"}}, &ListMeta{}, nil},
+		{[]*item{{"3"}, {"4"}}, &ListMeta{HasMore: true, TotalCount: 0, URL: ""}, nil},
+		{[]*item{{"1"}, {"2"}}, &ListMeta{}, nil},
 	}
-	want := []*item{&item{"4"}, &item{"3"}, &item{"2"}, &item{"1"}}
+	want := []*item{{"4"}, {"3"}, {"2"}, {"1"}}
 	g, gerr := collectList(getV1List(&ListParams{EndingBefore: String("x")}, tq.query))
 	assert.Equal(t, 0, len(tq))
 	assert.Equal(t, want, g)


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
For V2 support, we offer pagination using Go's `iter.Seq2` interface, so iterating over V2 accounts looks like this:
```go
for acct, err := range sc.V2Accounts.All(params) {
        // do something
}
```
This compares to V1 where it looks like this:
```go
i := sc.Accounts.List(params)
for i.Next() {
	acct := i.Account()
        // do something
}

if err := i.Err(); err != nil {
	// handle
}
```
With the new `stripe.Client` type in a future PR, we will be providing the former style pagination for both V1 and V2.

This PR paves the way by introducing the mechanism for V1 to cleanly paginate in `List` methods.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds an unexported (i.e., internal-only) type `v1List` with an `All` method for pagination. This is not currently used anywhere, but will be leveraged by `stripe.Client` in a subsequent PR.

### See Also
<!-- Include any links or additional information that help explain this change. -->
