### PR TITLE
Update param in deprecation docs link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         go:
           # most recent 4 versions, once we're on schedule
-          # https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy
+          # https://docs.stripe.com/sdks/versioning?lang=go#stripe-sdk-language-version-support-policy
           - "1.25"
           - "1.24"
           - "1.23"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This release changes the pinned API version to `2025-09-30.clover` and contains 
 * [#2143](https://github.com/stripe/stripe-go/pull/2143) Change RelatedObject to V2CoreEventRelatedObject
   - ⚠️ Changes the name of the `stripe.RelatedObject` struct to `stripe.V2CoreEventRelatedObject`.
 * [#2142](https://github.com/stripe/stripe-go/pull/2142) ⚠️ Drop support for Go < 1.20 & clarify policy
-  - Read our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy)
+  - Read our new [language version support policy](https://docs.stripe.com/sdks/versioning?lang=go#stripe-sdk-language-version-support-policy)
      - ⚠️ In this release, we drop support for Go versions 1.18 and 1.19
      - Go 1.20 and 1.21 support is deprecated will be removed in the next scheduled major release (March 2026)
 * [#2134](https://github.com/stripe/stripe-go/pull/2134) Remove extraneous parameters from `CardUpdateParams` and `BankAccountUpdateParams`

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The official [Stripe][stripe] Go client library.
 
 ## Requirements
 
-Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy), we support the 4 most recent Go versions at the time of release. Currently, that's **Go 1.20+**.
+Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?lang=go#stripe-sdk-language-version-support-policy), we support the 4 most recent Go versions at the time of release. Currently, that's **Go 1.20+**.
 
-Note: Support for Go 1.20 and 1.21 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?server=go#stripe-sdk-language-version-support-policy
+Note: Support for Go 1.20 and 1.21 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?lang=go#stripe-sdk-language-version-support-policy
 
 ## Installation
 


### PR DESCRIPTION
### Why?

We're using a different `pref` name in the docs for the version deprecation policy, so these links need to be updated.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- replace `?server=` with `?lang=` in links
