### PR TITLE
extend ChargePaymentMethodDetailsCardPresent with reader and location

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -1226,6 +1226,8 @@ type ChargePaymentMethodDetailsCardPresent struct {
 	IncrementalAuthorizationSupported bool `json:"incremental_authorization_supported"`
 	// The last four digits of the card.
 	Last4 string `json:"last4"`
+	// ID of the [location](https://docs.stripe.com/api/terminal/locations) that this transaction's reader is assigned to.
+	Location string `json:"location"`
 	// Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`.
 	Network ChargePaymentMethodDetailsCardPresentNetwork `json:"network"`
 	// This is used by the financial networks to identify a transaction. Visa calls this the Transaction ID, Mastercard calls this the Trace ID, and American Express calls this the Acquirer Reference Data. This value will be present if it is returned by the financial network in the authorization response, and null otherwise.
@@ -1238,6 +1240,8 @@ type ChargePaymentMethodDetailsCardPresent struct {
 	PreferredLocales []string `json:"preferred_locales"`
 	// How card details were read in this transaction.
 	ReadMethod string `json:"read_method"`
+	// ID of the [reader](https://docs.stripe.com/api/terminal/readers) this transaction was made on.
+	Reader string `json:"reader"`
 	// A collection of fields required to be displayed on receipts. Only required for EMV transactions.
 	Receipt *ChargePaymentMethodDetailsCardPresentReceipt `json:"receipt"`
 	Wallet  *ChargePaymentMethodDetailsCardPresentWallet  `json:"wallet"`


### PR DESCRIPTION
### Why?
When processing tap-to-pay (or physical terminal) payments, we need to identify which terminal reader and location were used for each transaction. Currently, our ChargePaymentMethodDetailsCardPresent struct does not include these fields, making it impossible to trace a payment back to a specific terminal device.

### What?
- Added Reader and Location fields to ChargePaymentMethodDetailsCardPresent to capture the terminal reader ID

### See Also
No more info, the PR is pretty simple.
