### PR TITLE
build SDK w/ new spec

### DIFF
--- a/error.go
+++ b/error.go
@@ -413,7 +413,7 @@ func (e *IdempotencyError) Error() string {
 // errorStructs: The beginning of the section generated from our OpenAPI spec
 
 // TemporarySessionExpiredError is the Go struct corresponding to the error type "temporary_session_expired."
-// The temporary session token has expired.
+// Information about the error that occurred
 type TemporarySessionExpiredError struct {
 	APIResource
 	Code        string    `json:"code"`

--- a/v2/core/eventdestination/client.go
+++ b/v2/core/eventdestination/client.go
@@ -63,9 +63,9 @@ func (c Client) Update(id string, params *stripe.V2CoreEventDestinationParams) (
 // Deprecated: Client methods are deprecated. This should be accessed instead through [stripe.Client]. See the [migration guide] for more info.
 //
 // [migration guide]: https://github.com/stripe/stripe-go/wiki/Migration-guide-for-Stripe-Client
-func (c Client) Del(id string, params *stripe.V2CoreEventDestinationParams) (*stripe.V2EventDestination, error) {
+func (c Client) Del(id string, params *stripe.V2CoreEventDestinationParams) (*stripe.V2DeletedObject, error) {
 	path := stripe.FormatURLPath("/v2/core/event_destinations/%s", id)
-	eventdestination := &stripe.V2EventDestination{}
+	eventdestination := &stripe.V2CoreEventDestination{}
 	err := c.B.Call(http.MethodDelete, path, c.Key, params, eventdestination)
 	return eventdestination, err
 }

--- a/v2_event.go
+++ b/v2_event.go
@@ -27,7 +27,7 @@ type V2EventReasonRequest struct {
 // Reason for the event.
 type V2EventReason struct {
 	// Information on the API request that instigated the event.
-	Request *V2EventReasonRequest `json:"request"`
+	Request *V2EventReasonRequest `json:"request,omitempty"`
 	// Event reason type.
 	Type V2EventReasonType `json:"type"`
 }
@@ -36,7 +36,7 @@ type V2EventReason struct {
 type V2BaseEvent struct {
 	APIResource
 	// Authentication context needed to fetch the event or related object.
-	Context string `json:"context"`
+	Context string `json:"context,omitempty"`
 	// Time at which the object was created.
 	Created time.Time `json:"created"`
 	// Unique identifier for the event.
@@ -46,7 +46,7 @@ type V2BaseEvent struct {
 	// String representing the object's type. Objects of the same type share the same value of the object field.
 	Object string `json:"object"`
 	// Reason for the event.
-	Reason *V2EventReason `json:"reason"`
+	Reason *V2EventReason `json:"reason,omitempty"`
 	// The type of the event.
 	Type string `json:"type"`
 }

--- a/v2_eventdestination.go
+++ b/v2_eventdestination.go
@@ -73,7 +73,7 @@ type V2EventDestinationStatusDetailsDisabled struct {
 // Additional information about event destination status.
 type V2EventDestinationStatusDetails struct {
 	// Details about why the event destination has been disabled.
-	Disabled *V2EventDestinationStatusDetailsDisabled `json:"disabled"`
+	Disabled *V2EventDestinationStatusDetailsDisabled `json:"disabled,omitempty"`
 }
 
 // Amazon EventBridge configuration.
@@ -89,16 +89,16 @@ type V2EventDestinationAmazonEventbridge struct {
 // Webhook endpoint configuration.
 type V2EventDestinationWebhookEndpoint struct {
 	// The signing secret of the webhook endpoint, only includable on creation.
-	SigningSecret string `json:"signing_secret"`
+	SigningSecret string `json:"signing_secret,omitempty"`
 	// The URL of the webhook endpoint, includable.
-	URL string `json:"url"`
+	URL string `json:"url,omitempty"`
 }
 
 // Set up an event destination to receive events from Stripe across multiple destination types, including [webhook endpoints](https://docs.stripe.com/webhooks) and [Amazon EventBridge](https://docs.stripe.com/event-destinations/eventbridge). Event destinations support receiving [thin events](https://docs.stripe.com/api/v2/events) and [snapshot events](https://docs.stripe.com/api/events).
 type V2EventDestination struct {
 	APIResource
 	// Amazon EventBridge configuration.
-	AmazonEventbridge *V2EventDestinationAmazonEventbridge `json:"amazon_eventbridge"`
+	AmazonEventbridge *V2EventDestinationAmazonEventbridge `json:"amazon_eventbridge,omitempty"`
 	// Time at which the object was created.
 	Created time.Time `json:"created"`
 	// An optional description of what the event destination is used for.
@@ -108,27 +108,27 @@ type V2EventDestination struct {
 	// Payload type of events being subscribed to.
 	EventPayload V2EventDestinationEventPayload `json:"event_payload"`
 	// Where events should be routed from.
-	EventsFrom []V2EventDestinationEventsFrom `json:"events_from"`
+	EventsFrom []V2EventDestinationEventsFrom `json:"events_from,omitempty"`
 	// Unique identifier for the object.
 	ID string `json:"id"`
 	// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
 	Livemode bool `json:"livemode"`
 	// Metadata.
-	Metadata map[string]string `json:"metadata"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 	// Event destination name.
 	Name string `json:"name"`
 	// String representing the object's type. Objects of the same type share the same value of the object field.
 	Object string `json:"object"`
 	// If using the snapshot event payload, the API version events are rendered as.
-	SnapshotAPIVersion string `json:"snapshot_api_version"`
+	SnapshotAPIVersion string `json:"snapshot_api_version,omitempty"`
 	// Status. It can be set to either enabled or disabled.
 	Status V2EventDestinationStatus `json:"status"`
 	// Additional information about event destination status.
-	StatusDetails *V2EventDestinationStatusDetails `json:"status_details"`
+	StatusDetails *V2EventDestinationStatusDetails `json:"status_details,omitempty"`
 	// Event destination type.
 	Type V2EventDestinationType `json:"type"`
 	// Time at which the object was last updated.
 	Updated time.Time `json:"updated"`
 	// Webhook endpoint configuration.
-	WebhookEndpoint *V2EventDestinationWebhookEndpoint `json:"webhook_endpoint"`
+	WebhookEndpoint *V2EventDestinationWebhookEndpoint `json:"webhook_endpoint,omitempty"`
 }

--- a/v2core_eventdestination_params.go
+++ b/v2core_eventdestination_params.go
@@ -6,6 +6,15 @@
 
 package stripe
 
+// Lists all event destinations.
+type V2CoreEventDestinationListParams struct {
+	Params `form:"*"`
+	// Additional fields to include in the response. Currently supports `webhook_endpoint.url`.
+	Include []*string `form:"include" json:"include,omitempty"`
+	// The page size.
+	Limit *int64 `form:"limit" json:"limit,omitempty"`
+}
+
 // Amazon EventBridge configuration.
 type V2CoreEventDestinationAmazonEventbridgeParams struct {
 	// The AWS account ID.
@@ -64,15 +73,6 @@ type V2CoreEventDestinationDisableParams struct {
 // Enable an event destination.
 type V2CoreEventDestinationEnableParams struct {
 	Params `form:"*"`
-}
-
-// Lists all event destinations.
-type V2CoreEventDestinationListParams struct {
-	Params `form:"*"`
-	// Additional fields to include in the response. Currently supports `webhook_endpoint.url`.
-	Include []*string `form:"include" json:"include,omitempty"`
-	// The page size.
-	Limit *int64 `form:"limit" json:"limit,omitempty"`
 }
 
 // Send a `ping` event to an event destination.

--- a/v2core_eventdestination_service.go
+++ b/v2core_eventdestination_service.go
@@ -54,13 +54,13 @@ func (c v2CoreEventDestinationService) Update(ctx context.Context, id string, pa
 }
 
 // Delete an event destination.
-func (c v2CoreEventDestinationService) Delete(ctx context.Context, id string, params *V2CoreEventDestinationDeleteParams) (*V2EventDestination, error) {
+func (c v2CoreEventDestinationService) Delete(ctx context.Context, id string, params *V2CoreEventDestinationDeleteParams) (*V2DeletedObject, error) {
 	if params == nil {
 		params = &V2CoreEventDestinationDeleteParams{}
 	}
 	params.Context = ctx
 	path := FormatURLPath("/v2/core/event_destinations/%s", id)
-	eventdestination := &V2EventDestination{}
+	eventdestination := &V2CoreEventDestination{}
 	err := c.B.Call(http.MethodDelete, path, c.Key, params, eventdestination)
 	return eventdestination, err
 }


### PR DESCRIPTION
DON'T MERGE. This is just to see the output of snapshots built w/ openapi v2.

CI may fail because of changes to `DeletedObject`, which is expected