### PR TITLE
Add `context.Context` param to `V2CoreEventDestinations.Ping`

### DIFF
--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -13223,7 +13223,8 @@ func TestV2CoreEventDestinationPost5Client(t *testing.T) {
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
-	result, err := sc.V2CoreEventDestinations.Ping("id_123", params)
+	result, err := sc.V2CoreEventDestinations.Ping(
+		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
 	assert.Nil(t, err)
 }

--- a/v2core_eventdestination_service.go
+++ b/v2core_eventdestination_service.go
@@ -90,7 +90,11 @@ func (c v2CoreEventDestinationService) Enable(ctx context.Context, id string, pa
 }
 
 // Send a `ping` event to an event destination.
-func (c v2CoreEventDestinationService) Ping(id string, params *V2CoreEventDestinationPingParams) (V2Event, error) {
+func (c v2CoreEventDestinationService) Ping(ctx context.Context, id string, params *V2CoreEventDestinationPingParams) (V2Event, error) {
+	if params == nil {
+		params = &V2CoreEventDestinationPingParams{}
+	}
+	params.Context = ctx
 	path := FormatURLPath("/v2/core/event_destinations/%s/ping", id)
 	raw := &V2RawEvent{}
 	err := c.B.Call(http.MethodPost, path, c.Key, params, raw)


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
When we added support for V2 in Go, we needed to manually maintain EventDestination.Ping because it does not follow common API patterns (e.g., it returns a polymorphic type). When writing it, we inadvertently left out the `context.Context` parameter in its first argument. This PR adds it back in.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds a `context.Context` parameter to the `V2CoreEventDestinations.Ping` method on `stripe.Client`.

## Changelog
*  ⚠️ Adds a `context.Context` parameter to the `V2CoreEventDestinations.Ping` method on `stripe.Client`
