### PR TITLE
update changelog example to feature APIs that are not part of a preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ Starting with v82.1, the new `stripe.Client` type is replacing `client.API` to p
 1. Service method names now align with Stripe API docs. The `stripe.Client` uses `Create`, `Retrieve`, `Update`, and `Delete` (instead of `New`, `Get`, `Update`, and `Del`).  
 2. The first argument of each service method is a `context.Context`.  
 3. Parameter objects are now method-specific. For example, `CustomerCreateParams` and `CustomerDeleteParams` instead of simply `CustomerParams`. This allows us to put the right fields in the right methods at compile time.  
-4. Services are all version-namespaced for symmetry. E.g. `stripeClient.V1Accounts` and `stripeClient.V2Accounts`.  
+4. Services are all version-namespaced for symmetry. E.g. `stripeClient.V1BillingMeterEvents` and `stripeClient.V2BillingMeterEvents`.
 5. `List` methods return an `iter.Seq2`, so they can be ranged over without explicit calls to `Next`, `Current`, and `Err`. 
 
   ### 🎉 Native support in Go for V2 APIs


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There was user confusion in https://github.com/stripe/stripe-go/issues/2085 because we used a public beta API as an example in the changelog, but they weren't able to use that API in the GA SDK.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- tweaked an example in the changelog

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-1793](https://go/j/RUN_DEVSDK-1793)
- fixes https://github.com/stripe/stripe-go/issues/2085
