### PR TITLE
add `StripeContext` field to `ListParams` and `SearchParams`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ This release changes the pinned API version to `2025-09-30.clover` and contains 
       - This function now returns a `EventNotificationContainer` (which is an interface that all `EventNotification`s adhere to) instead of `ThinEvent`. When applicable, these event notifications will have the `RelatedObject` field and a function `FetchRelatedObject()`. They also have a `FetchEvent()` method to retrieve their corresponding event.
       - If you parse an event the SDK doesn't have types for (e.g. it's newer than the SDK you're using), you'll get an instance of `UnknownEventNotification` instead of a more specific type. It has both the `RelatedObject` field and the function `FetchRelatedObject()` (but they may be `nil`)
   - ⚠️ Removed `API.parseThinEvent`. Use `Client.ParseEventNotification` instead (referring to the [migration guide](https://github.com/stripe/stripe-go/wiki/Migration-guide-for-Stripe-Client) if necessary).
-* [#2133](https://github.com/stripe/stripe-go/pull/2133) Add `StripeContext` object
-  - Add the `stripe.Context` struct. Previously, you could set the stripe context only as a string via `SetStripeContext()`. You can now set it using the new struct as well via `SetStripeContextFrom()`.
+* [#2133](https://github.com/stripe/stripe-go/pull/2133) Add `stripe.Context` object
+  - This is a new struct that helps with accessing parent and child contexts.
+  - Previously, you could set the stripe context only as a string via `SetStripeContext()`. You can now set it using the new struct as well via `SetStripeContextFrom()`.
   - ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `stripe.Context`
 * [#2114](https://github.com/stripe/stripe-go/pull/2114) ⚠️ Build SDK w/ V2 OpenAPI spec
   - ⚠️ The delete methods for v2 APIs (the ones in the `V2` prefix) now return a `V2DeletedObject` which has the id of the object that has been deleted and a string representing the type of the object that has been deleted.

--- a/params.go
+++ b/params.go
@@ -164,6 +164,13 @@ func (p *ListParams) SetStripeContext(val string) {
 	p.StripeContext = &val
 }
 
+// SetStripeContextFrom sets a value for the Stripe-Context header using a stripe.Context object.
+func (p *ListParams) SetStripeContextFrom(val *Context) {
+	if val != nil {
+		p.StripeContext = val.StringPtr()
+	}
+}
+
 // ToParams converts a ListParams to a Params by moving over any fields that
 // have valid targets in the new type. This is useful because fields in
 // Params can be injected directly into an http.Request while generally
@@ -309,7 +316,7 @@ func (p *Params) SetStripeContext(val string) {
 	p.StripeContext = &val
 }
 
-// SetStripeContextFrom sets a value for the Stripe-Context header using a StripeContext object.
+// SetStripeContextFrom sets a value for the Stripe-Context header using a stripe.Context object.
 func (p *Params) SetStripeContextFrom(val *Context) {
 	if val != nil {
 		p.StripeContext = val.StringPtr()

--- a/params.go
+++ b/params.go
@@ -127,6 +127,11 @@ type ListParams struct {
 	// account instead of under the account of the owner of the configured
 	// Stripe key.
 	StripeAccount *string `form:"-"` // Passed as header
+
+	// StripeContext is used to set the Stripe-Context header on a request.
+	// The Stripe-Context header can be used to set the account with which
+	// the request is made. It is preferred to using StripeAccount in new code.
+	StripeContext *string `form:"-" json:"-"` // Passed as header
 }
 
 // AddExpand on the embedded ListParams struct is deprecated.
@@ -154,6 +159,11 @@ func (p *ListParams) SetStripeAccount(val string) {
 	p.StripeAccount = &val
 }
 
+// SetStripeContext sets a value for the Stripe-Context header.
+func (p *ListParams) SetStripeContext(val string) {
+	p.StripeContext = &val
+}
+
 // ToParams converts a ListParams to a Params by moving over any fields that
 // have valid targets in the new type. This is useful because fields in
 // Params can be injected directly into an http.Request while generally
@@ -162,6 +172,7 @@ func (p *ListParams) ToParams() *Params {
 	return &Params{
 		Context:       p.Context,
 		StripeAccount: p.StripeAccount,
+		StripeContext: p.StripeContext,
 	}
 }
 
@@ -223,7 +234,7 @@ type Params struct {
 
 	// StripeContext is used to set the Stripe-Context header on a request.
 	// The Stripe-Context header can be used to set the account with which
-	// the request is made.
+	// the request is made. It is preferred to using StripeAccount in new code.
 	StripeContext *string `form:"-" json:"-"` // Passed as header
 
 	usage []string `form:"-" json:"-"` // Tracked behaviors

--- a/params_test.go
+++ b/params_test.go
@@ -241,6 +241,19 @@ func TestParams_SetStripeAccount(t *testing.T) {
 	assert.Equal(t, TestMerchantID, *p.StripeAccount)
 }
 
+func TestParams_SetStripeContext(t *testing.T) {
+	p := &stripe.Params{}
+	p.SetStripeContext(TestMerchantID)
+	assert.Equal(t, TestMerchantID, *p.StripeContext)
+}
+
+func TestListParams_SetStripeContext(t *testing.T) {
+	p := &stripe.ListParams{}
+	p.SetStripeContext(TestMerchantID)
+	assert.Equal(t, TestMerchantID, *p.StripeContext)
+	assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+}
+
 //
 // ---
 //

--- a/params_test.go
+++ b/params_test.go
@@ -242,16 +242,35 @@ func TestParams_SetStripeAccount(t *testing.T) {
 }
 
 func TestParams_SetStripeContext(t *testing.T) {
-	p := &stripe.Params{}
-	p.SetStripeContext(TestMerchantID)
-	assert.Equal(t, TestMerchantID, *p.StripeContext)
+	{
+		p := &stripe.Params{}
+		p.SetStripeContext(TestMerchantID)
+		assert.Equal(t, TestMerchantID, *p.StripeContext)
+		assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+	}
+
+	{
+		p := &stripe.Params{}
+		p.SetStripeContextFrom(stripe.NewStripeContext([]string{TestMerchantID}))
+		assert.Equal(t, TestMerchantID, *p.StripeContext)
+		assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+	}
 }
 
 func TestListParams_SetStripeContext(t *testing.T) {
-	p := &stripe.ListParams{}
-	p.SetStripeContext(TestMerchantID)
-	assert.Equal(t, TestMerchantID, *p.StripeContext)
-	assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+	{
+		p := &stripe.ListParams{}
+		p.SetStripeContext(TestMerchantID)
+		assert.Equal(t, TestMerchantID, *p.StripeContext)
+		assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+	}
+
+	{
+		p := &stripe.ListParams{}
+		p.SetStripeContextFrom(stripe.NewStripeContext([]string{TestMerchantID}))
+		assert.Equal(t, TestMerchantID, *p.StripeContext)
+		assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+	}
 }
 
 //

--- a/search_params.go
+++ b/search_params.go
@@ -63,6 +63,11 @@ type SearchParams struct {
 	// account instead of under the account of the owner of the configured
 	// Stripe key.
 	StripeAccount *string `form:"-"` // Passed as header
+
+	// StripeContext is used to set the Stripe-Context header on a request.
+	// The Stripe-Context header can be used to set the account with which
+	// the request is made. It is preferred to using StripeAccount in new code.
+	StripeContext *string `form:"-" json:"-"` // Passed as header
 }
 
 // AddExpand on the embedded SearchParams struct is deprecated
@@ -90,6 +95,11 @@ func (p *SearchParams) SetStripeAccount(val string) {
 	p.StripeAccount = &val
 }
 
+// SetStripeContext sets a value for the Stripe-Context header.
+func (p *SearchParams) SetStripeContext(val string) {
+	p.StripeContext = &val
+}
+
 // ToParams converts a SearchParams to a Params by moving over any fields that
 // have valid targets in the new type. This is useful because fields in
 // Params can be injected directly into an http.Request while generally
@@ -98,6 +108,7 @@ func (p *SearchParams) ToParams() *Params {
 	return &Params{
 		Context:       p.Context,
 		StripeAccount: p.StripeAccount,
+		StripeContext: p.StripeContext,
 	}
 }
 

--- a/search_params.go
+++ b/search_params.go
@@ -100,6 +100,13 @@ func (p *SearchParams) SetStripeContext(val string) {
 	p.StripeContext = &val
 }
 
+// SetStripeContextFrom sets a value for the Stripe-Context header using a stripe.Context object.
+func (p *SearchParams) SetStripeContextFrom(val *Context) {
+	if val != nil {
+		p.StripeContext = val.StringPtr()
+	}
+}
+
 // ToParams converts a SearchParams to a Params by moving over any fields that
 // have valid targets in the new type. This is useful because fields in
 // Params can be injected directly into an http.Request while generally

--- a/search_params_test.go
+++ b/search_params_test.go
@@ -69,6 +69,13 @@ func TestSearchParams_SetStripeAccount(t *testing.T) {
 	assert.Equal(t, TestMerchantID, *p.StripeAccount)
 }
 
+func TestSearchParams_SetStripeContext(t *testing.T) {
+	p := &stripe.SearchParams{}
+	p.SetStripeContext(TestMerchantID)
+	assert.Equal(t, TestMerchantID, *p.StripeContext)
+	assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+}
+
 func TestSearchParams_ToParams(t *testing.T) {
 	SearchParams := &stripe.SearchParams{
 		Context: context.Background(),

--- a/search_params_test.go
+++ b/search_params_test.go
@@ -70,10 +70,19 @@ func TestSearchParams_SetStripeAccount(t *testing.T) {
 }
 
 func TestSearchParams_SetStripeContext(t *testing.T) {
-	p := &stripe.SearchParams{}
-	p.SetStripeContext(TestMerchantID)
-	assert.Equal(t, TestMerchantID, *p.StripeContext)
-	assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+	{
+		p := &stripe.SearchParams{}
+		p.SetStripeContext(TestMerchantID)
+		assert.Equal(t, TestMerchantID, *p.StripeContext)
+		assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+	}
+
+	{
+		p := &stripe.SearchParams{}
+		p.SetStripeContextFrom(stripe.NewStripeContext([]string{TestMerchantID}))
+		assert.Equal(t, TestMerchantID, *p.StripeContext)
+		assert.Equal(t, TestMerchantID, *p.GetParams().StripeContext)
+	}
 }
 
 func TestSearchParams_ToParams(t *testing.T) {

--- a/stripe_context.go
+++ b/stripe_context.go
@@ -12,7 +12,7 @@ type Context struct {
 	Segments []string
 }
 
-// NewStripeContext creates a new StripeContext with the given segments.
+// NewStripeContext creates a new stripe.Context with the given segments.
 // If segments is nil or empty, creates an empty context.
 func NewStripeContext(segments []string) *Context {
 	if len(segments) == 0 {
@@ -30,8 +30,8 @@ func NewStripeContext(segments []string) *Context {
 	}
 }
 
-// ParseStripeContext parses a context string into a StripeContext instance.
-// If contextStr is empty, returns an empty StripeContext.
+// ParseStripeContext parses a context string into a stripe.Context instance.
+// If contextStr is empty, returns nil.
 func ParseStripeContext(contextStr string) *Context {
 	if contextStr == "" {
 		return nil
@@ -56,7 +56,7 @@ func (c *Context) Push(segment string) (*Context, error) {
 }
 
 // Pop creates a new StripeContext with the last segment removed.
-// If there are no segments, returns a new empty StripeContext.
+// If there are no segments, returns an error.
 func (c *Context) Pop() (*Context, error) {
 	if len(c.Segments) == 0 {
 		return nil, fmt.Errorf("cannot pop from empty context")
@@ -65,14 +65,14 @@ func (c *Context) Pop() (*Context, error) {
 	return NewStripeContext(c.Segments[:len(c.Segments)-1]), nil
 }
 
-// StringPtr returns the string representation of the StripeContext.
+// StringPtr returns the string representation of the stripe.Context.
 // Segments are joined with "/" as the separator.
 func (c *Context) StringPtr() *string {
 	result := strings.Join(c.Segments, "/")
 	return &result
 }
 
-// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface for StripeContext.
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface for stripe.Context.
 func (c *Context) UnmarshalJSON(data []byte) error {
 	var contextStr string
 	if err := json.Unmarshal(data, &contextStr); err != nil {


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Users should be able to specify `StripeContext` in all API calls, not just the ones that use the `Params` struct.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add missing fields & methods
- add tests
- tweak changelog for clarity

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog

- Fixes an issue where it wasn't possible to add `StripeContext` to list and search calls.