### PR TITLE
Change RelatedObject to V2CoreEventRelatedObject

### DIFF
--- a/event_notification.go
+++ b/event_notification.go
@@ -47,7 +47,7 @@ type EventNotificationContainer interface {
 	GetEventNotification() *V2CoreEventNotification
 }
 
-type RelatedObject struct {
+type V2CoreEventRelatedObject struct {
 	ID   string `json:"id"`
 	Type string `json:"type"`
 	URL  string `json:"url"`
@@ -57,7 +57,7 @@ type UnknownEventNotification struct {
 	V2CoreEventNotification
 
 	// [Optional] Object containing the reference to API resource relevant to the event
-	RelatedObject *RelatedObject `json:"related_object"`
+	RelatedObject *V2CoreEventRelatedObject `json:"related_object"`
 }
 
 func (n *UnknownEventNotification) FetchEvent(ctx context.Context) (V2CoreEvent, error) {

--- a/stripe_client_test.go
+++ b/stripe_client_test.go
@@ -85,7 +85,7 @@ func TestParseEventNotification(t *testing.T) {
 			Created:  time.Now(),
 			Context:  nil,
 		},
-		RelatedObject: stripe.RelatedObject{
+		RelatedObject: stripe.V2CoreEventRelatedObject{
 			ID:   "bm_123",
 			Type: "billing.meter",
 			URL:  "/v1/billing/meters/bm_123",
@@ -131,7 +131,7 @@ func TestParseEventNotificationNoTolerance(t *testing.T) {
 			Created:  time.Now(),
 			Context:  nil,
 		},
-		RelatedObject: &stripe.RelatedObject{
+		RelatedObject: &stripe.V2CoreEventRelatedObject{
 			ID:   "ch_123",
 			Type: "charge",
 			URL:  "/v1/charges/ch_123",

--- a/v2/core/event/client_test.go
+++ b/v2/core/event/client_test.go
@@ -26,7 +26,7 @@ func TestEventGet(t *testing.T) {
 			Data: stripe.V1BillingMeterErrorReportTriggeredEventData{
 				DeveloperMessageSummary: "This is a developer message",
 			},
-			RelatedObject: stripe.RelatedObject{
+			RelatedObject: stripe.V2CoreEventRelatedObject{
 				ID: "ro_123",
 			},
 		})
@@ -61,7 +61,7 @@ func TestEventAll(t *testing.T) {
 					Data: stripe.V1BillingMeterErrorReportTriggeredEventData{
 						DeveloperMessageSummary: "This is a developer message",
 					},
-					RelatedObject: stripe.RelatedObject{
+					RelatedObject: stripe.V2CoreEventRelatedObject{
 						ID: "ro_123",
 					},
 				},

--- a/v2/core/eventdestination/client_test.go
+++ b/v2/core/eventdestination/client_test.go
@@ -219,7 +219,7 @@ func TestEventDestinationPing(t *testing.T) {
 				Object:  "v2.core.event",
 				Type:    "v2.core.event_destination.ping",
 			},
-			RelatedObject: &stripe.RelatedObject{
+			RelatedObject: &stripe.V2CoreEventRelatedObject{
 				ID: "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92",
 			},
 		})

--- a/v2_events.go
+++ b/v2_events.go
@@ -52,8 +52,8 @@ type V2CoreEvent interface {
 // type when the event type is not known.
 type V2CoreRawEvent struct {
 	V2BaseEvent
-	Data          *json.RawMessage `json:"data"`
-	RelatedObject *RelatedObject   `json:"related_object"`
+	Data          *json.RawMessage          `json:"data"`
+	RelatedObject *V2CoreEventRelatedObject `json:"related_object"`
 }
 
 // Used for everything internal to the EventNotifications
@@ -66,7 +66,7 @@ type eventNotificationParams struct {
 type V1BillingMeterErrorReportTriggeredEvent struct {
 	V2BaseEvent
 	Data               V1BillingMeterErrorReportTriggeredEventData `json:"data"`
-	RelatedObject      RelatedObject                               `json:"related_object"`
+	RelatedObject      V2CoreEventRelatedObject                    `json:"related_object"`
 	fetchRelatedObject func() (*BillingMeter, error)
 }
 
@@ -79,7 +79,7 @@ func (e *V1BillingMeterErrorReportTriggeredEvent) FetchRelatedObject(ctx context
 // Occurs when a Meter has invalid async usage events.
 type V1BillingMeterErrorReportTriggeredEventNotification struct {
 	V2CoreEventNotification
-	RelatedObject RelatedObject `json:"related_object"`
+	RelatedObject V2CoreEventRelatedObject `json:"related_object"`
 }
 
 // FetchEvent retrieves the V1BillingMeterErrorReportTriggeredEvent that created this Notification
@@ -127,7 +127,7 @@ func (n *V1BillingMeterNoMeterFoundEventNotification) FetchEvent(ctx context.Con
 // A ping event used to test the connection to an EventDestination.
 type V2CoreEventDestinationPingEvent struct {
 	V2BaseEvent
-	RelatedObject      RelatedObject `json:"related_object"`
+	RelatedObject      V2CoreEventRelatedObject `json:"related_object"`
 	fetchRelatedObject func() (*V2CoreEventDestination, error)
 }
 
@@ -140,7 +140,7 @@ func (e *V2CoreEventDestinationPingEvent) FetchRelatedObject(ctx context.Context
 // A ping event used to test the connection to an EventDestination.
 type V2CoreEventDestinationPingEventNotification struct {
 	V2CoreEventNotification
-	RelatedObject RelatedObject `json:"related_object"`
+	RelatedObject V2CoreEventRelatedObject `json:"related_object"`
 }
 
 // FetchEvent retrieves the V2CoreEventDestinationPingEvent that created this Notification


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The type `stripe.RelatedObject` should be namespaced to `stripe.V2CoreEventRelatedObject` like our other Event-related types.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Changes the name of the `stripe.RelatedObject` struct to `stripe.V2CoreEventRelatedObject`.

## Changelog
- ⚠️ Changes the name of the `stripe.RelatedObject` struct to `stripe.V2CoreEventRelatedObject`.
