### PR TITLE
Remove Go VS Code setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
   // Show the repo name in the top window bar.
   "window.title": "${rootName}${separator}${activeEditorMedium}",
-  "go.alternateTools": {
-      "go": "~/.local/share/mise/installs/go/latest/bin/go"
-  }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
I no longer need the Go-specific VS code setting, so it's best to keep things as clean as possible

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Removes   "go.alternateTools" from settings.json

### See Also
<!-- Include any links or additional information that help explain this change. -->
