### PR TITLE
removed useless nil checks

### DIFF
--- a/cashbalance_service.go
+++ b/cashbalance_service.go
@@ -37,9 +37,7 @@ func (c v1CashBalanceService) Update(ctx context.Context, params *CashBalanceUpd
 		return nil, fmt.Errorf(
 			"params cannot be nil, and params.Customer must be set")
 	}
-	if params == nil {
-		params = &CashBalanceUpdateParams{}
-	}
+
 	params.Context = ctx
 	path := FormatURLPath(
 		"/v1/customers/%s/cash_balance", StringValue(params.Customer))

--- a/feerefund_service.go
+++ b/feerefund_service.go
@@ -64,9 +64,7 @@ func (c v1FeeRefundService) Update(ctx context.Context, id string, params *FeeRe
 	if params.Fee == nil {
 		return nil, fmt.Errorf("params.Fee must be set")
 	}
-	if params == nil {
-		params = &FeeRefundUpdateParams{}
-	}
+
 	params.Context = ctx
 	path := FormatURLPath(
 		"/v1/application_fees/%s/refunds/%s", StringValue(params.Fee), id)

--- a/paymentsource_service.go
+++ b/paymentsource_service.go
@@ -58,9 +58,7 @@ func (c v1PaymentSourceService) Update(ctx context.Context, id string, params *P
 	if params.Customer == nil {
 		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
 	}
-	if params == nil {
-		params = &PaymentSourceUpdateParams{}
-	}
+
 	params.Context = ctx
 	path := FormatURLPath(
 		"/v1/customers/%s/sources/%s", StringValue(params.Customer), id)


### PR DESCRIPTION
### Why?
There were some nil == nil, checks which were annoying, especially because the go compiler did not stop crying about it in my IDE.

### What?
Removed 3 useless nil checks from 3 files (paymentsource_service.go, feerefund_service.go, cashbalance_service.go).  These nil checks were checking if the params was nil, even though it already checked it previously.

### See Also
/
