### PR TITLE
Switch to use generated API versions and add major/monthly constants

### DIFF
--- a/api_version.go
+++ b/api_version.go
@@ -7,5 +7,7 @@
 package stripe
 
 const (
-	apiVersion string = "2025-05-28.basil"
+	APIVersion        string = "2025-05-28.basil"
+	APIMajorVersion   string = "basil"
+	APIMonthlyVersion string = "2025-05-28"
 )

--- a/stripe.go
+++ b/stripe.go
@@ -29,9 +29,6 @@ import (
 //
 
 const (
-	// APIVersion is the currently supported API version
-	APIVersion string = apiVersion
-
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"
 
@@ -571,7 +568,7 @@ func (s *BackendImplementation) NewRequest(method, path, key, contentType string
 
 	req.Header.Add("Authorization", authorization)
 	req.Header.Add("Content-Type", contentType)
-	req.Header.Add("Stripe-Version", apiVersion)
+	req.Header.Add("Stripe-Version", APIVersion)
 	req.Header.Add("User-Agent", encodedUserAgent)
 	req.Header.Add("X-Stripe-Client-User-Agent", getEncodedStripeUserAgent())
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -1549,7 +1549,7 @@ func TestRawRequestStandardGet(t *testing.T) {
 	assert.Equal(t, `/v1/abc?foo=myFoo`, path)
 	assert.Equal(t, `GET`, method)
 	assert.Equal(t, `application/x-www-form-urlencoded`, contentType)
-	assert.Equal(t, apiVersion, stripeVersion)
+	assert.Equal(t, APIVersion, stripeVersion)
 	assert.NoError(t, err)
 	defer testServer.Close()
 }
@@ -1587,7 +1587,7 @@ func TestRawRequestStandardPost(t *testing.T) {
 	assert.Equal(t, `/v1/abc`, path)
 	assert.Equal(t, `POST`, method)
 	assert.Equal(t, `application/x-www-form-urlencoded`, contentType)
-	assert.Equal(t, apiVersion, stripeVersion)
+	assert.Equal(t, APIVersion, stripeVersion)
 	assert.NoError(t, err)
 	defer testServer.Close()
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Export the variables from the generated `api_version.go`, for easier future iteration. This should be a no-op for users.

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* Export constants for the major and monthly API versions
  * e.g. `2025-05-28.basil` has major version `basil` and monthly version `2025-05-28`