### PR TITLE
Unexport GetBaseEvent and V2ErrorCode

### DIFF
--- a/error.go
+++ b/error.go
@@ -215,16 +215,6 @@ const (
 
 // v1ErrorCodes: The end of the section generated from our OpenAPI spec
 
-// V2ErrorCode is the list of allowed values for the V2 error's code.
-type V2ErrorCode string
-
-// v2ErrorCodes: The beginning of the section generated from our OpenAPI spec
-const (
-	ErrorCodeBillingMeterEventSessionExpired V2ErrorCode = "billing_meter_event_session_expired"
-)
-
-// v2ErrorCodes: The end of the section generated from our OpenAPI spec
-
 // List of DeclineCode values.
 // For descriptions see https://stripe.com/docs/declines/codes
 const (
@@ -426,11 +416,11 @@ func (e *IdempotencyError) Error() string {
 // The temporary session token has expired.
 type TemporarySessionExpiredError struct {
 	APIResource
-	Code        V2ErrorCode `json:"code"`
-	DocURL      *string     `json:"doc_url,omitempty"`
-	Message     string      `json:"message"`
-	Type        ErrorType   `json:"type"`
-	UserMessage *string     `json:"user_message,omitempty"`
+	Code        string    `json:"code"`
+	DocURL      *string   `json:"doc_url,omitempty"`
+	Message     string    `json:"message"`
+	Type        ErrorType `json:"type"`
+	UserMessage *string   `json:"user_message,omitempty"`
 }
 
 // Error serializes the error object to JSON and returns it as a string.

--- a/v2/core/eventdestination/client_test.go
+++ b/v2/core/eventdestination/client_test.go
@@ -229,10 +229,13 @@ func TestEventDestinationPing(t *testing.T) {
 	defer testServer.Close()
 	event, err := sc.V2CoreEventDestinations.Ping("evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92", nil)
 	assert.Nil(t, err)
-	assert.Equal(t, event.GetBaseEvent().ID, "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92")
-	assert.Equal(t, event.GetBaseEvent().Type, "v2.core.event_destination.ping")
-	assert.True(t, event.GetBaseEvent().Created.Equal(timeNow))
-	assert.Equal(t, event.GetBaseEvent().Object, "v2.core.event")
+	ping, ok := event.(*stripe.V2CoreEventDestinationPingEvent)
+	assert.True(t, ok)
+	assert.Equal(t, ping.ID, "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92")
+	assert.Equal(t, ping.Type, "v2.core.event_destination.ping")
+	assert.True(t, ping.Created.Equal(timeNow))
+	assert.Equal(t, ping.Object, "v2.core.event")
+	assert.Equal(t, ping.RelatedObject.ID, "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92")
 }
 
 func TestEventDestinationList_SinglePage(t *testing.T) {

--- a/v2_event.go
+++ b/v2_event.go
@@ -51,6 +51,6 @@ type V2BaseEvent struct {
 	Type string `json:"type"`
 }
 
-func (e *V2BaseEvent) GetBaseEvent() *V2BaseEvent {
+func (e *V2BaseEvent) getBaseEvent() *V2BaseEvent {
 	return e
 }

--- a/v2_events.go
+++ b/v2_events.go
@@ -47,7 +47,7 @@ const (
 // V2Event is the interface implemented by V2 Events. To get the underlying Event,
 // use a type switch or type assertion to one of the concrete event types.
 type V2Event interface {
-	GetBaseEvent() *V2BaseEvent
+	getBaseEvent() *V2BaseEvent
 }
 
 // V2RawEvent is the raw event type for V2 events. It is used to unmarshal the


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
* The `GetBaseEvent` method on `V2Event` is confusing because the user shouldn't be using it--instead they should type-cast to the appropriate concrete event. Therefore, we shouldn't even expose it.
* The `V2ErrorCode` looks like something that should be handled programmatically, but shouldn't. Therefore, we will just treat it as a `string` to avoid that footgun. 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Unexport `GetBaseEvent` method.
- Remove `V2ErrorCode` type.

## Changelog
* Unexported `GetBaseEvent` --> `getBaseEvent`. This function should not be called. Instead, type-cast the `V2Event` to a concrete Event struct.
* Removed the `V2ErrorCode` type. Error codes should not be handled programmatically for V2 errors.
