### PR TITLE
Fix event data unmarshaling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   // Show the repo name in the top window bar.
-  "window.title": "${rootName}${separator}${activeEditorMedium}"
+  "window.title": "${rootName}${separator}${activeEditorMedium}",
+  "go.alternateTools": {
+      "go": "~/.local/share/mise/installs/go/latest/bin/go"
+  }
 }

--- a/v2/core/event/client_test.go
+++ b/v2/core/event/client_test.go
@@ -1,0 +1,133 @@
+package event_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"fmt"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/mock"
+)
+
+func TestEventGet(t *testing.T) {
+	timeNow := time.Now()
+	params := stripe.V2CoreEventParams{}
+	testServer, sc := mock.Server(t, string(http.MethodGet), "/v2/core/events/evt_123", nil, func(p *stripe.V2CoreEventParams) []byte {
+		data, err := json.Marshal(stripe.V1BillingMeterErrorReportTriggeredEvent{
+			V2RawEvent: stripe.V2RawEvent{
+				V2BaseEvent: stripe.V2BaseEvent{
+					Created: timeNow,
+					ID:      "evt_123",
+					Type:    "v1.billing.meter.error_report_triggered",
+				},
+				RelatedObject: &stripe.RelatedObject{
+					ID: "ro_123",
+				},
+			},
+			Data: stripe.V1BillingMeterErrorReportTriggeredEventData{
+				DeveloperMessageSummary: "This is a developer message",
+			},
+			RelatedObject: stripe.RelatedObject{
+				ID: "ro_123",
+			},
+		})
+		assert.NoError(t, err)
+		return data
+	})
+	defer testServer.Close()
+
+	event, err := sc.V2CoreEvents.Get("evt_123", &params)
+	assert.Nil(t, err)
+	v1BillingEvent, ok := event.(*stripe.V1BillingMeterErrorReportTriggeredEvent)
+	assert.True(t, ok)
+	assert.Equal(t, v1BillingEvent.ID, "evt_123")
+	assert.Equal(t, v1BillingEvent.Type, "v1.billing.meter.error_report_triggered")
+	assert.True(t, v1BillingEvent.Created.Equal(timeNow))
+	assert.Equal(t, v1BillingEvent.Data.DeveloperMessageSummary, "This is a developer message")
+	assert.Equal(t, v1BillingEvent.RelatedObject.ID, "ro_123")
+}
+
+func TestEventAll(t *testing.T) {
+	timeNow := time.Now()
+	params := &stripe.V2CoreEventListParams{}
+	testServer, sc := mock.Server(t, string(http.MethodGet), "/v2/core/events", params, func(p *stripe.V2CoreEventListParams) []byte {
+		data, err := json.Marshal(stripe.V2Page[stripe.V2Event]{
+			Data: []stripe.V2Event{
+				&stripe.V1BillingMeterErrorReportTriggeredEvent{
+					V2RawEvent: stripe.V2RawEvent{
+						V2BaseEvent: stripe.V2BaseEvent{
+							Created: timeNow,
+							ID:      "evt_1",
+							Type:    "v1.billing.meter.error_report_triggered",
+						},
+						RelatedObject: &stripe.RelatedObject{
+							ID: "ro_123",
+						},
+					},
+					Data: stripe.V1BillingMeterErrorReportTriggeredEventData{
+						DeveloperMessageSummary: "This is a developer message",
+					},
+					RelatedObject: stripe.RelatedObject{
+						ID: "ro_123",
+					},
+				},
+				&stripe.V1BillingMeterNoMeterFoundEvent{
+					V2RawEvent: stripe.V2RawEvent{
+						V2BaseEvent: stripe.V2BaseEvent{
+							Created: timeNow,
+							ID:      "evt_2",
+							Type:    "v1.billing.meter.no_meter_found",
+						},
+					},
+					Data: stripe.V1BillingMeterNoMeterFoundEventData{
+						DeveloperMessageSummary: "This is another developer message",
+					},
+				},
+				&stripe.V1BillingMeterNoMeterFoundEvent{
+					V2RawEvent: stripe.V2RawEvent{
+						V2BaseEvent: stripe.V2BaseEvent{
+							Created: timeNow,
+							ID:      "evt_3",
+							Type:    "v1.billing.meter.no_meter_found",
+						},
+					},
+					Data: stripe.V1BillingMeterNoMeterFoundEventData{
+						DeveloperMessageSummary: "This is yet another developer message",
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		return data
+	})
+	defer testServer.Close()
+	cnt := 1
+	sc.V2CoreEvents.All(params)(func(event stripe.V2Event, err error) bool {
+		assert.Nil(t, err)
+		assert.NotNil(t, event)
+		if cnt == 1 {
+			v1BillingEvent, ok := event.(*stripe.V1BillingMeterErrorReportTriggeredEvent)
+			assert.True(t, ok)
+			assert.Equal(t, v1BillingEvent.ID, "evt_1")
+			assert.Equal(t, v1BillingEvent.Type, "v1.billing.meter.error_report_triggered")
+			assert.True(t, v1BillingEvent.Created.Equal(timeNow))
+			assert.Equal(t, v1BillingEvent.Data.DeveloperMessageSummary, "This is a developer message")
+			assert.Equal(t, v1BillingEvent.RelatedObject.ID, "ro_123")
+		} else {
+			v1BillingEvent, ok := event.(*stripe.V1BillingMeterNoMeterFoundEvent)
+			assert.True(t, ok)
+			assert.Equal(t, v1BillingEvent.ID, fmt.Sprintf("evt_%d", cnt))
+			assert.Equal(t, v1BillingEvent.Type, "v1.billing.meter.no_meter_found")
+			assert.True(t, v1BillingEvent.Created.Equal(timeNow))
+			assert.Equal(t, v1BillingEvent.Data.DeveloperMessageSummary, fmt.Sprintf("This is %s developer message", map[int]string{2: "another", 3: "yet another"}[cnt]))
+		}
+		cnt++
+
+		return true
+	})
+	assert.Equal(t, cnt, 4)
+}

--- a/v2_events.go
+++ b/v2_events.go
@@ -181,14 +181,14 @@ func ConvertRawEvent(event *V2RawEvent, backend Backend, key string) (V2Event, e
 			err := backend.Call(http.MethodGet, event.RelatedObject.URL, key, nil, v)
 			return v, err
 		}
-		if err := json.Unmarshal(*event.Data, result); err != nil {
+		if err := json.Unmarshal(*event.Data, &result.Data); err != nil {
 			return nil, err
 		}
 		return result, nil
 	case "v1.billing.meter.no_meter_found":
 		result := &V1BillingMeterNoMeterFoundEvent{}
 		result.V2BaseEvent = event.V2BaseEvent
-		if err := json.Unmarshal(*event.Data, result); err != nil {
+		if err := json.Unmarshal(*event.Data, &result.Data); err != nil {
 			return nil, err
 		}
 		return result, nil


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Currently, we are not correctly unmarshaling V2 event `Data`, and the resulting event will have an empty `Data` struct.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Fixes V2 event data unmarshaling

### See Also
<!-- Include any links or additional information that help explain this change. -->
