### PR TITLE
Simplify public preview SDK instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,10 +487,10 @@ func UseMockedStripeClient(t *testing.T) {
 
 ### Public Preview SDKs
 
-Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `82.2.0-beta.2`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-The public preview SDKs are a different version of the same package as the stable SDKs. These versions are appended with `-beta.X` such as `v82.2.0-beta.2`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-go/releases/) and use it in your `go.mod` file:
+To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-go/releases/) and use it in your `go.mod` file:
 
 ```
 require (
@@ -503,7 +503,7 @@ require (
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version.
 
-If your preview feature requires a `Stripe-Version` header to be sent, set the `stripe.APIVersion` field using the `stripe.AddBetaVersion` function (available only in the public preview SDKs):
+Some preview features require a name and version to be set in the `Stripe-Version` header like `feature_beta=v3`. If your preview feature has this requirement, use the `stripe.AddBetaVersion` function (available only in the public preview SDKs):
 
 ```go
 stripe.AddBetaVersion("feature_beta", "v3")


### PR DESCRIPTION
### Why?
Follow up to https://github.com/stripe/stripe-go/pull/2064

### What?
- Avoid mentioning "beta version"
- Add more explanation to beta header usage

