### PR TITLE
Delete API_VERSION file as it is no longer needed

### DIFF
--- a/API_VERSION
+++ b/API_VERSION
@@ -1,1 +1,0 @@
-bc2a2b73b8f1dddbb5b3b46f7c50f04ad09bc778


### PR DESCRIPTION
### Why?
This file contained information about our code generator. The name `API_VERSION` was misleading. Since we now have a more accurately named file `CODEGEN_VERSION`, we can now delete this file


