### PR TITLE
removed useless nil checks

### DIFF
--- a/paymentsource_service.go
+++ b/paymentsource_service.go
@@ -58,9 +58,6 @@ func (c v1PaymentSourceService) Update(ctx context.Context, id string, params *P
 	if params.Customer == nil {
 		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
 	}
-	if params == nil {
-		params = &PaymentSourceUpdateParams{}
-	}
 	params.Context = ctx
 	path := FormatURLPath(
 		"/v1/customers/%s/sources/%s", StringValue(params.Customer), id)


### PR DESCRIPTION
### Why?
Quick removal of useless nil checks, as my Go formatter could not stop crying about it.

### What?
The 3 files that I modified were only removals. Most of the time, the params were re-checked if they were nil or not, even though the nil check was done previously.

### See Also
/