### PR TITLE
Emit warning when `stripe-notify` header is present in response

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -987,6 +987,10 @@ func (s *BackendImplementation) requestWithRetriesAndTelemetry(
 		return nil, nil, nil, err
 	}
 
+	if notice := resp.Header.Get("Stripe-Notice"); notice != "" {
+		s.logWarnf(req.Context(), "%s", notice)
+	}
+
 	return resp, result, &requestDuration, nil
 }
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -435,6 +435,90 @@ func TestDo_LastResponsePopulated(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, resource.LastResponse.StatusCode)
 }
 
+func TestDo_StripeNoticeHeaderLogged(t *testing.T) {
+	type testServerResponse struct {
+		APIResource
+		Message string `json:"message"`
+	}
+
+	noticeMessage := "This is a notice from Stripe."
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Stripe-Notice", noticeMessage)
+
+		data, err := json.Marshal(testServerResponse{Message: "Hello, client."})
+		assert.NoError(t, err)
+
+		_, err = w.Write(data)
+		assert.NoError(t, err)
+	}))
+	defer testServer.Close()
+
+	var stderr bytes.Buffer
+	warnLogger := &LeveledLogger{
+		Level:          LevelWarn,
+		stderrOverride: &stderr,
+	}
+
+	backend := GetBackendWithConfig(
+		APIBackend,
+		&BackendConfig{
+			LeveledLogger:     warnLogger,
+			MaxNetworkRetries: Int64(0),
+			URL:               String(testServer.URL),
+		},
+	).(*BackendImplementation)
+
+	request, err := backend.NewRequest(http.MethodGet, "/v1/hello", "sk_test_123", "application/x-www-form-urlencoded", nil)
+	assert.NoError(t, err)
+
+	var response testServerResponse
+	err = backend.Do(request, nil, &response)
+	assert.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), noticeMessage)
+}
+
+func TestDo_StripeNoticeHeaderAbsent(t *testing.T) {
+	type testServerResponse struct {
+		APIResource
+		Message string `json:"message"`
+	}
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := json.Marshal(testServerResponse{Message: "Hello, client."})
+		assert.NoError(t, err)
+
+		_, err = w.Write(data)
+		assert.NoError(t, err)
+	}))
+	defer testServer.Close()
+
+	var stderr bytes.Buffer
+	warnLogger := &LeveledLogger{
+		Level:          LevelWarn,
+		stderrOverride: &stderr,
+	}
+
+	backend := GetBackendWithConfig(
+		APIBackend,
+		&BackendConfig{
+			LeveledLogger:     warnLogger,
+			MaxNetworkRetries: Int64(0),
+			URL:               String(testServer.URL),
+		},
+	).(*BackendImplementation)
+
+	request, err := backend.NewRequest(http.MethodGet, "/v1/hello", "sk_test_123", "application/x-www-form-urlencoded", nil)
+	assert.NoError(t, err)
+
+	var response testServerResponse
+	err = backend.Do(request, nil, &response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "", stderr.String())
+}
+
 // Test that telemetry metrics are not sent by default
 func TestCall_TelemetryDisabled(t *testing.T) {
 	type testServerResponse struct {


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've noticed a trend where users (and their agents) will sometimes reach for suboptimal API endpoints/methods because of outdated information. For example, using `/v1/accounts` when `/v2/core/accounts` is available and has a superset of the functionality from v1.

In an effort to help steer users towards best practices, we're introducing a new header to provide feedback during the development process. The SDK is responsible for surfacing this header, if present.

Once enabled internally, the header will be returned by the server for:

- all testmode calls
- livemode calls made by an agent

We may tweak that going forwards. But no matter the conditions, the SDKs will act as a thin pipe.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Emit warning when we see the `Stripe-Notice` header in a response
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://go/agent-steering
- [DEVSDK-2430](https://go/j/browse/DEVSDK-2430)
