### PR TITLE
Add related object to ping test

### DIFF
--- a/v2/core/eventdestination/client_test.go
+++ b/v2/core/eventdestination/client_test.go
@@ -212,12 +212,17 @@ func TestEventDestinationEnable(t *testing.T) {
 func TestEventDestinationPing(t *testing.T) {
 	timeNow := time.Now()
 	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92/ping", nil, func(p *stripe.V2CoreEventDestinationParams) []byte {
-		data, err := json.Marshal(stripe.V2RawEvent{V2BaseEvent: stripe.V2BaseEvent{
-			ID:      "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92",
-			Created: timeNow,
-			Object:  "v2.core.event",
-			Type:    "v2.core.event_destination.ping",
-		}})
+		data, err := json.Marshal(stripe.V2RawEvent{
+			V2BaseEvent: stripe.V2BaseEvent{
+				ID:      "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92",
+				Created: timeNow,
+				Object:  "v2.core.event",
+				Type:    "v2.core.event_destination.ping",
+			},
+			RelatedObject: &stripe.RelatedObject{
+				ID: "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92",
+			},
+		})
 		assert.NoError(t, err)
 		return data
 	})


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
In an upcoming change, the ping event will get its own `Event` object, which will have a related object. The `TestEventDestinationPing` will fail once we pull that change.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds `RelatedObject` data to the `TestEventDestinationPing` unit test

### See Also
<!-- Include any links or additional information that help explain this change. -->
