### PR TITLE
Xavdid/merge go beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@
   * Add support for `ConfirmConfig` on `TerminalReaderActionConfirmPaymentIntent` and `TerminalReaderConfirmPaymentIntentParams`
   * Add support for error code `forwarding_api_upstream_error` on `QuotePreviewInvoiceLastFinalizationError`
 
+## 82.2.1 - 2025-06-04
+* [#2073](https://github.com/stripe/stripe-go/pull/2073) Update `DisputeReason` to include value `noncompliant`
+  * Adds `noncompliant` to `DisputeReason` enum
+* [#2070](https://github.com/stripe/stripe-go/pull/2070) Fix failing telemetry test
+* [#2068](https://github.com/stripe/stripe-go/pull/2068) Deduplicate telemetry strings
+  * Fixes a bug where telemetry strings could have duplicate values
+
 ## 82.2.0 - 2025-05-29
  This release changes the pinned API version to `2025-05-28.basil`.
 

--- a/api_version.go
+++ b/api_version.go
@@ -7,5 +7,7 @@
 package stripe
 
 const (
-	apiVersion string = "2025-05-28.preview"
+	APIVersion        string = "2025-05-28.preview"
+	APIMajorVersion   string = "preview"
+	APIMonthlyVersion string = "2025-05-28"
 )

--- a/dispute.go
+++ b/dispute.go
@@ -100,6 +100,7 @@ const (
 	DisputeReasonGeneral                 DisputeReason = "general"
 	DisputeReasonIncorrectAccountDetails DisputeReason = "incorrect_account_details"
 	DisputeReasonInsufficientFunds       DisputeReason = "insufficient_funds"
+	DisputeReasonNoncompliant            DisputeReason = "noncompliant"
 	DisputeReasonProductNotReceived      DisputeReason = "product_not_received"
 	DisputeReasonProductUnacceptable     DisputeReason = "product_unacceptable"
 	DisputeReasonSubscriptionCanceled    DisputeReason = "subscription_canceled"

--- a/params.go
+++ b/params.go
@@ -235,10 +235,26 @@ func (p *Params) AddExpand(f string) {
 	p.Expand = append(p.Expand, &f)
 }
 
-// InternalSetUsage sets the usage field on the Params struct.
+// InternalSetUsage sets the usage field on the Params struct, removing duplicates.
 // Unstable: for internal stripe-go usage only.
 func (p *Params) InternalSetUsage(usage []string) {
-	p.usage = append(p.usage, usage...)
+	// Optimization for nil or empty usage
+	if len(usage) == 0 {
+		return
+	}
+
+	// Use a map to track unique usage values
+	usageMap := make(map[string]struct{})
+	for _, u := range p.usage {
+		usageMap[u] = struct{}{}
+	}
+	for _, u := range usage {
+		usageMap[u] = struct{}{}
+	}
+	p.usage = p.usage[:0] // Reset the slice to avoid retaining old values
+	for u := range usageMap {
+		p.usage = append(p.usage, u)
+	}
 }
 
 // AddExtra adds a new arbitrary key-value pair to the request data

--- a/params_internal_test.go
+++ b/params_internal_test.go
@@ -1,0 +1,37 @@
+package stripe
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestInternalSetUsage_Deduplication(t *testing.T) {
+	p := &Params{}
+	p.InternalSetUsage([]string{"foo", "bar"})
+	assert.ElementsMatch(t, []string{"foo", "bar"}, p.usage)
+
+	// Add duplicate and new usage
+	p.InternalSetUsage([]string{"bar", "baz"})
+	// Should contain all unique values
+	assert.ElementsMatch(t, []string{"foo", "bar", "baz"}, p.usage)
+}
+
+func TestInternalSetUsage_Nil(t *testing.T) {
+	p := &Params{}
+	p.InternalSetUsage(nil)
+	assert.Empty(t, p.usage)
+}
+
+func TestInternalSetUsage_Empty(t *testing.T) {
+	p := &Params{}
+	p.InternalSetUsage([]string{})
+	assert.Empty(t, p.usage)
+}
+
+func TestInternalSetUsage_Idempotent(t *testing.T) {
+	p := &Params{}
+	p.InternalSetUsage([]string{"foo"})
+	p.InternalSetUsage([]string{"foo"})
+	assert.Equal(t, []string{"foo"}, p.usage)
+}

--- a/stripe.go
+++ b/stripe.go
@@ -30,9 +30,6 @@ import (
 //
 
 const (
-	// APIVersion is the currently supported API version
-	APIVersion string = apiVersion
-
 	// APIBackend is a constant representing the API service backend.
 	APIBackend SupportedBackend = "api"
 

--- a/stripe.go
+++ b/stripe.go
@@ -1695,7 +1695,7 @@ var encodedStripeUserAgentReady *sync.Once
 var encodedUserAgent string
 
 // API Version with beta headers if any
-var apiVersionWithBetaHeaders string = apiVersion
+var apiVersionWithBetaHeaders string = APIVersion
 
 // The default HTTP client used for communication with any of Stripe's
 // backends.

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -604,7 +604,7 @@ func TestCall_TelemetryEnabled(t *testing.T) {
 
 			// The telemetry in the second request should contain the
 			// expected usage
-			assert.Equal(t, telemetry.LastRequestMetrics.Usage, []string{"llama", "bufo"})
+			assert.ElementsMatch(t, telemetry.LastRequestMetrics.Usage, []string{"llama", "bufo"})
 		default:
 			assert.Fail(t, "Should not have reached request %v", requestNum)
 		}
@@ -1629,7 +1629,7 @@ func TestRawRequestStandardGet(t *testing.T) {
 	assert.Equal(t, `/v1/abc?foo=myFoo`, path)
 	assert.Equal(t, `GET`, method)
 	assert.Equal(t, `application/x-www-form-urlencoded`, contentType)
-	assert.Equal(t, apiVersion, stripeVersion)
+	assert.Equal(t, APIVersion, stripeVersion)
 	assert.NoError(t, err)
 	defer testServer.Close()
 }
@@ -1667,7 +1667,7 @@ func TestRawRequestStandardPost(t *testing.T) {
 	assert.Equal(t, `/v1/abc`, path)
 	assert.Equal(t, `POST`, method)
 	assert.Equal(t, `application/x-www-form-urlencoded`, contentType)
-	assert.Equal(t, apiVersion, stripeVersion)
+	assert.Equal(t, APIVersion, stripeVersion)
 	assert.NoError(t, err)
 	defer testServer.Close()
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Mostly the result of the merge script, though I ran `just gen go --beta` to populate the preview api version and fixed a couple of places that `apiVersion` wasn't migrated

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
