### PR TITLE
Update CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - uses: extractions/setup-just@v2
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
 
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.19"
+          go-version: "1.25"
 
       - name: lint
         run: |
@@ -42,11 +42,11 @@ jobs:
     name: govulncheck
     runs-on: "ubuntu-24.04"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -69,9 +69,9 @@ jobs:
     name: "Test: go v${{ matrix.go }}"
     steps:
       - uses: extractions/setup-just@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - uses: stripe/openapi/actions/stripe-mock@master
@@ -86,7 +86,7 @@ jobs:
       endsWith(github.actor, '-stripe')
     runs-on: "ubuntu-24.04"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: stripe/openapi/actions/notify-release@master
         if: always()
         with:

--- a/justfile
+++ b/justfile
@@ -36,8 +36,8 @@ build:
 # install dependencies (including those needed for development). Mostly called by other recipes
 install:
     go get -t
-    go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
-    go install golang.org/x/tools/cmd/goimports@v0.24.0
+    go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
+    go install golang.org/x/tools/cmd/goimports@v0.39.0
 
 # run benchmarking to check for performance regressions
 bench:


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
We have a wide variety of old dependencies in `ci.yml`.  We were getting failures in CI:
* Silent failure of `setup-go/v1`: https://github.com/stripe/stripe-go/actions/runs/19909971395/job/57080959944
* Tooling error during `just install`: https://github.com/stripe/stripe-go/actions/runs/19914360864/job/57089882809

At minimum, we would need to update the `setup-go`, Go version, and `staticcheck` dependencies to fix these issues. Since we're already pointing to `checkout@master`, I decided to upgrade everything in the CI file to the latest stable versions.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Update `staticcheck` version to the latest
- Update `goimports` version to latest
- Update Go version in CI steps to latest
- Update GitHub actions `checkout` and `setup-go` to latest

### See Also
<!-- Include any links or additional information that help explain this change. -->
