### PR TITLE
Add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,16 @@ on:
       - sdk-release/**
       - feature/**
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint
 
     runs-on: "ubuntu-24.04"
+
+    permissions:
+      contents: read
 
     steps:
       - uses: extractions/setup-just@v2
@@ -41,6 +46,8 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Set up Go
@@ -55,6 +62,8 @@ jobs:
 
   test:
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     strategy:
       matrix:
         go:
@@ -85,6 +94,8 @@ jobs:
       startsWith(github.ref, 'refs/tags/v') &&
       endsWith(github.actor, '-stripe')
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: stripe/openapi/actions/notify-release@master

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -7,6 +7,8 @@ on:
     types:
       - auto_merge_enabled
 
+permissions: {}
+
 jobs:
   require_merge_commit_on_merge_script_pr:
     name: Merge script PRs must create merge commits


### PR DESCRIPTION
### Why?
Fix code scanning alerts about unlimited permissions in GitHub workflows. By default, workflows have read/write access to all scopes, which is a security concern. This change applies the principle of least privilege.

### What?
- Added `permissions: {}` at workflow level to restrict default permissions
- Added `contents: read` permission to each job that needs repository access
- The `rules` workflow gets empty permissions as it only runs shell scripts

### See Also
- [GitHub docs on workflow permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)