### PR TITLE
Improved options patterns for stripe.Client

### DIFF
--- a/stripe_client_test.go
+++ b/stripe_client_test.go
@@ -1,0 +1,96 @@
+package stripe_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v82"
+)
+
+func TestNewClient(t *testing.T) {
+	client := stripe.NewClient("foo")
+	assert.NotNil(t, client)
+}
+
+func TestNewClientWithNilBackend(t *testing.T) {
+	client := stripe.NewClient("foo", nil)
+	assert.NotNil(t, client)
+}
+
+func TestParseThinEvent(t *testing.T) {
+	thinEvent := &stripe.ThinEvent{
+		ID:       "evt_123",
+		Object:   "event",
+		Type:     "charge.succeeded",
+		Livemode: true,
+		Created:  time.Now(),
+		Context:  nil,
+		RelatedObject: &stripe.RelatedObject{
+			ID:   "ch_123",
+			Type: "charge",
+			URL:  "/v1/charges/ch_123",
+		},
+	}
+	thinEventJSON, err := json.Marshal(thinEvent)
+	assert.NoError(t, err)
+	p := stripe.SignedPayload{
+		UnsignedPayload: stripe.UnsignedPayload{
+			Payload:   thinEventJSON,
+			Timestamp: time.Now(),
+			Secret:    "whsec_test_secret",
+			Scheme:    "v1",
+		},
+	}
+	p.Signature = stripe.ComputeSignature(p.Timestamp, p.Payload, p.Secret)
+	p.Header = generateHeader(p)
+	sc := stripe.NewClient("sk_test_secret")
+	thinEvent, err = sc.ParseThinEvent(p.Payload, p.Header, p.Secret)
+	assert.NoError(t, err)
+	assert.Equal(t, "evt_123", thinEvent.ID)
+	assert.Equal(t, "event", thinEvent.Object)
+	assert.Equal(t, "charge.succeeded", thinEvent.Type)
+	assert.Equal(t, true, thinEvent.Livemode)
+	assert.Equal(t, "ch_123", thinEvent.RelatedObject.ID)
+	assert.Equal(t, "charge", thinEvent.RelatedObject.Type)
+	assert.Equal(t, "/v1/charges/ch_123", thinEvent.RelatedObject.URL)
+	assert.NotNil(t, thinEvent)
+}
+
+func TestParseThinEventNoTolerance(t *testing.T) {
+	thinEvent := &stripe.ThinEvent{
+		ID:       "evt_123",
+		Object:   "event",
+		Type:     "charge.succeeded",
+		Livemode: true,
+		Created:  time.Now(),
+		Context:  nil,
+		RelatedObject: &stripe.RelatedObject{
+			ID:   "ch_123",
+			Type: "charge",
+			URL:  "/v1/charges/ch_123",
+		},
+	}
+	thinEventJSON, err := json.Marshal(thinEvent)
+	assert.NoError(t, err)
+	p := stripe.SignedPayload{
+		UnsignedPayload: stripe.UnsignedPayload{
+			Payload:   thinEventJSON,
+			Timestamp: time.Now(),
+			Secret:    "whsec_test_secret",
+			Scheme:    "v1",
+		},
+	}
+	p.Signature = stripe.ComputeSignature(p.Timestamp, p.Payload, p.Secret)
+	p.Header = generateHeader(p)
+	sc := stripe.NewClient("sk_test_secret")
+	thinEvent, err = sc.ParseThinEvent(p.Payload, p.Header, p.Secret, stripe.WithTolerance(0))
+	assert.Equal(t, stripe.ErrWebhookTooOld, err)
+}
+
+func generateHeader(p stripe.SignedPayload) string {
+	return fmt.Sprintf("t=%d,%s=%s", p.Timestamp.Unix(), p.Scheme, hex.EncodeToString(p.Signature))
+}

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -160,20 +160,20 @@ func TestTokenNew(t *testing.T) {
 	p = newSignedPayload(func(p *SignedPayload) {
 		p.Timestamp = time.Now().Add(-15 * time.Second)
 	})
-	err = ValidatePayloadWithTolerance(p.Payload, p.Header, p.Secret, 10*time.Second)
+	err = ValidatePayload(p.Payload, p.Header, p.Secret, WithTolerance(10*time.Second))
 	if err != ErrWebhookTooOld {
 		t.Errorf("Received %v error when validating timestamp outside of allowed timing window", err)
 	}
-	evt, err = ConstructEventWithTolerance(p.Payload, p.Header, p.Secret, 10*time.Second)
+	evt, err = ConstructEvent(p.Payload, p.Header, p.Secret, WithTolerance(10*time.Second))
 	if err != ErrWebhookTooOld {
 		t.Errorf("Received %v error when validating timestamp outside of allowed timing window", err)
 	}
 
-	err = ValidatePayloadWithTolerance(p.Payload, p.Header, p.Secret, 20*time.Second)
+	err = ValidatePayload(p.Payload, p.Header, p.Secret, WithTolerance(20*time.Second))
 	if err != nil {
 		t.Errorf("Received %v error when validating timestamp inside allowed timing window", err)
 	}
-	evt, err = ConstructEventWithTolerance(p.Payload, p.Header, p.Secret, 20*time.Second)
+	evt, err = ConstructEvent(p.Payload, p.Header, p.Secret, WithTolerance(20*time.Second))
 	if err != nil {
 		t.Errorf("Received %v error when validating timestamp inside allowed timing window", err)
 	}
@@ -181,11 +181,11 @@ func TestTokenNew(t *testing.T) {
 	p = newSignedPayload(func(p *SignedPayload) {
 		p.Timestamp = time.Unix(12345, 0)
 	})
-	err = ValidatePayloadIgnoringTolerance(p.Payload, p.Header, p.Secret)
+	err = ValidatePayload(p.Payload, p.Header, p.Secret, WithIgnoreTolerance())
 	if err != nil {
 		t.Errorf("Received %v error when timestamp outside window but no tolerance specified", err)
 	}
-	evt, err = ConstructEventIgnoringTolerance(p.Payload, p.Header, p.Secret)
+	evt, err = ConstructEvent(p.Payload, p.Header, p.Secret, WithIgnoreTolerance())
 	if err != nil {
 		t.Errorf("Received %v error when timestamp outside window but no tolerance specified", err)
 	}
@@ -266,7 +266,7 @@ func TestConstructEventWithOptions_IgnoreAPIVersionMismatch(t *testing.T) {
 		p.Payload = testPayloadWithAPIVersionMismatch
 	})
 
-	evt, err := ConstructEventWithOptions(p.Payload, p.Header, p.Secret, ConstructEventOptions{IgnoreAPIVersionMismatch: true})
+	evt, err := ConstructEvent(p.Payload, p.Header, p.Secret, WithIgnoreAPIVersionMismatch())
 
 	if err != nil {
 		t.Errorf("Expected no error due ignoreAPIVersionMismatch.")
@@ -285,7 +285,7 @@ func TestConstructEventWithOptions_UsesDefaultToleranceWhenNoneProvided(t *testi
 		p.Timestamp = time.Now().Add(-WebhookDefaultTolerance).Add(1 * time.Second)
 	})
 
-	_, err := ConstructEventWithOptions(p.Payload, p.Header, p.Secret, ConstructEventOptions{})
+	_, err := ConstructEvent(p.Payload, p.Header, p.Secret, nil)
 
 	if err != nil {
 		t.Errorf("Expected no error due tolerance, but got %v.", err)
@@ -295,7 +295,7 @@ func TestConstructEventWithOptions_UsesDefaultToleranceWhenNoneProvided(t *testi
 		p.Timestamp = time.Now().Add(-WebhookDefaultTolerance).Add(-1 * time.Millisecond)
 	})
 
-	_, err = ConstructEventWithOptions(p.Payload, p.Header, p.Secret, ConstructEventOptions{})
+	_, err = ConstructEvent(p.Payload, p.Header, p.Secret, nil)
 
 	if err != ErrWebhookTooOld {
 		t.Errorf("Expected error due to being too old, but got %v.", err)


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
During our bug bash, we found that the Go SDK segfaults on a `nil` ClientOption. We also found that `stripe.Client` was missing `ConstructEvent` functionality. This PR kills two birds with one stone.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Makes `...ClientOption` parameter in `stripe.NewClient` `nil`-safe
- Adds `ConstructEvent` method on `stripe.Client`
- Adds a `nil`-safe options pattern to both `ParseThinEvent` and `ConstructEvent` methods

Note that neither `stripe_client.go` nor `webhooks.go` has been released yet, so there are no actual backwards incompatible changes in this PR.
