### PR TITLE
Drop support for Go < 1.20 & clarify policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,14 @@ jobs:
     strategy:
       matrix:
         go:
+          # most recent 4 versions, once we're on schedule
+          # https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy
+          - "1.25"
           - "1.24"
           - "1.23"
           - "1.22"
           - "1.21"
           - "1.20"
-          - "1.19"
-          - "1.18"
     name: "Test: go v${{ matrix.go }}"
     steps:
       - uses: extractions/setup-just@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ The official [Stripe][stripe] Go client library.
 
 ## Requirements
 
-- Go 1.18 or later
+Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy), we support the 4 most recent Go versions at the time of release. Currently, that's **Go 1.20+**.
+
+Note: Support for Go 1.20 and 1.21 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stripe/stripe-go/v82
 
-go 1.18
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Per our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy), we're dropping support for some older runtimes in this release.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- drop unsupported versions from CI
- update readme

### See Also
<!-- Include any links or additional information that help explain this change. -->

[DEVSDK-2772](https://go/j/DEVSDK-2772)

## Changelog

- Publish our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy) and add a link to the README.
- ⚠️ Drop support for Go versions 1.18 and 1.19
- announce deprecation of Go 1.20 and 1.21 support, which will be removed in the next scheduled major release (March 2026)
