### PR TITLE
Add auto-pagination for search

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -144,7 +144,7 @@ func (it *v1List[T]) All() Seq2[*T, error] {
 			}
 		}
 		if it.err != nil {
-			if !yield(new(T), it.err) {
+			if !yield(nil, it.err) {
 				return
 			}
 		}

--- a/search_iter_test.go
+++ b/search_iter_test.go
@@ -324,9 +324,7 @@ func (c TestServer) Search(ctx context.Context, params *SearchParams) Seq2[*Test
 		list := &TestSearchResult{}
 		err := c.B.CallRaw(http.MethodGet, "/v1/something/search", c.Key, []byte(b.Encode()), p, list)
 		ret := make([]*TestEntity, len(list.Data))
-		for i, v := range list.Data {
-			ret[i] = v
-		}
+		copy(ret, list.Data)
 		return ret, list, err
 	}).All()
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
This is a follow-up to https://github.com/stripe/stripe-go/pull/2027 in which we laid the groundwork for cleaner `List` pagination for V1 services. This PR does the same for `Search` pagination.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds an unexported (i.e., internal-only) type `v1SearchList` with an `All `method for pagination. This is not currently used anywhere, but will be leveraged by `stripe.Client` in a subsequent PR.
- Also made a minor simplification to `iter.go` that I noticed while re-implementing the same logic in `search_iter.go`. That is, I replaced `new(T)` with `nil` when calling `yield` on an `error`.

### See Also
<!-- Include any links or additional information that help explain this change. -->
