### PR TITLE
Reapply #2267

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: lint
         run: |
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: '1.26'
           check-latest: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -69,6 +69,7 @@ jobs:
         go:
           # most recent 4 versions, once we're on schedule
           # https://docs.stripe.com/sdks/versioning?lang=go#stripe-sdk-language-version-support-policy
+          - "1.26"
           - "1.25"
           - "1.24"
           - "1.23"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,28 @@ This release changes the pinned API version to `2026-01-28.preview`.
       - after: `func (h *EventNotificationHandler) OnV1BillingMeterErrorReportTriggered(callback func(ctx context.Context, notif *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error) error`
   - this is a breaking change if you're already using the new `EventNotificationHandler`. You'll need to update the function you're registering.
 
+## 84.3.0 - 2026-01-28
+This release changes the pinned API version to `2026-01-28.clover`.
+
+* [#2258](https://github.com/stripe/stripe-go/pull/2258) Update generated code
+  * Add support for new resource `RadarPaymentEvaluation`
+  * Add support for `New` method on resource `RadarPaymentEvaluation`
+  * Add support for `AdjustableQuantity` on `LineItem`
+  * Add support for new value `risk_reserved` on enum `BalanceTransaction.BalanceType`
+  * Add support for new values `reserve_hold` and `reserve_release` on enum `BalanceTransaction.Type`
+  * Add support for new value `pl_nip` on enums `CheckoutSessionCustomerDetailsTaxIds.Type`, `TaxCalculationCustomerDetailsTaxId.Type`, `TaxId.Type`, and `TaxTransactionCustomerDetailsTaxId.Type`
+  * Add support for new value `adyen` on enums `ConfirmationTokenPaymentMethodPreviewIdeal.Bank`, `PaymentAttemptRecordPaymentMethodDetailsIdeal.Bank`, and `PaymentRecordPaymentMethodDetailsIdeal.Bank`
+  * Add support for new value `ADYBNL2A` on enums `ConfirmationTokenPaymentMethodPreviewIdeal.BIC`, `PaymentAttemptRecordPaymentMethodDetailsIdeal.BIC`, and `PaymentRecordPaymentMethodDetailsIdeal.BIC`
+  * Add support for `EnforceArithmeticValidation` on `PaymentIntentAmountDetailsParams`, `PaymentIntentCaptureAmountDetailsParams`, `PaymentIntentConfirmAmountDetailsParams`, and `PaymentIntentIncrementAuthorizationAmountDetailsParams`
+  * Add support for `Error` on `PaymentIntentAmountDetails`
+  * Remove support for `Bgn` on `TerminalConfigurationTippingParams` and `TerminalConfigurationTipping`
+  * Add support for `Topup` on `TreasuryReceivedDebitLinkedFlows`
+  * Add support for `ContactPhone` on `V2CoreAccountParams`, `V2CoreAccountTokenParams`, and `V2CoreAccount`
+  * Add support for `RegistrationDate` on `V2CoreAccountIdentityBusinessDetailsParams`, `V2CoreAccountIdentityBusinessDetails`, and `V2CoreAccountTokenIdentityBusinessDetailsParams`
+  * Add support for new value `gb_vat` on enum `V2CoreAccountIdentityBusinessDetailsIdNumber.Type`
+  * Add support for error code `request_blocked` on `Error`, `InvoiceLastFinalizationError`, `PaymentIntentLastPaymentError`, `SetupAttemptSetupError`, `SetupIntentLastSetupError`, and `StripeError`
+* [#2178](https://github.com/stripe/stripe-go/pull/2178) Add context-aware logging interface and update logger usage
+
 ## 84.2.0 - 2026-01-16
 * [#2255](https://github.com/stripe/stripe-go/pull/2255) Update generated code
   * Add support for event notifications `V2CoreAccountClosedEvent`, `V2CoreAccountCreatedEvent`, `V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEvent`, `V2CoreAccountIncludingConfigurationCustomerUpdatedEvent`, `V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEvent`, `V2CoreAccountIncludingConfigurationMerchantUpdatedEvent`, `V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEvent`, `V2CoreAccountIncludingConfigurationRecipientUpdatedEvent`, `V2CoreAccountIncludingDefaultsUpdatedEvent`, `V2CoreAccountIncludingFutureRequirementsUpdatedEvent`, `V2CoreAccountIncludingIdentityUpdatedEvent`, `V2CoreAccountIncludingRequirementsUpdatedEvent`, and `V2CoreAccountUpdatedEvent` with related object `V2CoreAccount`


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Reapplies https://github.com/stripe/stripe-go/pull/2267, which was reverted in https://github.com/stripe/stripe-go/pull/2272

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
