### PR TITLE
Pull in OffSessionPayment changes for the May release

### DIFF
--- a/api_version.go
+++ b/api_version.go
@@ -7,7 +7,5 @@
 package stripe
 
 const (
-	APIVersion        string = "2025-05-28.preview"
-	APIMajorVersion   string = "preview"
-	APIMonthlyVersion string = "2025-05-28"
+	apiVersion string = "2025-05-28.preview"
 )

--- a/api_version.go
+++ b/api_version.go
@@ -7,5 +7,5 @@
 package stripe
 
 const (
-	apiVersion string = "2025-05-28.preview"
+	APIVersion string = "2025-05-28.preview"
 )

--- a/v2payments_offsessionpayment.go
+++ b/v2payments_offsessionpayment.go
@@ -70,8 +70,6 @@ type V2PaymentsOffSessionPayment struct {
 	APIResource
 	// The amount you requested to be collected on the OSP upon creation.
 	AmountRequested Amount `json:"amount_requested"`
-	// Number of authorization attempts.
-	Attempts int64 `json:"attempts"`
 	// The frequency of the underlying payment that this OSP represents.
 	Cadence V2PaymentsOffSessionPaymentCadence `json:"cadence"`
 	// ID of owning compartment.

--- a/v2payments_offsessionpayment_params.go
+++ b/v2payments_offsessionpayment_params.go
@@ -20,7 +20,7 @@ type V2PaymentsOffSessionPaymentRetryDetailsParams struct {
 // How you want to transfer the funds to your connected accounts.
 type V2PaymentsOffSessionPaymentTransferDataParams struct {
 	// Amount in minor units that you want to transfer.
-	Amount *int64 `form:"amount" json:"amount"`
+	Amount *int64 `form:"amount" json:"amount,omitempty"`
 	// ID of the connected account where you want money to go.
 	Destination *string `form:"destination" json:"destination"`
 }
@@ -77,7 +77,7 @@ type V2PaymentsOffSessionPaymentCreateRetryDetailsParams struct {
 // How you want to transfer the funds to your connected accounts.
 type V2PaymentsOffSessionPaymentCreateTransferDataParams struct {
 	// Amount in minor units that you want to transfer.
-	Amount *int64 `form:"amount" json:"amount"`
+	Amount *int64 `form:"amount" json:"amount,omitempty"`
 	// ID of the connected account where you want money to go.
 	Destination *string `form:"destination" json:"destination"`
 }


### PR DESCRIPTION
### Why?
Changes were done to OffSessionPayment API in the May release which did not make it to the SDKs. Pulling those changes in now and making another SDK release for the `2025-05-28.preview` API version

### What?
- Pull protos in codegen for `2025-05-28.preview`
- Generate the SDK 
