### PR TITLE
Update README.md with instructions for accessing LastResponse in a List method

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,17 @@ if ok {
 }
 ```
 
+For `List` and `Search` operations, you can access each resource's `RawJSON` as you iterate
+```go
+for cust, err := range sc.V1Customers.List(context.TODO(), &stripe.CustomerListParams{}) {
+    if err != nil {
+        return err
+    }
+    customerJSON := cust.LastResponse.RawJSON
+    log.Printf("Customer JSON: %s", customerJSON) // {"id":"cus_123",...}
+}
+```
+
 ### Webhook signing
 
 Stripe can optionally sign the webhook events it sends to your endpoint, allowing you to validate that they were not sent by a third-party. You can read more about it [here](https://stripe.com/docs/webhooks/signatures).


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
In https://github.com/stripe/stripe-go/pull/2117 we added the ability to access `RawJSON` while iterating. This PR adds those instructions to the `README.md`.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Updates `README.md` to include instructions for accessing the `RawJSON` in a `List` or `Search` method
