### PR TITLE
Remove extraneous parameters from `CardUpdateParams` and `BankAccountUpdateParams`

### DIFF
--- a/bankaccount.go
+++ b/bankaccount.go
@@ -466,32 +466,14 @@ type BankAccountUpdateParams struct {
 	AccountHolderType *string `form:"account_holder_type"`
 	// The bank account type. This can only be `checking` or `savings` in most countries. In Japan, this can only be `futsu` or `toza`.
 	AccountType *string `form:"account_type"`
-	// City/District/Suburb/Town/Village.
-	AddressCity *string `form:"address_city"`
-	// Billing address country, if provided when creating card.
-	AddressCountry *string `form:"address_country"`
-	// Address line 1 (Street address/PO Box/Company name).
-	AddressLine1 *string `form:"address_line1"`
-	// Address line 2 (Apartment/Suite/Unit/Building).
-	AddressLine2 *string `form:"address_line2"`
-	// State/County/Province/Region.
-	AddressState *string `form:"address_state"`
-	// ZIP or postal code.
-	AddressZip *string `form:"address_zip"`
 	// When set to true, this becomes the default external account for its currency.
 	DefaultForCurrency *bool `form:"default_for_currency"`
 	// Documents that may be submitted to satisfy various informational requests.
 	Documents *BankAccountUpdateDocumentsParams `form:"documents"`
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand"`
-	// Two digit number representing the card's expiration month.
-	ExpMonth *string `form:"exp_month"`
-	// Four digit number representing the card's expiration year.
-	ExpYear *string `form:"exp_year"`
 	// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
 	Metadata map[string]string `form:"metadata"`
-	// Cardholder name.
-	Name *string `form:"name"`
 }
 
 // AddExpand appends a new field to expand.

--- a/card.go
+++ b/card.go
@@ -329,10 +329,6 @@ type CardUpdateParams struct {
 	Params   `form:"*"`
 	Account  *string `form:"-"` // Included in URL
 	Customer *string `form:"-"` // Included in URL
-	// The name of the person or business that owns the bank account.
-	AccountHolderName *string `form:"account_holder_name"`
-	// The type of entity that holds the account. This can be either `individual` or `company`.
-	AccountHolderType *string `form:"account_holder_type"`
 	// City/District/Suburb/Town/Village.
 	AddressCity *string `form:"address_city"`
 	// Billing address country, if provided when creating card.
@@ -345,10 +341,6 @@ type CardUpdateParams struct {
 	AddressState *string `form:"address_state"`
 	// ZIP or postal code.
 	AddressZip *string `form:"address_zip"`
-	// Required when adding a card to an account (not applicable to customers or recipients). The card (which must be a debit card) can be used as a transfer destination for funds in this currency.
-	Currency *string `form:"currency"`
-	// Card security code. Highly recommended to always include this value, but it's required only for accounts based in European countries.
-	CVC *string `form:"cvc"`
 	// Applicable only on accounts (not customers or recipients). If you set this to `true` (or if this is the first external account being added in this currency), this card will become the default external account for its currency.
 	DefaultForCurrency *bool `form:"default_for_currency"`
 	// Specifies which fields in the response should be expanded.
@@ -361,9 +353,6 @@ type CardUpdateParams struct {
 	Metadata map[string]string `form:"metadata"`
 	// Cardholder name.
 	Name *string `form:"name"`
-	// The card number, as a string without any separators.
-	Number *string                `form:"number"`
-	Owner  *CardUpdateOwnerParams `form:"owner"`
 }
 
 // AddExpand appends a new field to expand.

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -2634,8 +2634,8 @@ func TestCustomersSourcesGet4Client(t *testing.T) {
 
 func TestCustomersSourcesPost(t *testing.T) {
 	params := &stripe.CardParams{
-		AccountHolderName: stripe.String("Kamil"),
-		Customer:          stripe.String("cus_123"),
+		Name:     stripe.String("Kamil"),
+		Customer: stripe.String("cus_123"),
 	}
 	result, err := card.Update("card_123", params)
 	assert.NotNil(t, result)
@@ -2645,8 +2645,8 @@ func TestCustomersSourcesPost(t *testing.T) {
 func TestCustomersSourcesPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, nil)
 	params := &stripe.CardParams{
-		AccountHolderName: stripe.String("Kamil"),
-		Customer:          stripe.String("cus_123"),
+		Name:     stripe.String("Kamil"),
+		Customer: stripe.String("cus_123"),
 	}
 	result, err := sc.Cards.Update("card_123", params)
 	assert.NotNil(t, result)
@@ -2656,8 +2656,8 @@ func TestCustomersSourcesPostService(t *testing.T) {
 func TestCustomersSourcesPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey)
 	params := &stripe.CardUpdateParams{
-		AccountHolderName: stripe.String("Kamil"),
-		Customer:          stripe.String("cus_123"),
+		Name:     stripe.String("Kamil"),
+		Customer: stripe.String("cus_123"),
 	}
 	result, err := sc.V1Cards.Update(context.TODO(), "card_123", params)
 	assert.NotNil(t, result)


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The `v1CardService` and `v1BankAccountService` are two bespoke services for which we have many manual overrides, that among other things, merge together methods and params that only apply to one of those two payment methods. As a result of some mistakes in that manual logic, we have several parameters in `CardUpdateParams` that only make sense for Bank Accounts (e.g. `AccountHolderName`), and vice versa with parameters in `BankAccountUpdateParams` that only make sense for Cards (e.g. `ExpMonth` and `ExpYear`). Although using those parameters will compile in the SDK, using them in a request results in a 400 from the Stripe API.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Removes `address_city`, `address_country`, `address_line1`, `address_line2`, `address_state`, `address_zip`, `exp_month`, `exp_year`, and `name` from `BankAccountUpdateParams`
- Removes `account_holder_name`, `account_holder_type`, and `owner` from `CardAccountParams`

## Changelog
- ⚠️ Removes `address_city`, `address_country`, `address_line1`, `address_line2`, `address_state`, `address_zip`, `exp_month`, `exp_year`, and `name` from `BankAccountUpdateParams`.
- ⚠️ Removes `account_holder_name`, `account_holder_type`, `cvc`, `number`, and `owner` from `CardAccountParams`.
