### PR TITLE
Deduplicate telemetry strings

### DIFF
--- a/params.go
+++ b/params.go
@@ -239,7 +239,7 @@ func (p *Params) AddExpand(f string) {
 // Unstable: for internal stripe-go usage only.
 func (p *Params) InternalSetUsage(usage []string) {
 	// Optimization for nil or empty usage
-	if usage == nil || len(usage) == 0 {
+	if len(usage) == 0 {
 		return
 	}
 

--- a/params.go
+++ b/params.go
@@ -235,10 +235,26 @@ func (p *Params) AddExpand(f string) {
 	p.Expand = append(p.Expand, &f)
 }
 
-// InternalSetUsage sets the usage field on the Params struct.
+// InternalSetUsage sets the usage field on the Params struct, removing duplicates.
 // Unstable: for internal stripe-go usage only.
 func (p *Params) InternalSetUsage(usage []string) {
-	p.usage = append(p.usage, usage...)
+	// Optimization for nil or empty usage
+	if usage == nil || len(usage) == 0 {
+		return
+	}
+
+	// Use a map to track unique usage values
+	usageMap := make(map[string]struct{})
+	for _, u := range p.usage {
+		usageMap[u] = struct{}{}
+	}
+	for _, u := range usage {
+		usageMap[u] = struct{}{}
+	}
+	p.usage = p.usage[:0] // Reset the slice to avoid retaining old values
+	for u := range usageMap {
+		p.usage = append(p.usage, u)
+	}
 }
 
 // AddExtra adds a new arbitrary key-value pair to the request data

--- a/params_internal_test.go
+++ b/params_internal_test.go
@@ -1,0 +1,37 @@
+package stripe
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestInternalSetUsage_Deduplication(t *testing.T) {
+	p := &Params{}
+	p.InternalSetUsage([]string{"foo", "bar"})
+	assert.ElementsMatch(t, []string{"foo", "bar"}, p.usage)
+
+	// Add duplicate and new usage
+	p.InternalSetUsage([]string{"bar", "baz"})
+	// Should contain all unique values
+	assert.ElementsMatch(t, []string{"foo", "bar", "baz"}, p.usage)
+}
+
+func TestInternalSetUsage_Nil(t *testing.T) {
+	p := &Params{}
+	p.InternalSetUsage(nil)
+	assert.Empty(t, p.usage)
+}
+
+func TestInternalSetUsage_Empty(t *testing.T) {
+	p := &Params{}
+	p.InternalSetUsage([]string{})
+	assert.Empty(t, p.usage)
+}
+
+func TestInternalSetUsage_Idempotent(t *testing.T) {
+	p := &Params{}
+	p.InternalSetUsage([]string{"foo"})
+	p.InternalSetUsage([]string{"foo"})
+	assert.Equal(t, []string{"foo"}, p.usage)
+}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
It was previously possible, and occasionally seen in real usage, that a telemetry string could be duplicated when sent to Stripe (e.g. `stripe_client,stripe_client,stripe_client`). This could lead to very long usage strings that could eventually affect performance and hit payload limits.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
* Deduplicates usage arrays

## Changelog
* Fixes a bug where telemetry strings could have duplicate values
