### PR TITLE
Add min version for custom request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,8 @@ Stripe has features in the [private preview phase](https://docs.stripe.com/relea
 
 ### Custom Request
 
+> This feature is only available from version 80 of this SDK.
+
 If you would like to send a request to an API that is:
 
 - undocumented (like a preview feature), or


### PR DESCRIPTION
### Why?
The raw/custom request is only available in recent versions of the SDK

### What?
Add min version for custom request support


