### PR TITLE
add missing expand param in `get /v1/accounts/{account}/external_accounts`

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -407,6 +407,8 @@ type BankAccountListParams struct {
 	// The identifier of the parent account under which the bank accounts are
 	// nested. Either Account or Customer should be populated.
 	Account *string `form:"-"` // Included in URL
+	// Specifies which fields in the response should be expanded.
+	Expand []*string `form:"expand"`
 	// Filter according to a particular object type. Valid values are "bank_account" or "card".
 	Object *string `form:"object"`
 }
@@ -416,6 +418,11 @@ type BankAccountListParams struct {
 // other specified parameters.
 func (p *BankAccountListParams) AppendTo(body *form.Values, keyParts []string) {
 	body.Add(form.FormatKey(append(keyParts, "object")), "bank_account")
+}
+
+// AddExpand appends a new field to expand.
+func (p *BankAccountListParams) AddExpand(f string) {
+	p.Expand = append(p.Expand, &f)
 }
 
 // Delete a specified external account for a given account.

--- a/card.go
+++ b/card.go
@@ -280,7 +280,9 @@ type CardListParams struct {
 	ListParams `form:"*"`
 	Customer   *string `form:"-"` // Included in URL
 	Account    *string `form:"-"` // Included in URL
-	Object     *string `form:"object"`
+	// Specifies which fields in the response should be expanded.
+	Expand []*string `form:"expand"`
+	Object *string   `form:"object"`
 }
 
 // AppendTo implements custom encoding logic for CardListParams
@@ -290,6 +292,11 @@ func (p *CardListParams) AppendTo(body *form.Values, keyParts []string) {
 	if p.Account != nil || p.Customer != nil {
 		body.Add(form.FormatKey(append(keyParts, "object")), "card")
 	}
+}
+
+// AddExpand appends a new field to expand.
+func (p *CardListParams) AddExpand(f string) {
+	p.Expand = append(p.Expand, &f)
 }
 
 // Delete a specified source for a given customer.

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -12917,7 +12917,7 @@ func TestV2BillingMeterEventStreamPostService(t *testing.T) {
 			{
 				EventName:  stripe.String("event_name"),
 				Identifier: stripe.String("identifier"),
-				Payload:    map[string]string{"undefined": "payload"},
+				Payload:    map[string]string{"key": "payload"},
 				Timestamp:  stripe.Time(time.Now()),
 			},
 		},
@@ -12937,7 +12937,7 @@ func TestV2BillingMeterEventStreamPostClient(t *testing.T) {
 			{
 				EventName:  stripe.String("event_name"),
 				Identifier: stripe.String("identifier"),
-				Payload:    map[string]string{"undefined": "payload"},
+				Payload:    map[string]string{"key": "payload"},
 				Timestamp:  stripe.Time(time.Now()),
 			},
 		},
@@ -12954,10 +12954,10 @@ func TestV2BillingMeterEventStreamPostClient(t *testing.T) {
 func TestV2BillingMeterEventPostService(t *testing.T) {
 	params := &stripe.V2BillingMeterEventParams{
 		EventName: stripe.String("event_name"),
-		Payload:   map[string]string{"undefined": "payload"},
+		Payload:   map[string]string{"key": "payload"},
 	}
 	testServer := MockServer(
-		t, http.MethodPost, "/v2/billing/meter_events", params, "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"undefined\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}")
+		t, http.MethodPost, "/v2/billing/meter_events", params, "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"key\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}")
 	defer testServer.Close()
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
@@ -12970,10 +12970,10 @@ func TestV2BillingMeterEventPostService(t *testing.T) {
 func TestV2BillingMeterEventPostClient(t *testing.T) {
 	params := &stripe.V2BillingMeterEventCreateParams{
 		EventName: stripe.String("event_name"),
-		Payload:   map[string]string{"undefined": "payload"},
+		Payload:   map[string]string{"key": "payload"},
 	}
 	testServer := MockServer(
-		t, http.MethodPost, "/v2/billing/meter_events", params, "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"undefined\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}")
+		t, http.MethodPost, "/v2/billing/meter_events", params, "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"key\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}")
 	defer testServer.Close()
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
@@ -13259,7 +13259,7 @@ func TestTemporarySessionExpiredErrorService(t *testing.T) {
 		Events: []*stripe.V2BillingMeterEventStreamEventParams{
 			{
 				EventName: stripe.String("event_name"),
-				Payload:   map[string]string{"undefined": "payload"},
+				Payload:   map[string]string{"key": "payload"},
 			},
 		},
 	}
@@ -13277,7 +13277,7 @@ func TestTemporarySessionExpiredErrorClient(t *testing.T) {
 		Events: []*stripe.V2BillingMeterEventStreamCreateEventParams{
 			{
 				EventName: stripe.String("event_name"),
-				Payload:   map[string]string{"undefined": "payload"},
+				Payload:   map[string]string{"key": "payload"},
 			},
 		},
 	}

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -12917,7 +12917,7 @@ func TestV2BillingMeterEventStreamPostService(t *testing.T) {
 			{
 				EventName:  stripe.String("event_name"),
 				Identifier: stripe.String("identifier"),
-				Payload:    map[string]string{"key": "payload"},
+				Payload:    map[string]string{"undefined": "payload"},
 				Timestamp:  stripe.Time(time.Now()),
 			},
 		},
@@ -12937,7 +12937,7 @@ func TestV2BillingMeterEventStreamPostClient(t *testing.T) {
 			{
 				EventName:  stripe.String("event_name"),
 				Identifier: stripe.String("identifier"),
-				Payload:    map[string]string{"key": "payload"},
+				Payload:    map[string]string{"undefined": "payload"},
 				Timestamp:  stripe.Time(time.Now()),
 			},
 		},
@@ -12954,10 +12954,10 @@ func TestV2BillingMeterEventStreamPostClient(t *testing.T) {
 func TestV2BillingMeterEventPostService(t *testing.T) {
 	params := &stripe.V2BillingMeterEventParams{
 		EventName: stripe.String("event_name"),
-		Payload:   map[string]string{"key": "payload"},
+		Payload:   map[string]string{"undefined": "payload"},
 	}
 	testServer := MockServer(
-		t, http.MethodPost, "/v2/billing/meter_events", params, "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"key\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}")
+		t, http.MethodPost, "/v2/billing/meter_events", params, "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"undefined\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}")
 	defer testServer.Close()
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
@@ -12970,10 +12970,10 @@ func TestV2BillingMeterEventPostService(t *testing.T) {
 func TestV2BillingMeterEventPostClient(t *testing.T) {
 	params := &stripe.V2BillingMeterEventCreateParams{
 		EventName: stripe.String("event_name"),
-		Payload:   map[string]string{"key": "payload"},
+		Payload:   map[string]string{"undefined": "payload"},
 	}
 	testServer := MockServer(
-		t, http.MethodPost, "/v2/billing/meter_events", params, "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"key\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}")
+		t, http.MethodPost, "/v2/billing/meter_events", params, "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"undefined\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}")
 	defer testServer.Close()
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
@@ -13259,7 +13259,7 @@ func TestTemporarySessionExpiredErrorService(t *testing.T) {
 		Events: []*stripe.V2BillingMeterEventStreamEventParams{
 			{
 				EventName: stripe.String("event_name"),
-				Payload:   map[string]string{"key": "payload"},
+				Payload:   map[string]string{"undefined": "payload"},
 			},
 		},
 	}
@@ -13277,7 +13277,7 @@ func TestTemporarySessionExpiredErrorClient(t *testing.T) {
 		Events: []*stripe.V2BillingMeterEventStreamCreateEventParams{
 			{
 				EventName: stripe.String("event_name"),
-				Payload:   map[string]string{"key": "payload"},
+				Payload:   map[string]string{"undefined": "payload"},
 			},
 		},
 	}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We didn't support an `expand` parameter where there should have been done.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- codegen for missing param

### See Also
<!-- Include any links or additional information that help explain this change. -->

RUN_DEVSDK-1881
