### PR TITLE
Add `StripeContext` object

### DIFF
--- a/params.go
+++ b/params.go
@@ -226,6 +226,10 @@ type Params struct {
 	// the request is made.
 	StripeContext *string `form:"-" json:"-"` // Passed as header
 
+	// StripeContextValue contains a StripeContext object for more advanced context handling.
+	// If both StripeContext (string) and StripeContextValue are set, StripeContextValue takes precedence.
+	StripeContextValue *StripeContext `form:"-" json:"-"` // Passed as header
+
 	usage []string `form:"-" json:"-"` // Tracked behaviors
 }
 
@@ -296,6 +300,24 @@ func (p *Params) SetStripeAccount(val string) {
 // SetStripeContext sets a value for the Stripe-Context header.
 func (p *Params) SetStripeContext(val string) {
 	p.StripeContext = &val
+}
+
+// SetStripeContextValue sets a StripeContext object for the Stripe-Context header.
+func (p *Params) SetStripeContextValue(val *StripeContext) {
+	p.StripeContextValue = val
+}
+
+// GetEffectiveStripeContext returns the effective Stripe-Context value as a string.
+// If StripeContextValue is set, it takes precedence over StripeContext.
+// Returns an empty string if neither is set.
+func (p *Params) GetEffectiveStripeContext() string {
+	if p.StripeContextValue != nil {
+		return p.StripeContextValue.String()
+	}
+	if p.StripeContext != nil {
+		return *p.StripeContext
+	}
+	return ""
 }
 
 // ParamsContainer is a general interface for which all parameter structs

--- a/stripe_context.go
+++ b/stripe_context.go
@@ -1,0 +1,94 @@
+package stripe
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// StripeContext represents a context identifier that can be used to segment API requests
+// and events. It consists of segments separated by forward slashes, similar to a file path.
+// StripeContext is externally immutable - all methods return new instances rather than
+// modifying the receiver.
+type StripeContext struct {
+	segments []string
+}
+
+// Parse creates a new StripeContext from a string representation.
+// The string should be in the format "segment1/segment2/segment3".
+// Empty strings are allowed and result in an empty context.
+func ParseStripeContext(s string) *StripeContext {
+	if s == "" {
+		return &StripeContext{segments: []string{}}
+	}
+
+	segments := strings.Split(s, "/")
+	return &StripeContext{segments: segments}
+}
+
+// Parent returns a new StripeContext with the last segment removed.
+// Returns an error if the context is empty (has no segments).
+func (sc *StripeContext) Parent() (*StripeContext, error) {
+	if len(sc.segments) == 0 {
+		return nil, errors.New("cannot get parent of empty StripeContext")
+	}
+
+	if len(sc.segments) == 1 {
+		return &StripeContext{segments: []string{}}, nil
+	}
+
+	newSegments := make([]string, len(sc.segments)-1)
+	copy(newSegments, sc.segments[:len(sc.segments)-1])
+	return &StripeContext{segments: newSegments}, nil
+}
+
+// Child returns a new StripeContext with the given segment appended.
+func (sc *StripeContext) Child(segment string) *StripeContext {
+	newSegments := make([]string, len(sc.segments)+1)
+	copy(newSegments, sc.segments)
+	newSegments[len(newSegments)-1] = segment
+	return &StripeContext{segments: newSegments}
+}
+
+// String returns the string representation of the StripeContext.
+// Segments are joined with forward slashes.
+func (sc *StripeContext) String() string {
+	if len(sc.segments) == 0 {
+		return ""
+	}
+	return strings.Join(sc.segments, "/")
+}
+
+// IsEmpty returns true if the context has no segments.
+func (sc *StripeContext) IsEmpty() bool {
+	return len(sc.segments) == 0
+}
+
+// Segments returns a copy of the segments slice to prevent external modification.
+func (sc *StripeContext) Segments() []string {
+	if len(sc.segments) == 0 {
+		return []string{}
+	}
+	result := make([]string, len(sc.segments))
+	copy(result, sc.segments)
+	return result
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// It marshals the StripeContext as a JSON string.
+func (sc *StripeContext) MarshalJSON() ([]byte, error) {
+	return json.Marshal(sc.String())
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// It unmarshals a JSON string into a StripeContext.
+func (sc *StripeContext) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	parsed := ParseStripeContext(s)
+	sc.segments = parsed.segments
+	return nil
+}

--- a/stripe_context_params_test.go
+++ b/stripe_context_params_test.go
@@ -1,0 +1,311 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestParams_StripeContextIntegration(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupParams     func(*Params)
+		expectedContext string
+	}{
+		{
+			name: "string context only",
+			setupParams: func(p *Params) {
+				p.SetStripeContext("account1/user2")
+			},
+			expectedContext: "account1/user2",
+		},
+		{
+			name: "StripeContext only",
+			setupParams: func(p *Params) {
+				ctx := ParseStripeContext("account1/subaccount2/user3")
+				p.SetStripeContextValue(ctx)
+			},
+			expectedContext: "account1/subaccount2/user3",
+		},
+		{
+			name: "both set - StripeContextValue takes precedence",
+			setupParams: func(p *Params) {
+				p.SetStripeContext("old_context")
+				ctx := ParseStripeContext("new_context/priority")
+				p.SetStripeContextValue(ctx)
+			},
+			expectedContext: "new_context/priority",
+		},
+		{
+			name: "empty StripeContext takes precedence over string",
+			setupParams: func(p *Params) {
+				p.SetStripeContext("fallback_context")
+				ctx := ParseStripeContext("")
+				p.SetStripeContextValue(ctx)
+			},
+			expectedContext: "",
+		},
+		{
+			name: "neither set",
+			setupParams: func(p *Params) {
+				// Don't set anything
+			},
+			expectedContext: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &Params{}
+			tt.setupParams(params)
+
+			result := params.GetEffectiveStripeContext()
+			assert.Equal(t, tt.expectedContext, result)
+		})
+	}
+}
+
+func TestParams_StripeContextValueImmutability(t *testing.T) {
+	// Test that modifying a StripeContext after setting it doesn't affect the Params
+	originalCtx := ParseStripeContext("account1/user2")
+	params := &Params{}
+	params.SetStripeContextValue(originalCtx)
+
+	// Modify the original context (this should create a new instance)
+	childCtx := originalCtx.Child("extra")
+
+	// The params should still have the original context
+	assert.Equal(t, "account1/user2", params.GetEffectiveStripeContext())
+	assert.Equal(t, "account1/user2/extra", childCtx.String())
+}
+
+func TestThinEvent_JSONWithStripeContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    ThinEvent
+		expected string
+	}{
+		{
+			name: "event with context",
+			event: ThinEvent{
+				ID:      "evt_123",
+				Type:    "test.event",
+				Context: ParseStripeContext("account1/user2"),
+			},
+			expected: `{"id":"evt_123","object":"","type":"test.event","livemode":false,"created":"0001-01-01T00:00:00Z","related_object":null,"context":"account1/user2","reason":null}`,
+		},
+		{
+			name: "event without context",
+			event: ThinEvent{
+				ID:   "evt_456",
+				Type: "test.event",
+			},
+			expected: `{"id":"evt_456","object":"","type":"test.event","livemode":false,"created":"0001-01-01T00:00:00Z","related_object":null,"context":null,"reason":null}`,
+		},
+		{
+			name: "event with empty context",
+			event: ThinEvent{
+				ID:      "evt_789",
+				Type:    "test.event",
+				Context: ParseStripeContext(""),
+			},
+			expected: `{"id":"evt_789","object":"","type":"test.event","livemode":false,"created":"0001-01-01T00:00:00Z","related_object":null,"context":"","reason":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_marshal", func(t *testing.T) {
+			data, err := json.Marshal(tt.event)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+
+		t.Run(tt.name+"_unmarshal", func(t *testing.T) {
+			var event ThinEvent
+			err := json.Unmarshal([]byte(tt.expected), &event)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.event.ID, event.ID)
+			assert.Equal(t, tt.event.Type, event.Type)
+
+			if tt.event.Context == nil {
+				assert.Nil(t, event.Context)
+			} else {
+				assert.NotNil(t, event.Context)
+				assert.Equal(t, tt.event.Context.String(), event.Context.String())
+			}
+		})
+	}
+}
+
+func TestV2BaseEvent_JSONWithStripeContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    V2BaseEvent
+		expected string
+	}{
+		{
+			name: "event with context",
+			event: V2BaseEvent{
+				ID:      "evt_123",
+				Type:    "test.event",
+				Context: ParseStripeContext("account1/user2"),
+			},
+			expected: `{"context":"account1/user2","created":"0001-01-01T00:00:00Z","id":"evt_123","livemode":false,"object":"","reason":null,"type":"test.event"}`,
+		},
+		{
+			name: "event without context",
+			event: V2BaseEvent{
+				ID:   "evt_456",
+				Type: "test.event",
+			},
+			expected: `{"created":"0001-01-01T00:00:00Z","id":"evt_456","livemode":false,"object":"","reason":null,"type":"test.event"}`,
+		},
+		{
+			name: "event with empty context",
+			event: V2BaseEvent{
+				ID:      "evt_789",
+				Type:    "test.event",
+				Context: ParseStripeContext(""),
+			},
+			expected: `{"context":"","created":"0001-01-01T00:00:00Z","id":"evt_789","livemode":false,"object":"","reason":null,"type":"test.event"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_marshal", func(t *testing.T) {
+			data, err := json.Marshal(tt.event)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+
+		t.Run(tt.name+"_unmarshal", func(t *testing.T) {
+			var event V2BaseEvent
+			err := json.Unmarshal([]byte(tt.expected), &event)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.event.ID, event.ID)
+			assert.Equal(t, tt.event.Type, event.Type)
+
+			if tt.event.Context == nil {
+				assert.Nil(t, event.Context)
+			} else {
+				assert.NotNil(t, event.Context)
+				assert.Equal(t, tt.event.Context.String(), event.Context.String())
+			}
+		})
+	}
+}
+
+func TestStripeContext_UsageExamples(t *testing.T) {
+	// Example usage patterns that would be common in real code
+
+	t.Run("hierarchical account structure", func(t *testing.T) {
+		// Start with a main account
+		mainAccount := ParseStripeContext("acct_main")
+		assert.Equal(t, "acct_main", mainAccount.String())
+
+		// Add a sub-account
+		subAccount := mainAccount.Child("acct_sub1")
+		assert.Equal(t, "acct_main/acct_sub1", subAccount.String())
+
+		// Add a user to the sub-account
+		user := subAccount.Child("user_123")
+		assert.Equal(t, "acct_main/acct_sub1/user_123", user.String())
+
+		// Get back to the sub-account
+		backToSub, err := user.Parent()
+		assert.NoError(t, err)
+		assert.Equal(t, "acct_main/acct_sub1", backToSub.String())
+
+		// Get back to the main account
+		backToMain, err := backToSub.Parent()
+		assert.NoError(t, err)
+		assert.Equal(t, "acct_main", backToMain.String())
+	})
+
+	t.Run("context-aware API calls", func(t *testing.T) {
+		// Simulate creating parameters for an API call
+		params := &Params{}
+
+		// Set context using the new StripeContext
+		accountContext := ParseStripeContext("organization1/team2/project3")
+		params.SetStripeContextValue(accountContext)
+
+		// Verify the effective context
+		assert.Equal(t, "organization1/team2/project3", params.GetEffectiveStripeContext())
+
+		// For a child operation, create a child context
+		childContext := accountContext.Child("operation4")
+		childParams := &Params{}
+		childParams.SetStripeContextValue(childContext)
+
+		assert.Equal(t, "organization1/team2/project3/operation4", childParams.GetEffectiveStripeContext())
+	})
+
+	t.Run("parsing webhook context", func(t *testing.T) {
+		// Simulate receiving a webhook with context
+		webhookJSON := `{
+			"id": "evt_webhook_123",
+			"type": "payment_intent.succeeded",
+			"context": "merchant1/location2/terminal3"
+		}`
+
+		var event ThinEvent
+		err := json.Unmarshal([]byte(webhookJSON), &event)
+		assert.NoError(t, err)
+
+		assert.NotNil(t, event.Context)
+		assert.Equal(t, "merchant1/location2/terminal3", event.Context.String())
+
+		// Extract individual segments
+		segments := event.Context.Segments()
+		assert.Equal(t, []string{"merchant1", "location2", "terminal3"}, segments)
+
+		// Get parent contexts
+		locationContext, err := event.Context.Parent()
+		assert.NoError(t, err)
+		assert.Equal(t, "merchant1/location2", locationContext.String())
+
+		merchantContext, err := locationContext.Parent()
+		assert.NoError(t, err)
+		assert.Equal(t, "merchant1", merchantContext.String())
+	})
+}
+
+func TestStripeContext_EdgeCases(t *testing.T) {
+	t.Run("parent of empty context", func(t *testing.T) {
+		empty := ParseStripeContext("")
+		parent, err := empty.Parent()
+		assert.Error(t, err)
+		assert.Nil(t, parent)
+		assert.Contains(t, err.Error(), "empty StripeContext")
+	})
+
+	t.Run("parent of single segment returns empty", func(t *testing.T) {
+		single := ParseStripeContext("single")
+		parent, err := single.Parent()
+		assert.NoError(t, err)
+		assert.NotNil(t, parent)
+		assert.True(t, parent.IsEmpty())
+		assert.Equal(t, "", parent.String())
+	})
+
+	t.Run("child of empty context", func(t *testing.T) {
+		empty := ParseStripeContext("")
+		child := empty.Child("first")
+		assert.Equal(t, "first", child.String())
+		assert.Equal(t, []string{"first"}, child.Segments())
+	})
+
+	t.Run("context with forward slash in segment", func(t *testing.T) {
+		// Note: This might be an edge case that the API doesn't support,
+		// but our implementation should handle it consistently
+		ctx := ParseStripeContext("account1/segment with / slash/account3")
+		segments := ctx.Segments()
+		expected := []string{"account1", "segment with ", " slash", "account3"}
+		assert.Equal(t, expected, segments)
+		assert.Equal(t, "account1/segment with / slash/account3", ctx.String())
+	})
+}

--- a/stripe_context_test.go
+++ b/stripe_context_test.go
@@ -1,0 +1,372 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestParseStripeContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "single segment",
+			input:    "account1",
+			expected: []string{"account1"},
+		},
+		{
+			name:     "multiple segments",
+			input:    "account1/subaccount2/user3",
+			expected: []string{"account1", "subaccount2", "user3"},
+		},
+		{
+			name:     "segments with special characters",
+			input:    "account-1/sub_account.2/user@3",
+			expected: []string{"account-1", "sub_account.2", "user@3"},
+		},
+		{
+			name:     "segments with spaces",
+			input:    "account 1/sub account 2",
+			expected: []string{"account 1", "sub account 2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := ParseStripeContext(tt.input)
+			assert.Equal(t, tt.expected, ctx.segments)
+			assert.Equal(t, tt.expected, ctx.Segments()) // Test the public Segments() method
+		})
+	}
+}
+
+func TestStripeContext_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		segments []string
+		expected string
+	}{
+		{
+			name:     "empty context",
+			segments: []string{},
+			expected: "",
+		},
+		{
+			name:     "single segment",
+			segments: []string{"account1"},
+			expected: "account1",
+		},
+		{
+			name:     "multiple segments",
+			segments: []string{"account1", "subaccount2", "user3"},
+			expected: "account1/subaccount2/user3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &StripeContext{segments: tt.segments}
+			assert.Equal(t, tt.expected, ctx.String())
+		})
+	}
+}
+
+func TestStripeContext_Parent(t *testing.T) {
+	tests := []struct {
+		name          string
+		segments      []string
+		expectedSegs  []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "empty context",
+			segments:      []string{},
+			expectedSegs:  nil,
+			expectError:   true,
+			errorContains: "cannot get parent of empty StripeContext",
+		},
+		{
+			name:         "single segment",
+			segments:     []string{"account1"},
+			expectedSegs: []string{},
+			expectError:  false,
+		},
+		{
+			name:         "two segments",
+			segments:     []string{"account1", "subaccount2"},
+			expectedSegs: []string{"account1"},
+			expectError:  false,
+		},
+		{
+			name:         "multiple segments",
+			segments:     []string{"account1", "subaccount2", "user3"},
+			expectedSegs: []string{"account1", "subaccount2"},
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &StripeContext{segments: tt.segments}
+			parent, err := ctx.Parent()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Nil(t, parent)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, parent)
+				assert.Equal(t, tt.expectedSegs, parent.segments)
+			}
+		})
+	}
+}
+
+func TestStripeContext_Child(t *testing.T) {
+	tests := []struct {
+		name         string
+		segments     []string
+		childSegment string
+		expectedSegs []string
+	}{
+		{
+			name:         "empty context",
+			segments:     []string{},
+			childSegment: "account1",
+			expectedSegs: []string{"account1"},
+		},
+		{
+			name:         "single segment",
+			segments:     []string{"account1"},
+			childSegment: "subaccount2",
+			expectedSegs: []string{"account1", "subaccount2"},
+		},
+		{
+			name:         "multiple segments",
+			segments:     []string{"account1", "subaccount2"},
+			childSegment: "user3",
+			expectedSegs: []string{"account1", "subaccount2", "user3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &StripeContext{segments: tt.segments}
+			child := ctx.Child(tt.childSegment)
+
+			assert.Equal(t, tt.expectedSegs, child.segments)
+			// Ensure original context is unchanged (immutability)
+			assert.Equal(t, tt.segments, ctx.segments)
+		})
+	}
+}
+
+func TestStripeContext_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		segments []string
+		expected bool
+	}{
+		{
+			name:     "empty context",
+			segments: []string{},
+			expected: true,
+		},
+		{
+			name:     "non-empty context",
+			segments: []string{"account1"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &StripeContext{segments: tt.segments}
+			assert.Equal(t, tt.expected, ctx.IsEmpty())
+		})
+	}
+}
+
+func TestStripeContext_Segments(t *testing.T) {
+	original := []string{"account1", "subaccount2", "user3"}
+	ctx := &StripeContext{segments: original}
+
+	segments := ctx.Segments()
+	assert.Equal(t, original, segments)
+
+	// Modify the returned slice to ensure it doesn't affect the original
+	segments[0] = "modified"
+	assert.Equal(t, original, ctx.segments) // Original should be unchanged
+	assert.NotEqual(t, segments, ctx.segments)
+}
+
+func TestStripeContext_ImmutabilityChain(t *testing.T) {
+	// Test that chaining operations doesn't modify original contexts
+	original := ParseStripeContext("account1/subaccount2/user3")
+	originalStr := original.String()
+
+	child := original.Child("extra")
+	parent, err := original.Parent()
+	assert.NoError(t, err)
+
+	// Original should be unchanged
+	assert.Equal(t, originalStr, original.String())
+	assert.Equal(t, "account1/subaccount2/user3/extra", child.String())
+	assert.Equal(t, "account1/subaccount2", parent.String())
+
+	// Test multiple operations on same original
+	child2 := original.Child("another")
+	parent2, err := original.Parent()
+	assert.NoError(t, err)
+
+	assert.Equal(t, originalStr, original.String())
+	assert.Equal(t, "account1/subaccount2/user3/another", child2.String())
+	assert.Equal(t, "account1/subaccount2", parent2.String())
+}
+
+func TestStripeContext_ParseAndStringRoundTrip(t *testing.T) {
+	testCases := []string{
+		"",
+		"account1",
+		"account1/subaccount2",
+		"account1/subaccount2/user3",
+		"complex-account_1/sub.account@2/user with spaces",
+	}
+
+	for _, original := range testCases {
+		t.Run("roundtrip_"+original, func(t *testing.T) {
+			ctx := ParseStripeContext(original)
+			result := ctx.String()
+			assert.Equal(t, original, result)
+		})
+	}
+}
+
+func TestStripeContext_JSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		context  *StripeContext
+		jsonStr  string
+	}{
+		{
+			name:    "empty context",
+			context: ParseStripeContext(""),
+			jsonStr: `""`,
+		},
+		{
+			name:    "single segment",
+			context: ParseStripeContext("account1"),
+			jsonStr: `"account1"`,
+		},
+		{
+			name:    "multiple segments",
+			context: ParseStripeContext("account1/subaccount2/user3"),
+			jsonStr: `"account1/subaccount2/user3"`,
+		},
+		{
+			name:    "nil context",
+			context: nil,
+			jsonStr: `null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_marshal", func(t *testing.T) {
+			data, err := json.Marshal(tt.context)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.jsonStr, string(data))
+		})
+
+		if tt.context != nil {
+			t.Run(tt.name+"_unmarshal", func(t *testing.T) {
+				var ctx StripeContext
+				err := json.Unmarshal([]byte(tt.jsonStr), &ctx)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.context.String(), ctx.String())
+				assert.Equal(t, tt.context.segments, ctx.segments)
+			})
+		}
+	}
+}
+
+func TestStripeContext_JSONInStruct(t *testing.T) {
+	type TestStruct struct {
+		Context *StripeContext `json:"context,omitempty"`
+		Name    string         `json:"name"`
+	}
+
+	tests := []struct {
+		name     string
+		data     TestStruct
+		expected string
+	}{
+		{
+			name: "with context",
+			data: TestStruct{
+				Context: ParseStripeContext("account1/user2"),
+				Name:    "test",
+			},
+			expected: `{"context":"account1/user2","name":"test"}`,
+		},
+		{
+			name: "without context",
+			data: TestStruct{
+				Name: "test",
+			},
+			expected: `{"name":"test"}`,
+		},
+		{
+			name: "with empty context",
+			data: TestStruct{
+				Context: ParseStripeContext(""),
+				Name:    "test",
+			},
+			expected: `{"context":"","name":"test"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_marshal", func(t *testing.T) {
+			data, err := json.Marshal(tt.data)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+
+		t.Run(tt.name+"_unmarshal", func(t *testing.T) {
+			var result TestStruct
+			err := json.Unmarshal([]byte(tt.expected), &result)
+			assert.NoError(t, err)
+
+			if tt.data.Context == nil {
+				assert.Nil(t, result.Context)
+			} else {
+				assert.NotNil(t, result.Context)
+				assert.Equal(t, tt.data.Context.String(), result.Context.String())
+			}
+			assert.Equal(t, tt.data.Name, result.Name)
+		})
+	}
+}
+
+func TestStripeContext_JSONUnmarshalError(t *testing.T) {
+	var ctx StripeContext
+
+	// Test invalid JSON
+	err := json.Unmarshal([]byte(`123`), &ctx)
+	assert.Error(t, err)
+
+	// Test malformed JSON
+	err = json.Unmarshal([]byte(`{`), &ctx)
+	assert.Error(t, err)
+}

--- a/thinevent.go
+++ b/thinevent.go
@@ -20,7 +20,7 @@ type ThinEvent struct {
 	// [Optional] Object containing the reference to API resource relevant to the event
 	RelatedObject *RelatedObject `json:"related_object"`
 	// [Optional] Authentication context needed to fetch the event or related object
-	Context *string `json:"context"`
+	Context *StripeContext `json:"context"`
 	// [Optional] Reason for the event
 	Reason *V2EventReason `json:"reason"`
 }

--- a/v2_event.go
+++ b/v2_event.go
@@ -36,7 +36,7 @@ type V2EventReason struct {
 type V2BaseEvent struct {
 	APIResource
 	// Authentication context needed to fetch the event or related object.
-	Context string `json:"context,omitempty"`
+	Context *StripeContext `json:"context,omitempty"`
 	// Time at which the object was created.
 	Created time.Time `json:"created"`
 	// Unique identifier for the event.


### PR DESCRIPTION
### Why?

As the `stripe-context` header is evolving, we want to give better tools for creating and managing contexts. This PR adds a new class, `StripeContext`. It can be used anywhere the context option is supplied and gets serialized to a string when making requests. It's also found on the `EventNotification.context` property.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `StripeContext` class
- allow it to be supplied for RequestOptions.context; serialize it into strings
- add tests

## Changelog

- Add the `StripeContext` class
- ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `StripeContext`
