### PR TITLE
Mbroshi/run devsdk 1828/fix payment method services

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -8,9 +8,8 @@ package stripe
 
 import (
 	"encoding/json"
-	"strconv"
-
 	"github.com/stripe/stripe-go/v82/form"
+	"strconv"
 )
 
 // The type of entity that holds the account. This can be either `individual` or `company`.
@@ -495,7 +494,7 @@ func (p *BankAccountUpdateParams) AddMetadata(key string, value string) {
 	p.Metadata[key] = value
 }
 
-// New creates a new bank account
+// Create creates a new bank account
 type BankAccountCreateParams struct {
 	Params   `form:"*"`
 	Account  *string `form:"-"` // Included in URL
@@ -519,8 +518,7 @@ type BankAccountCreateParams struct {
 	RoutingNumber *string `form:"routing_number"`
 }
 
-// AppendToAsSourceOrExternalAccount appends the given BankCreateAccountParams as
-// either a source or external account.
+// AppendToAsSourceOrExternalAccount appends the given BankAccountCreateParams as either a source or external account.
 func (p *BankAccountCreateParams) AppendToAsSourceOrExternalAccount(body *form.Values) {
 	// Rather than being called in addition to `AppendTo`, this function
 	// *replaces* `AppendTo`, so we must also make sure to handle the encoding

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -24,12 +24,12 @@ type Client struct {
 	Key string
 }
 
-// New creates a new bank account
+// Create creates a new bank account
 func New(params *stripe.BankAccountParams) (*stripe.BankAccount, error) {
 	return getC().New(params)
 }
 
-// New creates a new bank account
+// Create creates a new bank account
 //
 // Deprecated: Client methods are deprecated. This should be accessed instead through [stripe.Client]. See the [migration guide] for more info.
 //

--- a/bankaccount_service_test.go
+++ b/bankaccount_service_test.go
@@ -1,0 +1,76 @@
+package stripe_test
+
+import (
+	"context"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v82"
+	. "github.com/stripe/stripe-go/v82/testing"
+)
+
+func TestBankAccountDelete_ByAccount(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	bankAccount, err := sc.V1BankAccounts.Delete(context.TODO(), "ba_123", &stripe.BankAccountDeleteParams{
+		Account: stripe.String("acct_123"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, bankAccount)
+}
+
+func TestBankAccountRetrieve_ByAccount(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	bankAccount, err := sc.V1BankAccounts.Retrieve(context.TODO(), "ba_123", &stripe.BankAccountRetrieveParams{Account: stripe.String("acct_123")})
+	assert.Nil(t, err)
+	assert.NotNil(t, bankAccount)
+}
+
+func TestBankAccountList_ByAccount(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	i := sc.V1BankAccounts.List(context.TODO(), &stripe.BankAccountListParams{Account: stripe.String("acct_123")})
+	i(func(ba *stripe.BankAccount, err error) bool {
+		assert.Nil(t, err)
+		assert.NotNil(t, ba)
+		return true
+	})
+}
+
+func TestBankAccountList_ByCustomer(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	i := sc.V1BankAccounts.List(context.TODO(), &stripe.BankAccountListParams{Customer: stripe.String("cus_123")})
+	i(func(ba *stripe.BankAccount, err error) bool {
+		assert.Nil(t, err)
+		assert.NotNil(t, ba)
+		return true
+	})
+}
+
+func TestBankAccountCreate_ByAccount(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	bankAccount, err := sc.V1BankAccounts.Create(context.TODO(), &stripe.BankAccountCreateParams{
+		Account: stripe.String("acct_123"),
+		Token:   stripe.String("tok_123"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, bankAccount)
+}
+
+func TestBankAccountCreate_ByCustomer(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	bankAccount, err := sc.V1BankAccounts.Create(context.TODO(), &stripe.BankAccountCreateParams{
+		Customer: stripe.String("cus_123"),
+		Token:    stripe.String("tok_123"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, bankAccount)
+}
+
+func TestBankAccountUpdate_ByAccount(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	bankAccount, err := sc.V1BankAccounts.Update(context.TODO(), "ba_123", &stripe.BankAccountUpdateParams{
+		Account:            stripe.String("acct_123"),
+		DefaultForCurrency: stripe.Bool(true),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, bankAccount)
+}

--- a/card.go
+++ b/card.go
@@ -373,7 +373,7 @@ func (p *CardUpdateParams) AddMetadata(key string, value string) {
 	p.Metadata[key] = value
 }
 
-// New creates a new card
+// Create creates a new card
 type CardCreateParams struct {
 	Params   `form:"*"`
 	Account  *string `form:"-"` // Included in URL
@@ -388,7 +388,6 @@ func (p *CardCreateParams) AppendToAsCardSourceOrExternalAccount(body *form.Valu
 	// *replaces* `AppendTo`, so we must also make sure to handle the encoding
 	// of `Params` so metadata and the like is included in the encoded payload.
 	form.AppendToPrefixed(body, p.Params, keyParts)
-
 	if p.Token != nil {
 		if p.Account != nil {
 			body.Add(form.FormatKey(append(keyParts, "external_account")), StringValue(p.Token))

--- a/card.go
+++ b/card.go
@@ -8,8 +8,9 @@ package stripe
 
 import (
 	"encoding/json"
-	"github.com/stripe/stripe-go/v82/form"
 	"strconv"
+
+	"github.com/stripe/stripe-go/v82/form"
 )
 
 // If `address_line1` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.
@@ -378,6 +379,23 @@ type CardCreateParams struct {
 	Account  *string `form:"-"` // Included in URL
 	Customer *string `form:"-"` // Included in URL
 	Token    *string `form:"-"` // Included in URL
+}
+
+// AppendToAsCardSourceOrExternalAccount appends the given CardCreateParams as either a
+// card or external account.
+func (p *CardCreateParams) AppendToAsCardSourceOrExternalAccount(body *form.Values, keyParts []string) {
+	// Rather than being called in addition to `AppendTo`, this function
+	// *replaces* `AppendTo`, so we must also make sure to handle the encoding
+	// of `Params` so metadata and the like is included in the encoded payload.
+	form.AppendToPrefixed(body, p.Params, keyParts)
+
+	if p.Token != nil {
+		if p.Account != nil {
+			body.Add(form.FormatKey(append(keyParts, "external_account")), StringValue(p.Token))
+		} else {
+			body.Add(form.FormatKey(append(keyParts, cardSource)), StringValue(p.Token))
+		}
+	}
 }
 
 // Get returns the details of a card.

--- a/card/client.go
+++ b/card/client.go
@@ -24,12 +24,12 @@ type Client struct {
 	Key string
 }
 
-// New creates a new card
+// Create creates a new card
 func New(params *stripe.CardParams) (*stripe.Card, error) {
 	return getC().New(params)
 }
 
-// New creates a new card
+// Create creates a new card
 //
 // Deprecated: Client methods are deprecated. This should be accessed instead through [stripe.Client]. See the [migration guide] for more info.
 //

--- a/card_service.go
+++ b/card_service.go
@@ -20,21 +20,17 @@ type v1CardService struct {
 	Key string
 }
 
-// New creates a new card
+// Create creates a new card
 func (c v1CardService) Create(ctx context.Context, params *CardCreateParams) (*Card, error) {
-	if params == nil {
-		params = &CardCreateParams{}
-	}
-	params.Context = ctx
 	var path string
-	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
+	if params == nil || (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
 		return nil, fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts", StringValue(params.Account))
 	} else if params.Customer != nil {
 		path = FormatURLPath("/v1/customers/%s/sources", StringValue(params.Customer))
 	}
-
+	params.Context = ctx
 	body := &form.Values{}
 
 	// Note that we call this special append method instead of the standard one
@@ -52,11 +48,8 @@ func (c v1CardService) Create(ctx context.Context, params *CardCreateParams) (*C
 
 // Get returns the details of a card.
 func (c v1CardService) Retrieve(ctx context.Context, id string, params *CardRetrieveParams) (*Card, error) {
-	if params == nil {
-		params = &CardRetrieveParams{}
-	}
-	if params.Account == nil {
-		return nil, fmt.Errorf("Invalid card params: Account is required")
+	if params == nil || params.Account == nil {
+		return nil, fmt.Errorf("invalid card params: Account is required")
 	}
 	params.Context = ctx
 	path := FormatURLPath(
@@ -68,11 +61,8 @@ func (c v1CardService) Retrieve(ctx context.Context, id string, params *CardRetr
 
 // Update a specified source for a given customer.
 func (c v1CardService) Update(ctx context.Context, id string, params *CardUpdateParams) (*Card, error) {
-	if params == nil {
-		params = &CardUpdateParams{}
-	}
-	if params.Customer == nil {
-		return nil, fmt.Errorf("Invalid card params: Customer is required")
+	if params == nil || params.Customer == nil {
+		return nil, fmt.Errorf("invalid card params: Customer is required")
 	}
 	params.Context = ctx
 	path := FormatURLPath(
@@ -84,11 +74,8 @@ func (c v1CardService) Update(ctx context.Context, id string, params *CardUpdate
 
 // Delete a specified source for a given customer.
 func (c v1CardService) Delete(ctx context.Context, id string, params *CardDeleteParams) (*Card, error) {
-	if params == nil {
-		params = &CardDeleteParams{}
-	}
-	if params.Customer == nil {
-		return nil, fmt.Errorf("Invalid card params: Customer is required")
+	if params == nil || params.Customer == nil {
+		return nil, fmt.Errorf("invalid card params: Customer is required")
 	}
 	params.Context = ctx
 	path := FormatURLPath(
@@ -98,11 +85,6 @@ func (c v1CardService) Delete(ctx context.Context, id string, params *CardDelete
 	return card, err
 }
 func (c v1CardService) List(ctx context.Context, listParams *CardListParams) Seq2[*Card, error] {
-	if listParams == nil {
-		listParams = &CardListParams{}
-	}
-	listParams.Context = ctx
-
 	var path string
 	var outerErr error
 
@@ -121,11 +103,14 @@ func (c v1CardService) List(ctx context.Context, listParams *CardListParams) Seq
 		path = FormatURLPath("/v1/customers/%s/sources",
 			StringValue(listParams.Customer))
 	}
+	listParams.Context = ctx
 	return newV1List(listParams, func(p *Params, b *form.Values) ([]*Card, ListContainer, error) {
+		list := &CardList{}
+
 		if outerErr != nil {
 			return nil, nil, outerErr
 		}
-		list := &CardList{}
+
 		if p == nil {
 			p = &Params{}
 		}

--- a/card_service_test.go
+++ b/card_service_test.go
@@ -1,0 +1,78 @@
+package stripe_test
+
+import (
+	"context"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v82"
+	. "github.com/stripe/stripe-go/v82/testing"
+)
+
+func TestCardDelete_ByCustomer(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	card, err := sc.V1Cards.Delete(context.TODO(), "card_123", &stripe.CardDeleteParams{
+		Customer: stripe.String("cus_123"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, card)
+}
+
+func TestCardRetrieve_ByAccount(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	card, err := sc.V1Cards.Retrieve(context.TODO(), "card_123", &stripe.CardRetrieveParams{
+		Account: stripe.String("acct_123"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, card)
+}
+
+func TestCardList_ByCustomer(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	i := sc.V1Cards.List(context.TODO(), &stripe.CardListParams{Customer: stripe.String("cus_123")})
+	i(func(card *stripe.Card, err error) bool {
+		assert.Nil(t, err)
+		assert.NotNil(t, card)
+		return true
+	})
+}
+
+func TestCardList_ByAccount(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	i := sc.V1Cards.List(context.TODO(), &stripe.CardListParams{Account: stripe.String("acct_123")})
+	i(func(card *stripe.Card, err error) bool {
+		assert.Nil(t, err)
+		assert.NotNil(t, card)
+		return true
+	})
+}
+
+func TestCardCreate_ByCustomer(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	card, err := sc.V1Cards.Create(context.TODO(), &stripe.CardCreateParams{
+		Customer: stripe.String("cus_123"),
+		Token:    stripe.String("tok_123"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, card)
+}
+
+func TestCardCreate_ByAccount(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	card, err := sc.V1Cards.Create(context.TODO(), &stripe.CardCreateParams{
+		Account: stripe.String("acct_123"),
+		Token:   stripe.String("tok_123"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, card)
+}
+
+func TestCardUpdate_ByCustomer(t *testing.T) {
+	sc := stripe.NewClient(TestAPIKey)
+	card, err := sc.V1Cards.Update(context.TODO(), "card_123", &stripe.CardUpdateParams{
+		Customer: stripe.String("cus_123"),
+		Name:     stripe.String("New Name"),
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, card)
+}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
In https://github.com/stripe/stripe-go/issues/2093, it was brought to our attention that there was a bug in the `stripe.Client.V1BankAccounts` service's `Create` method. It turns out there were actually a few bugs in both the `V1BankAccounts` and `V1Cards` services, which are non-standard Stripe services that we did not correctly port over to the new `stripe.Client` pattern.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds custom parameter serialization to `BankAccountCreateParams` and `CardCreateParams`
- Fixes `Create` and `List` methods in `V1BankAccounts` and `V1Cards` services.
- Adds `nil`-checking to `Retrieve`, `Update`, and `Delete` methods  in `V1BankAccounts` and `V1Cards` services.
- Adds unit tests for both services

### See Also
<!-- Include any links or additional information that help explain this change. -->
* https://github.com/stripe/stripe-go/issues/2093

## Changelog
* Fixes bugs in `Create` and `List` methods in `V1BankAccounts` and `V1Cards` services in the `stripe.Client` pattern.