### PR TITLE
Fix failing telemetry test

### DIFF
--- a/stripe_test.go
+++ b/stripe_test.go
@@ -524,7 +524,7 @@ func TestCall_TelemetryEnabled(t *testing.T) {
 
 			// The telemetry in the second request should contain the
 			// expected usage
-			assert.Equal(t, telemetry.LastRequestMetrics.Usage, []string{"llama", "bufo"})
+			assert.ElementsMatch(t, telemetry.LastRequestMetrics.Usage, []string{"llama", "bufo"})
 		default:
 			assert.Fail(t, "Should not have reached request %v", requestNum)
 		}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
This is a follow-up to https://github.com/stripe/stripe-go/pull/2068 which caused a unit test depending on the order of telemetry arrays to intermittently fail.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Fixes the telemetry test to no longer depend on the order of usage strings

### See Also
<!-- Include any links or additional information that help explain this change. -->
