### PR TITLE
Embed `V2BaseEvent` in V2 events instead of `V2RawEvent`

### DIFF
--- a/v2/core/event/client_test.go
+++ b/v2/core/event/client_test.go
@@ -18,15 +18,10 @@ func TestEventGet(t *testing.T) {
 	params := stripe.V2CoreEventParams{}
 	testServer, sc := mock.Server(t, string(http.MethodGet), "/v2/core/events/evt_123", nil, func(p *stripe.V2CoreEventParams) []byte {
 		data, err := json.Marshal(stripe.V1BillingMeterErrorReportTriggeredEvent{
-			V2RawEvent: stripe.V2RawEvent{
-				V2BaseEvent: stripe.V2BaseEvent{
-					Created: timeNow,
-					ID:      "evt_123",
-					Type:    "v1.billing.meter.error_report_triggered",
-				},
-				RelatedObject: &stripe.RelatedObject{
-					ID: "ro_123",
-				},
+			V2BaseEvent: stripe.V2BaseEvent{
+				Created: timeNow,
+				ID:      "evt_123",
+				Type:    "v1.billing.meter.error_report_triggered",
 			},
 			Data: stripe.V1BillingMeterErrorReportTriggeredEventData{
 				DeveloperMessageSummary: "This is a developer message",
@@ -58,15 +53,10 @@ func TestEventAll(t *testing.T) {
 		data, err := json.Marshal(stripe.V2Page[stripe.V2Event]{
 			Data: []stripe.V2Event{
 				&stripe.V1BillingMeterErrorReportTriggeredEvent{
-					V2RawEvent: stripe.V2RawEvent{
-						V2BaseEvent: stripe.V2BaseEvent{
-							Created: timeNow,
-							ID:      "evt_1",
-							Type:    "v1.billing.meter.error_report_triggered",
-						},
-						RelatedObject: &stripe.RelatedObject{
-							ID: "ro_123",
-						},
+					V2BaseEvent: stripe.V2BaseEvent{
+						Created: timeNow,
+						ID:      "evt_1",
+						Type:    "v1.billing.meter.error_report_triggered",
 					},
 					Data: stripe.V1BillingMeterErrorReportTriggeredEventData{
 						DeveloperMessageSummary: "This is a developer message",
@@ -76,24 +66,20 @@ func TestEventAll(t *testing.T) {
 					},
 				},
 				&stripe.V1BillingMeterNoMeterFoundEvent{
-					V2RawEvent: stripe.V2RawEvent{
-						V2BaseEvent: stripe.V2BaseEvent{
-							Created: timeNow,
-							ID:      "evt_2",
-							Type:    "v1.billing.meter.no_meter_found",
-						},
+					V2BaseEvent: stripe.V2BaseEvent{
+						Created: timeNow,
+						ID:      "evt_2",
+						Type:    "v1.billing.meter.no_meter_found",
 					},
 					Data: stripe.V1BillingMeterNoMeterFoundEventData{
 						DeveloperMessageSummary: "This is another developer message",
 					},
 				},
 				&stripe.V1BillingMeterNoMeterFoundEvent{
-					V2RawEvent: stripe.V2RawEvent{
-						V2BaseEvent: stripe.V2BaseEvent{
-							Created: timeNow,
-							ID:      "evt_3",
-							Type:    "v1.billing.meter.no_meter_found",
-						},
+					V2BaseEvent: stripe.V2BaseEvent{
+						Created: timeNow,
+						ID:      "evt_3",
+						Type:    "v1.billing.meter.no_meter_found",
 					},
 					Data: stripe.V1BillingMeterNoMeterFoundEventData{
 						DeveloperMessageSummary: "This is yet another developer message",

--- a/v2_events.go
+++ b/v2_events.go
@@ -62,7 +62,7 @@ type V2RawEvent struct {
 // V1BillingMeterErrorReportTriggeredEvent is the Go struct for the "v1.billing.meter.error_report_triggered" event.
 // This event occurs when there are invalid async usage events for a given meter.
 type V1BillingMeterErrorReportTriggeredEvent struct {
-	V2RawEvent
+	V2BaseEvent
 	Data               V1BillingMeterErrorReportTriggeredEventData
 	RelatedObject      RelatedObject
 	fetchRelatedObject func() (*BillingMeter, error)
@@ -76,8 +76,21 @@ func (e V1BillingMeterErrorReportTriggeredEvent) FetchRelatedObject() (*BillingM
 // V1BillingMeterNoMeterFoundEvent is the Go struct for the "v1.billing.meter.no_meter_found" event.
 // This event occurs when async usage events have missing or invalid meter ids.
 type V1BillingMeterNoMeterFoundEvent struct {
-	V2RawEvent
+	V2BaseEvent
 	Data V1BillingMeterNoMeterFoundEventData
+}
+
+// V2CoreEventDestinationPingEvent is the Go struct for the "v2.core.event_destination.ping" event.
+// A ping event used to test the connection to an event destination.
+type V2CoreEventDestinationPingEvent struct {
+	V2BaseEvent
+	RelatedObject      RelatedObject
+	fetchRelatedObject func() (*V2EventDestination, error)
+}
+
+// FetchRelatedObject fetches the related V2EventDestination object for the event.
+func (e V2CoreEventDestinationPingEvent) FetchRelatedObject() (*V2EventDestination, error) {
+	return e.fetchRelatedObject()
 }
 
 // The request causes the error.
@@ -181,14 +194,27 @@ func ConvertRawEvent(event *V2RawEvent, backend Backend, key string) (V2Event, e
 			err := backend.Call(http.MethodGet, event.RelatedObject.URL, key, nil, v)
 			return v, err
 		}
-		if err := json.Unmarshal(*event.Data, &result.Data); err != nil {
+		if err := json.Unmarshal(*event.Data, result); err != nil {
 			return nil, err
 		}
 		return result, nil
 	case "v1.billing.meter.no_meter_found":
 		result := &V1BillingMeterNoMeterFoundEvent{}
 		result.V2BaseEvent = event.V2BaseEvent
-		if err := json.Unmarshal(*event.Data, &result.Data); err != nil {
+		if err := json.Unmarshal(*event.Data, result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	case "v2.core.event_destination.ping":
+		result := &V2CoreEventDestinationPingEvent{}
+		result.V2BaseEvent = event.V2BaseEvent
+		result.RelatedObject = *event.RelatedObject
+		result.fetchRelatedObject = func() (*V2EventDestination, error) {
+			v := &V2EventDestination{}
+			err := backend.Call(http.MethodGet, event.RelatedObject.URL, key, nil, v)
+			return v, err
+		}
+		if err := json.Unmarshal(*event.Data, result); err != nil {
 			return nil, err
 		}
 		return result, nil

--- a/v2_events.go
+++ b/v2_events.go
@@ -63,8 +63,8 @@ type V2RawEvent struct {
 // This event occurs when there are invalid async usage events for a given meter.
 type V1BillingMeterErrorReportTriggeredEvent struct {
 	V2BaseEvent
-	Data               V1BillingMeterErrorReportTriggeredEventData
-	RelatedObject      RelatedObject
+	Data               V1BillingMeterErrorReportTriggeredEventData `json:"data"`
+	RelatedObject      RelatedObject                               `json:"related_object"`
 	fetchRelatedObject func() (*BillingMeter, error)
 }
 
@@ -77,14 +77,14 @@ func (e V1BillingMeterErrorReportTriggeredEvent) FetchRelatedObject() (*BillingM
 // This event occurs when async usage events have missing or invalid meter ids.
 type V1BillingMeterNoMeterFoundEvent struct {
 	V2BaseEvent
-	Data V1BillingMeterNoMeterFoundEventData
+	Data V1BillingMeterNoMeterFoundEventData `json:"data"`
 }
 
 // V2CoreEventDestinationPingEvent is the Go struct for the "v2.core.event_destination.ping" event.
 // A ping event used to test the connection to an event destination.
 type V2CoreEventDestinationPingEvent struct {
 	V2BaseEvent
-	RelatedObject      RelatedObject
+	RelatedObject      RelatedObject `json:"related_object"`
 	fetchRelatedObject func() (*V2EventDestination, error)
 }
 
@@ -194,14 +194,14 @@ func ConvertRawEvent(event *V2RawEvent, backend Backend, key string) (V2Event, e
 			err := backend.Call(http.MethodGet, event.RelatedObject.URL, key, nil, v)
 			return v, err
 		}
-		if err := json.Unmarshal(*event.Data, result); err != nil {
+		if err := json.Unmarshal(*event.Data, &result.Data); err != nil {
 			return nil, err
 		}
 		return result, nil
 	case "v1.billing.meter.no_meter_found":
 		result := &V1BillingMeterNoMeterFoundEvent{}
 		result.V2BaseEvent = event.V2BaseEvent
-		if err := json.Unmarshal(*event.Data, result); err != nil {
+		if err := json.Unmarshal(*event.Data, &result.Data); err != nil {
 			return nil, err
 		}
 		return result, nil
@@ -213,9 +213,6 @@ func ConvertRawEvent(event *V2RawEvent, backend Backend, key string) (V2Event, e
 			v := &V2EventDestination{}
 			err := backend.Call(http.MethodGet, event.RelatedObject.URL, key, nil, v)
 			return v, err
-		}
-		if err := json.Unmarshal(*event.Data, result); err != nil {
-			return nil, err
 		}
 		return result, nil
 	default:


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Tests are failing on `master` because we have a few conflicting in-flight changes for Events coming from codegen. This PR picks out the changes that are needed to get tests passing again.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Updates events to embed `V2BaseEvent` instead of `V2RawEvent`
- Adds `json` tags to V2 events
- Updates a test to reflect the above

### See Also
<!-- Include any links or additional information that help explain this change. -->
