### PR TITLE
Add Go 1.26 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: lint
         run: |
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -69,6 +69,7 @@ jobs:
         go:
           # most recent 4 versions, once we're on schedule
           # https://docs.stripe.com/sdks/versioning?lang=go#stripe-sdk-language-version-support-policy
+          - "1.26"
           - "1.25"
           - "1.24"
           - "1.23"


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Go 1.26 just came out: https://go.dev/blog/go1.26

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Add 1.26 in CI test matrix
- Use 1.26 for build and lint steps

### See Also
<!-- Include any links or additional information that help explain this change. -->
