### PR TITLE
Unsuppress golangci-lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,20 +60,6 @@ linters:
         linters: [staticcheck]
         text: "SA1019"
 
-      # ST1000: missing package comment. TODO: add package docs in a follow-up PR.
-      - path: "^form/form\\.go$"
-        linters: [staticcheck]
-        text: "ST1000"
-      - path: "^mock/mock\\.go$"
-        linters: [staticcheck]
-        text: "ST1000"
-      - path: "^testing/testing\\.go$"
-        linters: [staticcheck]
-        text: "ST1000"
-      - path: "^webhook/client\\.go$"
-        linters: [staticcheck]
-        text: "ST1000"
-
       # ST1001: dot import in mock package test helper.
       # TODO: remove dot import in a follow-up cleanup.
       - path: "^mock/mock\\.go$"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     rules:
       # SA1019: deprecated client package usage. These files use the old client.API /
       # client.New surface intentionally (backward-compat tests or generated examples).
-      # TODO: migrate each file to stripe.NewClient in a follow-up PR.
       - path: "^account/client_test\\.go$"
         linters: [staticcheck]
         text: "SA1019"
@@ -28,12 +27,6 @@ linters:
       - path: "^example/generated_examples_test\\.go$"
         linters: [staticcheck]
         text: "SA1019"
-      - path: "^mock/mock\\.go$"
-        linters: [staticcheck]
-        text: "SA1019"
-      - path: "^oauth/client_test\\.go$"
-        linters: [staticcheck]
-        text: "SA1019"
       - path: "^v2/billing/meterevent/client_test\\.go$"
         linters: [staticcheck]
         text: "SA1019"
@@ -44,12 +37,6 @@ linters:
         linters: [staticcheck]
         text: "SA1019"
       - path: "^v2/billing/metereventstream/client_test\\.go$"
-        linters: [staticcheck]
-        text: "SA1019"
-      - path: "^v2/core/eventdestination/client_test\\.go$"
-        linters: [staticcheck]
-        text: "SA1019"
-      - path: "^webhook/client_test\\.go$"
         linters: [staticcheck]
         text: "SA1019"
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,23 +60,3 @@ linters:
         linters: [staticcheck]
         text: "SA1019"
 
-      # QF (quickfix) suggestions deferred to follow-up PRs to keep this migration
-      # scoped. Each entry below is the exhaustive list of currently-violating files.
-      - path: "^form/form\\.go$"
-        linters: [staticcheck]
-        text: "QF"
-      - path: "^search_iter_test\\.go$"
-        linters: [staticcheck]
-        text: "QF"
-      - path: "^stripe\\.go$"
-        linters: [staticcheck]
-        text: "QF"
-      - path: "^v2_events\\.go$"
-        linters: [staticcheck]
-        text: "QF"
-      - path: "^webhook/client\\.go$"
-        linters: [staticcheck]
-        text: "QF"
-      - path: "^webhooks\\.go$"
-        linters: [staticcheck]
-        text: "QF"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,11 +5,9 @@ linters:
     staticcheck:
       checks:
         - "all"
-        # ST1005/ST1020/ST1021 are comment-format rules. All current violations are in
-        # generated resource files (e.g. account.go, bankaccount/client.go) that cannot
-        # be edited. TODO: fix the code generator to emit compliant comments, then
-        # remove these suppressions.
-        - "-ST1005"
+        # ST1020/ST1021 are doc-comment format rules (comments must start with the
+        # exported symbol name). All violations are in generated files and require
+        # large-scale codegen changes to fix.
         - "-ST1020"
         - "-ST1021"
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,6 @@
 version: "2"
 
 linters:
-  disable:
-    # TODO: re-enable errcheck in a follow-up PR — production cases in stripe.go and
-    # log.go need per-case review before we can enable this broadly.
-    - errcheck
-
   settings:
     staticcheck:
       checks:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,12 +60,6 @@ linters:
         linters: [staticcheck]
         text: "SA1019"
 
-      # ST1001: dot import in mock package test helper.
-      # TODO: remove dot import in a follow-up cleanup.
-      - path: "^mock/mock\\.go$"
-        linters: [staticcheck]
-        text: "ST1001"
-
       # ST1003: naming convention (sdkApiVersion → sdkAPIVersion).
       # TODO: fix in a follow-up PR — rename requires updating callers.
       - path: "^webhook/client\\.go$"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,15 +60,6 @@ linters:
         linters: [staticcheck]
         text: "SA1019"
 
-      # ST1003: naming convention (sdkApiVersion → sdkAPIVersion).
-      # TODO: fix in a follow-up PR — rename requires updating callers.
-      - path: "^webhook/client\\.go$"
-        linters: [staticcheck]
-        text: "ST1003"
-      - path: "^webhook/client_test\\.go$"
-        linters: [staticcheck]
-        text: "ST1003"
-
       # QF (quickfix) suggestions deferred to follow-up PRs to keep this migration
       # scoped. Each entry below is the exhaustive list of currently-violating files.
       - path: "^form/form\\.go$"

--- a/bankaccount/client.go
+++ b/bankaccount/client.go
@@ -41,7 +41,7 @@ func (c Client) New(params *stripe.BankAccountParams) (*stripe.BankAccount, erro
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts", stripe.StringValue(params.Account))
 	} else if params.Customer != nil {
@@ -80,7 +80,7 @@ func (c Client) Get(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -123,7 +123,7 @@ func (c Client) Update(id string, params *stripe.BankAccountParams) (*stripe.Ban
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -152,7 +152,7 @@ func (c Client) Del(id string, params *stripe.BankAccountParams) (*stripe.BankAc
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -181,7 +181,7 @@ func (c Client) List(listParams *stripe.BankAccountListParams) *Iter {
 	if listParams == nil {
 		outerErr = fmt.Errorf("params should not be nil")
 	} else if (listParams.Account != nil && listParams.Customer != nil) || (listParams.Account == nil && listParams.Customer == nil) {
-		outerErr = fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		outerErr = fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if listParams.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts",
 			stripe.StringValue(listParams.Account))

--- a/bankaccount_service.go
+++ b/bankaccount_service.go
@@ -28,7 +28,7 @@ func (c v1BankAccountService) Create(ctx context.Context, params *BankAccountCre
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts", StringValue(params.Account))
 	} else if params.Customer != nil {
@@ -59,7 +59,7 @@ func (c v1BankAccountService) Retrieve(ctx context.Context, id string, params *B
 	}
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts/%s", StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -85,7 +85,7 @@ func (c v1BankAccountService) Update(ctx context.Context, id string, params *Ban
 	}
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts/%s", StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -104,7 +104,7 @@ func (c v1BankAccountService) Delete(ctx context.Context, id string, params *Ban
 	}
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts/%s", StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -126,7 +126,7 @@ func (c v1BankAccountService) List(ctx context.Context, listParams *BankAccountL
 	if listParams == nil {
 		outerErr = fmt.Errorf("params should not be nil")
 	} else if (listParams.Account != nil && listParams.Customer != nil) || (listParams.Account == nil && listParams.Customer == nil) {
-		outerErr = fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		outerErr = fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if listParams.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts",
 			StringValue(listParams.Account))

--- a/card/client.go
+++ b/card/client.go
@@ -41,7 +41,7 @@ func (c Client) New(params *stripe.CardParams) (*stripe.Card, error) {
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts", stripe.StringValue(params.Account))
 	} else if params.Customer != nil {
@@ -80,7 +80,7 @@ func (c Client) Get(id string, params *stripe.CardParams) (*stripe.Card, error) 
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -109,7 +109,7 @@ func (c Client) Update(id string, params *stripe.CardParams) (*stripe.Card, erro
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -138,7 +138,7 @@ func (c Client) Del(id string, params *stripe.CardParams) (*stripe.Card, error) 
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts/%s", stripe.StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -167,7 +167,7 @@ func (c Client) List(listParams *stripe.CardListParams) *Iter {
 	if listParams == nil {
 		outerErr = fmt.Errorf("params should not be nil")
 	} else if (listParams.Account != nil && listParams.Customer != nil) || (listParams.Account == nil && listParams.Customer == nil) {
-		outerErr = fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		outerErr = fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if listParams.Account != nil {
 		path = stripe.FormatURLPath("/v1/accounts/%s/external_accounts",
 			stripe.StringValue(listParams.Account))

--- a/card_service.go
+++ b/card_service.go
@@ -28,7 +28,7 @@ func (c v1CardService) Create(ctx context.Context, params *CardCreateParams) (*C
 
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid bank account params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid bank account params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts", StringValue(params.Account))
 	} else if params.Customer != nil {
@@ -59,7 +59,7 @@ func (c v1CardService) Retrieve(ctx context.Context, id string, params *CardRetr
 	}
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts/%s", StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -78,7 +78,7 @@ func (c v1CardService) Update(ctx context.Context, id string, params *CardUpdate
 	}
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts/%s", StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -97,7 +97,7 @@ func (c v1CardService) Delete(ctx context.Context, id string, params *CardDelete
 	}
 	var path string
 	if (params.Account != nil && params.Customer != nil) || (params.Account == nil && params.Customer == nil) {
-		return nil, fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		return nil, fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if params.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts/%s", StringValue(params.Account), id)
 	} else if params.Customer != nil {
@@ -119,7 +119,7 @@ func (c v1CardService) List(ctx context.Context, listParams *CardListParams) *V1
 	if listParams == nil {
 		outerErr = fmt.Errorf("params should not be nil")
 	} else if (listParams.Account != nil && listParams.Customer != nil) || (listParams.Account == nil && listParams.Customer == nil) {
-		outerErr = fmt.Errorf("Invalid card params: exactly one of Account or Customer need to be set")
+		outerErr = fmt.Errorf("invalid card params: exactly one of Account or Customer need to be set")
 	} else if listParams.Account != nil {
 		path = FormatURLPath("/v1/accounts/%s/external_accounts",
 			StringValue(listParams.Account))

--- a/error_test.go
+++ b/error_test.go
@@ -19,7 +19,8 @@ func TestErrorResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Request-Id", "req_123")
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, `{"error":{"message":"bar","type":"`+ErrorTypeInvalidRequest+`"}}`)
+		_, err := fmt.Fprintln(w, `{"error":{"message":"bar","type":"`+ErrorTypeInvalidRequest+`"}}`)
+		assert.NoError(t, err)
 	}))
 	defer ts.Close()
 

--- a/example/generated_examples_test.go
+++ b/example/generated_examples_test.go
@@ -129,7 +129,7 @@ func TestAccountLinksPost(t *testing.T) {
 	}
 	result, err := accountlink.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountLinksPostService(t *testing.T) {
@@ -142,7 +142,7 @@ func TestAccountLinksPostService(t *testing.T) {
 	}
 	result, err := sc.AccountLinks.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountLinksPostClient(t *testing.T) {
@@ -155,7 +155,7 @@ func TestAccountLinksPostClient(t *testing.T) {
 	}
 	result, err := sc.V1AccountLinks.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsCapabilitiesGet(t *testing.T) {
@@ -164,7 +164,7 @@ func TestAccountsCapabilitiesGet(t *testing.T) {
 	}
 	result := capability.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsCapabilitiesGetService(t *testing.T) {
@@ -174,7 +174,7 @@ func TestAccountsCapabilitiesGetService(t *testing.T) {
 	}
 	result := sc.Capabilities.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsCapabilitiesGetClient(t *testing.T) {
@@ -184,7 +184,7 @@ func TestAccountsCapabilitiesGetClient(t *testing.T) {
 	}
 	result := sc.V1Capabilities.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsCapabilitiesGet2(t *testing.T) {
@@ -193,7 +193,7 @@ func TestAccountsCapabilitiesGet2(t *testing.T) {
 	}
 	result, err := capability.Get("card_payments", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsCapabilitiesGet2Service(t *testing.T) {
@@ -203,7 +203,7 @@ func TestAccountsCapabilitiesGet2Service(t *testing.T) {
 	}
 	result, err := sc.Capabilities.Get("card_payments", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsCapabilitiesGet2Client(t *testing.T) {
@@ -214,7 +214,7 @@ func TestAccountsCapabilitiesGet2Client(t *testing.T) {
 	result, err := sc.V1Capabilities.Retrieve(
 		context.TODO(), "card_payments", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsCapabilitiesPost(t *testing.T) {
@@ -224,7 +224,7 @@ func TestAccountsCapabilitiesPost(t *testing.T) {
 	}
 	result, err := capability.Update("card_payments", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsCapabilitiesPostService(t *testing.T) {
@@ -235,7 +235,7 @@ func TestAccountsCapabilitiesPostService(t *testing.T) {
 	}
 	result, err := sc.Capabilities.Update("card_payments", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsCapabilitiesPostClient(t *testing.T) {
@@ -247,14 +247,14 @@ func TestAccountsCapabilitiesPostClient(t *testing.T) {
 	result, err := sc.V1Capabilities.Update(
 		context.TODO(), "card_payments", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsDelete(t *testing.T) {
 	params := &stripe.AccountParams{}
 	result, err := account.Del("acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsDeleteService(t *testing.T) {
@@ -262,7 +262,7 @@ func TestAccountsDeleteService(t *testing.T) {
 	params := &stripe.AccountParams{}
 	result, err := sc.Accounts.Del("acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsDeleteClient(t *testing.T) {
@@ -271,7 +271,7 @@ func TestAccountsDeleteClient(t *testing.T) {
 	result, err := sc.V1Accounts.Delete(
 		context.TODO(), "acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsDelete(t *testing.T) {
@@ -280,7 +280,7 @@ func TestAccountsExternalAccountsDelete(t *testing.T) {
 	}
 	result, err := bankaccount.Del("ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsDeleteService(t *testing.T) {
@@ -290,7 +290,7 @@ func TestAccountsExternalAccountsDeleteService(t *testing.T) {
 	}
 	result, err := sc.BankAccounts.Del("ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsDeleteClient(t *testing.T) {
@@ -301,7 +301,7 @@ func TestAccountsExternalAccountsDeleteClient(t *testing.T) {
 	result, err := sc.V1BankAccounts.Delete(
 		context.TODO(), "ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsDelete2(t *testing.T) {
@@ -310,7 +310,7 @@ func TestAccountsExternalAccountsDelete2(t *testing.T) {
 	}
 	result, err := bankaccount.Del("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsDelete2Service(t *testing.T) {
@@ -320,7 +320,7 @@ func TestAccountsExternalAccountsDelete2Service(t *testing.T) {
 	}
 	result, err := sc.BankAccounts.Del("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsDelete2Client(t *testing.T) {
@@ -331,7 +331,7 @@ func TestAccountsExternalAccountsDelete2Client(t *testing.T) {
 	result, err := sc.V1BankAccounts.Delete(
 		context.TODO(), "card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsPost3(t *testing.T) {
@@ -341,7 +341,7 @@ func TestAccountsExternalAccountsPost3(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := bankaccount.Update("ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsPost3Service(t *testing.T) {
@@ -352,7 +352,7 @@ func TestAccountsExternalAccountsPost3Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.BankAccounts.Update("ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsPost3Client(t *testing.T) {
@@ -364,7 +364,7 @@ func TestAccountsExternalAccountsPost3Client(t *testing.T) {
 	result, err := sc.V1BankAccounts.Update(
 		context.TODO(), "ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsPost4(t *testing.T) {
@@ -374,7 +374,7 @@ func TestAccountsExternalAccountsPost4(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := bankaccount.Update("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsPost4Service(t *testing.T) {
@@ -385,7 +385,7 @@ func TestAccountsExternalAccountsPost4Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.BankAccounts.Update("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsExternalAccountsPost4Client(t *testing.T) {
@@ -397,7 +397,7 @@ func TestAccountsExternalAccountsPost4Client(t *testing.T) {
 	result, err := sc.V1BankAccounts.Update(
 		context.TODO(), "card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsGet(t *testing.T) {
@@ -405,7 +405,7 @@ func TestAccountsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := account.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsGetService(t *testing.T) {
@@ -414,7 +414,7 @@ func TestAccountsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Accounts.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsGetClient(t *testing.T) {
@@ -423,14 +423,14 @@ func TestAccountsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Accounts.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsGet2(t *testing.T) {
 	params := &stripe.AccountParams{}
 	result, err := account.GetByID("acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsGet2Service(t *testing.T) {
@@ -438,7 +438,7 @@ func TestAccountsGet2Service(t *testing.T) {
 	params := &stripe.AccountParams{}
 	result, err := sc.Accounts.GetByID("acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsGet2Client(t *testing.T) {
@@ -447,7 +447,7 @@ func TestAccountsGet2Client(t *testing.T) {
 	result, err := sc.V1Accounts.GetByID(
 		context.TODO(), "acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsLoginLinksPost(t *testing.T) {
@@ -456,7 +456,7 @@ func TestAccountsLoginLinksPost(t *testing.T) {
 	}
 	result, err := loginlink.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsLoginLinksPostService(t *testing.T) {
@@ -466,7 +466,7 @@ func TestAccountsLoginLinksPostService(t *testing.T) {
 	}
 	result, err := sc.LoginLinks.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsLoginLinksPostClient(t *testing.T) {
@@ -476,14 +476,14 @@ func TestAccountsLoginLinksPostClient(t *testing.T) {
 	}
 	result, err := sc.V1LoginLinks.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsDelete(t *testing.T) {
 	params := &stripe.PersonParams{Account: stripe.String("acct_xxxxxxxxxxxxx")}
 	result, err := person.Del("person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsDeleteService(t *testing.T) {
@@ -491,7 +491,7 @@ func TestAccountsPersonsDeleteService(t *testing.T) {
 	params := &stripe.PersonParams{Account: stripe.String("acct_xxxxxxxxxxxxx")}
 	result, err := sc.Persons.Del("person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsDeleteClient(t *testing.T) {
@@ -502,7 +502,7 @@ func TestAccountsPersonsDeleteClient(t *testing.T) {
 	result, err := sc.V1Persons.Delete(
 		context.TODO(), "person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsGet(t *testing.T) {
@@ -512,7 +512,7 @@ func TestAccountsPersonsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := person.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsPersonsGetService(t *testing.T) {
@@ -523,7 +523,7 @@ func TestAccountsPersonsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Persons.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsPersonsGetClient(t *testing.T) {
@@ -534,14 +534,14 @@ func TestAccountsPersonsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Persons.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAccountsPersonsGet2(t *testing.T) {
 	params := &stripe.PersonParams{Account: stripe.String("acct_xxxxxxxxxxxxx")}
 	result, err := person.Get("person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsGet2Service(t *testing.T) {
@@ -549,7 +549,7 @@ func TestAccountsPersonsGet2Service(t *testing.T) {
 	params := &stripe.PersonParams{Account: stripe.String("acct_xxxxxxxxxxxxx")}
 	result, err := sc.Persons.Get("person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsGet2Client(t *testing.T) {
@@ -560,7 +560,7 @@ func TestAccountsPersonsGet2Client(t *testing.T) {
 	result, err := sc.V1Persons.Retrieve(
 		context.TODO(), "person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsPost(t *testing.T) {
@@ -571,7 +571,7 @@ func TestAccountsPersonsPost(t *testing.T) {
 	}
 	result, err := person.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsPostService(t *testing.T) {
@@ -583,7 +583,7 @@ func TestAccountsPersonsPostService(t *testing.T) {
 	}
 	result, err := sc.Persons.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsPostClient(t *testing.T) {
@@ -595,7 +595,7 @@ func TestAccountsPersonsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Persons.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsPost2(t *testing.T) {
@@ -603,7 +603,7 @@ func TestAccountsPersonsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := person.Update("person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsPost2Service(t *testing.T) {
@@ -612,7 +612,7 @@ func TestAccountsPersonsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Persons.Update("person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPersonsPost2Client(t *testing.T) {
@@ -624,7 +624,7 @@ func TestAccountsPersonsPost2Client(t *testing.T) {
 	result, err := sc.V1Persons.Update(
 		context.TODO(), "person_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPost(t *testing.T) {
@@ -643,7 +643,7 @@ func TestAccountsPost(t *testing.T) {
 	}
 	result, err := account.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPostService(t *testing.T) {
@@ -663,7 +663,7 @@ func TestAccountsPostService(t *testing.T) {
 	}
 	result, err := sc.Accounts.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPostClient(t *testing.T) {
@@ -683,7 +683,7 @@ func TestAccountsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Accounts.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPost2(t *testing.T) {
@@ -691,7 +691,7 @@ func TestAccountsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := account.Update("acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPost2Service(t *testing.T) {
@@ -700,7 +700,7 @@ func TestAccountsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Accounts.Update("acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsPost2Client(t *testing.T) {
@@ -710,14 +710,14 @@ func TestAccountsPost2Client(t *testing.T) {
 	result, err := sc.V1Accounts.Update(
 		context.TODO(), "acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsRejectPost(t *testing.T) {
 	params := &stripe.AccountRejectParams{Reason: stripe.String("fraud")}
 	result, err := account.Reject("acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsRejectPostService(t *testing.T) {
@@ -725,7 +725,7 @@ func TestAccountsRejectPostService(t *testing.T) {
 	params := &stripe.AccountRejectParams{Reason: stripe.String("fraud")}
 	result, err := sc.Accounts.Reject("acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAccountsRejectPostClient(t *testing.T) {
@@ -734,7 +734,7 @@ func TestAccountsRejectPostClient(t *testing.T) {
 	result, err := sc.V1Accounts.Reject(
 		context.TODO(), "acct_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesGet(t *testing.T) {
@@ -742,7 +742,7 @@ func TestApplicationFeesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := applicationfee.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestApplicationFeesGetService(t *testing.T) {
@@ -751,7 +751,7 @@ func TestApplicationFeesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.ApplicationFees.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestApplicationFeesGetClient(t *testing.T) {
@@ -760,14 +760,14 @@ func TestApplicationFeesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1ApplicationFees.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestApplicationFeesGet2(t *testing.T) {
 	params := &stripe.ApplicationFeeParams{}
 	result, err := applicationfee.Get("fee_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesGet2Service(t *testing.T) {
@@ -775,7 +775,7 @@ func TestApplicationFeesGet2Service(t *testing.T) {
 	params := &stripe.ApplicationFeeParams{}
 	result, err := sc.ApplicationFees.Get("fee_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesGet2Client(t *testing.T) {
@@ -784,7 +784,7 @@ func TestApplicationFeesGet2Client(t *testing.T) {
 	result, err := sc.V1ApplicationFees.Retrieve(
 		context.TODO(), "fee_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsGet(t *testing.T) {
@@ -792,7 +792,7 @@ func TestApplicationFeesRefundsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := feerefund.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestApplicationFeesRefundsGetService(t *testing.T) {
@@ -801,7 +801,7 @@ func TestApplicationFeesRefundsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.FeeRefunds.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestApplicationFeesRefundsGetClient(t *testing.T) {
@@ -810,14 +810,14 @@ func TestApplicationFeesRefundsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1FeeRefunds.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestApplicationFeesRefundsGet2(t *testing.T) {
 	params := &stripe.FeeRefundParams{Fee: stripe.String("fee_xxxxxxxxxxxxx")}
 	result, err := feerefund.Get("fr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsGet2Service(t *testing.T) {
@@ -825,7 +825,7 @@ func TestApplicationFeesRefundsGet2Service(t *testing.T) {
 	params := &stripe.FeeRefundParams{Fee: stripe.String("fee_xxxxxxxxxxxxx")}
 	result, err := sc.FeeRefunds.Get("fr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsGet2Client(t *testing.T) {
@@ -836,14 +836,14 @@ func TestApplicationFeesRefundsGet2Client(t *testing.T) {
 	result, err := sc.V1FeeRefunds.Retrieve(
 		context.TODO(), "fr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsPost(t *testing.T) {
 	params := &stripe.FeeRefundParams{ID: stripe.String("fee_xxxxxxxxxxxxx")}
 	result, err := feerefund.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsPostService(t *testing.T) {
@@ -851,7 +851,7 @@ func TestApplicationFeesRefundsPostService(t *testing.T) {
 	params := &stripe.FeeRefundParams{ID: stripe.String("fee_xxxxxxxxxxxxx")}
 	result, err := sc.FeeRefunds.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsPostClient(t *testing.T) {
@@ -861,7 +861,7 @@ func TestApplicationFeesRefundsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1FeeRefunds.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsPost2(t *testing.T) {
@@ -869,7 +869,7 @@ func TestApplicationFeesRefundsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := feerefund.Update("fr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsPost2Service(t *testing.T) {
@@ -878,7 +878,7 @@ func TestApplicationFeesRefundsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.FeeRefunds.Update("fr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestApplicationFeesRefundsPost2Client(t *testing.T) {
@@ -890,7 +890,7 @@ func TestApplicationFeesRefundsPost2Client(t *testing.T) {
 	result, err := sc.V1FeeRefunds.Update(
 		context.TODO(), "fr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsDeletePost(t *testing.T) {
@@ -902,7 +902,7 @@ func TestAppsSecretsDeletePost(t *testing.T) {
 	}
 	result, err := apps_secret.DeleteWhere(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsDeletePostService(t *testing.T) {
@@ -915,7 +915,7 @@ func TestAppsSecretsDeletePostService(t *testing.T) {
 	}
 	result, err := sc.AppsSecrets.DeleteWhere(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsDeletePostClient(t *testing.T) {
@@ -928,7 +928,7 @@ func TestAppsSecretsDeletePostClient(t *testing.T) {
 	}
 	result, err := sc.V1AppsSecrets.DeleteWhere(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsFindGet(t *testing.T) {
@@ -940,7 +940,7 @@ func TestAppsSecretsFindGet(t *testing.T) {
 	}
 	result, err := apps_secret.Find(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsFindGetService(t *testing.T) {
@@ -953,7 +953,7 @@ func TestAppsSecretsFindGetService(t *testing.T) {
 	}
 	result, err := sc.AppsSecrets.Find(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsFindGetClient(t *testing.T) {
@@ -966,7 +966,7 @@ func TestAppsSecretsFindGetClient(t *testing.T) {
 	}
 	result, err := sc.V1AppsSecrets.Find(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsGet(t *testing.T) {
@@ -978,7 +978,7 @@ func TestAppsSecretsGet(t *testing.T) {
 	params.Limit = stripe.Int64(2)
 	result := apps_secret.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAppsSecretsGetService(t *testing.T) {
@@ -991,7 +991,7 @@ func TestAppsSecretsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(2)
 	result := sc.AppsSecrets.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAppsSecretsGetClient(t *testing.T) {
@@ -1004,7 +1004,7 @@ func TestAppsSecretsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(2)
 	result := sc.V1AppsSecrets.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAppsSecretsGet2(t *testing.T) {
@@ -1016,7 +1016,7 @@ func TestAppsSecretsGet2(t *testing.T) {
 	params.Limit = stripe.Int64(2)
 	result := apps_secret.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAppsSecretsGet2Service(t *testing.T) {
@@ -1029,7 +1029,7 @@ func TestAppsSecretsGet2Service(t *testing.T) {
 	params.Limit = stripe.Int64(2)
 	result := sc.AppsSecrets.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAppsSecretsGet2Client(t *testing.T) {
@@ -1042,7 +1042,7 @@ func TestAppsSecretsGet2Client(t *testing.T) {
 	params.Limit = stripe.Int64(2)
 	result := sc.V1AppsSecrets.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestAppsSecretsPost(t *testing.T) {
@@ -1055,7 +1055,7 @@ func TestAppsSecretsPost(t *testing.T) {
 	}
 	result, err := apps_secret.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsPostService(t *testing.T) {
@@ -1069,7 +1069,7 @@ func TestAppsSecretsPostService(t *testing.T) {
 	}
 	result, err := sc.AppsSecrets.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsPostClient(t *testing.T) {
@@ -1083,7 +1083,7 @@ func TestAppsSecretsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1AppsSecrets.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsPost2(t *testing.T) {
@@ -1096,7 +1096,7 @@ func TestAppsSecretsPost2(t *testing.T) {
 	}
 	result, err := apps_secret.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsPost2Service(t *testing.T) {
@@ -1110,7 +1110,7 @@ func TestAppsSecretsPost2Service(t *testing.T) {
 	}
 	result, err := sc.AppsSecrets.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAppsSecretsPost2Client(t *testing.T) {
@@ -1124,7 +1124,7 @@ func TestAppsSecretsPost2Client(t *testing.T) {
 	}
 	result, err := sc.V1AppsSecrets.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBalanceTransactionsGet(t *testing.T) {
@@ -1132,7 +1132,7 @@ func TestBalanceTransactionsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := balancetransaction.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestBalanceTransactionsGetService(t *testing.T) {
@@ -1141,7 +1141,7 @@ func TestBalanceTransactionsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.BalanceTransactions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestBalanceTransactionsGetClient(t *testing.T) {
@@ -1150,14 +1150,14 @@ func TestBalanceTransactionsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1BalanceTransactions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestBalanceTransactionsGet2(t *testing.T) {
 	params := &stripe.BalanceTransactionParams{}
 	result, err := balancetransaction.Get("txn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBalanceTransactionsGet2Service(t *testing.T) {
@@ -1165,7 +1165,7 @@ func TestBalanceTransactionsGet2Service(t *testing.T) {
 	params := &stripe.BalanceTransactionParams{}
 	result, err := sc.BalanceTransactions.Get("txn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBalanceTransactionsGet2Client(t *testing.T) {
@@ -1174,7 +1174,7 @@ func TestBalanceTransactionsGet2Client(t *testing.T) {
 	result, err := sc.V1BalanceTransactions.Retrieve(
 		context.TODO(), "txn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsGet(t *testing.T) {
@@ -1182,7 +1182,7 @@ func TestBillingPortalConfigurationsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := billingportal_configuration.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestBillingPortalConfigurationsGetService(t *testing.T) {
@@ -1191,7 +1191,7 @@ func TestBillingPortalConfigurationsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.BillingPortalConfigurations.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestBillingPortalConfigurationsGetClient(t *testing.T) {
@@ -1200,14 +1200,14 @@ func TestBillingPortalConfigurationsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1BillingPortalConfigurations.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestBillingPortalConfigurationsGet2(t *testing.T) {
 	params := &stripe.BillingPortalConfigurationParams{}
 	result, err := billingportal_configuration.Get("bpc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsGet2Service(t *testing.T) {
@@ -1215,7 +1215,7 @@ func TestBillingPortalConfigurationsGet2Service(t *testing.T) {
 	params := &stripe.BillingPortalConfigurationParams{}
 	result, err := sc.BillingPortalConfigurations.Get("bpc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsGet2Client(t *testing.T) {
@@ -1224,7 +1224,7 @@ func TestBillingPortalConfigurationsGet2Client(t *testing.T) {
 	result, err := sc.V1BillingPortalConfigurations.Retrieve(
 		context.TODO(), "bpc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsPost(t *testing.T) {
@@ -1248,7 +1248,7 @@ func TestBillingPortalConfigurationsPost(t *testing.T) {
 	}
 	result, err := billingportal_configuration.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsPostService(t *testing.T) {
@@ -1273,7 +1273,7 @@ func TestBillingPortalConfigurationsPostService(t *testing.T) {
 	}
 	result, err := sc.BillingPortalConfigurations.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsPostClient(t *testing.T) {
@@ -1298,7 +1298,7 @@ func TestBillingPortalConfigurationsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1BillingPortalConfigurations.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsPost2(t *testing.T) {
@@ -1310,7 +1310,7 @@ func TestBillingPortalConfigurationsPost2(t *testing.T) {
 	}
 	result, err := billingportal_configuration.Update("bpc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsPost2Service(t *testing.T) {
@@ -1324,7 +1324,7 @@ func TestBillingPortalConfigurationsPost2Service(t *testing.T) {
 	result, err := sc.BillingPortalConfigurations.Update(
 		"bpc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalConfigurationsPost2Client(t *testing.T) {
@@ -1338,7 +1338,7 @@ func TestBillingPortalConfigurationsPost2Client(t *testing.T) {
 	result, err := sc.V1BillingPortalConfigurations.Update(
 		context.TODO(), "bpc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalSessionsPost(t *testing.T) {
@@ -1348,7 +1348,7 @@ func TestBillingPortalSessionsPost(t *testing.T) {
 	}
 	result, err := billingportal_session.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalSessionsPostService(t *testing.T) {
@@ -1359,7 +1359,7 @@ func TestBillingPortalSessionsPostService(t *testing.T) {
 	}
 	result, err := sc.BillingPortalSessions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBillingPortalSessionsPostClient(t *testing.T) {
@@ -1370,14 +1370,14 @@ func TestBillingPortalSessionsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1BillingPortalSessions.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesCapturePost(t *testing.T) {
 	params := &stripe.ChargeCaptureParams{}
 	result, err := charge.Capture("ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesCapturePostService(t *testing.T) {
@@ -1385,7 +1385,7 @@ func TestChargesCapturePostService(t *testing.T) {
 	params := &stripe.ChargeCaptureParams{}
 	result, err := sc.Charges.Capture("ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesCapturePostClient(t *testing.T) {
@@ -1394,7 +1394,7 @@ func TestChargesCapturePostClient(t *testing.T) {
 	result, err := sc.V1Charges.Capture(
 		context.TODO(), "ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesGet(t *testing.T) {
@@ -1402,7 +1402,7 @@ func TestChargesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := charge.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestChargesGetService(t *testing.T) {
@@ -1411,7 +1411,7 @@ func TestChargesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Charges.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestChargesGetClient(t *testing.T) {
@@ -1420,14 +1420,14 @@ func TestChargesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Charges.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestChargesGet2(t *testing.T) {
 	params := &stripe.ChargeParams{}
 	result, err := charge.Get("ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesGet2Service(t *testing.T) {
@@ -1435,7 +1435,7 @@ func TestChargesGet2Service(t *testing.T) {
 	params := &stripe.ChargeParams{}
 	result, err := sc.Charges.Get("ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesGet2Client(t *testing.T) {
@@ -1444,7 +1444,7 @@ func TestChargesGet2Client(t *testing.T) {
 	result, err := sc.V1Charges.Retrieve(
 		context.TODO(), "ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesPost(t *testing.T) {
@@ -1456,7 +1456,7 @@ func TestChargesPost(t *testing.T) {
 	}
 	result, err := charge.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesPostService(t *testing.T) {
@@ -1469,7 +1469,7 @@ func TestChargesPostService(t *testing.T) {
 	}
 	result, err := sc.Charges.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesPostClient(t *testing.T) {
@@ -1482,7 +1482,7 @@ func TestChargesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Charges.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesPost2(t *testing.T) {
@@ -1490,7 +1490,7 @@ func TestChargesPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := charge.Update("ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesPost2Service(t *testing.T) {
@@ -1499,7 +1499,7 @@ func TestChargesPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Charges.Update("ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesPost2Client(t *testing.T) {
@@ -1508,7 +1508,7 @@ func TestChargesPost2Client(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.V1Charges.Update(context.TODO(), "ch_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestChargesSearchGet(t *testing.T) {
@@ -1519,7 +1519,7 @@ func TestChargesSearchGet(t *testing.T) {
 	}
 	result := charge.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestChargesSearchGetService(t *testing.T) {
@@ -1531,7 +1531,7 @@ func TestChargesSearchGetService(t *testing.T) {
 	}
 	result := sc.Charges.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestChargesSearchGetClient(t *testing.T) {
@@ -1543,14 +1543,14 @@ func TestChargesSearchGetClient(t *testing.T) {
 	}
 	result := sc.V1Charges.Search(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCheckoutSessionsExpirePost(t *testing.T) {
 	params := &stripe.CheckoutSessionExpireParams{}
 	result, err := checkout_session.Expire("sess_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsExpirePostService(t *testing.T) {
@@ -1558,7 +1558,7 @@ func TestCheckoutSessionsExpirePostService(t *testing.T) {
 	params := &stripe.CheckoutSessionExpireParams{}
 	result, err := sc.CheckoutSessions.Expire("sess_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsExpirePostClient(t *testing.T) {
@@ -1567,14 +1567,14 @@ func TestCheckoutSessionsExpirePostClient(t *testing.T) {
 	result, err := sc.V1CheckoutSessions.Expire(
 		context.TODO(), "sess_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsExpirePost2(t *testing.T) {
 	params := &stripe.CheckoutSessionExpireParams{}
 	result, err := checkout_session.Expire("cs_test_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsExpirePost2Service(t *testing.T) {
@@ -1582,7 +1582,7 @@ func TestCheckoutSessionsExpirePost2Service(t *testing.T) {
 	params := &stripe.CheckoutSessionExpireParams{}
 	result, err := sc.CheckoutSessions.Expire("cs_test_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsExpirePost2Client(t *testing.T) {
@@ -1591,7 +1591,7 @@ func TestCheckoutSessionsExpirePost2Client(t *testing.T) {
 	result, err := sc.V1CheckoutSessions.Expire(
 		context.TODO(), "cs_test_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsGet(t *testing.T) {
@@ -1599,7 +1599,7 @@ func TestCheckoutSessionsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := checkout_session.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCheckoutSessionsGetService(t *testing.T) {
@@ -1608,7 +1608,7 @@ func TestCheckoutSessionsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.CheckoutSessions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCheckoutSessionsGetClient(t *testing.T) {
@@ -1617,14 +1617,14 @@ func TestCheckoutSessionsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1CheckoutSessions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCheckoutSessionsGet2(t *testing.T) {
 	params := &stripe.CheckoutSessionParams{}
 	result, err := checkout_session.Get("cs_test_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsGet2Service(t *testing.T) {
@@ -1632,7 +1632,7 @@ func TestCheckoutSessionsGet2Service(t *testing.T) {
 	params := &stripe.CheckoutSessionParams{}
 	result, err := sc.CheckoutSessions.Get("cs_test_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsGet2Client(t *testing.T) {
@@ -1641,7 +1641,7 @@ func TestCheckoutSessionsGet2Client(t *testing.T) {
 	result, err := sc.V1CheckoutSessions.Retrieve(
 		context.TODO(), "cs_test_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsLineItemsGet(t *testing.T) {
@@ -1650,7 +1650,7 @@ func TestCheckoutSessionsLineItemsGet(t *testing.T) {
 	}
 	result := checkout_session.ListLineItems(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCheckoutSessionsLineItemsGetService(t *testing.T) {
@@ -1660,7 +1660,7 @@ func TestCheckoutSessionsLineItemsGetService(t *testing.T) {
 	}
 	result := sc.CheckoutSessions.ListLineItems(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCheckoutSessionsLineItemsGetClient(t *testing.T) {
@@ -1670,7 +1670,7 @@ func TestCheckoutSessionsLineItemsGetClient(t *testing.T) {
 	}
 	result := sc.V1CheckoutSessions.ListLineItems(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCheckoutSessionsPost(t *testing.T) {
@@ -1701,7 +1701,7 @@ func TestCheckoutSessionsPost(t *testing.T) {
 	}
 	result, err := checkout_session.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsPostService(t *testing.T) {
@@ -1733,7 +1733,7 @@ func TestCheckoutSessionsPostService(t *testing.T) {
 	}
 	result, err := sc.CheckoutSessions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsPostClient(t *testing.T) {
@@ -1765,7 +1765,7 @@ func TestCheckoutSessionsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1CheckoutSessions.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsPost2(t *testing.T) {
@@ -1781,7 +1781,7 @@ func TestCheckoutSessionsPost2(t *testing.T) {
 	}
 	result, err := checkout_session.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsPost2Service(t *testing.T) {
@@ -1798,7 +1798,7 @@ func TestCheckoutSessionsPost2Service(t *testing.T) {
 	}
 	result, err := sc.CheckoutSessions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckoutSessionsPost2Client(t *testing.T) {
@@ -1815,7 +1815,7 @@ func TestCheckoutSessionsPost2Client(t *testing.T) {
 	}
 	result, err := sc.V1CheckoutSessions.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCountrySpecsGet(t *testing.T) {
@@ -1823,7 +1823,7 @@ func TestCountrySpecsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := countryspec.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCountrySpecsGetService(t *testing.T) {
@@ -1832,7 +1832,7 @@ func TestCountrySpecsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.CountrySpecs.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCountrySpecsGetClient(t *testing.T) {
@@ -1841,14 +1841,14 @@ func TestCountrySpecsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1CountrySpecs.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCountrySpecsGet2(t *testing.T) {
 	params := &stripe.CountrySpecParams{}
 	result, err := countryspec.Get("US", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCountrySpecsGet2Service(t *testing.T) {
@@ -1856,7 +1856,7 @@ func TestCountrySpecsGet2Service(t *testing.T) {
 	params := &stripe.CountrySpecParams{}
 	result, err := sc.CountrySpecs.Get("US", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCountrySpecsGet2Client(t *testing.T) {
@@ -1864,14 +1864,14 @@ func TestCountrySpecsGet2Client(t *testing.T) {
 	params := &stripe.CountrySpecRetrieveParams{}
 	result, err := sc.V1CountrySpecs.Retrieve(context.TODO(), "US", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsDelete(t *testing.T) {
 	params := &stripe.CouponParams{}
 	result, err := coupon.Del("Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsDeleteService(t *testing.T) {
@@ -1879,7 +1879,7 @@ func TestCouponsDeleteService(t *testing.T) {
 	params := &stripe.CouponParams{}
 	result, err := sc.Coupons.Del("Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsDeleteClient(t *testing.T) {
@@ -1887,7 +1887,7 @@ func TestCouponsDeleteClient(t *testing.T) {
 	params := &stripe.CouponDeleteParams{}
 	result, err := sc.V1Coupons.Delete(context.TODO(), "Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsGet(t *testing.T) {
@@ -1895,7 +1895,7 @@ func TestCouponsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := coupon.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCouponsGetService(t *testing.T) {
@@ -1904,7 +1904,7 @@ func TestCouponsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Coupons.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCouponsGetClient(t *testing.T) {
@@ -1913,14 +1913,14 @@ func TestCouponsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Coupons.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCouponsGet2(t *testing.T) {
 	params := &stripe.CouponParams{}
 	result, err := coupon.Get("Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsGet2Service(t *testing.T) {
@@ -1928,7 +1928,7 @@ func TestCouponsGet2Service(t *testing.T) {
 	params := &stripe.CouponParams{}
 	result, err := sc.Coupons.Get("Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsGet2Client(t *testing.T) {
@@ -1936,7 +1936,7 @@ func TestCouponsGet2Client(t *testing.T) {
 	params := &stripe.CouponRetrieveParams{}
 	result, err := sc.V1Coupons.Retrieve(context.TODO(), "Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsPost(t *testing.T) {
@@ -1946,7 +1946,7 @@ func TestCouponsPost(t *testing.T) {
 	}
 	result, err := coupon.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsPostService(t *testing.T) {
@@ -1957,7 +1957,7 @@ func TestCouponsPostService(t *testing.T) {
 	}
 	result, err := sc.Coupons.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsPostClient(t *testing.T) {
@@ -1968,7 +1968,7 @@ func TestCouponsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Coupons.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsPost2(t *testing.T) {
@@ -1976,7 +1976,7 @@ func TestCouponsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := coupon.Update("Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsPost2Service(t *testing.T) {
@@ -1985,7 +1985,7 @@ func TestCouponsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Coupons.Update("Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCouponsPost2Client(t *testing.T) {
@@ -1994,7 +1994,7 @@ func TestCouponsPost2Client(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.V1Coupons.Update(context.TODO(), "Z4OV52SU", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomerSessionsPost(t *testing.T) {
@@ -2008,7 +2008,7 @@ func TestCustomerSessionsPost(t *testing.T) {
 	}
 	result, err := customersession.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomerSessionsPostService(t *testing.T) {
@@ -2023,7 +2023,7 @@ func TestCustomerSessionsPostService(t *testing.T) {
 	}
 	result, err := sc.CustomerSessions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomerSessionsPostClient(t *testing.T) {
@@ -2038,7 +2038,7 @@ func TestCustomerSessionsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1CustomerSessions.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsGet(t *testing.T) {
@@ -2048,7 +2048,7 @@ func TestCustomersBalanceTransactionsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := customerbalancetransaction.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersBalanceTransactionsGetService(t *testing.T) {
@@ -2059,7 +2059,7 @@ func TestCustomersBalanceTransactionsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.CustomerBalanceTransactions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersBalanceTransactionsGetClient(t *testing.T) {
@@ -2070,7 +2070,7 @@ func TestCustomersBalanceTransactionsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1CustomerBalanceTransactions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersBalanceTransactionsGet2(t *testing.T) {
@@ -2079,7 +2079,7 @@ func TestCustomersBalanceTransactionsGet2(t *testing.T) {
 	}
 	result, err := customerbalancetransaction.Get("cbtxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsGet2Service(t *testing.T) {
@@ -2090,7 +2090,7 @@ func TestCustomersBalanceTransactionsGet2Service(t *testing.T) {
 	result, err := sc.CustomerBalanceTransactions.Get(
 		"cbtxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsGet2Client(t *testing.T) {
@@ -2101,7 +2101,7 @@ func TestCustomersBalanceTransactionsGet2Client(t *testing.T) {
 	result, err := sc.V1CustomerBalanceTransactions.Retrieve(
 		context.TODO(), "cbtxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsPost(t *testing.T) {
@@ -2112,7 +2112,7 @@ func TestCustomersBalanceTransactionsPost(t *testing.T) {
 	}
 	result, err := customerbalancetransaction.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsPostService(t *testing.T) {
@@ -2124,7 +2124,7 @@ func TestCustomersBalanceTransactionsPostService(t *testing.T) {
 	}
 	result, err := sc.CustomerBalanceTransactions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsPostClient(t *testing.T) {
@@ -2136,7 +2136,7 @@ func TestCustomersBalanceTransactionsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1CustomerBalanceTransactions.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsPost2(t *testing.T) {
@@ -2147,7 +2147,7 @@ func TestCustomersBalanceTransactionsPost2(t *testing.T) {
 	result, err := customerbalancetransaction.Update(
 		"cbtxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsPost2Service(t *testing.T) {
@@ -2159,7 +2159,7 @@ func TestCustomersBalanceTransactionsPost2Service(t *testing.T) {
 	result, err := sc.CustomerBalanceTransactions.Update(
 		"cbtxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersBalanceTransactionsPost2Client(t *testing.T) {
@@ -2171,14 +2171,14 @@ func TestCustomersBalanceTransactionsPost2Client(t *testing.T) {
 	result, err := sc.V1CustomerBalanceTransactions.Update(
 		context.TODO(), "cbtxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersCashBalanceGet(t *testing.T) {
 	params := &stripe.CashBalanceParams{Customer: stripe.String("cus_123")}
 	result, err := cashbalance.Get(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersCashBalanceGetService(t *testing.T) {
@@ -2186,7 +2186,7 @@ func TestCustomersCashBalanceGetService(t *testing.T) {
 	params := &stripe.CashBalanceParams{Customer: stripe.String("cus_123")}
 	result, err := sc.CashBalances.Get(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersCashBalanceGetClient(t *testing.T) {
@@ -2196,7 +2196,7 @@ func TestCustomersCashBalanceGetClient(t *testing.T) {
 	}
 	result, err := sc.V1CashBalances.Retrieve(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersCashBalancePost(t *testing.T) {
@@ -2208,7 +2208,7 @@ func TestCustomersCashBalancePost(t *testing.T) {
 	}
 	result, err := cashbalance.Update(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersCashBalancePostService(t *testing.T) {
@@ -2221,7 +2221,7 @@ func TestCustomersCashBalancePostService(t *testing.T) {
 	}
 	result, err := sc.CashBalances.Update(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersCashBalancePostClient(t *testing.T) {
@@ -2234,7 +2234,7 @@ func TestCustomersCashBalancePostClient(t *testing.T) {
 	}
 	result, err := sc.V1CashBalances.Update(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersCashBalanceTransactionsGet(t *testing.T) {
@@ -2244,7 +2244,7 @@ func TestCustomersCashBalanceTransactionsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := customercashbalancetransaction.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersCashBalanceTransactionsGetService(t *testing.T) {
@@ -2255,7 +2255,7 @@ func TestCustomersCashBalanceTransactionsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.CustomerCashBalanceTransactions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersCashBalanceTransactionsGetClient(t *testing.T) {
@@ -2266,14 +2266,14 @@ func TestCustomersCashBalanceTransactionsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1CustomerCashBalanceTransactions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersDelete(t *testing.T) {
 	params := &stripe.CustomerParams{}
 	result, err := customer.Del("cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersDeleteService(t *testing.T) {
@@ -2281,7 +2281,7 @@ func TestCustomersDeleteService(t *testing.T) {
 	params := &stripe.CustomerParams{}
 	result, err := sc.Customers.Del("cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersDeleteClient(t *testing.T) {
@@ -2290,7 +2290,7 @@ func TestCustomersDeleteClient(t *testing.T) {
 	result, err := sc.V1Customers.Delete(
 		context.TODO(), "cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersFundingInstructionsPost(t *testing.T) {
@@ -2304,7 +2304,7 @@ func TestCustomersFundingInstructionsPost(t *testing.T) {
 	}
 	result, err := customer.CreateFundingInstructions("cus_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersFundingInstructionsPostService(t *testing.T) {
@@ -2319,7 +2319,7 @@ func TestCustomersFundingInstructionsPostService(t *testing.T) {
 	}
 	result, err := sc.Customers.CreateFundingInstructions("cus_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersFundingInstructionsPostClient(t *testing.T) {
@@ -2335,7 +2335,7 @@ func TestCustomersFundingInstructionsPostClient(t *testing.T) {
 	result, err := sc.V1Customers.CreateFundingInstructions(
 		context.TODO(), "cus_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersGet(t *testing.T) {
@@ -2343,7 +2343,7 @@ func TestCustomersGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := customer.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersGetService(t *testing.T) {
@@ -2352,7 +2352,7 @@ func TestCustomersGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Customers.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersGetClient(t *testing.T) {
@@ -2361,7 +2361,7 @@ func TestCustomersGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Customers.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersGet2(t *testing.T) {
@@ -2369,7 +2369,7 @@ func TestCustomersGet2(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := customer.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersGet2Service(t *testing.T) {
@@ -2378,7 +2378,7 @@ func TestCustomersGet2Service(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Customers.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersGet2Client(t *testing.T) {
@@ -2387,14 +2387,14 @@ func TestCustomersGet2Client(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Customers.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersGet3(t *testing.T) {
 	params := &stripe.CustomerParams{}
 	result, err := customer.Get("cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersGet3Service(t *testing.T) {
@@ -2402,7 +2402,7 @@ func TestCustomersGet3Service(t *testing.T) {
 	params := &stripe.CustomerParams{}
 	result, err := sc.Customers.Get("cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersGet3Client(t *testing.T) {
@@ -2411,7 +2411,7 @@ func TestCustomersGet3Client(t *testing.T) {
 	result, err := sc.V1Customers.Retrieve(
 		context.TODO(), "cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersPaymentMethodsGet(t *testing.T) {
@@ -2421,7 +2421,7 @@ func TestCustomersPaymentMethodsGet(t *testing.T) {
 	}
 	result := customer.ListPaymentMethods(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersPaymentMethodsGetService(t *testing.T) {
@@ -2432,7 +2432,7 @@ func TestCustomersPaymentMethodsGetService(t *testing.T) {
 	}
 	result := sc.Customers.ListPaymentMethods(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersPaymentMethodsGetClient(t *testing.T) {
@@ -2443,7 +2443,7 @@ func TestCustomersPaymentMethodsGetClient(t *testing.T) {
 	}
 	result := sc.V1Customers.ListPaymentMethods(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersPaymentMethodsGet2(t *testing.T) {
@@ -2453,7 +2453,7 @@ func TestCustomersPaymentMethodsGet2(t *testing.T) {
 	}
 	result := customer.ListPaymentMethods(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersPaymentMethodsGet2Service(t *testing.T) {
@@ -2464,7 +2464,7 @@ func TestCustomersPaymentMethodsGet2Service(t *testing.T) {
 	}
 	result := sc.Customers.ListPaymentMethods(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersPaymentMethodsGet2Client(t *testing.T) {
@@ -2475,7 +2475,7 @@ func TestCustomersPaymentMethodsGet2Client(t *testing.T) {
 	}
 	result := sc.V1Customers.ListPaymentMethods(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersPost(t *testing.T) {
@@ -2484,7 +2484,7 @@ func TestCustomersPost(t *testing.T) {
 	}
 	result, err := customer.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersPostService(t *testing.T) {
@@ -2494,7 +2494,7 @@ func TestCustomersPostService(t *testing.T) {
 	}
 	result, err := sc.Customers.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersPostClient(t *testing.T) {
@@ -2504,7 +2504,7 @@ func TestCustomersPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Customers.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersPost2(t *testing.T) {
@@ -2512,7 +2512,7 @@ func TestCustomersPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := customer.Update("cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersPost2Service(t *testing.T) {
@@ -2521,7 +2521,7 @@ func TestCustomersPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Customers.Update("cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersPost2Client(t *testing.T) {
@@ -2531,7 +2531,7 @@ func TestCustomersPost2Client(t *testing.T) {
 	result, err := sc.V1Customers.Update(
 		context.TODO(), "cus_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSearchGet(t *testing.T) {
@@ -2542,7 +2542,7 @@ func TestCustomersSearchGet(t *testing.T) {
 	}
 	result := customer.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSearchGetService(t *testing.T) {
@@ -2554,7 +2554,7 @@ func TestCustomersSearchGetService(t *testing.T) {
 	}
 	result := sc.Customers.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSearchGetClient(t *testing.T) {
@@ -2566,7 +2566,7 @@ func TestCustomersSearchGetClient(t *testing.T) {
 	}
 	result := sc.V1Customers.Search(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSearchGet2(t *testing.T) {
@@ -2577,7 +2577,7 @@ func TestCustomersSearchGet2(t *testing.T) {
 	}
 	result := customer.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSearchGet2Service(t *testing.T) {
@@ -2589,7 +2589,7 @@ func TestCustomersSearchGet2Service(t *testing.T) {
 	}
 	result := sc.Customers.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSearchGet2Client(t *testing.T) {
@@ -2601,14 +2601,14 @@ func TestCustomersSearchGet2Client(t *testing.T) {
 	}
 	result := sc.V1Customers.Search(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSourcesDelete(t *testing.T) {
 	params := &stripe.CardParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := card.Del("ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesDeleteService(t *testing.T) {
@@ -2616,7 +2616,7 @@ func TestCustomersSourcesDeleteService(t *testing.T) {
 	params := &stripe.CardParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := sc.Cards.Del("ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesDeleteClient(t *testing.T) {
@@ -2626,14 +2626,14 @@ func TestCustomersSourcesDeleteClient(t *testing.T) {
 	}
 	result, err := sc.V1Cards.Delete(context.TODO(), "ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesDelete2(t *testing.T) {
 	params := &stripe.CardParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := card.Del("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesDelete2Service(t *testing.T) {
@@ -2641,7 +2641,7 @@ func TestCustomersSourcesDelete2Service(t *testing.T) {
 	params := &stripe.CardParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := sc.Cards.Del("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesDelete2Client(t *testing.T) {
@@ -2651,7 +2651,7 @@ func TestCustomersSourcesDelete2Client(t *testing.T) {
 	}
 	result, err := sc.V1Cards.Delete(context.TODO(), "card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesGet(t *testing.T) {
@@ -2662,7 +2662,7 @@ func TestCustomersSourcesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := paymentsource.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSourcesGetService(t *testing.T) {
@@ -2674,7 +2674,7 @@ func TestCustomersSourcesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.PaymentSources.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSourcesGetClient(t *testing.T) {
@@ -2686,7 +2686,7 @@ func TestCustomersSourcesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1PaymentSources.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSourcesGet2(t *testing.T) {
@@ -2697,7 +2697,7 @@ func TestCustomersSourcesGet2(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := paymentsource.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSourcesGet2Service(t *testing.T) {
@@ -2709,7 +2709,7 @@ func TestCustomersSourcesGet2Service(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.PaymentSources.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSourcesGet2Client(t *testing.T) {
@@ -2721,7 +2721,7 @@ func TestCustomersSourcesGet2Client(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1PaymentSources.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersSourcesGet3(t *testing.T) {
@@ -2730,7 +2730,7 @@ func TestCustomersSourcesGet3(t *testing.T) {
 	}
 	result, err := paymentsource.Get("ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesGet3Service(t *testing.T) {
@@ -2740,7 +2740,7 @@ func TestCustomersSourcesGet3Service(t *testing.T) {
 	}
 	result, err := sc.PaymentSources.Get("ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesGet3Client(t *testing.T) {
@@ -2751,7 +2751,7 @@ func TestCustomersSourcesGet3Client(t *testing.T) {
 	result, err := sc.V1PaymentSources.Retrieve(
 		context.TODO(), "ba_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesGet4(t *testing.T) {
@@ -2760,7 +2760,7 @@ func TestCustomersSourcesGet4(t *testing.T) {
 	}
 	result, err := paymentsource.Get("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesGet4Service(t *testing.T) {
@@ -2770,7 +2770,7 @@ func TestCustomersSourcesGet4Service(t *testing.T) {
 	}
 	result, err := sc.PaymentSources.Get("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesGet4Client(t *testing.T) {
@@ -2781,7 +2781,7 @@ func TestCustomersSourcesGet4Client(t *testing.T) {
 	result, err := sc.V1PaymentSources.Retrieve(
 		context.TODO(), "card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesPost(t *testing.T) {
@@ -2791,7 +2791,7 @@ func TestCustomersSourcesPost(t *testing.T) {
 	}
 	result, err := card.Update("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesPostService(t *testing.T) {
@@ -2802,7 +2802,7 @@ func TestCustomersSourcesPostService(t *testing.T) {
 	}
 	result, err := sc.Cards.Update("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesPostClient(t *testing.T) {
@@ -2813,7 +2813,7 @@ func TestCustomersSourcesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Cards.Update(context.TODO(), "card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesPost5(t *testing.T) {
@@ -2823,7 +2823,7 @@ func TestCustomersSourcesPost5(t *testing.T) {
 	}
 	result, err := card.Update("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesPost5Service(t *testing.T) {
@@ -2834,7 +2834,7 @@ func TestCustomersSourcesPost5Service(t *testing.T) {
 	}
 	result, err := sc.Cards.Update("card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersSourcesPost5Client(t *testing.T) {
@@ -2845,14 +2845,14 @@ func TestCustomersSourcesPost5Client(t *testing.T) {
 	}
 	result, err := sc.V1Cards.Update(context.TODO(), "card_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsDelete(t *testing.T) {
 	params := &stripe.TaxIDParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := taxid.Del("txi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsDeleteService(t *testing.T) {
@@ -2860,7 +2860,7 @@ func TestCustomersTaxIdsDeleteService(t *testing.T) {
 	params := &stripe.TaxIDParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := sc.TaxIDs.Del("txi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsDeleteClient(t *testing.T) {
@@ -2870,7 +2870,7 @@ func TestCustomersTaxIdsDeleteClient(t *testing.T) {
 	}
 	result, err := sc.V1TaxIDs.Delete(context.TODO(), "txi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsGet(t *testing.T) {
@@ -2880,7 +2880,7 @@ func TestCustomersTaxIdsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := taxid.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersTaxIdsGetService(t *testing.T) {
@@ -2891,7 +2891,7 @@ func TestCustomersTaxIdsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TaxIDs.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersTaxIdsGetClient(t *testing.T) {
@@ -2902,14 +2902,14 @@ func TestCustomersTaxIdsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TaxIDs.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestCustomersTaxIdsGet2(t *testing.T) {
 	params := &stripe.TaxIDParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := taxid.Get("txi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsGet2Service(t *testing.T) {
@@ -2917,7 +2917,7 @@ func TestCustomersTaxIdsGet2Service(t *testing.T) {
 	params := &stripe.TaxIDParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := sc.TaxIDs.Get("txi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsGet2Client(t *testing.T) {
@@ -2928,7 +2928,7 @@ func TestCustomersTaxIdsGet2Client(t *testing.T) {
 	result, err := sc.V1TaxIDs.Retrieve(
 		context.TODO(), "txi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsPost(t *testing.T) {
@@ -2939,7 +2939,7 @@ func TestCustomersTaxIdsPost(t *testing.T) {
 	}
 	result, err := taxid.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsPostService(t *testing.T) {
@@ -2951,7 +2951,7 @@ func TestCustomersTaxIdsPostService(t *testing.T) {
 	}
 	result, err := sc.TaxIDs.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCustomersTaxIdsPostClient(t *testing.T) {
@@ -2963,14 +2963,14 @@ func TestCustomersTaxIdsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TaxIDs.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesClosePost(t *testing.T) {
 	params := &stripe.DisputeParams{}
 	result, err := dispute.Close("dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesClosePostService(t *testing.T) {
@@ -2978,7 +2978,7 @@ func TestDisputesClosePostService(t *testing.T) {
 	params := &stripe.DisputeParams{}
 	result, err := sc.Disputes.Close("dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesClosePostClient(t *testing.T) {
@@ -2986,7 +2986,7 @@ func TestDisputesClosePostClient(t *testing.T) {
 	params := &stripe.DisputeCloseParams{}
 	result, err := sc.V1Disputes.Close(context.TODO(), "dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesGet(t *testing.T) {
@@ -2994,7 +2994,7 @@ func TestDisputesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := dispute.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestDisputesGetService(t *testing.T) {
@@ -3003,7 +3003,7 @@ func TestDisputesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Disputes.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestDisputesGetClient(t *testing.T) {
@@ -3012,14 +3012,14 @@ func TestDisputesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Disputes.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestDisputesGet2(t *testing.T) {
 	params := &stripe.DisputeParams{}
 	result, err := dispute.Get("dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesGet2Service(t *testing.T) {
@@ -3027,7 +3027,7 @@ func TestDisputesGet2Service(t *testing.T) {
 	params := &stripe.DisputeParams{}
 	result, err := sc.Disputes.Get("dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesGet2Client(t *testing.T) {
@@ -3036,7 +3036,7 @@ func TestDisputesGet2Client(t *testing.T) {
 	result, err := sc.V1Disputes.Retrieve(
 		context.TODO(), "dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesPost(t *testing.T) {
@@ -3044,7 +3044,7 @@ func TestDisputesPost(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := dispute.Update("dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesPostService(t *testing.T) {
@@ -3053,7 +3053,7 @@ func TestDisputesPostService(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Disputes.Update("dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDisputesPostClient(t *testing.T) {
@@ -3063,7 +3063,7 @@ func TestDisputesPostClient(t *testing.T) {
 	result, err := sc.V1Disputes.Update(
 		context.TODO(), "dp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestEventsGet(t *testing.T) {
@@ -3071,7 +3071,7 @@ func TestEventsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := event.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestEventsGetService(t *testing.T) {
@@ -3080,7 +3080,7 @@ func TestEventsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Events.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestEventsGetClient(t *testing.T) {
@@ -3089,14 +3089,14 @@ func TestEventsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Events.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestEventsGet2(t *testing.T) {
 	params := &stripe.EventParams{}
 	result, err := event.Get("evt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestEventsGet2Service(t *testing.T) {
@@ -3104,7 +3104,7 @@ func TestEventsGet2Service(t *testing.T) {
 	params := &stripe.EventParams{}
 	result, err := sc.Events.Get("evt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestEventsGet2Client(t *testing.T) {
@@ -3113,14 +3113,14 @@ func TestEventsGet2Client(t *testing.T) {
 	result, err := sc.V1Events.Retrieve(
 		context.TODO(), "evt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsDisconnectPost(t *testing.T) {
 	params := &stripe.FinancialConnectionsAccountDisconnectParams{}
 	result, err := financialconnections_account.Disconnect("fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsDisconnectPostService(t *testing.T) {
@@ -3128,7 +3128,7 @@ func TestFinancialConnectionsAccountsDisconnectPostService(t *testing.T) {
 	params := &stripe.FinancialConnectionsAccountDisconnectParams{}
 	result, err := sc.FinancialConnectionsAccounts.Disconnect("fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsDisconnectPostClient(t *testing.T) {
@@ -3137,7 +3137,7 @@ func TestFinancialConnectionsAccountsDisconnectPostClient(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsAccounts.Disconnect(
 		context.TODO(), "fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsDisconnectPost2(t *testing.T) {
@@ -3145,7 +3145,7 @@ func TestFinancialConnectionsAccountsDisconnectPost2(t *testing.T) {
 	result, err := financialconnections_account.Disconnect(
 		"fca_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsDisconnectPost2Service(t *testing.T) {
@@ -3154,7 +3154,7 @@ func TestFinancialConnectionsAccountsDisconnectPost2Service(t *testing.T) {
 	result, err := sc.FinancialConnectionsAccounts.Disconnect(
 		"fca_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsDisconnectPost2Client(t *testing.T) {
@@ -3163,14 +3163,14 @@ func TestFinancialConnectionsAccountsDisconnectPost2Client(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsAccounts.Disconnect(
 		context.TODO(), "fca_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsGet(t *testing.T) {
 	params := &stripe.FinancialConnectionsAccountListParams{}
 	result := financialconnections_account.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsGetService(t *testing.T) {
@@ -3178,7 +3178,7 @@ func TestFinancialConnectionsAccountsGetService(t *testing.T) {
 	params := &stripe.FinancialConnectionsAccountListParams{}
 	result := sc.FinancialConnectionsAccounts.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsGetClient(t *testing.T) {
@@ -3186,14 +3186,14 @@ func TestFinancialConnectionsAccountsGetClient(t *testing.T) {
 	params := &stripe.FinancialConnectionsAccountListParams{}
 	result := sc.V1FinancialConnectionsAccounts.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsGet2(t *testing.T) {
 	params := &stripe.FinancialConnectionsAccountParams{}
 	result, err := financialconnections_account.GetByID("fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsGet2Service(t *testing.T) {
@@ -3201,7 +3201,7 @@ func TestFinancialConnectionsAccountsGet2Service(t *testing.T) {
 	params := &stripe.FinancialConnectionsAccountParams{}
 	result, err := sc.FinancialConnectionsAccounts.GetByID("fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsGet2Client(t *testing.T) {
@@ -3210,7 +3210,7 @@ func TestFinancialConnectionsAccountsGet2Client(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsAccounts.GetByID(
 		context.TODO(), "fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsGet3(t *testing.T) {
@@ -3221,7 +3221,7 @@ func TestFinancialConnectionsAccountsGet3(t *testing.T) {
 	}
 	result := financialconnections_account.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsGet3Service(t *testing.T) {
@@ -3233,7 +3233,7 @@ func TestFinancialConnectionsAccountsGet3Service(t *testing.T) {
 	}
 	result := sc.FinancialConnectionsAccounts.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsGet3Client(t *testing.T) {
@@ -3245,7 +3245,7 @@ func TestFinancialConnectionsAccountsGet3Client(t *testing.T) {
 	}
 	result := sc.V1FinancialConnectionsAccounts.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsGet4(t *testing.T) {
@@ -3253,7 +3253,7 @@ func TestFinancialConnectionsAccountsGet4(t *testing.T) {
 	result, err := financialconnections_account.GetByID(
 		"fca_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsGet4Service(t *testing.T) {
@@ -3262,7 +3262,7 @@ func TestFinancialConnectionsAccountsGet4Service(t *testing.T) {
 	result, err := sc.FinancialConnectionsAccounts.GetByID(
 		"fca_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsGet4Client(t *testing.T) {
@@ -3271,7 +3271,7 @@ func TestFinancialConnectionsAccountsGet4Client(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsAccounts.GetByID(
 		context.TODO(), "fca_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsOwnersGet(t *testing.T) {
@@ -3281,7 +3281,7 @@ func TestFinancialConnectionsAccountsOwnersGet(t *testing.T) {
 	}
 	result := financialconnections_account.ListOwners(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsOwnersGetService(t *testing.T) {
@@ -3292,7 +3292,7 @@ func TestFinancialConnectionsAccountsOwnersGetService(t *testing.T) {
 	}
 	result := sc.FinancialConnectionsAccounts.ListOwners(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsOwnersGetClient(t *testing.T) {
@@ -3303,7 +3303,7 @@ func TestFinancialConnectionsAccountsOwnersGetClient(t *testing.T) {
 	}
 	result := sc.V1FinancialConnectionsAccounts.ListOwners(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsOwnersGet2(t *testing.T) {
@@ -3314,7 +3314,7 @@ func TestFinancialConnectionsAccountsOwnersGet2(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := financialconnections_account.ListOwners(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsOwnersGet2Service(t *testing.T) {
@@ -3326,7 +3326,7 @@ func TestFinancialConnectionsAccountsOwnersGet2Service(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.FinancialConnectionsAccounts.ListOwners(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsOwnersGet2Client(t *testing.T) {
@@ -3338,7 +3338,7 @@ func TestFinancialConnectionsAccountsOwnersGet2Client(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1FinancialConnectionsAccounts.ListOwners(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsAccountsRefreshPost(t *testing.T) {
@@ -3347,7 +3347,7 @@ func TestFinancialConnectionsAccountsRefreshPost(t *testing.T) {
 	}
 	result, err := financialconnections_account.Refresh("fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsRefreshPostService(t *testing.T) {
@@ -3357,7 +3357,7 @@ func TestFinancialConnectionsAccountsRefreshPostService(t *testing.T) {
 	}
 	result, err := sc.FinancialConnectionsAccounts.Refresh("fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsRefreshPostClient(t *testing.T) {
@@ -3368,7 +3368,7 @@ func TestFinancialConnectionsAccountsRefreshPostClient(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsAccounts.Refresh(
 		context.TODO(), "fca_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsSubscribePost(t *testing.T) {
@@ -3377,7 +3377,7 @@ func TestFinancialConnectionsAccountsSubscribePost(t *testing.T) {
 	}
 	result, err := financialconnections_account.Subscribe("fa_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsSubscribePostService(t *testing.T) {
@@ -3387,7 +3387,7 @@ func TestFinancialConnectionsAccountsSubscribePostService(t *testing.T) {
 	}
 	result, err := sc.FinancialConnectionsAccounts.Subscribe("fa_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsSubscribePostClient(t *testing.T) {
@@ -3398,7 +3398,7 @@ func TestFinancialConnectionsAccountsSubscribePostClient(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsAccounts.Subscribe(
 		context.TODO(), "fa_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsUnsubscribePost(t *testing.T) {
@@ -3407,7 +3407,7 @@ func TestFinancialConnectionsAccountsUnsubscribePost(t *testing.T) {
 	}
 	result, err := financialconnections_account.Unsubscribe("fa_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsUnsubscribePostService(t *testing.T) {
@@ -3417,7 +3417,7 @@ func TestFinancialConnectionsAccountsUnsubscribePostService(t *testing.T) {
 	}
 	result, err := sc.FinancialConnectionsAccounts.Unsubscribe("fa_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsAccountsUnsubscribePostClient(t *testing.T) {
@@ -3428,14 +3428,14 @@ func TestFinancialConnectionsAccountsUnsubscribePostClient(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsAccounts.Unsubscribe(
 		context.TODO(), "fa_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsGet(t *testing.T) {
 	params := &stripe.FinancialConnectionsSessionParams{}
 	result, err := financialconnections_session.Get("fcsess_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsGetService(t *testing.T) {
@@ -3443,7 +3443,7 @@ func TestFinancialConnectionsSessionsGetService(t *testing.T) {
 	params := &stripe.FinancialConnectionsSessionParams{}
 	result, err := sc.FinancialConnectionsSessions.Get("fcsess_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsGetClient(t *testing.T) {
@@ -3452,7 +3452,7 @@ func TestFinancialConnectionsSessionsGetClient(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsSessions.Retrieve(
 		context.TODO(), "fcsess_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsGet2(t *testing.T) {
@@ -3460,7 +3460,7 @@ func TestFinancialConnectionsSessionsGet2(t *testing.T) {
 	result, err := financialconnections_session.Get(
 		"fcsess_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsGet2Service(t *testing.T) {
@@ -3469,7 +3469,7 @@ func TestFinancialConnectionsSessionsGet2Service(t *testing.T) {
 	result, err := sc.FinancialConnectionsSessions.Get(
 		"fcsess_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsGet2Client(t *testing.T) {
@@ -3478,7 +3478,7 @@ func TestFinancialConnectionsSessionsGet2Client(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsSessions.Retrieve(
 		context.TODO(), "fcsess_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsPost(t *testing.T) {
@@ -3493,7 +3493,7 @@ func TestFinancialConnectionsSessionsPost(t *testing.T) {
 	}
 	result, err := financialconnections_session.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsPostService(t *testing.T) {
@@ -3509,7 +3509,7 @@ func TestFinancialConnectionsSessionsPostService(t *testing.T) {
 	}
 	result, err := sc.FinancialConnectionsSessions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsPostClient(t *testing.T) {
@@ -3526,7 +3526,7 @@ func TestFinancialConnectionsSessionsPostClient(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsSessions.Create(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsPost2(t *testing.T) {
@@ -3545,7 +3545,7 @@ func TestFinancialConnectionsSessionsPost2(t *testing.T) {
 	}
 	result, err := financialconnections_session.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsPost2Service(t *testing.T) {
@@ -3565,7 +3565,7 @@ func TestFinancialConnectionsSessionsPost2Service(t *testing.T) {
 	}
 	result, err := sc.FinancialConnectionsSessions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsSessionsPost2Client(t *testing.T) {
@@ -3586,14 +3586,14 @@ func TestFinancialConnectionsSessionsPost2Client(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsSessions.Create(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsTransactionsGet(t *testing.T) {
 	params := &stripe.FinancialConnectionsTransactionParams{}
 	result, err := financialconnections_transaction.Get("tr_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsTransactionsGetService(t *testing.T) {
@@ -3601,7 +3601,7 @@ func TestFinancialConnectionsTransactionsGetService(t *testing.T) {
 	params := &stripe.FinancialConnectionsTransactionParams{}
 	result, err := sc.FinancialConnectionsTransactions.Get("tr_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsTransactionsGetClient(t *testing.T) {
@@ -3610,7 +3610,7 @@ func TestFinancialConnectionsTransactionsGetClient(t *testing.T) {
 	result, err := sc.V1FinancialConnectionsTransactions.Retrieve(
 		context.TODO(), "tr_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestFinancialConnectionsTransactionsGet2(t *testing.T) {
@@ -3619,7 +3619,7 @@ func TestFinancialConnectionsTransactionsGet2(t *testing.T) {
 	}
 	result := financialconnections_transaction.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsTransactionsGet2Service(t *testing.T) {
@@ -3629,7 +3629,7 @@ func TestFinancialConnectionsTransactionsGet2Service(t *testing.T) {
 	}
 	result := sc.FinancialConnectionsTransactions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestFinancialConnectionsTransactionsGet2Client(t *testing.T) {
@@ -3639,7 +3639,7 @@ func TestFinancialConnectionsTransactionsGet2Client(t *testing.T) {
 	}
 	result := sc.V1FinancialConnectionsTransactions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIdentityVerificationReportsGet(t *testing.T) {
@@ -3647,7 +3647,7 @@ func TestIdentityVerificationReportsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := identity_verificationreport.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIdentityVerificationReportsGetService(t *testing.T) {
@@ -3656,7 +3656,7 @@ func TestIdentityVerificationReportsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.IdentityVerificationReports.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIdentityVerificationReportsGetClient(t *testing.T) {
@@ -3665,14 +3665,14 @@ func TestIdentityVerificationReportsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1IdentityVerificationReports.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIdentityVerificationReportsGet2(t *testing.T) {
 	params := &stripe.IdentityVerificationReportParams{}
 	result, err := identity_verificationreport.Get("vr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationReportsGet2Service(t *testing.T) {
@@ -3680,7 +3680,7 @@ func TestIdentityVerificationReportsGet2Service(t *testing.T) {
 	params := &stripe.IdentityVerificationReportParams{}
 	result, err := sc.IdentityVerificationReports.Get("vr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationReportsGet2Client(t *testing.T) {
@@ -3689,14 +3689,14 @@ func TestIdentityVerificationReportsGet2Client(t *testing.T) {
 	result, err := sc.V1IdentityVerificationReports.Retrieve(
 		context.TODO(), "vr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsCancelPost(t *testing.T) {
 	params := &stripe.IdentityVerificationSessionCancelParams{}
 	result, err := identity_verificationsession.Cancel("vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsCancelPostService(t *testing.T) {
@@ -3705,7 +3705,7 @@ func TestIdentityVerificationSessionsCancelPostService(t *testing.T) {
 	result, err := sc.IdentityVerificationSessions.Cancel(
 		"vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsCancelPostClient(t *testing.T) {
@@ -3714,7 +3714,7 @@ func TestIdentityVerificationSessionsCancelPostClient(t *testing.T) {
 	result, err := sc.V1IdentityVerificationSessions.Cancel(
 		context.TODO(), "vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsGet(t *testing.T) {
@@ -3722,7 +3722,7 @@ func TestIdentityVerificationSessionsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := identity_verificationsession.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIdentityVerificationSessionsGetService(t *testing.T) {
@@ -3731,7 +3731,7 @@ func TestIdentityVerificationSessionsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.IdentityVerificationSessions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIdentityVerificationSessionsGetClient(t *testing.T) {
@@ -3740,14 +3740,14 @@ func TestIdentityVerificationSessionsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1IdentityVerificationSessions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIdentityVerificationSessionsGet2(t *testing.T) {
 	params := &stripe.IdentityVerificationSessionParams{}
 	result, err := identity_verificationsession.Get("vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsGet2Service(t *testing.T) {
@@ -3755,7 +3755,7 @@ func TestIdentityVerificationSessionsGet2Service(t *testing.T) {
 	params := &stripe.IdentityVerificationSessionParams{}
 	result, err := sc.IdentityVerificationSessions.Get("vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsGet2Client(t *testing.T) {
@@ -3764,7 +3764,7 @@ func TestIdentityVerificationSessionsGet2Client(t *testing.T) {
 	result, err := sc.V1IdentityVerificationSessions.Retrieve(
 		context.TODO(), "vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsPost(t *testing.T) {
@@ -3773,7 +3773,7 @@ func TestIdentityVerificationSessionsPost(t *testing.T) {
 	}
 	result, err := identity_verificationsession.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsPostService(t *testing.T) {
@@ -3783,7 +3783,7 @@ func TestIdentityVerificationSessionsPostService(t *testing.T) {
 	}
 	result, err := sc.IdentityVerificationSessions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsPostClient(t *testing.T) {
@@ -3794,7 +3794,7 @@ func TestIdentityVerificationSessionsPostClient(t *testing.T) {
 	result, err := sc.V1IdentityVerificationSessions.Create(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsPost2(t *testing.T) {
@@ -3803,7 +3803,7 @@ func TestIdentityVerificationSessionsPost2(t *testing.T) {
 	}
 	result, err := identity_verificationsession.Update("vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsPost2Service(t *testing.T) {
@@ -3814,7 +3814,7 @@ func TestIdentityVerificationSessionsPost2Service(t *testing.T) {
 	result, err := sc.IdentityVerificationSessions.Update(
 		"vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsPost2Client(t *testing.T) {
@@ -3825,14 +3825,14 @@ func TestIdentityVerificationSessionsPost2Client(t *testing.T) {
 	result, err := sc.V1IdentityVerificationSessions.Update(
 		context.TODO(), "vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsRedactPost(t *testing.T) {
 	params := &stripe.IdentityVerificationSessionRedactParams{}
 	result, err := identity_verificationsession.Redact("vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsRedactPostService(t *testing.T) {
@@ -3841,7 +3841,7 @@ func TestIdentityVerificationSessionsRedactPostService(t *testing.T) {
 	result, err := sc.IdentityVerificationSessions.Redact(
 		"vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIdentityVerificationSessionsRedactPostClient(t *testing.T) {
@@ -3850,14 +3850,14 @@ func TestIdentityVerificationSessionsRedactPostClient(t *testing.T) {
 	result, err := sc.V1IdentityVerificationSessions.Redact(
 		context.TODO(), "vs_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsDelete(t *testing.T) {
 	params := &stripe.InvoiceItemParams{}
 	result, err := invoiceitem.Del("ii_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsDeleteService(t *testing.T) {
@@ -3865,7 +3865,7 @@ func TestInvoiceitemsDeleteService(t *testing.T) {
 	params := &stripe.InvoiceItemParams{}
 	result, err := sc.InvoiceItems.Del("ii_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsDeleteClient(t *testing.T) {
@@ -3874,7 +3874,7 @@ func TestInvoiceitemsDeleteClient(t *testing.T) {
 	result, err := sc.V1InvoiceItems.Delete(
 		context.TODO(), "ii_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsPost(t *testing.T) {
@@ -3883,7 +3883,7 @@ func TestInvoiceitemsPost(t *testing.T) {
 	}
 	result, err := invoiceitem.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsPostService(t *testing.T) {
@@ -3893,7 +3893,7 @@ func TestInvoiceitemsPostService(t *testing.T) {
 	}
 	result, err := sc.InvoiceItems.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsPostClient(t *testing.T) {
@@ -3903,7 +3903,7 @@ func TestInvoiceitemsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1InvoiceItems.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsPost2(t *testing.T) {
@@ -3911,7 +3911,7 @@ func TestInvoiceitemsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := invoiceitem.Update("ii_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsPost2Service(t *testing.T) {
@@ -3920,7 +3920,7 @@ func TestInvoiceitemsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.InvoiceItems.Update("ii_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoiceitemsPost2Client(t *testing.T) {
@@ -3930,14 +3930,14 @@ func TestInvoiceitemsPost2Client(t *testing.T) {
 	result, err := sc.V1InvoiceItems.Update(
 		context.TODO(), "ii_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesDelete(t *testing.T) {
 	params := &stripe.InvoiceParams{}
 	result, err := invoice.Del("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesDeleteService(t *testing.T) {
@@ -3945,7 +3945,7 @@ func TestInvoicesDeleteService(t *testing.T) {
 	params := &stripe.InvoiceParams{}
 	result, err := sc.Invoices.Del("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesDeleteClient(t *testing.T) {
@@ -3954,14 +3954,14 @@ func TestInvoicesDeleteClient(t *testing.T) {
 	result, err := sc.V1Invoices.Delete(
 		context.TODO(), "in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesFinalizePost(t *testing.T) {
 	params := &stripe.InvoiceFinalizeInvoiceParams{}
 	result, err := invoice.FinalizeInvoice("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesFinalizePostService(t *testing.T) {
@@ -3969,7 +3969,7 @@ func TestInvoicesFinalizePostService(t *testing.T) {
 	params := &stripe.InvoiceFinalizeInvoiceParams{}
 	result, err := sc.Invoices.FinalizeInvoice("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesFinalizePostClient(t *testing.T) {
@@ -3978,7 +3978,7 @@ func TestInvoicesFinalizePostClient(t *testing.T) {
 	result, err := sc.V1Invoices.FinalizeInvoice(
 		context.TODO(), "in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesGet(t *testing.T) {
@@ -3986,7 +3986,7 @@ func TestInvoicesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := invoice.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestInvoicesGetService(t *testing.T) {
@@ -3995,7 +3995,7 @@ func TestInvoicesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Invoices.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestInvoicesGetClient(t *testing.T) {
@@ -4004,14 +4004,14 @@ func TestInvoicesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Invoices.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestInvoicesGet2(t *testing.T) {
 	params := &stripe.InvoiceParams{}
 	result, err := invoice.Get("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesGet2Service(t *testing.T) {
@@ -4019,7 +4019,7 @@ func TestInvoicesGet2Service(t *testing.T) {
 	params := &stripe.InvoiceParams{}
 	result, err := sc.Invoices.Get("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesGet2Client(t *testing.T) {
@@ -4028,7 +4028,7 @@ func TestInvoicesGet2Client(t *testing.T) {
 	result, err := sc.V1Invoices.Retrieve(
 		context.TODO(), "in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesGet3(t *testing.T) {
@@ -4036,7 +4036,7 @@ func TestInvoicesGet3(t *testing.T) {
 	params.AddExpand("customer")
 	result, err := invoice.Get("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesGet3Service(t *testing.T) {
@@ -4045,7 +4045,7 @@ func TestInvoicesGet3Service(t *testing.T) {
 	params.AddExpand("customer")
 	result, err := sc.Invoices.Get("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesGet3Client(t *testing.T) {
@@ -4055,14 +4055,14 @@ func TestInvoicesGet3Client(t *testing.T) {
 	result, err := sc.V1Invoices.Retrieve(
 		context.TODO(), "in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPayPost(t *testing.T) {
 	params := &stripe.InvoicePayParams{}
 	result, err := invoice.Pay("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPayPostService(t *testing.T) {
@@ -4070,7 +4070,7 @@ func TestInvoicesPayPostService(t *testing.T) {
 	params := &stripe.InvoicePayParams{}
 	result, err := sc.Invoices.Pay("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPayPostClient(t *testing.T) {
@@ -4078,14 +4078,14 @@ func TestInvoicesPayPostClient(t *testing.T) {
 	params := &stripe.InvoicePayParams{}
 	result, err := sc.V1Invoices.Pay(context.TODO(), "in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPost(t *testing.T) {
 	params := &stripe.InvoiceParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := invoice.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPostService(t *testing.T) {
@@ -4093,7 +4093,7 @@ func TestInvoicesPostService(t *testing.T) {
 	params := &stripe.InvoiceParams{Customer: stripe.String("cus_xxxxxxxxxxxxx")}
 	result, err := sc.Invoices.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPostClient(t *testing.T) {
@@ -4103,7 +4103,7 @@ func TestInvoicesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Invoices.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPost2(t *testing.T) {
@@ -4111,7 +4111,7 @@ func TestInvoicesPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := invoice.Update("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPost2Service(t *testing.T) {
@@ -4120,7 +4120,7 @@ func TestInvoicesPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Invoices.Update("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesPost2Client(t *testing.T) {
@@ -4130,7 +4130,7 @@ func TestInvoicesPost2Client(t *testing.T) {
 	result, err := sc.V1Invoices.Update(
 		context.TODO(), "in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesSearchGet(t *testing.T) {
@@ -4141,7 +4141,7 @@ func TestInvoicesSearchGet(t *testing.T) {
 	}
 	result := invoice.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestInvoicesSearchGetService(t *testing.T) {
@@ -4153,7 +4153,7 @@ func TestInvoicesSearchGetService(t *testing.T) {
 	}
 	result := sc.Invoices.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestInvoicesSearchGetClient(t *testing.T) {
@@ -4165,14 +4165,14 @@ func TestInvoicesSearchGetClient(t *testing.T) {
 	}
 	result := sc.V1Invoices.Search(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestInvoicesSendPost(t *testing.T) {
 	params := &stripe.InvoiceSendInvoiceParams{}
 	result, err := invoice.SendInvoice("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesSendPostService(t *testing.T) {
@@ -4180,7 +4180,7 @@ func TestInvoicesSendPostService(t *testing.T) {
 	params := &stripe.InvoiceSendInvoiceParams{}
 	result, err := sc.Invoices.SendInvoice("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesSendPostClient(t *testing.T) {
@@ -4189,14 +4189,14 @@ func TestInvoicesSendPostClient(t *testing.T) {
 	result, err := sc.V1Invoices.SendInvoice(
 		context.TODO(), "in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesVoidPost(t *testing.T) {
 	params := &stripe.InvoiceVoidInvoiceParams{}
 	result, err := invoice.VoidInvoice("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesVoidPostService(t *testing.T) {
@@ -4204,7 +4204,7 @@ func TestInvoicesVoidPostService(t *testing.T) {
 	params := &stripe.InvoiceVoidInvoiceParams{}
 	result, err := sc.Invoices.VoidInvoice("in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInvoicesVoidPostClient(t *testing.T) {
@@ -4213,14 +4213,14 @@ func TestInvoicesVoidPostClient(t *testing.T) {
 	result, err := sc.V1Invoices.VoidInvoice(
 		context.TODO(), "in_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsApprovePost(t *testing.T) {
 	params := &stripe.IssuingAuthorizationApproveParams{}
 	result, err := issuing_authorization.Approve("iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsApprovePostService(t *testing.T) {
@@ -4228,7 +4228,7 @@ func TestIssuingAuthorizationsApprovePostService(t *testing.T) {
 	params := &stripe.IssuingAuthorizationApproveParams{}
 	result, err := sc.IssuingAuthorizations.Approve("iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsApprovePostClient(t *testing.T) {
@@ -4237,14 +4237,14 @@ func TestIssuingAuthorizationsApprovePostClient(t *testing.T) {
 	result, err := sc.V1IssuingAuthorizations.Approve(
 		context.TODO(), "iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsDeclinePost(t *testing.T) {
 	params := &stripe.IssuingAuthorizationDeclineParams{}
 	result, err := issuing_authorization.Decline("iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsDeclinePostService(t *testing.T) {
@@ -4252,7 +4252,7 @@ func TestIssuingAuthorizationsDeclinePostService(t *testing.T) {
 	params := &stripe.IssuingAuthorizationDeclineParams{}
 	result, err := sc.IssuingAuthorizations.Decline("iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsDeclinePostClient(t *testing.T) {
@@ -4261,7 +4261,7 @@ func TestIssuingAuthorizationsDeclinePostClient(t *testing.T) {
 	result, err := sc.V1IssuingAuthorizations.Decline(
 		context.TODO(), "iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsGet(t *testing.T) {
@@ -4269,7 +4269,7 @@ func TestIssuingAuthorizationsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := issuing_authorization.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingAuthorizationsGetService(t *testing.T) {
@@ -4278,7 +4278,7 @@ func TestIssuingAuthorizationsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.IssuingAuthorizations.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingAuthorizationsGetClient(t *testing.T) {
@@ -4287,14 +4287,14 @@ func TestIssuingAuthorizationsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1IssuingAuthorizations.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingAuthorizationsGet2(t *testing.T) {
 	params := &stripe.IssuingAuthorizationParams{}
 	result, err := issuing_authorization.Get("iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsGet2Service(t *testing.T) {
@@ -4302,7 +4302,7 @@ func TestIssuingAuthorizationsGet2Service(t *testing.T) {
 	params := &stripe.IssuingAuthorizationParams{}
 	result, err := sc.IssuingAuthorizations.Get("iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsGet2Client(t *testing.T) {
@@ -4311,7 +4311,7 @@ func TestIssuingAuthorizationsGet2Client(t *testing.T) {
 	result, err := sc.V1IssuingAuthorizations.Retrieve(
 		context.TODO(), "iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsPost(t *testing.T) {
@@ -4319,7 +4319,7 @@ func TestIssuingAuthorizationsPost(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := issuing_authorization.Update("iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsPostService(t *testing.T) {
@@ -4328,7 +4328,7 @@ func TestIssuingAuthorizationsPostService(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.IssuingAuthorizations.Update("iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingAuthorizationsPostClient(t *testing.T) {
@@ -4338,7 +4338,7 @@ func TestIssuingAuthorizationsPostClient(t *testing.T) {
 	result, err := sc.V1IssuingAuthorizations.Update(
 		context.TODO(), "iauth_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersGet(t *testing.T) {
@@ -4346,7 +4346,7 @@ func TestIssuingCardholdersGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := issuing_cardholder.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingCardholdersGetService(t *testing.T) {
@@ -4355,7 +4355,7 @@ func TestIssuingCardholdersGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.IssuingCardholders.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingCardholdersGetClient(t *testing.T) {
@@ -4364,14 +4364,14 @@ func TestIssuingCardholdersGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1IssuingCardholders.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingCardholdersGet2(t *testing.T) {
 	params := &stripe.IssuingCardholderParams{}
 	result, err := issuing_cardholder.Get("ich_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersGet2Service(t *testing.T) {
@@ -4379,7 +4379,7 @@ func TestIssuingCardholdersGet2Service(t *testing.T) {
 	params := &stripe.IssuingCardholderParams{}
 	result, err := sc.IssuingCardholders.Get("ich_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersGet2Client(t *testing.T) {
@@ -4388,7 +4388,7 @@ func TestIssuingCardholdersGet2Client(t *testing.T) {
 	result, err := sc.V1IssuingCardholders.Retrieve(
 		context.TODO(), "ich_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersPost(t *testing.T) {
@@ -4409,7 +4409,7 @@ func TestIssuingCardholdersPost(t *testing.T) {
 	}
 	result, err := issuing_cardholder.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersPostService(t *testing.T) {
@@ -4431,7 +4431,7 @@ func TestIssuingCardholdersPostService(t *testing.T) {
 	}
 	result, err := sc.IssuingCardholders.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersPostClient(t *testing.T) {
@@ -4453,7 +4453,7 @@ func TestIssuingCardholdersPostClient(t *testing.T) {
 	}
 	result, err := sc.V1IssuingCardholders.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersPost2(t *testing.T) {
@@ -4461,7 +4461,7 @@ func TestIssuingCardholdersPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := issuing_cardholder.Update("ich_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersPost2Service(t *testing.T) {
@@ -4470,7 +4470,7 @@ func TestIssuingCardholdersPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.IssuingCardholders.Update("ich_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardholdersPost2Client(t *testing.T) {
@@ -4480,7 +4480,7 @@ func TestIssuingCardholdersPost2Client(t *testing.T) {
 	result, err := sc.V1IssuingCardholders.Update(
 		context.TODO(), "ich_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsGet(t *testing.T) {
@@ -4488,7 +4488,7 @@ func TestIssuingCardsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := issuing_card.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingCardsGetService(t *testing.T) {
@@ -4497,7 +4497,7 @@ func TestIssuingCardsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.IssuingCards.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingCardsGetClient(t *testing.T) {
@@ -4506,14 +4506,14 @@ func TestIssuingCardsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1IssuingCards.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingCardsGet2(t *testing.T) {
 	params := &stripe.IssuingCardParams{}
 	result, err := issuing_card.Get("ic_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsGet2Service(t *testing.T) {
@@ -4521,7 +4521,7 @@ func TestIssuingCardsGet2Service(t *testing.T) {
 	params := &stripe.IssuingCardParams{}
 	result, err := sc.IssuingCards.Get("ic_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsGet2Client(t *testing.T) {
@@ -4530,7 +4530,7 @@ func TestIssuingCardsGet2Client(t *testing.T) {
 	result, err := sc.V1IssuingCards.Retrieve(
 		context.TODO(), "ic_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsPost(t *testing.T) {
@@ -4541,7 +4541,7 @@ func TestIssuingCardsPost(t *testing.T) {
 	}
 	result, err := issuing_card.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsPostService(t *testing.T) {
@@ -4553,7 +4553,7 @@ func TestIssuingCardsPostService(t *testing.T) {
 	}
 	result, err := sc.IssuingCards.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsPostClient(t *testing.T) {
@@ -4565,7 +4565,7 @@ func TestIssuingCardsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1IssuingCards.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsPost2(t *testing.T) {
@@ -4573,7 +4573,7 @@ func TestIssuingCardsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := issuing_card.Update("ic_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsPost2Service(t *testing.T) {
@@ -4582,7 +4582,7 @@ func TestIssuingCardsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.IssuingCards.Update("ic_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingCardsPost2Client(t *testing.T) {
@@ -4592,7 +4592,7 @@ func TestIssuingCardsPost2Client(t *testing.T) {
 	result, err := sc.V1IssuingCards.Update(
 		context.TODO(), "ic_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesGet(t *testing.T) {
@@ -4600,7 +4600,7 @@ func TestIssuingDisputesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := issuing_dispute.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingDisputesGetService(t *testing.T) {
@@ -4609,7 +4609,7 @@ func TestIssuingDisputesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.IssuingDisputes.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingDisputesGetClient(t *testing.T) {
@@ -4618,14 +4618,14 @@ func TestIssuingDisputesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1IssuingDisputes.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingDisputesGet2(t *testing.T) {
 	params := &stripe.IssuingDisputeParams{}
 	result, err := issuing_dispute.Get("idp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesGet2Service(t *testing.T) {
@@ -4633,7 +4633,7 @@ func TestIssuingDisputesGet2Service(t *testing.T) {
 	params := &stripe.IssuingDisputeParams{}
 	result, err := sc.IssuingDisputes.Get("idp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesGet2Client(t *testing.T) {
@@ -4642,7 +4642,7 @@ func TestIssuingDisputesGet2Client(t *testing.T) {
 	result, err := sc.V1IssuingDisputes.Retrieve(
 		context.TODO(), "idp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesPost(t *testing.T) {
@@ -4657,7 +4657,7 @@ func TestIssuingDisputesPost(t *testing.T) {
 	}
 	result, err := issuing_dispute.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesPostService(t *testing.T) {
@@ -4673,7 +4673,7 @@ func TestIssuingDisputesPostService(t *testing.T) {
 	}
 	result, err := sc.IssuingDisputes.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesPostClient(t *testing.T) {
@@ -4689,14 +4689,14 @@ func TestIssuingDisputesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1IssuingDisputes.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesSubmitPost(t *testing.T) {
 	params := &stripe.IssuingDisputeSubmitParams{}
 	result, err := issuing_dispute.Submit("idp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesSubmitPostService(t *testing.T) {
@@ -4704,7 +4704,7 @@ func TestIssuingDisputesSubmitPostService(t *testing.T) {
 	params := &stripe.IssuingDisputeSubmitParams{}
 	result, err := sc.IssuingDisputes.Submit("idp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingDisputesSubmitPostClient(t *testing.T) {
@@ -4713,14 +4713,14 @@ func TestIssuingDisputesSubmitPostClient(t *testing.T) {
 	result, err := sc.V1IssuingDisputes.Submit(
 		context.TODO(), "idp_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsGet(t *testing.T) {
 	params := &stripe.IssuingPersonalizationDesignListParams{}
 	result := issuing_personalizationdesign.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingPersonalizationDesignsGetService(t *testing.T) {
@@ -4728,7 +4728,7 @@ func TestIssuingPersonalizationDesignsGetService(t *testing.T) {
 	params := &stripe.IssuingPersonalizationDesignListParams{}
 	result := sc.IssuingPersonalizationDesigns.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingPersonalizationDesignsGetClient(t *testing.T) {
@@ -4736,14 +4736,14 @@ func TestIssuingPersonalizationDesignsGetClient(t *testing.T) {
 	params := &stripe.IssuingPersonalizationDesignListParams{}
 	result := sc.V1IssuingPersonalizationDesigns.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingPersonalizationDesignsGet2(t *testing.T) {
 	params := &stripe.IssuingPersonalizationDesignParams{}
 	result, err := issuing_personalizationdesign.Get("pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsGet2Service(t *testing.T) {
@@ -4751,7 +4751,7 @@ func TestIssuingPersonalizationDesignsGet2Service(t *testing.T) {
 	params := &stripe.IssuingPersonalizationDesignParams{}
 	result, err := sc.IssuingPersonalizationDesigns.Get("pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsGet2Client(t *testing.T) {
@@ -4760,7 +4760,7 @@ func TestIssuingPersonalizationDesignsGet2Client(t *testing.T) {
 	result, err := sc.V1IssuingPersonalizationDesigns.Retrieve(
 		context.TODO(), "pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsPost(t *testing.T) {
@@ -4769,7 +4769,7 @@ func TestIssuingPersonalizationDesignsPost(t *testing.T) {
 	}
 	result, err := issuing_personalizationdesign.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsPostService(t *testing.T) {
@@ -4779,7 +4779,7 @@ func TestIssuingPersonalizationDesignsPostService(t *testing.T) {
 	}
 	result, err := sc.IssuingPersonalizationDesigns.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsPostClient(t *testing.T) {
@@ -4790,14 +4790,14 @@ func TestIssuingPersonalizationDesignsPostClient(t *testing.T) {
 	result, err := sc.V1IssuingPersonalizationDesigns.Create(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsPost2(t *testing.T) {
 	params := &stripe.IssuingPersonalizationDesignParams{}
 	result, err := issuing_personalizationdesign.Update("pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsPost2Service(t *testing.T) {
@@ -4805,7 +4805,7 @@ func TestIssuingPersonalizationDesignsPost2Service(t *testing.T) {
 	params := &stripe.IssuingPersonalizationDesignParams{}
 	result, err := sc.IssuingPersonalizationDesigns.Update("pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPersonalizationDesignsPost2Client(t *testing.T) {
@@ -4814,14 +4814,14 @@ func TestIssuingPersonalizationDesignsPost2Client(t *testing.T) {
 	result, err := sc.V1IssuingPersonalizationDesigns.Update(
 		context.TODO(), "pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPhysicalBundlesGet(t *testing.T) {
 	params := &stripe.IssuingPhysicalBundleListParams{}
 	result := issuing_physicalbundle.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingPhysicalBundlesGetService(t *testing.T) {
@@ -4829,7 +4829,7 @@ func TestIssuingPhysicalBundlesGetService(t *testing.T) {
 	params := &stripe.IssuingPhysicalBundleListParams{}
 	result := sc.IssuingPhysicalBundles.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingPhysicalBundlesGetClient(t *testing.T) {
@@ -4837,14 +4837,14 @@ func TestIssuingPhysicalBundlesGetClient(t *testing.T) {
 	params := &stripe.IssuingPhysicalBundleListParams{}
 	result := sc.V1IssuingPhysicalBundles.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingPhysicalBundlesGet2(t *testing.T) {
 	params := &stripe.IssuingPhysicalBundleParams{}
 	result, err := issuing_physicalbundle.Get("pb_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPhysicalBundlesGet2Service(t *testing.T) {
@@ -4852,7 +4852,7 @@ func TestIssuingPhysicalBundlesGet2Service(t *testing.T) {
 	params := &stripe.IssuingPhysicalBundleParams{}
 	result, err := sc.IssuingPhysicalBundles.Get("pb_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingPhysicalBundlesGet2Client(t *testing.T) {
@@ -4861,7 +4861,7 @@ func TestIssuingPhysicalBundlesGet2Client(t *testing.T) {
 	result, err := sc.V1IssuingPhysicalBundles.Retrieve(
 		context.TODO(), "pb_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingTransactionsGet(t *testing.T) {
@@ -4869,7 +4869,7 @@ func TestIssuingTransactionsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := issuing_transaction.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingTransactionsGetService(t *testing.T) {
@@ -4878,7 +4878,7 @@ func TestIssuingTransactionsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.IssuingTransactions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingTransactionsGetClient(t *testing.T) {
@@ -4887,14 +4887,14 @@ func TestIssuingTransactionsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1IssuingTransactions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestIssuingTransactionsGet2(t *testing.T) {
 	params := &stripe.IssuingTransactionParams{}
 	result, err := issuing_transaction.Get("ipi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingTransactionsGet2Service(t *testing.T) {
@@ -4902,7 +4902,7 @@ func TestIssuingTransactionsGet2Service(t *testing.T) {
 	params := &stripe.IssuingTransactionParams{}
 	result, err := sc.IssuingTransactions.Get("ipi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingTransactionsGet2Client(t *testing.T) {
@@ -4911,7 +4911,7 @@ func TestIssuingTransactionsGet2Client(t *testing.T) {
 	result, err := sc.V1IssuingTransactions.Retrieve(
 		context.TODO(), "ipi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingTransactionsPost(t *testing.T) {
@@ -4919,7 +4919,7 @@ func TestIssuingTransactionsPost(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := issuing_transaction.Update("ipi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingTransactionsPostService(t *testing.T) {
@@ -4928,7 +4928,7 @@ func TestIssuingTransactionsPostService(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.IssuingTransactions.Update("ipi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIssuingTransactionsPostClient(t *testing.T) {
@@ -4938,14 +4938,14 @@ func TestIssuingTransactionsPostClient(t *testing.T) {
 	result, err := sc.V1IssuingTransactions.Update(
 		context.TODO(), "ipi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestMandatesGet(t *testing.T) {
 	params := &stripe.MandateParams{}
 	result, err := mandate.Get("mandate_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestMandatesGetService(t *testing.T) {
@@ -4953,7 +4953,7 @@ func TestMandatesGetService(t *testing.T) {
 	params := &stripe.MandateParams{}
 	result, err := sc.Mandates.Get("mandate_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestMandatesGetClient(t *testing.T) {
@@ -4962,14 +4962,14 @@ func TestMandatesGetClient(t *testing.T) {
 	result, err := sc.V1Mandates.Retrieve(
 		context.TODO(), "mandate_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsApplyCustomerBalancePost(t *testing.T) {
 	params := &stripe.PaymentIntentApplyCustomerBalanceParams{}
 	result, err := paymentintent.ApplyCustomerBalance("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsApplyCustomerBalancePostService(t *testing.T) {
@@ -4978,7 +4978,7 @@ func TestPaymentIntentsApplyCustomerBalancePostService(t *testing.T) {
 	result, err := sc.PaymentIntents.ApplyCustomerBalance(
 		"pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsApplyCustomerBalancePostClient(t *testing.T) {
@@ -4987,14 +4987,14 @@ func TestPaymentIntentsApplyCustomerBalancePostClient(t *testing.T) {
 	result, err := sc.V1PaymentIntents.ApplyCustomerBalance(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsCancelPost(t *testing.T) {
 	params := &stripe.PaymentIntentCancelParams{}
 	result, err := paymentintent.Cancel("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsCancelPostService(t *testing.T) {
@@ -5002,7 +5002,7 @@ func TestPaymentIntentsCancelPostService(t *testing.T) {
 	params := &stripe.PaymentIntentCancelParams{}
 	result, err := sc.PaymentIntents.Cancel("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsCancelPostClient(t *testing.T) {
@@ -5011,14 +5011,14 @@ func TestPaymentIntentsCancelPostClient(t *testing.T) {
 	result, err := sc.V1PaymentIntents.Cancel(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsCapturePost(t *testing.T) {
 	params := &stripe.PaymentIntentCaptureParams{}
 	result, err := paymentintent.Capture("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsCapturePostService(t *testing.T) {
@@ -5026,7 +5026,7 @@ func TestPaymentIntentsCapturePostService(t *testing.T) {
 	params := &stripe.PaymentIntentCaptureParams{}
 	result, err := sc.PaymentIntents.Capture("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsCapturePostClient(t *testing.T) {
@@ -5035,7 +5035,7 @@ func TestPaymentIntentsCapturePostClient(t *testing.T) {
 	result, err := sc.V1PaymentIntents.Capture(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsConfirmPost(t *testing.T) {
@@ -5044,7 +5044,7 @@ func TestPaymentIntentsConfirmPost(t *testing.T) {
 	}
 	result, err := paymentintent.Confirm("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsConfirmPostService(t *testing.T) {
@@ -5054,7 +5054,7 @@ func TestPaymentIntentsConfirmPostService(t *testing.T) {
 	}
 	result, err := sc.PaymentIntents.Confirm("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsConfirmPostClient(t *testing.T) {
@@ -5065,7 +5065,7 @@ func TestPaymentIntentsConfirmPostClient(t *testing.T) {
 	result, err := sc.V1PaymentIntents.Confirm(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsGet(t *testing.T) {
@@ -5073,7 +5073,7 @@ func TestPaymentIntentsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := paymentintent.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentIntentsGetService(t *testing.T) {
@@ -5082,7 +5082,7 @@ func TestPaymentIntentsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.PaymentIntents.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentIntentsGetClient(t *testing.T) {
@@ -5091,14 +5091,14 @@ func TestPaymentIntentsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1PaymentIntents.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentIntentsGet2(t *testing.T) {
 	params := &stripe.PaymentIntentParams{}
 	result, err := paymentintent.Get("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsGet2Service(t *testing.T) {
@@ -5106,7 +5106,7 @@ func TestPaymentIntentsGet2Service(t *testing.T) {
 	params := &stripe.PaymentIntentParams{}
 	result, err := sc.PaymentIntents.Get("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsGet2Client(t *testing.T) {
@@ -5115,7 +5115,7 @@ func TestPaymentIntentsGet2Client(t *testing.T) {
 	result, err := sc.V1PaymentIntents.Retrieve(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsIncrementAuthorizationPost(t *testing.T) {
@@ -5125,7 +5125,7 @@ func TestPaymentIntentsIncrementAuthorizationPost(t *testing.T) {
 	result, err := paymentintent.IncrementAuthorization(
 		"pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsIncrementAuthorizationPostService(t *testing.T) {
@@ -5136,7 +5136,7 @@ func TestPaymentIntentsIncrementAuthorizationPostService(t *testing.T) {
 	result, err := sc.PaymentIntents.IncrementAuthorization(
 		"pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsIncrementAuthorizationPostClient(t *testing.T) {
@@ -5147,7 +5147,7 @@ func TestPaymentIntentsIncrementAuthorizationPostClient(t *testing.T) {
 	result, err := sc.V1PaymentIntents.IncrementAuthorization(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost(t *testing.T) {
@@ -5160,7 +5160,7 @@ func TestPaymentIntentsPost(t *testing.T) {
 	}
 	result, err := paymentintent.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPostService(t *testing.T) {
@@ -5174,7 +5174,7 @@ func TestPaymentIntentsPostService(t *testing.T) {
 	}
 	result, err := sc.PaymentIntents.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPostClient(t *testing.T) {
@@ -5188,7 +5188,7 @@ func TestPaymentIntentsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1PaymentIntents.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost2(t *testing.T) {
@@ -5201,7 +5201,7 @@ func TestPaymentIntentsPost2(t *testing.T) {
 	}
 	result, err := paymentintent.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost2Service(t *testing.T) {
@@ -5215,7 +5215,7 @@ func TestPaymentIntentsPost2Service(t *testing.T) {
 	}
 	result, err := sc.PaymentIntents.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost2Client(t *testing.T) {
@@ -5229,7 +5229,7 @@ func TestPaymentIntentsPost2Client(t *testing.T) {
 	}
 	result, err := sc.V1PaymentIntents.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost3(t *testing.T) {
@@ -5237,7 +5237,7 @@ func TestPaymentIntentsPost3(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := paymentintent.Update("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost3Service(t *testing.T) {
@@ -5246,7 +5246,7 @@ func TestPaymentIntentsPost3Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.PaymentIntents.Update("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost3Client(t *testing.T) {
@@ -5256,7 +5256,7 @@ func TestPaymentIntentsPost3Client(t *testing.T) {
 	result, err := sc.V1PaymentIntents.Update(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost4(t *testing.T) {
@@ -5270,7 +5270,7 @@ func TestPaymentIntentsPost4(t *testing.T) {
 	}
 	result, err := paymentintent.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost4Service(t *testing.T) {
@@ -5285,7 +5285,7 @@ func TestPaymentIntentsPost4Service(t *testing.T) {
 	}
 	result, err := sc.PaymentIntents.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsPost4Client(t *testing.T) {
@@ -5300,7 +5300,7 @@ func TestPaymentIntentsPost4Client(t *testing.T) {
 	}
 	result, err := sc.V1PaymentIntents.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsSearchGet(t *testing.T) {
@@ -5311,7 +5311,7 @@ func TestPaymentIntentsSearchGet(t *testing.T) {
 	}
 	result := paymentintent.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentIntentsSearchGetService(t *testing.T) {
@@ -5323,7 +5323,7 @@ func TestPaymentIntentsSearchGetService(t *testing.T) {
 	}
 	result := sc.PaymentIntents.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentIntentsSearchGetClient(t *testing.T) {
@@ -5335,14 +5335,14 @@ func TestPaymentIntentsSearchGetClient(t *testing.T) {
 	}
 	result := sc.V1PaymentIntents.Search(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentIntentsVerifyMicrodepositsPost(t *testing.T) {
 	params := &stripe.PaymentIntentVerifyMicrodepositsParams{}
 	result, err := paymentintent.VerifyMicrodeposits("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsVerifyMicrodepositsPostService(t *testing.T) {
@@ -5351,7 +5351,7 @@ func TestPaymentIntentsVerifyMicrodepositsPostService(t *testing.T) {
 	result, err := sc.PaymentIntents.VerifyMicrodeposits(
 		"pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsVerifyMicrodepositsPostClient(t *testing.T) {
@@ -5360,7 +5360,7 @@ func TestPaymentIntentsVerifyMicrodepositsPostClient(t *testing.T) {
 	result, err := sc.V1PaymentIntents.VerifyMicrodeposits(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsVerifyMicrodepositsPost2(t *testing.T) {
@@ -5369,7 +5369,7 @@ func TestPaymentIntentsVerifyMicrodepositsPost2(t *testing.T) {
 	}
 	result, err := paymentintent.VerifyMicrodeposits("pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsVerifyMicrodepositsPost2Service(t *testing.T) {
@@ -5380,7 +5380,7 @@ func TestPaymentIntentsVerifyMicrodepositsPost2Service(t *testing.T) {
 	result, err := sc.PaymentIntents.VerifyMicrodeposits(
 		"pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentIntentsVerifyMicrodepositsPost2Client(t *testing.T) {
@@ -5391,14 +5391,14 @@ func TestPaymentIntentsVerifyMicrodepositsPost2Client(t *testing.T) {
 	result, err := sc.V1PaymentIntents.VerifyMicrodeposits(
 		context.TODO(), "pi_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksGet(t *testing.T) {
 	params := &stripe.PaymentLinkParams{}
 	result, err := paymentlink.Get("pl_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksGetService(t *testing.T) {
@@ -5406,7 +5406,7 @@ func TestPaymentLinksGetService(t *testing.T) {
 	params := &stripe.PaymentLinkParams{}
 	result, err := sc.PaymentLinks.Get("pl_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksGetClient(t *testing.T) {
@@ -5414,7 +5414,7 @@ func TestPaymentLinksGetClient(t *testing.T) {
 	params := &stripe.PaymentLinkRetrieveParams{}
 	result, err := sc.V1PaymentLinks.Retrieve(context.TODO(), "pl_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksGet2(t *testing.T) {
@@ -5422,7 +5422,7 @@ func TestPaymentLinksGet2(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := paymentlink.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentLinksGet2Service(t *testing.T) {
@@ -5431,7 +5431,7 @@ func TestPaymentLinksGet2Service(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.PaymentLinks.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentLinksGet2Client(t *testing.T) {
@@ -5440,14 +5440,14 @@ func TestPaymentLinksGet2Client(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1PaymentLinks.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentLinksGet3(t *testing.T) {
 	params := &stripe.PaymentLinkParams{}
 	result, err := paymentlink.Get("plink_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksGet3Service(t *testing.T) {
@@ -5455,7 +5455,7 @@ func TestPaymentLinksGet3Service(t *testing.T) {
 	params := &stripe.PaymentLinkParams{}
 	result, err := sc.PaymentLinks.Get("plink_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksGet3Client(t *testing.T) {
@@ -5464,7 +5464,7 @@ func TestPaymentLinksGet3Client(t *testing.T) {
 	result, err := sc.V1PaymentLinks.Retrieve(
 		context.TODO(), "plink_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksLineItemsGet(t *testing.T) {
@@ -5473,7 +5473,7 @@ func TestPaymentLinksLineItemsGet(t *testing.T) {
 	}
 	result := paymentlink.ListLineItems(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentLinksLineItemsGetService(t *testing.T) {
@@ -5483,7 +5483,7 @@ func TestPaymentLinksLineItemsGetService(t *testing.T) {
 	}
 	result := sc.PaymentLinks.ListLineItems(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentLinksLineItemsGetClient(t *testing.T) {
@@ -5493,7 +5493,7 @@ func TestPaymentLinksLineItemsGetClient(t *testing.T) {
 	}
 	result := sc.V1PaymentLinks.ListLineItems(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentLinksPost(t *testing.T) {
@@ -5507,7 +5507,7 @@ func TestPaymentLinksPost(t *testing.T) {
 	}
 	result, err := paymentlink.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksPostService(t *testing.T) {
@@ -5522,7 +5522,7 @@ func TestPaymentLinksPostService(t *testing.T) {
 	}
 	result, err := sc.PaymentLinks.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksPostClient(t *testing.T) {
@@ -5537,7 +5537,7 @@ func TestPaymentLinksPostClient(t *testing.T) {
 	}
 	result, err := sc.V1PaymentLinks.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksPost2(t *testing.T) {
@@ -5551,7 +5551,7 @@ func TestPaymentLinksPost2(t *testing.T) {
 	}
 	result, err := paymentlink.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksPost2Service(t *testing.T) {
@@ -5566,7 +5566,7 @@ func TestPaymentLinksPost2Service(t *testing.T) {
 	}
 	result, err := sc.PaymentLinks.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksPost2Client(t *testing.T) {
@@ -5581,14 +5581,14 @@ func TestPaymentLinksPost2Client(t *testing.T) {
 	}
 	result, err := sc.V1PaymentLinks.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksPost3(t *testing.T) {
 	params := &stripe.PaymentLinkParams{Active: stripe.Bool(false)}
 	result, err := paymentlink.Update("plink_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksPost3Service(t *testing.T) {
@@ -5596,7 +5596,7 @@ func TestPaymentLinksPost3Service(t *testing.T) {
 	params := &stripe.PaymentLinkParams{Active: stripe.Bool(false)}
 	result, err := sc.PaymentLinks.Update("plink_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentLinksPost3Client(t *testing.T) {
@@ -5605,7 +5605,7 @@ func TestPaymentLinksPost3Client(t *testing.T) {
 	result, err := sc.V1PaymentLinks.Update(
 		context.TODO(), "plink_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsGet(t *testing.T) {
@@ -5614,7 +5614,7 @@ func TestPaymentMethodConfigurationsGet(t *testing.T) {
 	}
 	result := paymentmethodconfiguration.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentMethodConfigurationsGetService(t *testing.T) {
@@ -5624,7 +5624,7 @@ func TestPaymentMethodConfigurationsGetService(t *testing.T) {
 	}
 	result := sc.PaymentMethodConfigurations.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentMethodConfigurationsGetClient(t *testing.T) {
@@ -5634,14 +5634,14 @@ func TestPaymentMethodConfigurationsGetClient(t *testing.T) {
 	}
 	result := sc.V1PaymentMethodConfigurations.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentMethodConfigurationsGet2(t *testing.T) {
 	params := &stripe.PaymentMethodConfigurationParams{}
 	result, err := paymentmethodconfiguration.Get("foo", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsGet2Service(t *testing.T) {
@@ -5649,7 +5649,7 @@ func TestPaymentMethodConfigurationsGet2Service(t *testing.T) {
 	params := &stripe.PaymentMethodConfigurationParams{}
 	result, err := sc.PaymentMethodConfigurations.Get("foo", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsGet2Client(t *testing.T) {
@@ -5658,7 +5658,7 @@ func TestPaymentMethodConfigurationsGet2Client(t *testing.T) {
 	result, err := sc.V1PaymentMethodConfigurations.Retrieve(
 		context.TODO(), "foo", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsPost(t *testing.T) {
@@ -5676,7 +5676,7 @@ func TestPaymentMethodConfigurationsPost(t *testing.T) {
 	}
 	result, err := paymentmethodconfiguration.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsPostService(t *testing.T) {
@@ -5695,7 +5695,7 @@ func TestPaymentMethodConfigurationsPostService(t *testing.T) {
 	}
 	result, err := sc.PaymentMethodConfigurations.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsPostClient(t *testing.T) {
@@ -5714,7 +5714,7 @@ func TestPaymentMethodConfigurationsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1PaymentMethodConfigurations.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsPost2(t *testing.T) {
@@ -5727,7 +5727,7 @@ func TestPaymentMethodConfigurationsPost2(t *testing.T) {
 	}
 	result, err := paymentmethodconfiguration.Update("foo", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsPost2Service(t *testing.T) {
@@ -5741,7 +5741,7 @@ func TestPaymentMethodConfigurationsPost2Service(t *testing.T) {
 	}
 	result, err := sc.PaymentMethodConfigurations.Update("foo", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodConfigurationsPost2Client(t *testing.T) {
@@ -5756,7 +5756,7 @@ func TestPaymentMethodConfigurationsPost2Client(t *testing.T) {
 	result, err := sc.V1PaymentMethodConfigurations.Update(
 		context.TODO(), "foo", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsAttachPost(t *testing.T) {
@@ -5765,7 +5765,7 @@ func TestPaymentMethodsAttachPost(t *testing.T) {
 	}
 	result, err := paymentmethod.Attach("pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsAttachPostService(t *testing.T) {
@@ -5775,7 +5775,7 @@ func TestPaymentMethodsAttachPostService(t *testing.T) {
 	}
 	result, err := sc.PaymentMethods.Attach("pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsAttachPostClient(t *testing.T) {
@@ -5786,14 +5786,14 @@ func TestPaymentMethodsAttachPostClient(t *testing.T) {
 	result, err := sc.V1PaymentMethods.Attach(
 		context.TODO(), "pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsDetachPost(t *testing.T) {
 	params := &stripe.PaymentMethodDetachParams{}
 	result, err := paymentmethod.Detach("pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsDetachPostService(t *testing.T) {
@@ -5801,7 +5801,7 @@ func TestPaymentMethodsDetachPostService(t *testing.T) {
 	params := &stripe.PaymentMethodDetachParams{}
 	result, err := sc.PaymentMethods.Detach("pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsDetachPostClient(t *testing.T) {
@@ -5810,7 +5810,7 @@ func TestPaymentMethodsDetachPostClient(t *testing.T) {
 	result, err := sc.V1PaymentMethods.Detach(
 		context.TODO(), "pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsGet(t *testing.T) {
@@ -5820,7 +5820,7 @@ func TestPaymentMethodsGet(t *testing.T) {
 	}
 	result := paymentmethod.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentMethodsGetService(t *testing.T) {
@@ -5831,7 +5831,7 @@ func TestPaymentMethodsGetService(t *testing.T) {
 	}
 	result := sc.PaymentMethods.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentMethodsGetClient(t *testing.T) {
@@ -5842,14 +5842,14 @@ func TestPaymentMethodsGetClient(t *testing.T) {
 	}
 	result := sc.V1PaymentMethods.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPaymentMethodsGet2(t *testing.T) {
 	params := &stripe.PaymentMethodParams{}
 	result, err := paymentmethod.Get("pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsGet2Service(t *testing.T) {
@@ -5857,7 +5857,7 @@ func TestPaymentMethodsGet2Service(t *testing.T) {
 	params := &stripe.PaymentMethodParams{}
 	result, err := sc.PaymentMethods.Get("pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsGet2Client(t *testing.T) {
@@ -5866,7 +5866,7 @@ func TestPaymentMethodsGet2Client(t *testing.T) {
 	result, err := sc.V1PaymentMethods.Retrieve(
 		context.TODO(), "pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsPost(t *testing.T) {
@@ -5881,7 +5881,7 @@ func TestPaymentMethodsPost(t *testing.T) {
 	}
 	result, err := paymentmethod.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsPostService(t *testing.T) {
@@ -5897,7 +5897,7 @@ func TestPaymentMethodsPostService(t *testing.T) {
 	}
 	result, err := sc.PaymentMethods.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsPostClient(t *testing.T) {
@@ -5913,7 +5913,7 @@ func TestPaymentMethodsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1PaymentMethods.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsPost2(t *testing.T) {
@@ -5921,7 +5921,7 @@ func TestPaymentMethodsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := paymentmethod.Update("pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsPost2Service(t *testing.T) {
@@ -5930,7 +5930,7 @@ func TestPaymentMethodsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.PaymentMethods.Update("pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPaymentMethodsPost2Client(t *testing.T) {
@@ -5940,14 +5940,14 @@ func TestPaymentMethodsPost2Client(t *testing.T) {
 	result, err := sc.V1PaymentMethods.Update(
 		context.TODO(), "pm_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsCancelPost(t *testing.T) {
 	params := &stripe.PayoutParams{}
 	result, err := payout.Cancel("po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsCancelPostService(t *testing.T) {
@@ -5955,7 +5955,7 @@ func TestPayoutsCancelPostService(t *testing.T) {
 	params := &stripe.PayoutParams{}
 	result, err := sc.Payouts.Cancel("po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsCancelPostClient(t *testing.T) {
@@ -5963,7 +5963,7 @@ func TestPayoutsCancelPostClient(t *testing.T) {
 	params := &stripe.PayoutCancelParams{}
 	result, err := sc.V1Payouts.Cancel(context.TODO(), "po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsGet(t *testing.T) {
@@ -5971,7 +5971,7 @@ func TestPayoutsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := payout.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPayoutsGetService(t *testing.T) {
@@ -5980,7 +5980,7 @@ func TestPayoutsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Payouts.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPayoutsGetClient(t *testing.T) {
@@ -5989,14 +5989,14 @@ func TestPayoutsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Payouts.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPayoutsGet2(t *testing.T) {
 	params := &stripe.PayoutParams{}
 	result, err := payout.Get("po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsGet2Service(t *testing.T) {
@@ -6004,7 +6004,7 @@ func TestPayoutsGet2Service(t *testing.T) {
 	params := &stripe.PayoutParams{}
 	result, err := sc.Payouts.Get("po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsGet2Client(t *testing.T) {
@@ -6013,7 +6013,7 @@ func TestPayoutsGet2Client(t *testing.T) {
 	result, err := sc.V1Payouts.Retrieve(
 		context.TODO(), "po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsPost(t *testing.T) {
@@ -6023,7 +6023,7 @@ func TestPayoutsPost(t *testing.T) {
 	}
 	result, err := payout.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsPostService(t *testing.T) {
@@ -6034,7 +6034,7 @@ func TestPayoutsPostService(t *testing.T) {
 	}
 	result, err := sc.Payouts.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsPostClient(t *testing.T) {
@@ -6045,7 +6045,7 @@ func TestPayoutsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Payouts.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsPost2(t *testing.T) {
@@ -6053,7 +6053,7 @@ func TestPayoutsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := payout.Update("po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsPost2Service(t *testing.T) {
@@ -6062,7 +6062,7 @@ func TestPayoutsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Payouts.Update("po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsPost2Client(t *testing.T) {
@@ -6071,14 +6071,14 @@ func TestPayoutsPost2Client(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.V1Payouts.Update(context.TODO(), "po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsReversePost(t *testing.T) {
 	params := &stripe.PayoutReverseParams{}
 	result, err := payout.Reverse("po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsReversePostService(t *testing.T) {
@@ -6086,7 +6086,7 @@ func TestPayoutsReversePostService(t *testing.T) {
 	params := &stripe.PayoutReverseParams{}
 	result, err := sc.Payouts.Reverse("po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPayoutsReversePostClient(t *testing.T) {
@@ -6095,14 +6095,14 @@ func TestPayoutsReversePostClient(t *testing.T) {
 	result, err := sc.V1Payouts.Reverse(
 		context.TODO(), "po_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansDelete(t *testing.T) {
 	params := &stripe.PlanParams{}
 	result, err := plan.Del("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansDeleteService(t *testing.T) {
@@ -6110,7 +6110,7 @@ func TestPlansDeleteService(t *testing.T) {
 	params := &stripe.PlanParams{}
 	result, err := sc.Plans.Del("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansDeleteClient(t *testing.T) {
@@ -6119,7 +6119,7 @@ func TestPlansDeleteClient(t *testing.T) {
 	result, err := sc.V1Plans.Delete(
 		context.TODO(), "price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansGet(t *testing.T) {
@@ -6127,7 +6127,7 @@ func TestPlansGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := plan.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPlansGetService(t *testing.T) {
@@ -6136,7 +6136,7 @@ func TestPlansGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Plans.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPlansGetClient(t *testing.T) {
@@ -6145,14 +6145,14 @@ func TestPlansGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Plans.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPlansGet2(t *testing.T) {
 	params := &stripe.PlanParams{}
 	result, err := plan.Get("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansGet2Service(t *testing.T) {
@@ -6160,7 +6160,7 @@ func TestPlansGet2Service(t *testing.T) {
 	params := &stripe.PlanParams{}
 	result, err := sc.Plans.Get("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansGet2Client(t *testing.T) {
@@ -6169,7 +6169,7 @@ func TestPlansGet2Client(t *testing.T) {
 	result, err := sc.V1Plans.Retrieve(
 		context.TODO(), "price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansPost(t *testing.T) {
@@ -6181,7 +6181,7 @@ func TestPlansPost(t *testing.T) {
 	}
 	result, err := plan.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansPostService(t *testing.T) {
@@ -6194,7 +6194,7 @@ func TestPlansPostService(t *testing.T) {
 	}
 	result, err := sc.Plans.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansPostClient(t *testing.T) {
@@ -6207,7 +6207,7 @@ func TestPlansPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Plans.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansPost2(t *testing.T) {
@@ -6215,7 +6215,7 @@ func TestPlansPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := plan.Update("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansPost2Service(t *testing.T) {
@@ -6224,7 +6224,7 @@ func TestPlansPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Plans.Update("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPlansPost2Client(t *testing.T) {
@@ -6234,7 +6234,7 @@ func TestPlansPost2Client(t *testing.T) {
 	result, err := sc.V1Plans.Update(
 		context.TODO(), "price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesGet(t *testing.T) {
@@ -6242,7 +6242,7 @@ func TestPricesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := price.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPricesGetService(t *testing.T) {
@@ -6251,7 +6251,7 @@ func TestPricesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Prices.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPricesGetClient(t *testing.T) {
@@ -6260,14 +6260,14 @@ func TestPricesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Prices.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPricesGet2(t *testing.T) {
 	params := &stripe.PriceParams{}
 	result, err := price.Get("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesGet2Service(t *testing.T) {
@@ -6275,7 +6275,7 @@ func TestPricesGet2Service(t *testing.T) {
 	params := &stripe.PriceParams{}
 	result, err := sc.Prices.Get("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesGet2Client(t *testing.T) {
@@ -6284,7 +6284,7 @@ func TestPricesGet2Client(t *testing.T) {
 	result, err := sc.V1Prices.Retrieve(
 		context.TODO(), "price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPost(t *testing.T) {
@@ -6302,7 +6302,7 @@ func TestPricesPost(t *testing.T) {
 	}
 	result, err := price.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPostService(t *testing.T) {
@@ -6321,7 +6321,7 @@ func TestPricesPostService(t *testing.T) {
 	}
 	result, err := sc.Prices.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPostClient(t *testing.T) {
@@ -6344,7 +6344,7 @@ func TestPricesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Prices.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPost2(t *testing.T) {
@@ -6358,7 +6358,7 @@ func TestPricesPost2(t *testing.T) {
 	}
 	result, err := price.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPost2Service(t *testing.T) {
@@ -6373,7 +6373,7 @@ func TestPricesPost2Service(t *testing.T) {
 	}
 	result, err := sc.Prices.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPost2Client(t *testing.T) {
@@ -6388,7 +6388,7 @@ func TestPricesPost2Client(t *testing.T) {
 	}
 	result, err := sc.V1Prices.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPost3(t *testing.T) {
@@ -6396,7 +6396,7 @@ func TestPricesPost3(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := price.Update("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPost3Service(t *testing.T) {
@@ -6405,7 +6405,7 @@ func TestPricesPost3Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Prices.Update("price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesPost3Client(t *testing.T) {
@@ -6415,7 +6415,7 @@ func TestPricesPost3Client(t *testing.T) {
 	result, err := sc.V1Prices.Update(
 		context.TODO(), "price_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPricesSearchGet(t *testing.T) {
@@ -6426,7 +6426,7 @@ func TestPricesSearchGet(t *testing.T) {
 	}
 	result := price.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPricesSearchGetService(t *testing.T) {
@@ -6438,7 +6438,7 @@ func TestPricesSearchGetService(t *testing.T) {
 	}
 	result := sc.Prices.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPricesSearchGetClient(t *testing.T) {
@@ -6450,14 +6450,14 @@ func TestPricesSearchGetClient(t *testing.T) {
 	}
 	result := sc.V1Prices.Search(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestProductsDelete(t *testing.T) {
 	params := &stripe.ProductParams{}
 	result, err := product.Del("prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsDeleteService(t *testing.T) {
@@ -6465,7 +6465,7 @@ func TestProductsDeleteService(t *testing.T) {
 	params := &stripe.ProductParams{}
 	result, err := sc.Products.Del("prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsDeleteClient(t *testing.T) {
@@ -6474,7 +6474,7 @@ func TestProductsDeleteClient(t *testing.T) {
 	result, err := sc.V1Products.Delete(
 		context.TODO(), "prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsGet(t *testing.T) {
@@ -6482,7 +6482,7 @@ func TestProductsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := product.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestProductsGetService(t *testing.T) {
@@ -6491,7 +6491,7 @@ func TestProductsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Products.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestProductsGetClient(t *testing.T) {
@@ -6500,14 +6500,14 @@ func TestProductsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Products.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestProductsGet2(t *testing.T) {
 	params := &stripe.ProductParams{}
 	result, err := product.Get("prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsGet2Service(t *testing.T) {
@@ -6515,7 +6515,7 @@ func TestProductsGet2Service(t *testing.T) {
 	params := &stripe.ProductParams{}
 	result, err := sc.Products.Get("prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsGet2Client(t *testing.T) {
@@ -6524,14 +6524,14 @@ func TestProductsGet2Client(t *testing.T) {
 	result, err := sc.V1Products.Retrieve(
 		context.TODO(), "prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsPost(t *testing.T) {
 	params := &stripe.ProductParams{Name: stripe.String("Gold Special")}
 	result, err := product.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsPostService(t *testing.T) {
@@ -6539,7 +6539,7 @@ func TestProductsPostService(t *testing.T) {
 	params := &stripe.ProductParams{Name: stripe.String("Gold Special")}
 	result, err := sc.Products.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsPostClient(t *testing.T) {
@@ -6547,7 +6547,7 @@ func TestProductsPostClient(t *testing.T) {
 	params := &stripe.ProductCreateParams{Name: stripe.String("Gold Special")}
 	result, err := sc.V1Products.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsPost2(t *testing.T) {
@@ -6555,7 +6555,7 @@ func TestProductsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := product.Update("prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsPost2Service(t *testing.T) {
@@ -6564,7 +6564,7 @@ func TestProductsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Products.Update("prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsPost2Client(t *testing.T) {
@@ -6574,7 +6574,7 @@ func TestProductsPost2Client(t *testing.T) {
 	result, err := sc.V1Products.Update(
 		context.TODO(), "prod_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestProductsSearchGet(t *testing.T) {
@@ -6585,7 +6585,7 @@ func TestProductsSearchGet(t *testing.T) {
 	}
 	result := product.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestProductsSearchGetService(t *testing.T) {
@@ -6597,7 +6597,7 @@ func TestProductsSearchGetService(t *testing.T) {
 	}
 	result := sc.Products.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestProductsSearchGetClient(t *testing.T) {
@@ -6609,7 +6609,7 @@ func TestProductsSearchGetClient(t *testing.T) {
 	}
 	result := sc.V1Products.Search(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPromotionCodesGet(t *testing.T) {
@@ -6617,7 +6617,7 @@ func TestPromotionCodesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := promotioncode.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPromotionCodesGetService(t *testing.T) {
@@ -6626,7 +6626,7 @@ func TestPromotionCodesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.PromotionCodes.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPromotionCodesGetClient(t *testing.T) {
@@ -6635,14 +6635,14 @@ func TestPromotionCodesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1PromotionCodes.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestPromotionCodesGet2(t *testing.T) {
 	params := &stripe.PromotionCodeParams{}
 	result, err := promotioncode.Get("promo_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromotionCodesGet2Service(t *testing.T) {
@@ -6650,7 +6650,7 @@ func TestPromotionCodesGet2Service(t *testing.T) {
 	params := &stripe.PromotionCodeParams{}
 	result, err := sc.PromotionCodes.Get("promo_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromotionCodesGet2Client(t *testing.T) {
@@ -6659,7 +6659,7 @@ func TestPromotionCodesGet2Client(t *testing.T) {
 	result, err := sc.V1PromotionCodes.Retrieve(
 		context.TODO(), "promo_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromotionCodesPost(t *testing.T) {
@@ -6671,7 +6671,7 @@ func TestPromotionCodesPost(t *testing.T) {
 	}
 	result, err := promotioncode.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromotionCodesPostService(t *testing.T) {
@@ -6684,7 +6684,7 @@ func TestPromotionCodesPostService(t *testing.T) {
 	}
 	result, err := sc.PromotionCodes.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromotionCodesPostClient(t *testing.T) {
@@ -6697,7 +6697,7 @@ func TestPromotionCodesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1PromotionCodes.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromotionCodesPost2(t *testing.T) {
@@ -6705,7 +6705,7 @@ func TestPromotionCodesPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := promotioncode.Update("promo_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromotionCodesPost2Service(t *testing.T) {
@@ -6714,7 +6714,7 @@ func TestPromotionCodesPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.PromotionCodes.Update("promo_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromotionCodesPost2Client(t *testing.T) {
@@ -6724,14 +6724,14 @@ func TestPromotionCodesPost2Client(t *testing.T) {
 	result, err := sc.V1PromotionCodes.Update(
 		context.TODO(), "promo_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesAcceptPost(t *testing.T) {
 	params := &stripe.QuoteAcceptParams{}
 	result, err := quote.Accept("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesAcceptPostService(t *testing.T) {
@@ -6739,7 +6739,7 @@ func TestQuotesAcceptPostService(t *testing.T) {
 	params := &stripe.QuoteAcceptParams{}
 	result, err := sc.Quotes.Accept("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesAcceptPostClient(t *testing.T) {
@@ -6747,14 +6747,14 @@ func TestQuotesAcceptPostClient(t *testing.T) {
 	params := &stripe.QuoteAcceptParams{}
 	result, err := sc.V1Quotes.Accept(context.TODO(), "qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesCancelPost(t *testing.T) {
 	params := &stripe.QuoteCancelParams{}
 	result, err := quote.Cancel("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesCancelPostService(t *testing.T) {
@@ -6762,7 +6762,7 @@ func TestQuotesCancelPostService(t *testing.T) {
 	params := &stripe.QuoteCancelParams{}
 	result, err := sc.Quotes.Cancel("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesCancelPostClient(t *testing.T) {
@@ -6770,14 +6770,14 @@ func TestQuotesCancelPostClient(t *testing.T) {
 	params := &stripe.QuoteCancelParams{}
 	result, err := sc.V1Quotes.Cancel(context.TODO(), "qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesFinalizePost(t *testing.T) {
 	params := &stripe.QuoteFinalizeQuoteParams{}
 	result, err := quote.FinalizeQuote("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesFinalizePostService(t *testing.T) {
@@ -6785,7 +6785,7 @@ func TestQuotesFinalizePostService(t *testing.T) {
 	params := &stripe.QuoteFinalizeQuoteParams{}
 	result, err := sc.Quotes.FinalizeQuote("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesFinalizePostClient(t *testing.T) {
@@ -6794,7 +6794,7 @@ func TestQuotesFinalizePostClient(t *testing.T) {
 	result, err := sc.V1Quotes.FinalizeQuote(
 		context.TODO(), "qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesGet(t *testing.T) {
@@ -6802,7 +6802,7 @@ func TestQuotesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := quote.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestQuotesGetService(t *testing.T) {
@@ -6811,7 +6811,7 @@ func TestQuotesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Quotes.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestQuotesGetClient(t *testing.T) {
@@ -6820,14 +6820,14 @@ func TestQuotesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Quotes.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestQuotesGet2(t *testing.T) {
 	params := &stripe.QuoteParams{}
 	result, err := quote.Get("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesGet2Service(t *testing.T) {
@@ -6835,7 +6835,7 @@ func TestQuotesGet2Service(t *testing.T) {
 	params := &stripe.QuoteParams{}
 	result, err := sc.Quotes.Get("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesGet2Client(t *testing.T) {
@@ -6844,7 +6844,7 @@ func TestQuotesGet2Client(t *testing.T) {
 	result, err := sc.V1Quotes.Retrieve(
 		context.TODO(), "qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesLineItemsGet(t *testing.T) {
@@ -6853,7 +6853,7 @@ func TestQuotesLineItemsGet(t *testing.T) {
 	}
 	result := quote.ListLineItems(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestQuotesLineItemsGetService(t *testing.T) {
@@ -6863,7 +6863,7 @@ func TestQuotesLineItemsGetService(t *testing.T) {
 	}
 	result := sc.Quotes.ListLineItems(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestQuotesLineItemsGetClient(t *testing.T) {
@@ -6873,14 +6873,14 @@ func TestQuotesLineItemsGetClient(t *testing.T) {
 	}
 	result := sc.V1Quotes.ListLineItems(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestQuotesPdfGet(t *testing.T) {
 	params := &stripe.QuotePDFParams{}
 	result, err := quote.PDF("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesPdfGetService(t *testing.T) {
@@ -6888,7 +6888,7 @@ func TestQuotesPdfGetService(t *testing.T) {
 	params := &stripe.QuotePDFParams{}
 	result, err := sc.Quotes.PDF("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesPdfGetClient(t *testing.T) {
@@ -6896,7 +6896,7 @@ func TestQuotesPdfGetClient(t *testing.T) {
 	params := &stripe.QuotePDFParams{}
 	result, err := sc.V1Quotes.PDF(context.TODO(), "qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesPost(t *testing.T) {
@@ -6911,7 +6911,7 @@ func TestQuotesPost(t *testing.T) {
 	}
 	result, err := quote.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesPostService(t *testing.T) {
@@ -6927,7 +6927,7 @@ func TestQuotesPostService(t *testing.T) {
 	}
 	result, err := sc.Quotes.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesPostClient(t *testing.T) {
@@ -6943,7 +6943,7 @@ func TestQuotesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Quotes.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesPost2(t *testing.T) {
@@ -6951,7 +6951,7 @@ func TestQuotesPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := quote.Update("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesPost2Service(t *testing.T) {
@@ -6960,7 +6960,7 @@ func TestQuotesPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Quotes.Update("qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestQuotesPost2Client(t *testing.T) {
@@ -6969,7 +6969,7 @@ func TestQuotesPost2Client(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.V1Quotes.Update(context.TODO(), "qt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarEarlyFraudWarningsGet(t *testing.T) {
@@ -6977,7 +6977,7 @@ func TestRadarEarlyFraudWarningsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := radar_earlyfraudwarning.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarEarlyFraudWarningsGetService(t *testing.T) {
@@ -6986,7 +6986,7 @@ func TestRadarEarlyFraudWarningsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.RadarEarlyFraudWarnings.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarEarlyFraudWarningsGetClient(t *testing.T) {
@@ -6995,14 +6995,14 @@ func TestRadarEarlyFraudWarningsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1RadarEarlyFraudWarnings.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarEarlyFraudWarningsGet2(t *testing.T) {
 	params := &stripe.RadarEarlyFraudWarningParams{}
 	result, err := radar_earlyfraudwarning.Get("issfr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarEarlyFraudWarningsGet2Service(t *testing.T) {
@@ -7010,7 +7010,7 @@ func TestRadarEarlyFraudWarningsGet2Service(t *testing.T) {
 	params := &stripe.RadarEarlyFraudWarningParams{}
 	result, err := sc.RadarEarlyFraudWarnings.Get("issfr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarEarlyFraudWarningsGet2Client(t *testing.T) {
@@ -7019,14 +7019,14 @@ func TestRadarEarlyFraudWarningsGet2Client(t *testing.T) {
 	result, err := sc.V1RadarEarlyFraudWarnings.Retrieve(
 		context.TODO(), "issfr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsDelete(t *testing.T) {
 	params := &stripe.RadarValueListItemParams{}
 	result, err := radar_valuelistitem.Del("rsli_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsDeleteService(t *testing.T) {
@@ -7034,7 +7034,7 @@ func TestRadarValueListItemsDeleteService(t *testing.T) {
 	params := &stripe.RadarValueListItemParams{}
 	result, err := sc.RadarValueListItems.Del("rsli_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsDeleteClient(t *testing.T) {
@@ -7043,7 +7043,7 @@ func TestRadarValueListItemsDeleteClient(t *testing.T) {
 	result, err := sc.V1RadarValueListItems.Delete(
 		context.TODO(), "rsli_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsGet(t *testing.T) {
@@ -7053,7 +7053,7 @@ func TestRadarValueListItemsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := radar_valuelistitem.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarValueListItemsGetService(t *testing.T) {
@@ -7064,7 +7064,7 @@ func TestRadarValueListItemsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.RadarValueListItems.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarValueListItemsGetClient(t *testing.T) {
@@ -7075,14 +7075,14 @@ func TestRadarValueListItemsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1RadarValueListItems.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarValueListItemsGet2(t *testing.T) {
 	params := &stripe.RadarValueListItemParams{}
 	result, err := radar_valuelistitem.Get("rsli_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsGet2Service(t *testing.T) {
@@ -7090,7 +7090,7 @@ func TestRadarValueListItemsGet2Service(t *testing.T) {
 	params := &stripe.RadarValueListItemParams{}
 	result, err := sc.RadarValueListItems.Get("rsli_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsGet2Client(t *testing.T) {
@@ -7099,7 +7099,7 @@ func TestRadarValueListItemsGet2Client(t *testing.T) {
 	result, err := sc.V1RadarValueListItems.Retrieve(
 		context.TODO(), "rsli_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsPost(t *testing.T) {
@@ -7109,7 +7109,7 @@ func TestRadarValueListItemsPost(t *testing.T) {
 	}
 	result, err := radar_valuelistitem.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsPostService(t *testing.T) {
@@ -7120,7 +7120,7 @@ func TestRadarValueListItemsPostService(t *testing.T) {
 	}
 	result, err := sc.RadarValueListItems.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListItemsPostClient(t *testing.T) {
@@ -7131,14 +7131,14 @@ func TestRadarValueListItemsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1RadarValueListItems.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsDelete(t *testing.T) {
 	params := &stripe.RadarValueListParams{}
 	result, err := radar_valuelist.Del("rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsDeleteService(t *testing.T) {
@@ -7146,7 +7146,7 @@ func TestRadarValueListsDeleteService(t *testing.T) {
 	params := &stripe.RadarValueListParams{}
 	result, err := sc.RadarValueLists.Del("rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsDeleteClient(t *testing.T) {
@@ -7155,7 +7155,7 @@ func TestRadarValueListsDeleteClient(t *testing.T) {
 	result, err := sc.V1RadarValueLists.Delete(
 		context.TODO(), "rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsGet(t *testing.T) {
@@ -7163,7 +7163,7 @@ func TestRadarValueListsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := radar_valuelist.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarValueListsGetService(t *testing.T) {
@@ -7172,7 +7172,7 @@ func TestRadarValueListsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.RadarValueLists.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarValueListsGetClient(t *testing.T) {
@@ -7181,14 +7181,14 @@ func TestRadarValueListsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1RadarValueLists.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRadarValueListsGet2(t *testing.T) {
 	params := &stripe.RadarValueListParams{}
 	result, err := radar_valuelist.Get("rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsGet2Service(t *testing.T) {
@@ -7196,7 +7196,7 @@ func TestRadarValueListsGet2Service(t *testing.T) {
 	params := &stripe.RadarValueListParams{}
 	result, err := sc.RadarValueLists.Get("rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsGet2Client(t *testing.T) {
@@ -7205,7 +7205,7 @@ func TestRadarValueListsGet2Client(t *testing.T) {
 	result, err := sc.V1RadarValueLists.Retrieve(
 		context.TODO(), "rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsPost(t *testing.T) {
@@ -7216,7 +7216,7 @@ func TestRadarValueListsPost(t *testing.T) {
 	}
 	result, err := radar_valuelist.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsPostService(t *testing.T) {
@@ -7228,7 +7228,7 @@ func TestRadarValueListsPostService(t *testing.T) {
 	}
 	result, err := sc.RadarValueLists.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsPostClient(t *testing.T) {
@@ -7240,7 +7240,7 @@ func TestRadarValueListsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1RadarValueLists.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsPost2(t *testing.T) {
@@ -7249,7 +7249,7 @@ func TestRadarValueListsPost2(t *testing.T) {
 	}
 	result, err := radar_valuelist.Update("rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsPost2Service(t *testing.T) {
@@ -7259,7 +7259,7 @@ func TestRadarValueListsPost2Service(t *testing.T) {
 	}
 	result, err := sc.RadarValueLists.Update("rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRadarValueListsPost2Client(t *testing.T) {
@@ -7270,14 +7270,14 @@ func TestRadarValueListsPost2Client(t *testing.T) {
 	result, err := sc.V1RadarValueLists.Update(
 		context.TODO(), "rsl_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsCancelPost(t *testing.T) {
 	params := &stripe.RefundCancelParams{}
 	result, err := refund.Cancel("re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsCancelPostService(t *testing.T) {
@@ -7285,7 +7285,7 @@ func TestRefundsCancelPostService(t *testing.T) {
 	params := &stripe.RefundCancelParams{}
 	result, err := sc.Refunds.Cancel("re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsCancelPostClient(t *testing.T) {
@@ -7293,7 +7293,7 @@ func TestRefundsCancelPostClient(t *testing.T) {
 	params := &stripe.RefundCancelParams{}
 	result, err := sc.V1Refunds.Cancel(context.TODO(), "re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsGet(t *testing.T) {
@@ -7301,7 +7301,7 @@ func TestRefundsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := refund.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRefundsGetService(t *testing.T) {
@@ -7310,7 +7310,7 @@ func TestRefundsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Refunds.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRefundsGetClient(t *testing.T) {
@@ -7319,14 +7319,14 @@ func TestRefundsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Refunds.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestRefundsGet2(t *testing.T) {
 	params := &stripe.RefundParams{}
 	result, err := refund.Get("re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsGet2Service(t *testing.T) {
@@ -7334,7 +7334,7 @@ func TestRefundsGet2Service(t *testing.T) {
 	params := &stripe.RefundParams{}
 	result, err := sc.Refunds.Get("re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsGet2Client(t *testing.T) {
@@ -7343,14 +7343,14 @@ func TestRefundsGet2Client(t *testing.T) {
 	result, err := sc.V1Refunds.Retrieve(
 		context.TODO(), "re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsPost(t *testing.T) {
 	params := &stripe.RefundParams{Charge: stripe.String("ch_xxxxxxxxxxxxx")}
 	result, err := refund.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsPostService(t *testing.T) {
@@ -7358,7 +7358,7 @@ func TestRefundsPostService(t *testing.T) {
 	params := &stripe.RefundParams{Charge: stripe.String("ch_xxxxxxxxxxxxx")}
 	result, err := sc.Refunds.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsPostClient(t *testing.T) {
@@ -7368,7 +7368,7 @@ func TestRefundsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Refunds.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsPost2(t *testing.T) {
@@ -7376,7 +7376,7 @@ func TestRefundsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := refund.Update("re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsPost2Service(t *testing.T) {
@@ -7385,7 +7385,7 @@ func TestRefundsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Refunds.Update("re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRefundsPost2Client(t *testing.T) {
@@ -7394,7 +7394,7 @@ func TestRefundsPost2Client(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.V1Refunds.Update(context.TODO(), "re_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportRunsGet(t *testing.T) {
@@ -7402,7 +7402,7 @@ func TestReportingReportRunsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := reporting_reportrun.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReportingReportRunsGetService(t *testing.T) {
@@ -7411,7 +7411,7 @@ func TestReportingReportRunsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.ReportingReportRuns.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReportingReportRunsGetClient(t *testing.T) {
@@ -7420,14 +7420,14 @@ func TestReportingReportRunsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1ReportingReportRuns.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReportingReportRunsGet2(t *testing.T) {
 	params := &stripe.ReportingReportRunParams{}
 	result, err := reporting_reportrun.Get("frr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportRunsGet2Service(t *testing.T) {
@@ -7435,7 +7435,7 @@ func TestReportingReportRunsGet2Service(t *testing.T) {
 	params := &stripe.ReportingReportRunParams{}
 	result, err := sc.ReportingReportRuns.Get("frr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportRunsGet2Client(t *testing.T) {
@@ -7444,7 +7444,7 @@ func TestReportingReportRunsGet2Client(t *testing.T) {
 	result, err := sc.V1ReportingReportRuns.Retrieve(
 		context.TODO(), "frr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportRunsPost(t *testing.T) {
@@ -7457,7 +7457,7 @@ func TestReportingReportRunsPost(t *testing.T) {
 	}
 	result, err := reporting_reportrun.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportRunsPostService(t *testing.T) {
@@ -7471,7 +7471,7 @@ func TestReportingReportRunsPostService(t *testing.T) {
 	}
 	result, err := sc.ReportingReportRuns.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportRunsPostClient(t *testing.T) {
@@ -7485,14 +7485,14 @@ func TestReportingReportRunsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1ReportingReportRuns.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportTypesGet(t *testing.T) {
 	params := &stripe.ReportingReportTypeListParams{}
 	result := reporting_reporttype.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReportingReportTypesGetService(t *testing.T) {
@@ -7500,7 +7500,7 @@ func TestReportingReportTypesGetService(t *testing.T) {
 	params := &stripe.ReportingReportTypeListParams{}
 	result := sc.ReportingReportTypes.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReportingReportTypesGetClient(t *testing.T) {
@@ -7508,14 +7508,14 @@ func TestReportingReportTypesGetClient(t *testing.T) {
 	params := &stripe.ReportingReportTypeListParams{}
 	result := sc.V1ReportingReportTypes.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReportingReportTypesGet2(t *testing.T) {
 	params := &stripe.ReportingReportTypeParams{}
 	result, err := reporting_reporttype.Get("balance.summary.1", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportTypesGet2Service(t *testing.T) {
@@ -7523,7 +7523,7 @@ func TestReportingReportTypesGet2Service(t *testing.T) {
 	params := &stripe.ReportingReportTypeParams{}
 	result, err := sc.ReportingReportTypes.Get("balance.summary.1", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReportingReportTypesGet2Client(t *testing.T) {
@@ -7532,14 +7532,14 @@ func TestReportingReportTypesGet2Client(t *testing.T) {
 	result, err := sc.V1ReportingReportTypes.Retrieve(
 		context.TODO(), "balance.summary.1", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReviewsApprovePost(t *testing.T) {
 	params := &stripe.ReviewApproveParams{}
 	result, err := review.Approve("prv_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReviewsApprovePostService(t *testing.T) {
@@ -7547,7 +7547,7 @@ func TestReviewsApprovePostService(t *testing.T) {
 	params := &stripe.ReviewApproveParams{}
 	result, err := sc.Reviews.Approve("prv_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReviewsApprovePostClient(t *testing.T) {
@@ -7556,7 +7556,7 @@ func TestReviewsApprovePostClient(t *testing.T) {
 	result, err := sc.V1Reviews.Approve(
 		context.TODO(), "prv_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReviewsGet(t *testing.T) {
@@ -7564,7 +7564,7 @@ func TestReviewsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := review.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReviewsGetService(t *testing.T) {
@@ -7573,7 +7573,7 @@ func TestReviewsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Reviews.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReviewsGetClient(t *testing.T) {
@@ -7582,14 +7582,14 @@ func TestReviewsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Reviews.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestReviewsGet2(t *testing.T) {
 	params := &stripe.ReviewParams{}
 	result, err := review.Get("prv_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReviewsGet2Service(t *testing.T) {
@@ -7597,7 +7597,7 @@ func TestReviewsGet2Service(t *testing.T) {
 	params := &stripe.ReviewParams{}
 	result, err := sc.Reviews.Get("prv_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestReviewsGet2Client(t *testing.T) {
@@ -7606,7 +7606,7 @@ func TestReviewsGet2Client(t *testing.T) {
 	result, err := sc.V1Reviews.Retrieve(
 		context.TODO(), "prv_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupAttemptsGet(t *testing.T) {
@@ -7614,7 +7614,7 @@ func TestSetupAttemptsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := setupattempt.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSetupAttemptsGetService(t *testing.T) {
@@ -7623,7 +7623,7 @@ func TestSetupAttemptsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.SetupAttempts.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSetupAttemptsGetClient(t *testing.T) {
@@ -7632,14 +7632,14 @@ func TestSetupAttemptsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1SetupAttempts.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSetupIntentsCancelPost(t *testing.T) {
 	params := &stripe.SetupIntentCancelParams{}
 	result, err := setupintent.Cancel("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsCancelPostService(t *testing.T) {
@@ -7647,7 +7647,7 @@ func TestSetupIntentsCancelPostService(t *testing.T) {
 	params := &stripe.SetupIntentCancelParams{}
 	result, err := sc.SetupIntents.Cancel("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsCancelPostClient(t *testing.T) {
@@ -7656,7 +7656,7 @@ func TestSetupIntentsCancelPostClient(t *testing.T) {
 	result, err := sc.V1SetupIntents.Cancel(
 		context.TODO(), "seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsConfirmPost(t *testing.T) {
@@ -7665,7 +7665,7 @@ func TestSetupIntentsConfirmPost(t *testing.T) {
 	}
 	result, err := setupintent.Confirm("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsConfirmPostService(t *testing.T) {
@@ -7675,7 +7675,7 @@ func TestSetupIntentsConfirmPostService(t *testing.T) {
 	}
 	result, err := sc.SetupIntents.Confirm("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsConfirmPostClient(t *testing.T) {
@@ -7686,7 +7686,7 @@ func TestSetupIntentsConfirmPostClient(t *testing.T) {
 	result, err := sc.V1SetupIntents.Confirm(
 		context.TODO(), "seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsGet(t *testing.T) {
@@ -7694,7 +7694,7 @@ func TestSetupIntentsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := setupintent.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSetupIntentsGetService(t *testing.T) {
@@ -7703,7 +7703,7 @@ func TestSetupIntentsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.SetupIntents.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSetupIntentsGetClient(t *testing.T) {
@@ -7712,14 +7712,14 @@ func TestSetupIntentsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1SetupIntents.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSetupIntentsGet2(t *testing.T) {
 	params := &stripe.SetupIntentParams{}
 	result, err := setupintent.Get("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsGet2Service(t *testing.T) {
@@ -7727,7 +7727,7 @@ func TestSetupIntentsGet2Service(t *testing.T) {
 	params := &stripe.SetupIntentParams{}
 	result, err := sc.SetupIntents.Get("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsGet2Client(t *testing.T) {
@@ -7736,7 +7736,7 @@ func TestSetupIntentsGet2Client(t *testing.T) {
 	result, err := sc.V1SetupIntents.Retrieve(
 		context.TODO(), "seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsPost(t *testing.T) {
@@ -7745,7 +7745,7 @@ func TestSetupIntentsPost(t *testing.T) {
 	}
 	result, err := setupintent.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsPostService(t *testing.T) {
@@ -7755,7 +7755,7 @@ func TestSetupIntentsPostService(t *testing.T) {
 	}
 	result, err := sc.SetupIntents.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsPostClient(t *testing.T) {
@@ -7765,7 +7765,7 @@ func TestSetupIntentsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1SetupIntents.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsPost2(t *testing.T) {
@@ -7773,7 +7773,7 @@ func TestSetupIntentsPost2(t *testing.T) {
 	params.AddMetadata("user_id", "3435453")
 	result, err := setupintent.Update("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsPost2Service(t *testing.T) {
@@ -7782,7 +7782,7 @@ func TestSetupIntentsPost2Service(t *testing.T) {
 	params.AddMetadata("user_id", "3435453")
 	result, err := sc.SetupIntents.Update("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsPost2Client(t *testing.T) {
@@ -7792,14 +7792,14 @@ func TestSetupIntentsPost2Client(t *testing.T) {
 	result, err := sc.V1SetupIntents.Update(
 		context.TODO(), "seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsVerifyMicrodepositsPost(t *testing.T) {
 	params := &stripe.SetupIntentVerifyMicrodepositsParams{}
 	result, err := setupintent.VerifyMicrodeposits("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsVerifyMicrodepositsPostService(t *testing.T) {
@@ -7808,7 +7808,7 @@ func TestSetupIntentsVerifyMicrodepositsPostService(t *testing.T) {
 	result, err := sc.SetupIntents.VerifyMicrodeposits(
 		"seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsVerifyMicrodepositsPostClient(t *testing.T) {
@@ -7817,7 +7817,7 @@ func TestSetupIntentsVerifyMicrodepositsPostClient(t *testing.T) {
 	result, err := sc.V1SetupIntents.VerifyMicrodeposits(
 		context.TODO(), "seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsVerifyMicrodepositsPost2(t *testing.T) {
@@ -7826,7 +7826,7 @@ func TestSetupIntentsVerifyMicrodepositsPost2(t *testing.T) {
 	}
 	result, err := setupintent.VerifyMicrodeposits("seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsVerifyMicrodepositsPost2Service(t *testing.T) {
@@ -7837,7 +7837,7 @@ func TestSetupIntentsVerifyMicrodepositsPost2Service(t *testing.T) {
 	result, err := sc.SetupIntents.VerifyMicrodeposits(
 		"seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSetupIntentsVerifyMicrodepositsPost2Client(t *testing.T) {
@@ -7848,14 +7848,14 @@ func TestSetupIntentsVerifyMicrodepositsPost2Client(t *testing.T) {
 	result, err := sc.V1SetupIntents.VerifyMicrodeposits(
 		context.TODO(), "seti_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesGet(t *testing.T) {
 	params := &stripe.ShippingRateListParams{}
 	result := shippingrate.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestShippingRatesGetService(t *testing.T) {
@@ -7863,7 +7863,7 @@ func TestShippingRatesGetService(t *testing.T) {
 	params := &stripe.ShippingRateListParams{}
 	result := sc.ShippingRates.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestShippingRatesGetClient(t *testing.T) {
@@ -7871,7 +7871,7 @@ func TestShippingRatesGetClient(t *testing.T) {
 	params := &stripe.ShippingRateListParams{}
 	result := sc.V1ShippingRates.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestShippingRatesGet2(t *testing.T) {
@@ -7879,7 +7879,7 @@ func TestShippingRatesGet2(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := shippingrate.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestShippingRatesGet2Service(t *testing.T) {
@@ -7888,7 +7888,7 @@ func TestShippingRatesGet2Service(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.ShippingRates.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestShippingRatesGet2Client(t *testing.T) {
@@ -7897,14 +7897,14 @@ func TestShippingRatesGet2Client(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1ShippingRates.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestShippingRatesGet3(t *testing.T) {
 	params := &stripe.ShippingRateParams{}
 	result, err := shippingrate.Get("shr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesGet3Service(t *testing.T) {
@@ -7912,7 +7912,7 @@ func TestShippingRatesGet3Service(t *testing.T) {
 	params := &stripe.ShippingRateParams{}
 	result, err := sc.ShippingRates.Get("shr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesGet3Client(t *testing.T) {
@@ -7921,7 +7921,7 @@ func TestShippingRatesGet3Client(t *testing.T) {
 	result, err := sc.V1ShippingRates.Retrieve(
 		context.TODO(), "shr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPost(t *testing.T) {
@@ -7935,7 +7935,7 @@ func TestShippingRatesPost(t *testing.T) {
 	}
 	result, err := shippingrate.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPostService(t *testing.T) {
@@ -7950,7 +7950,7 @@ func TestShippingRatesPostService(t *testing.T) {
 	}
 	result, err := sc.ShippingRates.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPostClient(t *testing.T) {
@@ -7965,7 +7965,7 @@ func TestShippingRatesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1ShippingRates.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPost2(t *testing.T) {
@@ -7979,7 +7979,7 @@ func TestShippingRatesPost2(t *testing.T) {
 	}
 	result, err := shippingrate.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPost2Service(t *testing.T) {
@@ -7994,7 +7994,7 @@ func TestShippingRatesPost2Service(t *testing.T) {
 	}
 	result, err := sc.ShippingRates.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPost2Client(t *testing.T) {
@@ -8009,7 +8009,7 @@ func TestShippingRatesPost2Client(t *testing.T) {
 	}
 	result, err := sc.V1ShippingRates.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPost3(t *testing.T) {
@@ -8017,7 +8017,7 @@ func TestShippingRatesPost3(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := shippingrate.Update("shr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPost3Service(t *testing.T) {
@@ -8026,7 +8026,7 @@ func TestShippingRatesPost3Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.ShippingRates.Update("shr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestShippingRatesPost3Client(t *testing.T) {
@@ -8036,7 +8036,7 @@ func TestShippingRatesPost3Client(t *testing.T) {
 	result, err := sc.V1ShippingRates.Update(
 		context.TODO(), "shr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSigmaScheduledQueryRunsGet(t *testing.T) {
@@ -8044,7 +8044,7 @@ func TestSigmaScheduledQueryRunsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sigma_scheduledqueryrun.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSigmaScheduledQueryRunsGetService(t *testing.T) {
@@ -8053,7 +8053,7 @@ func TestSigmaScheduledQueryRunsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.SigmaScheduledQueryRuns.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSigmaScheduledQueryRunsGetClient(t *testing.T) {
@@ -8062,14 +8062,14 @@ func TestSigmaScheduledQueryRunsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1SigmaScheduledQueryRuns.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSigmaScheduledQueryRunsGet2(t *testing.T) {
 	params := &stripe.SigmaScheduledQueryRunParams{}
 	result, err := sigma_scheduledqueryrun.Get("sqr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSigmaScheduledQueryRunsGet2Service(t *testing.T) {
@@ -8077,7 +8077,7 @@ func TestSigmaScheduledQueryRunsGet2Service(t *testing.T) {
 	params := &stripe.SigmaScheduledQueryRunParams{}
 	result, err := sc.SigmaScheduledQueryRuns.Get("sqr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSigmaScheduledQueryRunsGet2Client(t *testing.T) {
@@ -8086,14 +8086,14 @@ func TestSigmaScheduledQueryRunsGet2Client(t *testing.T) {
 	result, err := sc.V1SigmaScheduledQueryRuns.Retrieve(
 		context.TODO(), "sqr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesGet(t *testing.T) {
 	params := &stripe.SourceParams{}
 	result, err := source.Get("src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesGetService(t *testing.T) {
@@ -8101,7 +8101,7 @@ func TestSourcesGetService(t *testing.T) {
 	params := &stripe.SourceParams{}
 	result, err := sc.Sources.Get("src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesGetClient(t *testing.T) {
@@ -8110,14 +8110,14 @@ func TestSourcesGetClient(t *testing.T) {
 	result, err := sc.V1Sources.Retrieve(
 		context.TODO(), "src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesGet2(t *testing.T) {
 	params := &stripe.SourceParams{}
 	result, err := source.Get("src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesGet2Service(t *testing.T) {
@@ -8125,7 +8125,7 @@ func TestSourcesGet2Service(t *testing.T) {
 	params := &stripe.SourceParams{}
 	result, err := sc.Sources.Get("src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesGet2Client(t *testing.T) {
@@ -8134,7 +8134,7 @@ func TestSourcesGet2Client(t *testing.T) {
 	result, err := sc.V1Sources.Retrieve(
 		context.TODO(), "src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesPost(t *testing.T) {
@@ -8142,7 +8142,7 @@ func TestSourcesPost(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := source.Update("src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesPostService(t *testing.T) {
@@ -8151,7 +8151,7 @@ func TestSourcesPostService(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Sources.Update("src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSourcesPostClient(t *testing.T) {
@@ -8161,14 +8161,14 @@ func TestSourcesPostClient(t *testing.T) {
 	result, err := sc.V1Sources.Update(
 		context.TODO(), "src_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsDelete(t *testing.T) {
 	params := &stripe.SubscriptionItemParams{}
 	result, err := subscriptionitem.Del("si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsDeleteService(t *testing.T) {
@@ -8176,7 +8176,7 @@ func TestSubscriptionItemsDeleteService(t *testing.T) {
 	params := &stripe.SubscriptionItemParams{}
 	result, err := sc.SubscriptionItems.Del("si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsDeleteClient(t *testing.T) {
@@ -8185,7 +8185,7 @@ func TestSubscriptionItemsDeleteClient(t *testing.T) {
 	result, err := sc.V1SubscriptionItems.Delete(
 		context.TODO(), "si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsGet(t *testing.T) {
@@ -8194,7 +8194,7 @@ func TestSubscriptionItemsGet(t *testing.T) {
 	}
 	result := subscriptionitem.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionItemsGetService(t *testing.T) {
@@ -8204,7 +8204,7 @@ func TestSubscriptionItemsGetService(t *testing.T) {
 	}
 	result := sc.SubscriptionItems.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionItemsGetClient(t *testing.T) {
@@ -8214,14 +8214,14 @@ func TestSubscriptionItemsGetClient(t *testing.T) {
 	}
 	result := sc.V1SubscriptionItems.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionItemsGet2(t *testing.T) {
 	params := &stripe.SubscriptionItemParams{}
 	result, err := subscriptionitem.Get("si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsGet2Service(t *testing.T) {
@@ -8229,7 +8229,7 @@ func TestSubscriptionItemsGet2Service(t *testing.T) {
 	params := &stripe.SubscriptionItemParams{}
 	result, err := sc.SubscriptionItems.Get("si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsGet2Client(t *testing.T) {
@@ -8238,7 +8238,7 @@ func TestSubscriptionItemsGet2Client(t *testing.T) {
 	result, err := sc.V1SubscriptionItems.Retrieve(
 		context.TODO(), "si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsPost(t *testing.T) {
@@ -8249,7 +8249,7 @@ func TestSubscriptionItemsPost(t *testing.T) {
 	}
 	result, err := subscriptionitem.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsPostService(t *testing.T) {
@@ -8261,7 +8261,7 @@ func TestSubscriptionItemsPostService(t *testing.T) {
 	}
 	result, err := sc.SubscriptionItems.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsPostClient(t *testing.T) {
@@ -8273,7 +8273,7 @@ func TestSubscriptionItemsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1SubscriptionItems.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsPost2(t *testing.T) {
@@ -8281,7 +8281,7 @@ func TestSubscriptionItemsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := subscriptionitem.Update("si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsPost2Service(t *testing.T) {
@@ -8290,7 +8290,7 @@ func TestSubscriptionItemsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.SubscriptionItems.Update("si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionItemsPost2Client(t *testing.T) {
@@ -8300,14 +8300,14 @@ func TestSubscriptionItemsPost2Client(t *testing.T) {
 	result, err := sc.V1SubscriptionItems.Update(
 		context.TODO(), "si_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesCancelPost(t *testing.T) {
 	params := &stripe.SubscriptionScheduleCancelParams{}
 	result, err := subscriptionschedule.Cancel("sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesCancelPostService(t *testing.T) {
@@ -8316,7 +8316,7 @@ func TestSubscriptionSchedulesCancelPostService(t *testing.T) {
 	result, err := sc.SubscriptionSchedules.Cancel(
 		"sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesCancelPostClient(t *testing.T) {
@@ -8325,7 +8325,7 @@ func TestSubscriptionSchedulesCancelPostClient(t *testing.T) {
 	result, err := sc.V1SubscriptionSchedules.Cancel(
 		context.TODO(), "sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesGet(t *testing.T) {
@@ -8333,7 +8333,7 @@ func TestSubscriptionSchedulesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := subscriptionschedule.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionSchedulesGetService(t *testing.T) {
@@ -8342,7 +8342,7 @@ func TestSubscriptionSchedulesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.SubscriptionSchedules.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionSchedulesGetClient(t *testing.T) {
@@ -8351,14 +8351,14 @@ func TestSubscriptionSchedulesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1SubscriptionSchedules.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionSchedulesGet2(t *testing.T) {
 	params := &stripe.SubscriptionScheduleParams{}
 	result, err := subscriptionschedule.Get("sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesGet2Service(t *testing.T) {
@@ -8366,7 +8366,7 @@ func TestSubscriptionSchedulesGet2Service(t *testing.T) {
 	params := &stripe.SubscriptionScheduleParams{}
 	result, err := sc.SubscriptionSchedules.Get("sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesGet2Client(t *testing.T) {
@@ -8375,7 +8375,7 @@ func TestSubscriptionSchedulesGet2Client(t *testing.T) {
 	result, err := sc.V1SubscriptionSchedules.Retrieve(
 		context.TODO(), "sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesPost(t *testing.T) {
@@ -8396,7 +8396,7 @@ func TestSubscriptionSchedulesPost(t *testing.T) {
 	}
 	result, err := subscriptionschedule.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesPostService(t *testing.T) {
@@ -8418,7 +8418,7 @@ func TestSubscriptionSchedulesPostService(t *testing.T) {
 	}
 	result, err := sc.SubscriptionSchedules.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesPostClient(t *testing.T) {
@@ -8440,7 +8440,7 @@ func TestSubscriptionSchedulesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1SubscriptionSchedules.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesPost2(t *testing.T) {
@@ -8449,7 +8449,7 @@ func TestSubscriptionSchedulesPost2(t *testing.T) {
 	}
 	result, err := subscriptionschedule.Update("sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesPost2Service(t *testing.T) {
@@ -8460,7 +8460,7 @@ func TestSubscriptionSchedulesPost2Service(t *testing.T) {
 	result, err := sc.SubscriptionSchedules.Update(
 		"sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesPost2Client(t *testing.T) {
@@ -8471,14 +8471,14 @@ func TestSubscriptionSchedulesPost2Client(t *testing.T) {
 	result, err := sc.V1SubscriptionSchedules.Update(
 		context.TODO(), "sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesReleasePost(t *testing.T) {
 	params := &stripe.SubscriptionScheduleReleaseParams{}
 	result, err := subscriptionschedule.Release("sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesReleasePostService(t *testing.T) {
@@ -8487,7 +8487,7 @@ func TestSubscriptionSchedulesReleasePostService(t *testing.T) {
 	result, err := sc.SubscriptionSchedules.Release(
 		"sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionSchedulesReleasePostClient(t *testing.T) {
@@ -8496,14 +8496,14 @@ func TestSubscriptionSchedulesReleasePostClient(t *testing.T) {
 	result, err := sc.V1SubscriptionSchedules.Release(
 		context.TODO(), "sub_sched_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsDelete(t *testing.T) {
 	params := &stripe.SubscriptionCancelParams{}
 	result, err := subscription.Cancel("sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsDeleteService(t *testing.T) {
@@ -8511,7 +8511,7 @@ func TestSubscriptionsDeleteService(t *testing.T) {
 	params := &stripe.SubscriptionCancelParams{}
 	result, err := sc.Subscriptions.Cancel("sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsDeleteClient(t *testing.T) {
@@ -8520,14 +8520,14 @@ func TestSubscriptionsDeleteClient(t *testing.T) {
 	result, err := sc.V1Subscriptions.Cancel(
 		context.TODO(), "sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsDiscountDelete(t *testing.T) {
 	params := &stripe.SubscriptionDeleteDiscountParams{}
 	result, err := subscription.DeleteDiscount("sub_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsDiscountDeleteService(t *testing.T) {
@@ -8535,7 +8535,7 @@ func TestSubscriptionsDiscountDeleteService(t *testing.T) {
 	params := &stripe.SubscriptionDeleteDiscountParams{}
 	result, err := sc.Subscriptions.DeleteDiscount("sub_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsDiscountDeleteClient(t *testing.T) {
@@ -8544,7 +8544,7 @@ func TestSubscriptionsDiscountDeleteClient(t *testing.T) {
 	result, err := sc.V1Subscriptions.DeleteDiscount(
 		context.TODO(), "sub_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsGet(t *testing.T) {
@@ -8552,7 +8552,7 @@ func TestSubscriptionsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := subscription.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionsGetService(t *testing.T) {
@@ -8561,7 +8561,7 @@ func TestSubscriptionsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Subscriptions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionsGetClient(t *testing.T) {
@@ -8570,14 +8570,14 @@ func TestSubscriptionsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Subscriptions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionsGet2(t *testing.T) {
 	params := &stripe.SubscriptionParams{}
 	result, err := subscription.Get("sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsGet2Service(t *testing.T) {
@@ -8585,7 +8585,7 @@ func TestSubscriptionsGet2Service(t *testing.T) {
 	params := &stripe.SubscriptionParams{}
 	result, err := sc.Subscriptions.Get("sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsGet2Client(t *testing.T) {
@@ -8594,7 +8594,7 @@ func TestSubscriptionsGet2Client(t *testing.T) {
 	result, err := sc.V1Subscriptions.Retrieve(
 		context.TODO(), "sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsPost(t *testing.T) {
@@ -8608,7 +8608,7 @@ func TestSubscriptionsPost(t *testing.T) {
 	}
 	result, err := subscription.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsPostService(t *testing.T) {
@@ -8623,7 +8623,7 @@ func TestSubscriptionsPostService(t *testing.T) {
 	}
 	result, err := sc.Subscriptions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsPostClient(t *testing.T) {
@@ -8638,7 +8638,7 @@ func TestSubscriptionsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Subscriptions.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsPost2(t *testing.T) {
@@ -8646,7 +8646,7 @@ func TestSubscriptionsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := subscription.Update("sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsPost2Service(t *testing.T) {
@@ -8655,7 +8655,7 @@ func TestSubscriptionsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Subscriptions.Update("sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsPost2Client(t *testing.T) {
@@ -8665,7 +8665,7 @@ func TestSubscriptionsPost2Client(t *testing.T) {
 	result, err := sc.V1Subscriptions.Update(
 		context.TODO(), "sub_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSubscriptionsSearchGet(t *testing.T) {
@@ -8676,7 +8676,7 @@ func TestSubscriptionsSearchGet(t *testing.T) {
 	}
 	result := subscription.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionsSearchGetService(t *testing.T) {
@@ -8688,7 +8688,7 @@ func TestSubscriptionsSearchGetService(t *testing.T) {
 	}
 	result := sc.Subscriptions.Search(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestSubscriptionsSearchGetClient(t *testing.T) {
@@ -8700,7 +8700,7 @@ func TestSubscriptionsSearchGetClient(t *testing.T) {
 	}
 	result := sc.V1Subscriptions.Search(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxCalculationsLineItemsGet(t *testing.T) {
@@ -8709,7 +8709,7 @@ func TestTaxCalculationsLineItemsGet(t *testing.T) {
 	}
 	result := tax_calculation.ListLineItems(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxCalculationsLineItemsGetService(t *testing.T) {
@@ -8719,7 +8719,7 @@ func TestTaxCalculationsLineItemsGetService(t *testing.T) {
 	}
 	result := sc.TaxCalculations.ListLineItems(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxCalculationsLineItemsGetClient(t *testing.T) {
@@ -8729,7 +8729,7 @@ func TestTaxCalculationsLineItemsGetClient(t *testing.T) {
 	}
 	result := sc.V1TaxCalculations.ListLineItems(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxCalculationsPost(t *testing.T) {
@@ -8754,7 +8754,7 @@ func TestTaxCalculationsPost(t *testing.T) {
 	}
 	result, err := tax_calculation.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxCalculationsPostService(t *testing.T) {
@@ -8780,7 +8780,7 @@ func TestTaxCalculationsPostService(t *testing.T) {
 	}
 	result, err := sc.TaxCalculations.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxCalculationsPostClient(t *testing.T) {
@@ -8806,7 +8806,7 @@ func TestTaxCalculationsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TaxCalculations.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxCodesGet(t *testing.T) {
@@ -8814,7 +8814,7 @@ func TestTaxCodesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := taxcode.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxCodesGetService(t *testing.T) {
@@ -8823,7 +8823,7 @@ func TestTaxCodesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TaxCodes.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxCodesGetClient(t *testing.T) {
@@ -8832,14 +8832,14 @@ func TestTaxCodesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TaxCodes.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxCodesGet2(t *testing.T) {
 	params := &stripe.TaxCodeParams{}
 	result, err := taxcode.Get("txcd_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxCodesGet2Service(t *testing.T) {
@@ -8847,7 +8847,7 @@ func TestTaxCodesGet2Service(t *testing.T) {
 	params := &stripe.TaxCodeParams{}
 	result, err := sc.TaxCodes.Get("txcd_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxCodesGet2Client(t *testing.T) {
@@ -8856,14 +8856,14 @@ func TestTaxCodesGet2Client(t *testing.T) {
 	result, err := sc.V1TaxCodes.Retrieve(
 		context.TODO(), "txcd_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsDelete(t *testing.T) {
 	params := &stripe.TaxIDParams{}
 	result, err := taxid.Del("taxid_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsDeleteService(t *testing.T) {
@@ -8871,7 +8871,7 @@ func TestTaxIdsDeleteService(t *testing.T) {
 	params := &stripe.TaxIDParams{}
 	result, err := sc.TaxIDs.Del("taxid_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsDeleteClient(t *testing.T) {
@@ -8879,14 +8879,14 @@ func TestTaxIdsDeleteClient(t *testing.T) {
 	params := &stripe.TaxIDDeleteParams{}
 	result, err := sc.V1TaxIDs.Delete(context.TODO(), "taxid_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsGet(t *testing.T) {
 	params := &stripe.TaxIDListParams{}
 	result := taxid.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxIdsGetService(t *testing.T) {
@@ -8894,7 +8894,7 @@ func TestTaxIdsGetService(t *testing.T) {
 	params := &stripe.TaxIDListParams{}
 	result := sc.TaxIDs.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxIdsGetClient(t *testing.T) {
@@ -8902,14 +8902,14 @@ func TestTaxIdsGetClient(t *testing.T) {
 	params := &stripe.TaxIDListParams{}
 	result := sc.V1TaxIDs.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxIdsGet2(t *testing.T) {
 	params := &stripe.TaxIDParams{}
 	result, err := taxid.Get("taxid_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsGet2Service(t *testing.T) {
@@ -8917,7 +8917,7 @@ func TestTaxIdsGet2Service(t *testing.T) {
 	params := &stripe.TaxIDParams{}
 	result, err := sc.TaxIDs.Get("taxid_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsGet2Client(t *testing.T) {
@@ -8925,7 +8925,7 @@ func TestTaxIdsGet2Client(t *testing.T) {
 	params := &stripe.TaxIDRetrieveParams{}
 	result, err := sc.V1TaxIDs.Retrieve(context.TODO(), "taxid_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsPost(t *testing.T) {
@@ -8935,7 +8935,7 @@ func TestTaxIdsPost(t *testing.T) {
 	}
 	result, err := taxid.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsPostService(t *testing.T) {
@@ -8946,7 +8946,7 @@ func TestTaxIdsPostService(t *testing.T) {
 	}
 	result, err := sc.TaxIDs.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxIdsPostClient(t *testing.T) {
@@ -8957,7 +8957,7 @@ func TestTaxIdsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TaxIDs.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesGet(t *testing.T) {
@@ -8965,7 +8965,7 @@ func TestTaxRatesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := taxrate.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxRatesGetService(t *testing.T) {
@@ -8974,7 +8974,7 @@ func TestTaxRatesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TaxRates.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxRatesGetClient(t *testing.T) {
@@ -8983,14 +8983,14 @@ func TestTaxRatesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TaxRates.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTaxRatesGet2(t *testing.T) {
 	params := &stripe.TaxRateParams{}
 	result, err := taxrate.Get("txr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesGet2Service(t *testing.T) {
@@ -8998,7 +8998,7 @@ func TestTaxRatesGet2Service(t *testing.T) {
 	params := &stripe.TaxRateParams{}
 	result, err := sc.TaxRates.Get("txr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesGet2Client(t *testing.T) {
@@ -9007,7 +9007,7 @@ func TestTaxRatesGet2Client(t *testing.T) {
 	result, err := sc.V1TaxRates.Retrieve(
 		context.TODO(), "txr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesPost(t *testing.T) {
@@ -9020,7 +9020,7 @@ func TestTaxRatesPost(t *testing.T) {
 	}
 	result, err := taxrate.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesPostService(t *testing.T) {
@@ -9034,7 +9034,7 @@ func TestTaxRatesPostService(t *testing.T) {
 	}
 	result, err := sc.TaxRates.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesPostClient(t *testing.T) {
@@ -9048,14 +9048,14 @@ func TestTaxRatesPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TaxRates.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesPost2(t *testing.T) {
 	params := &stripe.TaxRateParams{Active: stripe.Bool(false)}
 	result, err := taxrate.Update("txr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesPost2Service(t *testing.T) {
@@ -9063,7 +9063,7 @@ func TestTaxRatesPost2Service(t *testing.T) {
 	params := &stripe.TaxRateParams{Active: stripe.Bool(false)}
 	result, err := sc.TaxRates.Update("txr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxRatesPost2Client(t *testing.T) {
@@ -9072,14 +9072,14 @@ func TestTaxRatesPost2Client(t *testing.T) {
 	result, err := sc.V1TaxRates.Update(
 		context.TODO(), "txr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxSettingsGet(t *testing.T) {
 	params := &stripe.TaxSettingsParams{}
 	result, err := tax_settings.Get(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxSettingsGetService(t *testing.T) {
@@ -9087,7 +9087,7 @@ func TestTaxSettingsGetService(t *testing.T) {
 	params := &stripe.TaxSettingsParams{}
 	result, err := sc.TaxSettings.Get(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxSettingsGetClient(t *testing.T) {
@@ -9095,7 +9095,7 @@ func TestTaxSettingsGetClient(t *testing.T) {
 	params := &stripe.TaxSettingsRetrieveParams{}
 	result, err := sc.V1TaxSettings.Retrieve(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxSettingsPost(t *testing.T) {
@@ -9106,7 +9106,7 @@ func TestTaxSettingsPost(t *testing.T) {
 	}
 	result, err := tax_settings.Update(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxSettingsPostService(t *testing.T) {
@@ -9118,7 +9118,7 @@ func TestTaxSettingsPostService(t *testing.T) {
 	}
 	result, err := sc.TaxSettings.Update(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxSettingsPostClient(t *testing.T) {
@@ -9130,7 +9130,7 @@ func TestTaxSettingsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TaxSettings.Update(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxTransactionsCreateFromCalculationPost(t *testing.T) {
@@ -9140,7 +9140,7 @@ func TestTaxTransactionsCreateFromCalculationPost(t *testing.T) {
 	}
 	result, err := tax_transaction.CreateFromCalculation(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxTransactionsCreateFromCalculationPostService(t *testing.T) {
@@ -9151,7 +9151,7 @@ func TestTaxTransactionsCreateFromCalculationPostService(t *testing.T) {
 	}
 	result, err := sc.TaxTransactions.CreateFromCalculation(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTaxTransactionsCreateFromCalculationPostClient(t *testing.T) {
@@ -9163,14 +9163,14 @@ func TestTaxTransactionsCreateFromCalculationPostClient(t *testing.T) {
 	result, err := sc.V1TaxTransactions.CreateFromCalculation(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsDelete(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := terminal_configuration.Del("uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsDeleteService(t *testing.T) {
@@ -9178,7 +9178,7 @@ func TestTerminalConfigurationsDeleteService(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := sc.TerminalConfigurations.Del("uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsDeleteClient(t *testing.T) {
@@ -9187,14 +9187,14 @@ func TestTerminalConfigurationsDeleteClient(t *testing.T) {
 	result, err := sc.V1TerminalConfigurations.Delete(
 		context.TODO(), "uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsDelete2(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := terminal_configuration.Del("tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsDelete2Service(t *testing.T) {
@@ -9202,7 +9202,7 @@ func TestTerminalConfigurationsDelete2Service(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := sc.TerminalConfigurations.Del("tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsDelete2Client(t *testing.T) {
@@ -9211,14 +9211,14 @@ func TestTerminalConfigurationsDelete2Client(t *testing.T) {
 	result, err := sc.V1TerminalConfigurations.Delete(
 		context.TODO(), "tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsGet(t *testing.T) {
 	params := &stripe.TerminalConfigurationListParams{}
 	result := terminal_configuration.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalConfigurationsGetService(t *testing.T) {
@@ -9226,7 +9226,7 @@ func TestTerminalConfigurationsGetService(t *testing.T) {
 	params := &stripe.TerminalConfigurationListParams{}
 	result := sc.TerminalConfigurations.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalConfigurationsGetClient(t *testing.T) {
@@ -9234,14 +9234,14 @@ func TestTerminalConfigurationsGetClient(t *testing.T) {
 	params := &stripe.TerminalConfigurationListParams{}
 	result := sc.V1TerminalConfigurations.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalConfigurationsGet2(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := terminal_configuration.Get("uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsGet2Service(t *testing.T) {
@@ -9249,7 +9249,7 @@ func TestTerminalConfigurationsGet2Service(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := sc.TerminalConfigurations.Get("uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsGet2Client(t *testing.T) {
@@ -9258,7 +9258,7 @@ func TestTerminalConfigurationsGet2Client(t *testing.T) {
 	result, err := sc.V1TerminalConfigurations.Retrieve(
 		context.TODO(), "uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsGet3(t *testing.T) {
@@ -9266,7 +9266,7 @@ func TestTerminalConfigurationsGet3(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := terminal_configuration.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalConfigurationsGet3Service(t *testing.T) {
@@ -9275,7 +9275,7 @@ func TestTerminalConfigurationsGet3Service(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TerminalConfigurations.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalConfigurationsGet3Client(t *testing.T) {
@@ -9284,14 +9284,14 @@ func TestTerminalConfigurationsGet3Client(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TerminalConfigurations.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalConfigurationsGet4(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := terminal_configuration.Get("tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsGet4Service(t *testing.T) {
@@ -9299,7 +9299,7 @@ func TestTerminalConfigurationsGet4Service(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := sc.TerminalConfigurations.Get("tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsGet4Client(t *testing.T) {
@@ -9308,14 +9308,14 @@ func TestTerminalConfigurationsGet4Client(t *testing.T) {
 	result, err := sc.V1TerminalConfigurations.Retrieve(
 		context.TODO(), "tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := terminal_configuration.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPostService(t *testing.T) {
@@ -9323,7 +9323,7 @@ func TestTerminalConfigurationsPostService(t *testing.T) {
 	params := &stripe.TerminalConfigurationParams{}
 	result, err := sc.TerminalConfigurations.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPostClient(t *testing.T) {
@@ -9331,7 +9331,7 @@ func TestTerminalConfigurationsPostClient(t *testing.T) {
 	params := &stripe.TerminalConfigurationCreateParams{}
 	result, err := sc.V1TerminalConfigurations.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost2(t *testing.T) {
@@ -9344,7 +9344,7 @@ func TestTerminalConfigurationsPost2(t *testing.T) {
 	}
 	result, err := terminal_configuration.Update("uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost2Service(t *testing.T) {
@@ -9358,7 +9358,7 @@ func TestTerminalConfigurationsPost2Service(t *testing.T) {
 	}
 	result, err := sc.TerminalConfigurations.Update("uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost2Client(t *testing.T) {
@@ -9373,7 +9373,7 @@ func TestTerminalConfigurationsPost2Client(t *testing.T) {
 	result, err := sc.V1TerminalConfigurations.Update(
 		context.TODO(), "uc_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost3(t *testing.T) {
@@ -9384,7 +9384,7 @@ func TestTerminalConfigurationsPost3(t *testing.T) {
 	}
 	result, err := terminal_configuration.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost3Service(t *testing.T) {
@@ -9396,7 +9396,7 @@ func TestTerminalConfigurationsPost3Service(t *testing.T) {
 	}
 	result, err := sc.TerminalConfigurations.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost3Client(t *testing.T) {
@@ -9408,7 +9408,7 @@ func TestTerminalConfigurationsPost3Client(t *testing.T) {
 	}
 	result, err := sc.V1TerminalConfigurations.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost4(t *testing.T) {
@@ -9419,7 +9419,7 @@ func TestTerminalConfigurationsPost4(t *testing.T) {
 	}
 	result, err := terminal_configuration.Update("tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost4Service(t *testing.T) {
@@ -9431,7 +9431,7 @@ func TestTerminalConfigurationsPost4Service(t *testing.T) {
 	}
 	result, err := sc.TerminalConfigurations.Update("tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConfigurationsPost4Client(t *testing.T) {
@@ -9444,14 +9444,14 @@ func TestTerminalConfigurationsPost4Client(t *testing.T) {
 	result, err := sc.V1TerminalConfigurations.Update(
 		context.TODO(), "tmc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConnectionTokensPost(t *testing.T) {
 	params := &stripe.TerminalConnectionTokenParams{}
 	result, err := terminal_connectiontoken.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConnectionTokensPostService(t *testing.T) {
@@ -9459,7 +9459,7 @@ func TestTerminalConnectionTokensPostService(t *testing.T) {
 	params := &stripe.TerminalConnectionTokenParams{}
 	result, err := sc.TerminalConnectionTokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalConnectionTokensPostClient(t *testing.T) {
@@ -9467,14 +9467,14 @@ func TestTerminalConnectionTokensPostClient(t *testing.T) {
 	params := &stripe.TerminalConnectionTokenCreateParams{}
 	result, err := sc.V1TerminalConnectionTokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsDelete(t *testing.T) {
 	params := &stripe.TerminalLocationParams{}
 	result, err := terminal_location.Del("tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsDeleteService(t *testing.T) {
@@ -9482,7 +9482,7 @@ func TestTerminalLocationsDeleteService(t *testing.T) {
 	params := &stripe.TerminalLocationParams{}
 	result, err := sc.TerminalLocations.Del("tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsDeleteClient(t *testing.T) {
@@ -9491,7 +9491,7 @@ func TestTerminalLocationsDeleteClient(t *testing.T) {
 	result, err := sc.V1TerminalLocations.Delete(
 		context.TODO(), "tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsGet(t *testing.T) {
@@ -9499,7 +9499,7 @@ func TestTerminalLocationsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := terminal_location.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalLocationsGetService(t *testing.T) {
@@ -9508,7 +9508,7 @@ func TestTerminalLocationsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TerminalLocations.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalLocationsGetClient(t *testing.T) {
@@ -9517,14 +9517,14 @@ func TestTerminalLocationsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TerminalLocations.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalLocationsGet2(t *testing.T) {
 	params := &stripe.TerminalLocationParams{}
 	result, err := terminal_location.Get("tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsGet2Service(t *testing.T) {
@@ -9532,7 +9532,7 @@ func TestTerminalLocationsGet2Service(t *testing.T) {
 	params := &stripe.TerminalLocationParams{}
 	result, err := sc.TerminalLocations.Get("tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsGet2Client(t *testing.T) {
@@ -9541,7 +9541,7 @@ func TestTerminalLocationsGet2Client(t *testing.T) {
 	result, err := sc.V1TerminalLocations.Retrieve(
 		context.TODO(), "tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsPost(t *testing.T) {
@@ -9557,7 +9557,7 @@ func TestTerminalLocationsPost(t *testing.T) {
 	}
 	result, err := terminal_location.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsPostService(t *testing.T) {
@@ -9574,7 +9574,7 @@ func TestTerminalLocationsPostService(t *testing.T) {
 	}
 	result, err := sc.TerminalLocations.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsPostClient(t *testing.T) {
@@ -9591,7 +9591,7 @@ func TestTerminalLocationsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TerminalLocations.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsPost2(t *testing.T) {
@@ -9600,7 +9600,7 @@ func TestTerminalLocationsPost2(t *testing.T) {
 	}
 	result, err := terminal_location.Update("tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsPost2Service(t *testing.T) {
@@ -9610,7 +9610,7 @@ func TestTerminalLocationsPost2Service(t *testing.T) {
 	}
 	result, err := sc.TerminalLocations.Update("tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalLocationsPost2Client(t *testing.T) {
@@ -9621,14 +9621,14 @@ func TestTerminalLocationsPost2Client(t *testing.T) {
 	result, err := sc.V1TerminalLocations.Update(
 		context.TODO(), "tml_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersCancelActionPost(t *testing.T) {
 	params := &stripe.TerminalReaderCancelActionParams{}
 	result, err := terminal_reader.CancelAction("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersCancelActionPostService(t *testing.T) {
@@ -9636,7 +9636,7 @@ func TestTerminalReadersCancelActionPostService(t *testing.T) {
 	params := &stripe.TerminalReaderCancelActionParams{}
 	result, err := sc.TerminalReaders.CancelAction("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersCancelActionPostClient(t *testing.T) {
@@ -9645,14 +9645,14 @@ func TestTerminalReadersCancelActionPostClient(t *testing.T) {
 	result, err := sc.V1TerminalReaders.CancelAction(
 		context.TODO(), "tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersDelete(t *testing.T) {
 	params := &stripe.TerminalReaderParams{}
 	result, err := terminal_reader.Del("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersDeleteService(t *testing.T) {
@@ -9660,7 +9660,7 @@ func TestTerminalReadersDeleteService(t *testing.T) {
 	params := &stripe.TerminalReaderParams{}
 	result, err := sc.TerminalReaders.Del("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersDeleteClient(t *testing.T) {
@@ -9669,7 +9669,7 @@ func TestTerminalReadersDeleteClient(t *testing.T) {
 	result, err := sc.V1TerminalReaders.Delete(
 		context.TODO(), "tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersGet(t *testing.T) {
@@ -9677,7 +9677,7 @@ func TestTerminalReadersGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := terminal_reader.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalReadersGetService(t *testing.T) {
@@ -9686,7 +9686,7 @@ func TestTerminalReadersGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TerminalReaders.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalReadersGetClient(t *testing.T) {
@@ -9695,14 +9695,14 @@ func TestTerminalReadersGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TerminalReaders.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTerminalReadersGet2(t *testing.T) {
 	params := &stripe.TerminalReaderParams{}
 	result, err := terminal_reader.Get("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersGet2Service(t *testing.T) {
@@ -9710,7 +9710,7 @@ func TestTerminalReadersGet2Service(t *testing.T) {
 	params := &stripe.TerminalReaderParams{}
 	result, err := sc.TerminalReaders.Get("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersGet2Client(t *testing.T) {
@@ -9719,7 +9719,7 @@ func TestTerminalReadersGet2Client(t *testing.T) {
 	result, err := sc.V1TerminalReaders.Retrieve(
 		context.TODO(), "tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersPost(t *testing.T) {
@@ -9730,7 +9730,7 @@ func TestTerminalReadersPost(t *testing.T) {
 	}
 	result, err := terminal_reader.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersPostService(t *testing.T) {
@@ -9742,7 +9742,7 @@ func TestTerminalReadersPostService(t *testing.T) {
 	}
 	result, err := sc.TerminalReaders.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersPostClient(t *testing.T) {
@@ -9754,14 +9754,14 @@ func TestTerminalReadersPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TerminalReaders.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersPost2(t *testing.T) {
 	params := &stripe.TerminalReaderParams{Label: stripe.String("Blue Rabbit")}
 	result, err := terminal_reader.Update("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersPost2Service(t *testing.T) {
@@ -9769,7 +9769,7 @@ func TestTerminalReadersPost2Service(t *testing.T) {
 	params := &stripe.TerminalReaderParams{Label: stripe.String("Blue Rabbit")}
 	result, err := sc.TerminalReaders.Update("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersPost2Client(t *testing.T) {
@@ -9780,7 +9780,7 @@ func TestTerminalReadersPost2Client(t *testing.T) {
 	result, err := sc.V1TerminalReaders.Update(
 		context.TODO(), "tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersProcessPaymentIntentPost(t *testing.T) {
@@ -9790,7 +9790,7 @@ func TestTerminalReadersProcessPaymentIntentPost(t *testing.T) {
 	result, err := terminal_reader.ProcessPaymentIntent(
 		"tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersProcessPaymentIntentPostService(t *testing.T) {
@@ -9801,7 +9801,7 @@ func TestTerminalReadersProcessPaymentIntentPostService(t *testing.T) {
 	result, err := sc.TerminalReaders.ProcessPaymentIntent(
 		"tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersProcessPaymentIntentPostClient(t *testing.T) {
@@ -9812,7 +9812,7 @@ func TestTerminalReadersProcessPaymentIntentPostClient(t *testing.T) {
 	result, err := sc.V1TerminalReaders.ProcessPaymentIntent(
 		context.TODO(), "tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersProcessSetupIntentPost(t *testing.T) {
@@ -9822,7 +9822,7 @@ func TestTerminalReadersProcessSetupIntentPost(t *testing.T) {
 	}
 	result, err := terminal_reader.ProcessSetupIntent("tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersProcessSetupIntentPostService(t *testing.T) {
@@ -9834,7 +9834,7 @@ func TestTerminalReadersProcessSetupIntentPostService(t *testing.T) {
 	result, err := sc.TerminalReaders.ProcessSetupIntent(
 		"tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTerminalReadersProcessSetupIntentPostClient(t *testing.T) {
@@ -9846,7 +9846,7 @@ func TestTerminalReadersProcessSetupIntentPostClient(t *testing.T) {
 	result, err := sc.V1TerminalReaders.ProcessSetupIntent(
 		context.TODO(), "tmr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersCustomersFundCashBalancePost(t *testing.T) {
@@ -9856,7 +9856,7 @@ func TestTestHelpersCustomersFundCashBalancePost(t *testing.T) {
 	}
 	result, err := testhelpers_customer.FundCashBalance("cus_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersCustomersFundCashBalancePostService(t *testing.T) {
@@ -9867,7 +9867,7 @@ func TestTestHelpersCustomersFundCashBalancePostService(t *testing.T) {
 	}
 	result, err := sc.TestHelpersCustomers.FundCashBalance("cus_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersCustomersFundCashBalancePostClient(t *testing.T) {
@@ -9879,7 +9879,7 @@ func TestTestHelpersCustomersFundCashBalancePostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersCustomers.FundCashBalance(
 		context.TODO(), "cus_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsCapturePost(t *testing.T) {
@@ -9927,7 +9927,7 @@ func TestTestHelpersIssuingAuthorizationsCapturePost(t *testing.T) {
 	result, err := testhelpers_issuing_authorization.Capture(
 		"example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsCapturePostService(t *testing.T) {
@@ -9976,7 +9976,7 @@ func TestTestHelpersIssuingAuthorizationsCapturePostService(t *testing.T) {
 	result, err := sc.TestHelpersIssuingAuthorizations.Capture(
 		"example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsCapturePostClient(t *testing.T) {
@@ -10025,7 +10025,7 @@ func TestTestHelpersIssuingAuthorizationsCapturePostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingAuthorizations.Capture(
 		context.TODO(), "example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsExpirePost(t *testing.T) {
@@ -10033,7 +10033,7 @@ func TestTestHelpersIssuingAuthorizationsExpirePost(t *testing.T) {
 	result, err := testhelpers_issuing_authorization.Expire(
 		"example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsExpirePostService(t *testing.T) {
@@ -10042,7 +10042,7 @@ func TestTestHelpersIssuingAuthorizationsExpirePostService(t *testing.T) {
 	result, err := sc.TestHelpersIssuingAuthorizations.Expire(
 		"example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsExpirePostClient(t *testing.T) {
@@ -10051,7 +10051,7 @@ func TestTestHelpersIssuingAuthorizationsExpirePostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingAuthorizations.Expire(
 		context.TODO(), "example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsIncrementPost(t *testing.T) {
@@ -10062,7 +10062,7 @@ func TestTestHelpersIssuingAuthorizationsIncrementPost(t *testing.T) {
 	result, err := testhelpers_issuing_authorization.Increment(
 		"example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsIncrementPostService(t *testing.T) {
@@ -10074,7 +10074,7 @@ func TestTestHelpersIssuingAuthorizationsIncrementPostService(t *testing.T) {
 	result, err := sc.TestHelpersIssuingAuthorizations.Increment(
 		"example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsIncrementPostClient(t *testing.T) {
@@ -10086,7 +10086,7 @@ func TestTestHelpersIssuingAuthorizationsIncrementPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingAuthorizations.Increment(
 		context.TODO(), "example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsPost(t *testing.T) {
@@ -10123,7 +10123,7 @@ func TestTestHelpersIssuingAuthorizationsPost(t *testing.T) {
 	}
 	result, err := testhelpers_issuing_authorization.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsPostService(t *testing.T) {
@@ -10161,7 +10161,7 @@ func TestTestHelpersIssuingAuthorizationsPostService(t *testing.T) {
 	}
 	result, err := sc.TestHelpersIssuingAuthorizations.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsPostClient(t *testing.T) {
@@ -10200,7 +10200,7 @@ func TestTestHelpersIssuingAuthorizationsPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingAuthorizations.Create(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsReversePost(t *testing.T) {
@@ -10210,7 +10210,7 @@ func TestTestHelpersIssuingAuthorizationsReversePost(t *testing.T) {
 	result, err := testhelpers_issuing_authorization.Reverse(
 		"example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsReversePostService(t *testing.T) {
@@ -10221,7 +10221,7 @@ func TestTestHelpersIssuingAuthorizationsReversePostService(t *testing.T) {
 	result, err := sc.TestHelpersIssuingAuthorizations.Reverse(
 		"example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingAuthorizationsReversePostClient(t *testing.T) {
@@ -10232,14 +10232,14 @@ func TestTestHelpersIssuingAuthorizationsReversePostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingAuthorizations.Reverse(
 		context.TODO(), "example_authorization", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingDeliverPost(t *testing.T) {
 	params := &stripe.TestHelpersIssuingCardDeliverCardParams{}
 	result, err := testhelpers_issuing_card.DeliverCard("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingDeliverPostService(t *testing.T) {
@@ -10247,7 +10247,7 @@ func TestTestHelpersIssuingCardsShippingDeliverPostService(t *testing.T) {
 	params := &stripe.TestHelpersIssuingCardDeliverCardParams{}
 	result, err := sc.TestHelpersIssuingCards.DeliverCard("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingDeliverPostClient(t *testing.T) {
@@ -10256,14 +10256,14 @@ func TestTestHelpersIssuingCardsShippingDeliverPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingCards.DeliverCard(
 		context.TODO(), "card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingFailPost(t *testing.T) {
 	params := &stripe.TestHelpersIssuingCardFailCardParams{}
 	result, err := testhelpers_issuing_card.FailCard("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingFailPostService(t *testing.T) {
@@ -10271,7 +10271,7 @@ func TestTestHelpersIssuingCardsShippingFailPostService(t *testing.T) {
 	params := &stripe.TestHelpersIssuingCardFailCardParams{}
 	result, err := sc.TestHelpersIssuingCards.FailCard("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingFailPostClient(t *testing.T) {
@@ -10280,14 +10280,14 @@ func TestTestHelpersIssuingCardsShippingFailPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingCards.FailCard(
 		context.TODO(), "card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingReturnPost(t *testing.T) {
 	params := &stripe.TestHelpersIssuingCardReturnCardParams{}
 	result, err := testhelpers_issuing_card.ReturnCard("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingReturnPostService(t *testing.T) {
@@ -10295,7 +10295,7 @@ func TestTestHelpersIssuingCardsShippingReturnPostService(t *testing.T) {
 	params := &stripe.TestHelpersIssuingCardReturnCardParams{}
 	result, err := sc.TestHelpersIssuingCards.ReturnCard("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingReturnPostClient(t *testing.T) {
@@ -10304,14 +10304,14 @@ func TestTestHelpersIssuingCardsShippingReturnPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingCards.ReturnCard(
 		context.TODO(), "card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingShipPost(t *testing.T) {
 	params := &stripe.TestHelpersIssuingCardShipCardParams{}
 	result, err := testhelpers_issuing_card.ShipCard("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingShipPostService(t *testing.T) {
@@ -10319,7 +10319,7 @@ func TestTestHelpersIssuingCardsShippingShipPostService(t *testing.T) {
 	params := &stripe.TestHelpersIssuingCardShipCardParams{}
 	result, err := sc.TestHelpersIssuingCards.ShipCard("card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingCardsShippingShipPostClient(t *testing.T) {
@@ -10328,7 +10328,7 @@ func TestTestHelpersIssuingCardsShippingShipPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingCards.ShipCard(
 		context.TODO(), "card_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsActivatePost(t *testing.T) {
@@ -10336,7 +10336,7 @@ func TestTestHelpersIssuingPersonalizationDesignsActivatePost(t *testing.T) {
 	result, err := testhelpers_issuing_personalizationdesign.Activate(
 		"pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsActivatePostService(
@@ -10347,7 +10347,7 @@ func TestTestHelpersIssuingPersonalizationDesignsActivatePostService(
 	result, err := sc.TestHelpersIssuingPersonalizationDesigns.Activate(
 		"pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsActivatePostClient(
@@ -10358,7 +10358,7 @@ func TestTestHelpersIssuingPersonalizationDesignsActivatePostClient(
 	result, err := sc.V1TestHelpersIssuingPersonalizationDesigns.Activate(
 		context.TODO(), "pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsDeactivatePost(t *testing.T) {
@@ -10366,7 +10366,7 @@ func TestTestHelpersIssuingPersonalizationDesignsDeactivatePost(t *testing.T) {
 	result, err := testhelpers_issuing_personalizationdesign.Deactivate(
 		"pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsDeactivatePostService(
@@ -10377,7 +10377,7 @@ func TestTestHelpersIssuingPersonalizationDesignsDeactivatePostService(
 	result, err := sc.TestHelpersIssuingPersonalizationDesigns.Deactivate(
 		"pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsDeactivatePostClient(
@@ -10388,7 +10388,7 @@ func TestTestHelpersIssuingPersonalizationDesignsDeactivatePostClient(
 	result, err := sc.V1TestHelpersIssuingPersonalizationDesigns.Deactivate(
 		context.TODO(), "pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsRejectPost(t *testing.T) {
@@ -10402,7 +10402,7 @@ func TestTestHelpersIssuingPersonalizationDesignsRejectPost(t *testing.T) {
 	result, err := testhelpers_issuing_personalizationdesign.Reject(
 		"pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsRejectPostService(
@@ -10419,7 +10419,7 @@ func TestTestHelpersIssuingPersonalizationDesignsRejectPostService(
 	result, err := sc.TestHelpersIssuingPersonalizationDesigns.Reject(
 		"pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingPersonalizationDesignsRejectPostClient(
@@ -10436,7 +10436,7 @@ func TestTestHelpersIssuingPersonalizationDesignsRejectPostClient(
 	result, err := sc.V1TestHelpersIssuingPersonalizationDesigns.Reject(
 		context.TODO(), "pd_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsCreateForceCapturePost(t *testing.T) {
@@ -10494,7 +10494,7 @@ func TestTestHelpersIssuingTransactionsCreateForceCapturePost(t *testing.T) {
 	}
 	result, err := testhelpers_issuing_transaction.CreateForceCapture(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsCreateForceCapturePostService(
@@ -10555,7 +10555,7 @@ func TestTestHelpersIssuingTransactionsCreateForceCapturePostService(
 	}
 	result, err := sc.TestHelpersIssuingTransactions.CreateForceCapture(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsCreateForceCapturePostClient(
@@ -10617,7 +10617,7 @@ func TestTestHelpersIssuingTransactionsCreateForceCapturePostClient(
 	result, err := sc.V1TestHelpersIssuingTransactions.CreateForceCapture(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPost(t *testing.T) {
@@ -10675,7 +10675,7 @@ func TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPost(t *testing.T) {
 	}
 	result, err := testhelpers_issuing_transaction.CreateUnlinkedRefund(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPostService(
@@ -10736,7 +10736,7 @@ func TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPostService(
 	}
 	result, err := sc.TestHelpersIssuingTransactions.CreateUnlinkedRefund(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPostClient(
@@ -10798,7 +10798,7 @@ func TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPostClient(
 	result, err := sc.V1TestHelpersIssuingTransactions.CreateUnlinkedRefund(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsRefundPost(t *testing.T) {
@@ -10808,7 +10808,7 @@ func TestTestHelpersIssuingTransactionsRefundPost(t *testing.T) {
 	result, err := testhelpers_issuing_transaction.Refund(
 		"example_transaction", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsRefundPostService(t *testing.T) {
@@ -10819,7 +10819,7 @@ func TestTestHelpersIssuingTransactionsRefundPostService(t *testing.T) {
 	result, err := sc.TestHelpersIssuingTransactions.Refund(
 		"example_transaction", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersIssuingTransactionsRefundPostClient(t *testing.T) {
@@ -10830,14 +10830,14 @@ func TestTestHelpersIssuingTransactionsRefundPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersIssuingTransactions.Refund(
 		context.TODO(), "example_transaction", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersRefundsExpirePost(t *testing.T) {
 	params := &stripe.TestHelpersRefundExpireParams{}
 	result, err := testhelpers_refund.Expire("re_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersRefundsExpirePostService(t *testing.T) {
@@ -10845,7 +10845,7 @@ func TestTestHelpersRefundsExpirePostService(t *testing.T) {
 	params := &stripe.TestHelpersRefundExpireParams{}
 	result, err := sc.TestHelpersRefunds.Expire("re_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersRefundsExpirePostClient(t *testing.T) {
@@ -10854,7 +10854,7 @@ func TestTestHelpersRefundsExpirePostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersRefunds.Expire(
 		context.TODO(), "re_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksAdvancePost(t *testing.T) {
@@ -10863,7 +10863,7 @@ func TestTestHelpersTestClocksAdvancePost(t *testing.T) {
 	}
 	result, err := testhelpers_testclock.Advance("clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksAdvancePostService(t *testing.T) {
@@ -10873,7 +10873,7 @@ func TestTestHelpersTestClocksAdvancePostService(t *testing.T) {
 	}
 	result, err := sc.TestHelpersTestClocks.Advance("clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksAdvancePostClient(t *testing.T) {
@@ -10884,7 +10884,7 @@ func TestTestHelpersTestClocksAdvancePostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTestClocks.Advance(
 		context.TODO(), "clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksAdvancePost2(t *testing.T) {
@@ -10893,7 +10893,7 @@ func TestTestHelpersTestClocksAdvancePost2(t *testing.T) {
 	}
 	result, err := testhelpers_testclock.Advance("clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksAdvancePost2Service(t *testing.T) {
@@ -10903,7 +10903,7 @@ func TestTestHelpersTestClocksAdvancePost2Service(t *testing.T) {
 	}
 	result, err := sc.TestHelpersTestClocks.Advance("clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksAdvancePost2Client(t *testing.T) {
@@ -10914,14 +10914,14 @@ func TestTestHelpersTestClocksAdvancePost2Client(t *testing.T) {
 	result, err := sc.V1TestHelpersTestClocks.Advance(
 		context.TODO(), "clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksDelete(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{}
 	result, err := testhelpers_testclock.Del("clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksDeleteService(t *testing.T) {
@@ -10929,7 +10929,7 @@ func TestTestHelpersTestClocksDeleteService(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{}
 	result, err := sc.TestHelpersTestClocks.Del("clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksDeleteClient(t *testing.T) {
@@ -10938,14 +10938,14 @@ func TestTestHelpersTestClocksDeleteClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTestClocks.Delete(
 		context.TODO(), "clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksDelete2(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{}
 	result, err := testhelpers_testclock.Del("clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksDelete2Service(t *testing.T) {
@@ -10953,7 +10953,7 @@ func TestTestHelpersTestClocksDelete2Service(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{}
 	result, err := sc.TestHelpersTestClocks.Del("clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksDelete2Client(t *testing.T) {
@@ -10962,14 +10962,14 @@ func TestTestHelpersTestClocksDelete2Client(t *testing.T) {
 	result, err := sc.V1TestHelpersTestClocks.Delete(
 		context.TODO(), "clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksGet(t *testing.T) {
 	params := &stripe.TestHelpersTestClockListParams{}
 	result := testhelpers_testclock.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTestHelpersTestClocksGetService(t *testing.T) {
@@ -10977,7 +10977,7 @@ func TestTestHelpersTestClocksGetService(t *testing.T) {
 	params := &stripe.TestHelpersTestClockListParams{}
 	result := sc.TestHelpersTestClocks.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTestHelpersTestClocksGetClient(t *testing.T) {
@@ -10985,14 +10985,14 @@ func TestTestHelpersTestClocksGetClient(t *testing.T) {
 	params := &stripe.TestHelpersTestClockListParams{}
 	result := sc.V1TestHelpersTestClocks.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTestHelpersTestClocksGet2(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{}
 	result, err := testhelpers_testclock.Get("clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksGet2Service(t *testing.T) {
@@ -11000,7 +11000,7 @@ func TestTestHelpersTestClocksGet2Service(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{}
 	result, err := sc.TestHelpersTestClocks.Get("clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksGet2Client(t *testing.T) {
@@ -11009,7 +11009,7 @@ func TestTestHelpersTestClocksGet2Client(t *testing.T) {
 	result, err := sc.V1TestHelpersTestClocks.Retrieve(
 		context.TODO(), "clock_xyz", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksGet3(t *testing.T) {
@@ -11017,7 +11017,7 @@ func TestTestHelpersTestClocksGet3(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := testhelpers_testclock.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTestHelpersTestClocksGet3Service(t *testing.T) {
@@ -11026,7 +11026,7 @@ func TestTestHelpersTestClocksGet3Service(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TestHelpersTestClocks.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTestHelpersTestClocksGet3Client(t *testing.T) {
@@ -11035,14 +11035,14 @@ func TestTestHelpersTestClocksGet3Client(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TestHelpersTestClocks.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTestHelpersTestClocksGet4(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{}
 	result, err := testhelpers_testclock.Get("clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksGet4Service(t *testing.T) {
@@ -11050,7 +11050,7 @@ func TestTestHelpersTestClocksGet4Service(t *testing.T) {
 	params := &stripe.TestHelpersTestClockParams{}
 	result, err := sc.TestHelpersTestClocks.Get("clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksGet4Client(t *testing.T) {
@@ -11059,7 +11059,7 @@ func TestTestHelpersTestClocksGet4Client(t *testing.T) {
 	result, err := sc.V1TestHelpersTestClocks.Retrieve(
 		context.TODO(), "clock_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksPost(t *testing.T) {
@@ -11069,7 +11069,7 @@ func TestTestHelpersTestClocksPost(t *testing.T) {
 	}
 	result, err := testhelpers_testclock.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksPostService(t *testing.T) {
@@ -11080,7 +11080,7 @@ func TestTestHelpersTestClocksPostService(t *testing.T) {
 	}
 	result, err := sc.TestHelpersTestClocks.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksPostClient(t *testing.T) {
@@ -11091,7 +11091,7 @@ func TestTestHelpersTestClocksPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TestHelpersTestClocks.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksPost2(t *testing.T) {
@@ -11100,7 +11100,7 @@ func TestTestHelpersTestClocksPost2(t *testing.T) {
 	}
 	result, err := testhelpers_testclock.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksPost2Service(t *testing.T) {
@@ -11110,7 +11110,7 @@ func TestTestHelpersTestClocksPost2Service(t *testing.T) {
 	}
 	result, err := sc.TestHelpersTestClocks.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTestClocksPost2Client(t *testing.T) {
@@ -11120,7 +11120,7 @@ func TestTestHelpersTestClocksPost2Client(t *testing.T) {
 	}
 	result, err := sc.V1TestHelpersTestClocks.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersFailPost(t *testing.T) {
@@ -11131,7 +11131,7 @@ func TestTestHelpersTreasuryInboundTransfersFailPost(t *testing.T) {
 	}
 	result, err := testhelpers_treasury_inboundtransfer.Fail("ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersFailPostService(t *testing.T) {
@@ -11143,7 +11143,7 @@ func TestTestHelpersTreasuryInboundTransfersFailPostService(t *testing.T) {
 	}
 	result, err := sc.TestHelpersTreasuryInboundTransfers.Fail("ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersFailPostClient(t *testing.T) {
@@ -11156,7 +11156,7 @@ func TestTestHelpersTreasuryInboundTransfersFailPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTreasuryInboundTransfers.Fail(
 		context.TODO(), "ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersReturnPost(t *testing.T) {
@@ -11164,7 +11164,7 @@ func TestTestHelpersTreasuryInboundTransfersReturnPost(t *testing.T) {
 	result, err := testhelpers_treasury_inboundtransfer.ReturnInboundTransfer(
 		"ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersReturnPostService(t *testing.T) {
@@ -11173,7 +11173,7 @@ func TestTestHelpersTreasuryInboundTransfersReturnPostService(t *testing.T) {
 	result, err := sc.TestHelpersTreasuryInboundTransfers.ReturnInboundTransfer(
 		"ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersReturnPostClient(t *testing.T) {
@@ -11182,14 +11182,14 @@ func TestTestHelpersTreasuryInboundTransfersReturnPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTreasuryInboundTransfers.ReturnInboundTransfer(
 		context.TODO(), "ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersSucceedPost(t *testing.T) {
 	params := &stripe.TestHelpersTreasuryInboundTransferSucceedParams{}
 	result, err := testhelpers_treasury_inboundtransfer.Succeed("ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersSucceedPostService(t *testing.T) {
@@ -11198,7 +11198,7 @@ func TestTestHelpersTreasuryInboundTransfersSucceedPostService(t *testing.T) {
 	result, err := sc.TestHelpersTreasuryInboundTransfers.Succeed(
 		"ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryInboundTransfersSucceedPostClient(t *testing.T) {
@@ -11207,14 +11207,14 @@ func TestTestHelpersTreasuryInboundTransfersSucceedPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTreasuryInboundTransfers.Succeed(
 		context.TODO(), "ibt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersFailPost(t *testing.T) {
 	params := &stripe.TestHelpersTreasuryOutboundTransferFailParams{}
 	result, err := testhelpers_treasury_outboundtransfer.Fail("obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersFailPostService(t *testing.T) {
@@ -11222,7 +11222,7 @@ func TestTestHelpersTreasuryOutboundTransfersFailPostService(t *testing.T) {
 	params := &stripe.TestHelpersTreasuryOutboundTransferFailParams{}
 	result, err := sc.TestHelpersTreasuryOutboundTransfers.Fail("obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersFailPostClient(t *testing.T) {
@@ -11231,14 +11231,14 @@ func TestTestHelpersTreasuryOutboundTransfersFailPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTreasuryOutboundTransfers.Fail(
 		context.TODO(), "obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersPostPost(t *testing.T) {
 	params := &stripe.TestHelpersTreasuryOutboundTransferPostParams{}
 	result, err := testhelpers_treasury_outboundtransfer.Post("obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersPostPostService(t *testing.T) {
@@ -11246,7 +11246,7 @@ func TestTestHelpersTreasuryOutboundTransfersPostPostService(t *testing.T) {
 	params := &stripe.TestHelpersTreasuryOutboundTransferPostParams{}
 	result, err := sc.TestHelpersTreasuryOutboundTransfers.Post("obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersPostPostClient(t *testing.T) {
@@ -11255,7 +11255,7 @@ func TestTestHelpersTreasuryOutboundTransfersPostPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTreasuryOutboundTransfers.Post(
 		context.TODO(), "obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersReturnPost(t *testing.T) {
@@ -11267,7 +11267,7 @@ func TestTestHelpersTreasuryOutboundTransfersReturnPost(t *testing.T) {
 	result, err := testhelpers_treasury_outboundtransfer.ReturnOutboundTransfer(
 		"obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersReturnPostService(t *testing.T) {
@@ -11280,7 +11280,7 @@ func TestTestHelpersTreasuryOutboundTransfersReturnPostService(t *testing.T) {
 	result, err := sc.TestHelpersTreasuryOutboundTransfers.ReturnOutboundTransfer(
 		"obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryOutboundTransfersReturnPostClient(t *testing.T) {
@@ -11293,7 +11293,7 @@ func TestTestHelpersTreasuryOutboundTransfersReturnPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTreasuryOutboundTransfers.ReturnOutboundTransfer(
 		context.TODO(), "obt_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryReceivedCreditsPost(t *testing.T) {
@@ -11305,7 +11305,7 @@ func TestTestHelpersTreasuryReceivedCreditsPost(t *testing.T) {
 	}
 	result, err := testhelpers_treasury_receivedcredit.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryReceivedCreditsPostService(t *testing.T) {
@@ -11318,7 +11318,7 @@ func TestTestHelpersTreasuryReceivedCreditsPostService(t *testing.T) {
 	}
 	result, err := sc.TestHelpersTreasuryReceivedCredits.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryReceivedCreditsPostClient(t *testing.T) {
@@ -11332,7 +11332,7 @@ func TestTestHelpersTreasuryReceivedCreditsPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTreasuryReceivedCredits.Create(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryReceivedDebitsPost(t *testing.T) {
@@ -11344,7 +11344,7 @@ func TestTestHelpersTreasuryReceivedDebitsPost(t *testing.T) {
 	}
 	result, err := testhelpers_treasury_receiveddebit.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryReceivedDebitsPostService(t *testing.T) {
@@ -11357,7 +11357,7 @@ func TestTestHelpersTreasuryReceivedDebitsPostService(t *testing.T) {
 	}
 	result, err := sc.TestHelpersTreasuryReceivedDebits.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTestHelpersTreasuryReceivedDebitsPostClient(t *testing.T) {
@@ -11371,14 +11371,14 @@ func TestTestHelpersTreasuryReceivedDebitsPostClient(t *testing.T) {
 	result, err := sc.V1TestHelpersTreasuryReceivedDebits.Create(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensGet(t *testing.T) {
 	params := &stripe.TokenParams{}
 	result, err := token.Get("tok_xxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensGetService(t *testing.T) {
@@ -11386,7 +11386,7 @@ func TestTokensGetService(t *testing.T) {
 	params := &stripe.TokenParams{}
 	result, err := sc.Tokens.Get("tok_xxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensGetClient(t *testing.T) {
@@ -11394,7 +11394,7 @@ func TestTokensGetClient(t *testing.T) {
 	params := &stripe.TokenRetrieveParams{}
 	result, err := sc.V1Tokens.Retrieve(context.TODO(), "tok_xxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost(t *testing.T) {
@@ -11408,7 +11408,7 @@ func TestTokensPost(t *testing.T) {
 	}
 	result, err := token.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPostService(t *testing.T) {
@@ -11423,7 +11423,7 @@ func TestTokensPostService(t *testing.T) {
 	}
 	result, err := sc.Tokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPostClient(t *testing.T) {
@@ -11438,7 +11438,7 @@ func TestTokensPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Tokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost2(t *testing.T) {
@@ -11454,7 +11454,7 @@ func TestTokensPost2(t *testing.T) {
 	}
 	result, err := token.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost2Service(t *testing.T) {
@@ -11471,7 +11471,7 @@ func TestTokensPost2Service(t *testing.T) {
 	}
 	result, err := sc.Tokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost2Client(t *testing.T) {
@@ -11488,7 +11488,7 @@ func TestTokensPost2Client(t *testing.T) {
 	}
 	result, err := sc.V1Tokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost3(t *testing.T) {
@@ -11497,7 +11497,7 @@ func TestTokensPost3(t *testing.T) {
 	}
 	result, err := token.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost3Service(t *testing.T) {
@@ -11507,7 +11507,7 @@ func TestTokensPost3Service(t *testing.T) {
 	}
 	result, err := sc.Tokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost3Client(t *testing.T) {
@@ -11517,7 +11517,7 @@ func TestTokensPost3Client(t *testing.T) {
 	}
 	result, err := sc.V1Tokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost4(t *testing.T) {
@@ -11532,7 +11532,7 @@ func TestTokensPost4(t *testing.T) {
 	}
 	result, err := token.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost4Service(t *testing.T) {
@@ -11548,7 +11548,7 @@ func TestTokensPost4Service(t *testing.T) {
 	}
 	result, err := sc.Tokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost4Client(t *testing.T) {
@@ -11564,7 +11564,7 @@ func TestTokensPost4Client(t *testing.T) {
 	}
 	result, err := sc.V1Tokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost5(t *testing.T) {
@@ -11577,7 +11577,7 @@ func TestTokensPost5(t *testing.T) {
 	}
 	result, err := token.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost5Service(t *testing.T) {
@@ -11591,7 +11591,7 @@ func TestTokensPost5Service(t *testing.T) {
 	}
 	result, err := sc.Tokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost5Client(t *testing.T) {
@@ -11605,7 +11605,7 @@ func TestTokensPost5Client(t *testing.T) {
 	}
 	result, err := sc.V1Tokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost6(t *testing.T) {
@@ -11614,7 +11614,7 @@ func TestTokensPost6(t *testing.T) {
 	}
 	result, err := token.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost6Service(t *testing.T) {
@@ -11624,7 +11624,7 @@ func TestTokensPost6Service(t *testing.T) {
 	}
 	result, err := sc.Tokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTokensPost6Client(t *testing.T) {
@@ -11634,14 +11634,14 @@ func TestTokensPost6Client(t *testing.T) {
 	}
 	result, err := sc.V1Tokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsCancelPost(t *testing.T) {
 	params := &stripe.TopupParams{}
 	result, err := topup.Cancel("tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsCancelPostService(t *testing.T) {
@@ -11649,7 +11649,7 @@ func TestTopupsCancelPostService(t *testing.T) {
 	params := &stripe.TopupParams{}
 	result, err := sc.Topups.Cancel("tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsCancelPostClient(t *testing.T) {
@@ -11657,7 +11657,7 @@ func TestTopupsCancelPostClient(t *testing.T) {
 	params := &stripe.TopupCancelParams{}
 	result, err := sc.V1Topups.Cancel(context.TODO(), "tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsGet(t *testing.T) {
@@ -11665,7 +11665,7 @@ func TestTopupsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := topup.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTopupsGetService(t *testing.T) {
@@ -11674,7 +11674,7 @@ func TestTopupsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Topups.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTopupsGetClient(t *testing.T) {
@@ -11683,14 +11683,14 @@ func TestTopupsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Topups.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTopupsGet2(t *testing.T) {
 	params := &stripe.TopupParams{}
 	result, err := topup.Get("tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsGet2Service(t *testing.T) {
@@ -11698,7 +11698,7 @@ func TestTopupsGet2Service(t *testing.T) {
 	params := &stripe.TopupParams{}
 	result, err := sc.Topups.Get("tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsGet2Client(t *testing.T) {
@@ -11707,7 +11707,7 @@ func TestTopupsGet2Client(t *testing.T) {
 	result, err := sc.V1Topups.Retrieve(
 		context.TODO(), "tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsPost(t *testing.T) {
@@ -11719,7 +11719,7 @@ func TestTopupsPost(t *testing.T) {
 	}
 	result, err := topup.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsPostService(t *testing.T) {
@@ -11732,7 +11732,7 @@ func TestTopupsPostService(t *testing.T) {
 	}
 	result, err := sc.Topups.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsPostClient(t *testing.T) {
@@ -11745,7 +11745,7 @@ func TestTopupsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Topups.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsPost2(t *testing.T) {
@@ -11753,7 +11753,7 @@ func TestTopupsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := topup.Update("tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsPost2Service(t *testing.T) {
@@ -11762,7 +11762,7 @@ func TestTopupsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Topups.Update("tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopupsPost2Client(t *testing.T) {
@@ -11771,7 +11771,7 @@ func TestTopupsPost2Client(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.V1Topups.Update(context.TODO(), "tu_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersGet(t *testing.T) {
@@ -11779,7 +11779,7 @@ func TestTransfersGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := transfer.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTransfersGetService(t *testing.T) {
@@ -11788,7 +11788,7 @@ func TestTransfersGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.Transfers.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTransfersGetClient(t *testing.T) {
@@ -11797,14 +11797,14 @@ func TestTransfersGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1Transfers.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTransfersGet2(t *testing.T) {
 	params := &stripe.TransferParams{}
 	result, err := transfer.Get("tr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersGet2Service(t *testing.T) {
@@ -11812,7 +11812,7 @@ func TestTransfersGet2Service(t *testing.T) {
 	params := &stripe.TransferParams{}
 	result, err := sc.Transfers.Get("tr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersGet2Client(t *testing.T) {
@@ -11821,7 +11821,7 @@ func TestTransfersGet2Client(t *testing.T) {
 	result, err := sc.V1Transfers.Retrieve(
 		context.TODO(), "tr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersPost(t *testing.T) {
@@ -11833,7 +11833,7 @@ func TestTransfersPost(t *testing.T) {
 	}
 	result, err := transfer.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersPostService(t *testing.T) {
@@ -11846,7 +11846,7 @@ func TestTransfersPostService(t *testing.T) {
 	}
 	result, err := sc.Transfers.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersPostClient(t *testing.T) {
@@ -11859,7 +11859,7 @@ func TestTransfersPostClient(t *testing.T) {
 	}
 	result, err := sc.V1Transfers.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersPost2(t *testing.T) {
@@ -11867,7 +11867,7 @@ func TestTransfersPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := transfer.Update("tr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersPost2Service(t *testing.T) {
@@ -11876,7 +11876,7 @@ func TestTransfersPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.Transfers.Update("tr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersPost2Client(t *testing.T) {
@@ -11886,7 +11886,7 @@ func TestTransfersPost2Client(t *testing.T) {
 	result, err := sc.V1Transfers.Update(
 		context.TODO(), "tr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsGet(t *testing.T) {
@@ -11896,7 +11896,7 @@ func TestTransfersReversalsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := transferreversal.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTransfersReversalsGetService(t *testing.T) {
@@ -11907,7 +11907,7 @@ func TestTransfersReversalsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TransferReversals.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTransfersReversalsGetClient(t *testing.T) {
@@ -11918,7 +11918,7 @@ func TestTransfersReversalsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TransferReversals.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTransfersReversalsGet2(t *testing.T) {
@@ -11927,7 +11927,7 @@ func TestTransfersReversalsGet2(t *testing.T) {
 	}
 	result, err := transferreversal.Get("trr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsGet2Service(t *testing.T) {
@@ -11937,7 +11937,7 @@ func TestTransfersReversalsGet2Service(t *testing.T) {
 	}
 	result, err := sc.TransferReversals.Get("trr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsGet2Client(t *testing.T) {
@@ -11948,7 +11948,7 @@ func TestTransfersReversalsGet2Client(t *testing.T) {
 	result, err := sc.V1TransferReversals.Retrieve(
 		context.TODO(), "trr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsPost(t *testing.T) {
@@ -11958,7 +11958,7 @@ func TestTransfersReversalsPost(t *testing.T) {
 	}
 	result, err := transferreversal.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsPostService(t *testing.T) {
@@ -11969,7 +11969,7 @@ func TestTransfersReversalsPostService(t *testing.T) {
 	}
 	result, err := sc.TransferReversals.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsPostClient(t *testing.T) {
@@ -11980,7 +11980,7 @@ func TestTransfersReversalsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TransferReversals.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsPost2(t *testing.T) {
@@ -11990,7 +11990,7 @@ func TestTransfersReversalsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := transferreversal.Update("trr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsPost2Service(t *testing.T) {
@@ -12001,7 +12001,7 @@ func TestTransfersReversalsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.TransferReversals.Update("trr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTransfersReversalsPost2Client(t *testing.T) {
@@ -12013,7 +12013,7 @@ func TestTransfersReversalsPost2Client(t *testing.T) {
 	result, err := sc.V1TransferReversals.Update(
 		context.TODO(), "trr_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryCreditReversalsGet(t *testing.T) {
@@ -12023,7 +12023,7 @@ func TestTreasuryCreditReversalsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_creditreversal.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryCreditReversalsGetService(t *testing.T) {
@@ -12034,7 +12034,7 @@ func TestTreasuryCreditReversalsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryCreditReversals.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryCreditReversalsGetClient(t *testing.T) {
@@ -12045,14 +12045,14 @@ func TestTreasuryCreditReversalsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryCreditReversals.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryCreditReversalsGet2(t *testing.T) {
 	params := &stripe.TreasuryCreditReversalParams{}
 	result, err := treasury_creditreversal.Get("credrev_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryCreditReversalsGet2Service(t *testing.T) {
@@ -12060,7 +12060,7 @@ func TestTreasuryCreditReversalsGet2Service(t *testing.T) {
 	params := &stripe.TreasuryCreditReversalParams{}
 	result, err := sc.TreasuryCreditReversals.Get("credrev_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryCreditReversalsGet2Client(t *testing.T) {
@@ -12069,7 +12069,7 @@ func TestTreasuryCreditReversalsGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryCreditReversals.Retrieve(
 		context.TODO(), "credrev_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryCreditReversalsPost(t *testing.T) {
@@ -12078,7 +12078,7 @@ func TestTreasuryCreditReversalsPost(t *testing.T) {
 	}
 	result, err := treasury_creditreversal.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryCreditReversalsPostService(t *testing.T) {
@@ -12088,7 +12088,7 @@ func TestTreasuryCreditReversalsPostService(t *testing.T) {
 	}
 	result, err := sc.TreasuryCreditReversals.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryCreditReversalsPostClient(t *testing.T) {
@@ -12098,7 +12098,7 @@ func TestTreasuryCreditReversalsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TreasuryCreditReversals.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryDebitReversalsGet(t *testing.T) {
@@ -12108,7 +12108,7 @@ func TestTreasuryDebitReversalsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_debitreversal.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryDebitReversalsGetService(t *testing.T) {
@@ -12119,7 +12119,7 @@ func TestTreasuryDebitReversalsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryDebitReversals.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryDebitReversalsGetClient(t *testing.T) {
@@ -12130,14 +12130,14 @@ func TestTreasuryDebitReversalsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryDebitReversals.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryDebitReversalsGet2(t *testing.T) {
 	params := &stripe.TreasuryDebitReversalParams{}
 	result, err := treasury_debitreversal.Get("debrev_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryDebitReversalsGet2Service(t *testing.T) {
@@ -12145,7 +12145,7 @@ func TestTreasuryDebitReversalsGet2Service(t *testing.T) {
 	params := &stripe.TreasuryDebitReversalParams{}
 	result, err := sc.TreasuryDebitReversals.Get("debrev_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryDebitReversalsGet2Client(t *testing.T) {
@@ -12154,7 +12154,7 @@ func TestTreasuryDebitReversalsGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryDebitReversals.Retrieve(
 		context.TODO(), "debrev_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryDebitReversalsPost(t *testing.T) {
@@ -12163,7 +12163,7 @@ func TestTreasuryDebitReversalsPost(t *testing.T) {
 	}
 	result, err := treasury_debitreversal.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryDebitReversalsPostService(t *testing.T) {
@@ -12173,7 +12173,7 @@ func TestTreasuryDebitReversalsPostService(t *testing.T) {
 	}
 	result, err := sc.TreasuryDebitReversals.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryDebitReversalsPostClient(t *testing.T) {
@@ -12183,7 +12183,7 @@ func TestTreasuryDebitReversalsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TreasuryDebitReversals.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsFeaturesGet(t *testing.T) {
@@ -12191,7 +12191,7 @@ func TestTreasuryFinancialAccountsFeaturesGet(t *testing.T) {
 	result, err := treasury_financialaccount.RetrieveFeatures(
 		"fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsFeaturesGetService(t *testing.T) {
@@ -12200,7 +12200,7 @@ func TestTreasuryFinancialAccountsFeaturesGetService(t *testing.T) {
 	result, err := sc.TreasuryFinancialAccounts.RetrieveFeatures(
 		"fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsFeaturesGetClient(t *testing.T) {
@@ -12209,7 +12209,7 @@ func TestTreasuryFinancialAccountsFeaturesGetClient(t *testing.T) {
 	result, err := sc.V1TreasuryFinancialAccounts.RetrieveFeatures(
 		context.TODO(), "fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsGet(t *testing.T) {
@@ -12217,7 +12217,7 @@ func TestTreasuryFinancialAccountsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_financialaccount.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryFinancialAccountsGetService(t *testing.T) {
@@ -12226,7 +12226,7 @@ func TestTreasuryFinancialAccountsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryFinancialAccounts.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryFinancialAccountsGetClient(t *testing.T) {
@@ -12235,14 +12235,14 @@ func TestTreasuryFinancialAccountsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryFinancialAccounts.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryFinancialAccountsGet2(t *testing.T) {
 	params := &stripe.TreasuryFinancialAccountParams{}
 	result, err := treasury_financialaccount.Get("fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsGet2Service(t *testing.T) {
@@ -12250,7 +12250,7 @@ func TestTreasuryFinancialAccountsGet2Service(t *testing.T) {
 	params := &stripe.TreasuryFinancialAccountParams{}
 	result, err := sc.TreasuryFinancialAccounts.Get("fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsGet2Client(t *testing.T) {
@@ -12259,7 +12259,7 @@ func TestTreasuryFinancialAccountsGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryFinancialAccounts.Retrieve(
 		context.TODO(), "fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsPost(t *testing.T) {
@@ -12269,7 +12269,7 @@ func TestTreasuryFinancialAccountsPost(t *testing.T) {
 	}
 	result, err := treasury_financialaccount.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsPostService(t *testing.T) {
@@ -12280,7 +12280,7 @@ func TestTreasuryFinancialAccountsPostService(t *testing.T) {
 	}
 	result, err := sc.TreasuryFinancialAccounts.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsPostClient(t *testing.T) {
@@ -12291,7 +12291,7 @@ func TestTreasuryFinancialAccountsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TreasuryFinancialAccounts.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsPost2(t *testing.T) {
@@ -12299,7 +12299,7 @@ func TestTreasuryFinancialAccountsPost2(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := treasury_financialaccount.Update("fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsPost2Service(t *testing.T) {
@@ -12308,7 +12308,7 @@ func TestTreasuryFinancialAccountsPost2Service(t *testing.T) {
 	params.AddMetadata("order_id", "6735")
 	result, err := sc.TreasuryFinancialAccounts.Update("fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryFinancialAccountsPost2Client(t *testing.T) {
@@ -12318,14 +12318,14 @@ func TestTreasuryFinancialAccountsPost2Client(t *testing.T) {
 	result, err := sc.V1TreasuryFinancialAccounts.Update(
 		context.TODO(), "fa_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersCancelPost(t *testing.T) {
 	params := &stripe.TreasuryInboundTransferCancelParams{}
 	result, err := treasury_inboundtransfer.Cancel("ibt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersCancelPostService(t *testing.T) {
@@ -12333,7 +12333,7 @@ func TestTreasuryInboundTransfersCancelPostService(t *testing.T) {
 	params := &stripe.TreasuryInboundTransferCancelParams{}
 	result, err := sc.TreasuryInboundTransfers.Cancel("ibt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersCancelPostClient(t *testing.T) {
@@ -12342,7 +12342,7 @@ func TestTreasuryInboundTransfersCancelPostClient(t *testing.T) {
 	result, err := sc.V1TreasuryInboundTransfers.Cancel(
 		context.TODO(), "ibt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersGet(t *testing.T) {
@@ -12352,7 +12352,7 @@ func TestTreasuryInboundTransfersGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_inboundtransfer.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryInboundTransfersGetService(t *testing.T) {
@@ -12363,7 +12363,7 @@ func TestTreasuryInboundTransfersGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryInboundTransfers.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryInboundTransfersGetClient(t *testing.T) {
@@ -12374,14 +12374,14 @@ func TestTreasuryInboundTransfersGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryInboundTransfers.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryInboundTransfersGet2(t *testing.T) {
 	params := &stripe.TreasuryInboundTransferParams{}
 	result, err := treasury_inboundtransfer.Get("ibt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersGet2Service(t *testing.T) {
@@ -12389,7 +12389,7 @@ func TestTreasuryInboundTransfersGet2Service(t *testing.T) {
 	params := &stripe.TreasuryInboundTransferParams{}
 	result, err := sc.TreasuryInboundTransfers.Get("ibt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersGet2Client(t *testing.T) {
@@ -12398,7 +12398,7 @@ func TestTreasuryInboundTransfersGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryInboundTransfers.Retrieve(
 		context.TODO(), "ibt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersPost(t *testing.T) {
@@ -12411,7 +12411,7 @@ func TestTreasuryInboundTransfersPost(t *testing.T) {
 	}
 	result, err := treasury_inboundtransfer.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersPostService(t *testing.T) {
@@ -12425,7 +12425,7 @@ func TestTreasuryInboundTransfersPostService(t *testing.T) {
 	}
 	result, err := sc.TreasuryInboundTransfers.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryInboundTransfersPostClient(t *testing.T) {
@@ -12439,14 +12439,14 @@ func TestTreasuryInboundTransfersPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TreasuryInboundTransfers.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsCancelPost(t *testing.T) {
 	params := &stripe.TreasuryOutboundPaymentCancelParams{}
 	result, err := treasury_outboundpayment.Cancel("bot_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsCancelPostService(t *testing.T) {
@@ -12454,7 +12454,7 @@ func TestTreasuryOutboundPaymentsCancelPostService(t *testing.T) {
 	params := &stripe.TreasuryOutboundPaymentCancelParams{}
 	result, err := sc.TreasuryOutboundPayments.Cancel("bot_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsCancelPostClient(t *testing.T) {
@@ -12463,7 +12463,7 @@ func TestTreasuryOutboundPaymentsCancelPostClient(t *testing.T) {
 	result, err := sc.V1TreasuryOutboundPayments.Cancel(
 		context.TODO(), "bot_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsGet(t *testing.T) {
@@ -12473,7 +12473,7 @@ func TestTreasuryOutboundPaymentsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_outboundpayment.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryOutboundPaymentsGetService(t *testing.T) {
@@ -12484,7 +12484,7 @@ func TestTreasuryOutboundPaymentsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryOutboundPayments.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryOutboundPaymentsGetClient(t *testing.T) {
@@ -12495,14 +12495,14 @@ func TestTreasuryOutboundPaymentsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryOutboundPayments.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryOutboundPaymentsGet2(t *testing.T) {
 	params := &stripe.TreasuryOutboundPaymentParams{}
 	result, err := treasury_outboundpayment.Get("bot_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsGet2Service(t *testing.T) {
@@ -12510,7 +12510,7 @@ func TestTreasuryOutboundPaymentsGet2Service(t *testing.T) {
 	params := &stripe.TreasuryOutboundPaymentParams{}
 	result, err := sc.TreasuryOutboundPayments.Get("bot_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsGet2Client(t *testing.T) {
@@ -12519,7 +12519,7 @@ func TestTreasuryOutboundPaymentsGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryOutboundPayments.Retrieve(
 		context.TODO(), "bot_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsPost(t *testing.T) {
@@ -12533,7 +12533,7 @@ func TestTreasuryOutboundPaymentsPost(t *testing.T) {
 	}
 	result, err := treasury_outboundpayment.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsPostService(t *testing.T) {
@@ -12548,7 +12548,7 @@ func TestTreasuryOutboundPaymentsPostService(t *testing.T) {
 	}
 	result, err := sc.TreasuryOutboundPayments.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundPaymentsPostClient(t *testing.T) {
@@ -12563,14 +12563,14 @@ func TestTreasuryOutboundPaymentsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TreasuryOutboundPayments.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersCancelPost(t *testing.T) {
 	params := &stripe.TreasuryOutboundTransferCancelParams{}
 	result, err := treasury_outboundtransfer.Cancel("obt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersCancelPostService(t *testing.T) {
@@ -12579,7 +12579,7 @@ func TestTreasuryOutboundTransfersCancelPostService(t *testing.T) {
 	result, err := sc.TreasuryOutboundTransfers.Cancel(
 		"obt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersCancelPostClient(t *testing.T) {
@@ -12588,7 +12588,7 @@ func TestTreasuryOutboundTransfersCancelPostClient(t *testing.T) {
 	result, err := sc.V1TreasuryOutboundTransfers.Cancel(
 		context.TODO(), "obt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersGet(t *testing.T) {
@@ -12598,7 +12598,7 @@ func TestTreasuryOutboundTransfersGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_outboundtransfer.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryOutboundTransfersGetService(t *testing.T) {
@@ -12609,7 +12609,7 @@ func TestTreasuryOutboundTransfersGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryOutboundTransfers.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryOutboundTransfersGetClient(t *testing.T) {
@@ -12620,14 +12620,14 @@ func TestTreasuryOutboundTransfersGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryOutboundTransfers.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryOutboundTransfersGet2(t *testing.T) {
 	params := &stripe.TreasuryOutboundTransferParams{}
 	result, err := treasury_outboundtransfer.Get("obt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersGet2Service(t *testing.T) {
@@ -12635,7 +12635,7 @@ func TestTreasuryOutboundTransfersGet2Service(t *testing.T) {
 	params := &stripe.TreasuryOutboundTransferParams{}
 	result, err := sc.TreasuryOutboundTransfers.Get("obt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersGet2Client(t *testing.T) {
@@ -12644,7 +12644,7 @@ func TestTreasuryOutboundTransfersGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryOutboundTransfers.Retrieve(
 		context.TODO(), "obt_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersPost(t *testing.T) {
@@ -12657,7 +12657,7 @@ func TestTreasuryOutboundTransfersPost(t *testing.T) {
 	}
 	result, err := treasury_outboundtransfer.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersPostService(t *testing.T) {
@@ -12671,7 +12671,7 @@ func TestTreasuryOutboundTransfersPostService(t *testing.T) {
 	}
 	result, err := sc.TreasuryOutboundTransfers.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryOutboundTransfersPostClient(t *testing.T) {
@@ -12685,7 +12685,7 @@ func TestTreasuryOutboundTransfersPostClient(t *testing.T) {
 	}
 	result, err := sc.V1TreasuryOutboundTransfers.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryReceivedCreditsGet(t *testing.T) {
@@ -12695,7 +12695,7 @@ func TestTreasuryReceivedCreditsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_receivedcredit.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryReceivedCreditsGetService(t *testing.T) {
@@ -12706,7 +12706,7 @@ func TestTreasuryReceivedCreditsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryReceivedCredits.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryReceivedCreditsGetClient(t *testing.T) {
@@ -12717,14 +12717,14 @@ func TestTreasuryReceivedCreditsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryReceivedCredits.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryReceivedCreditsGet2(t *testing.T) {
 	params := &stripe.TreasuryReceivedCreditParams{}
 	result, err := treasury_receivedcredit.Get("rc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryReceivedCreditsGet2Service(t *testing.T) {
@@ -12732,7 +12732,7 @@ func TestTreasuryReceivedCreditsGet2Service(t *testing.T) {
 	params := &stripe.TreasuryReceivedCreditParams{}
 	result, err := sc.TreasuryReceivedCredits.Get("rc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryReceivedCreditsGet2Client(t *testing.T) {
@@ -12741,7 +12741,7 @@ func TestTreasuryReceivedCreditsGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryReceivedCredits.Retrieve(
 		context.TODO(), "rc_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryReceivedDebitsGet(t *testing.T) {
@@ -12751,7 +12751,7 @@ func TestTreasuryReceivedDebitsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_receiveddebit.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryReceivedDebitsGetService(t *testing.T) {
@@ -12762,7 +12762,7 @@ func TestTreasuryReceivedDebitsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryReceivedDebits.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryReceivedDebitsGetClient(t *testing.T) {
@@ -12773,14 +12773,14 @@ func TestTreasuryReceivedDebitsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryReceivedDebits.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryReceivedDebitsGet2(t *testing.T) {
 	params := &stripe.TreasuryReceivedDebitParams{}
 	result, err := treasury_receiveddebit.Get("rd_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryReceivedDebitsGet2Service(t *testing.T) {
@@ -12788,7 +12788,7 @@ func TestTreasuryReceivedDebitsGet2Service(t *testing.T) {
 	params := &stripe.TreasuryReceivedDebitParams{}
 	result, err := sc.TreasuryReceivedDebits.Get("rd_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryReceivedDebitsGet2Client(t *testing.T) {
@@ -12797,7 +12797,7 @@ func TestTreasuryReceivedDebitsGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryReceivedDebits.Retrieve(
 		context.TODO(), "rd_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryTransactionEntriesGet(t *testing.T) {
@@ -12807,7 +12807,7 @@ func TestTreasuryTransactionEntriesGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_transactionentry.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryTransactionEntriesGetService(t *testing.T) {
@@ -12818,7 +12818,7 @@ func TestTreasuryTransactionEntriesGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryTransactionEntries.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryTransactionEntriesGetClient(t *testing.T) {
@@ -12829,14 +12829,14 @@ func TestTreasuryTransactionEntriesGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryTransactionEntries.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryTransactionEntriesGet2(t *testing.T) {
 	params := &stripe.TreasuryTransactionEntryParams{}
 	result, err := treasury_transactionentry.Get("trxne_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryTransactionEntriesGet2Service(t *testing.T) {
@@ -12845,7 +12845,7 @@ func TestTreasuryTransactionEntriesGet2Service(t *testing.T) {
 	result, err := sc.TreasuryTransactionEntries.Get(
 		"trxne_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryTransactionEntriesGet2Client(t *testing.T) {
@@ -12854,7 +12854,7 @@ func TestTreasuryTransactionEntriesGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryTransactionEntries.Retrieve(
 		context.TODO(), "trxne_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryTransactionsGet(t *testing.T) {
@@ -12864,7 +12864,7 @@ func TestTreasuryTransactionsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := treasury_transaction.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryTransactionsGetService(t *testing.T) {
@@ -12875,7 +12875,7 @@ func TestTreasuryTransactionsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.TreasuryTransactions.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryTransactionsGetClient(t *testing.T) {
@@ -12886,14 +12886,14 @@ func TestTreasuryTransactionsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1TreasuryTransactions.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestTreasuryTransactionsGet2(t *testing.T) {
 	params := &stripe.TreasuryTransactionParams{}
 	result, err := treasury_transaction.Get("trxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryTransactionsGet2Service(t *testing.T) {
@@ -12901,7 +12901,7 @@ func TestTreasuryTransactionsGet2Service(t *testing.T) {
 	params := &stripe.TreasuryTransactionParams{}
 	result, err := sc.TreasuryTransactions.Get("trxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTreasuryTransactionsGet2Client(t *testing.T) {
@@ -12910,14 +12910,14 @@ func TestTreasuryTransactionsGet2Client(t *testing.T) {
 	result, err := sc.V1TreasuryTransactions.Retrieve(
 		context.TODO(), "trxn_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsDelete(t *testing.T) {
 	params := &stripe.WebhookEndpointParams{}
 	result, err := webhookendpoint.Del("we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsDeleteService(t *testing.T) {
@@ -12925,7 +12925,7 @@ func TestWebhookEndpointsDeleteService(t *testing.T) {
 	params := &stripe.WebhookEndpointParams{}
 	result, err := sc.WebhookEndpoints.Del("we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsDeleteClient(t *testing.T) {
@@ -12934,7 +12934,7 @@ func TestWebhookEndpointsDeleteClient(t *testing.T) {
 	result, err := sc.V1WebhookEndpoints.Delete(
 		context.TODO(), "we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsGet(t *testing.T) {
@@ -12942,7 +12942,7 @@ func TestWebhookEndpointsGet(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := webhookendpoint.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestWebhookEndpointsGetService(t *testing.T) {
@@ -12951,7 +12951,7 @@ func TestWebhookEndpointsGetService(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.WebhookEndpoints.List(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestWebhookEndpointsGetClient(t *testing.T) {
@@ -12960,14 +12960,14 @@ func TestWebhookEndpointsGetClient(t *testing.T) {
 	params.Limit = stripe.Int64(3)
 	result := sc.V1WebhookEndpoints.List(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, result.Err())
+	assert.NoError(t, result.Err())
 }
 
 func TestWebhookEndpointsGet2(t *testing.T) {
 	params := &stripe.WebhookEndpointParams{}
 	result, err := webhookendpoint.Get("we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsGet2Service(t *testing.T) {
@@ -12975,7 +12975,7 @@ func TestWebhookEndpointsGet2Service(t *testing.T) {
 	params := &stripe.WebhookEndpointParams{}
 	result, err := sc.WebhookEndpoints.Get("we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsGet2Client(t *testing.T) {
@@ -12984,7 +12984,7 @@ func TestWebhookEndpointsGet2Client(t *testing.T) {
 	result, err := sc.V1WebhookEndpoints.Retrieve(
 		context.TODO(), "we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsPost(t *testing.T) {
@@ -12997,7 +12997,7 @@ func TestWebhookEndpointsPost(t *testing.T) {
 	}
 	result, err := webhookendpoint.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsPostService(t *testing.T) {
@@ -13011,7 +13011,7 @@ func TestWebhookEndpointsPostService(t *testing.T) {
 	}
 	result, err := sc.WebhookEndpoints.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsPostClient(t *testing.T) {
@@ -13025,7 +13025,7 @@ func TestWebhookEndpointsPostClient(t *testing.T) {
 	}
 	result, err := sc.V1WebhookEndpoints.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsPost2(t *testing.T) {
@@ -13034,7 +13034,7 @@ func TestWebhookEndpointsPost2(t *testing.T) {
 	}
 	result, err := webhookendpoint.Update("we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsPost2Service(t *testing.T) {
@@ -13044,7 +13044,7 @@ func TestWebhookEndpointsPost2Service(t *testing.T) {
 	}
 	result, err := sc.WebhookEndpoints.Update("we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebhookEndpointsPost2Client(t *testing.T) {
@@ -13055,7 +13055,7 @@ func TestWebhookEndpointsPost2Client(t *testing.T) {
 	result, err := sc.V1WebhookEndpoints.Update(
 		context.TODO(), "we_xxxxxxxxxxxxx", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCoreEventsGetService(t *testing.T) {
@@ -13068,7 +13068,7 @@ func TestCoreEventsGetService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEvents.Get("ll_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCoreEventsGetClient(t *testing.T) {
@@ -13081,7 +13081,7 @@ func TestCoreEventsGetClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreEvents.Retrieve(context.TODO(), "ll_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2BillingMeterEventPostService(t *testing.T) {
@@ -13097,7 +13097,7 @@ func TestV2BillingMeterEventPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2BillingMeterEvents.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2BillingMeterEventPostClient(t *testing.T) {
@@ -13113,7 +13113,7 @@ func TestV2BillingMeterEventPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2BillingMeterEvents.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2BillingMeterEventAdjustmentPostService(t *testing.T) {
@@ -13132,7 +13132,7 @@ func TestV2BillingMeterEventAdjustmentPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2BillingMeterEventAdjustments.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2BillingMeterEventAdjustmentPostClient(t *testing.T) {
@@ -13152,7 +13152,7 @@ func TestV2BillingMeterEventAdjustmentPostClient(t *testing.T) {
 	result, err := sc.V2BillingMeterEventAdjustments.Create(
 		context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2BillingMeterEventSessionPostService(t *testing.T) {
@@ -13165,7 +13165,7 @@ func TestV2BillingMeterEventSessionPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2BillingMeterEventSessions.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2BillingMeterEventSessionPostClient(t *testing.T) {
@@ -13178,7 +13178,7 @@ func TestV2BillingMeterEventSessionPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2BillingMeterEventSessions.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2BillingMeterEventStreamPostService(t *testing.T) {
@@ -13198,7 +13198,8 @@ func TestV2BillingMeterEventStreamPostService(t *testing.T) {
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
 	sc := client.New(TestAPIKey, backends)
-	sc.V2BillingMeterEventStreams.New(params)
+	err := sc.V2BillingMeterEventStreams.New(params)
+	assert.NoError(t, err)
 }
 
 func TestV2BillingMeterEventStreamPostClient(t *testing.T) {
@@ -13218,7 +13219,8 @@ func TestV2BillingMeterEventStreamPostClient(t *testing.T) {
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
-	sc.V2BillingMeterEventStreams.Create(context.TODO(), params)
+	err := sc.V2BillingMeterEventStreams.Create(context.TODO(), params)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountGetService(t *testing.T) {
@@ -13255,7 +13257,7 @@ func TestV2CoreAccountPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccounts.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountPostClient(t *testing.T) {
@@ -13268,7 +13270,7 @@ func TestV2CoreAccountPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreAccounts.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountGet2Service(t *testing.T) {
@@ -13281,7 +13283,7 @@ func TestV2CoreAccountGet2Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccounts.Get("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountGet2Client(t *testing.T) {
@@ -13294,7 +13296,7 @@ func TestV2CoreAccountGet2Client(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreAccounts.Retrieve(context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountPost2Service(t *testing.T) {
@@ -13307,7 +13309,7 @@ func TestV2CoreAccountPost2Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccounts.Update("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountPost2Client(t *testing.T) {
@@ -13320,7 +13322,7 @@ func TestV2CoreAccountPost2Client(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreAccounts.Update(context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountPost3Service(t *testing.T) {
@@ -13333,7 +13335,7 @@ func TestV2CoreAccountPost3Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccounts.Close("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountPost3Client(t *testing.T) {
@@ -13346,7 +13348,7 @@ func TestV2CoreAccountPost3Client(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreAccounts.Close(context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonGetService(t *testing.T) {
@@ -13389,7 +13391,7 @@ func TestV2CoreAccountsPersonPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountsPersons.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonPostClient(t *testing.T) {
@@ -13404,7 +13406,7 @@ func TestV2CoreAccountsPersonPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreAccountsPersons.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonDeleteService(t *testing.T) {
@@ -13419,7 +13421,7 @@ func TestV2CoreAccountsPersonDeleteService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountsPersons.Del("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonDeleteClient(t *testing.T) {
@@ -13435,7 +13437,7 @@ func TestV2CoreAccountsPersonDeleteClient(t *testing.T) {
 	result, err := sc.V2CoreAccountsPersons.Delete(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonGet2Service(t *testing.T) {
@@ -13450,7 +13452,7 @@ func TestV2CoreAccountsPersonGet2Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountsPersons.Get("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonGet2Client(t *testing.T) {
@@ -13466,7 +13468,7 @@ func TestV2CoreAccountsPersonGet2Client(t *testing.T) {
 	result, err := sc.V2CoreAccountsPersons.Retrieve(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonPost2Service(t *testing.T) {
@@ -13481,7 +13483,7 @@ func TestV2CoreAccountsPersonPost2Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountsPersons.Update("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonPost2Client(t *testing.T) {
@@ -13497,7 +13499,7 @@ func TestV2CoreAccountsPersonPost2Client(t *testing.T) {
 	result, err := sc.V2CoreAccountsPersons.Update(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonTokenPostService(t *testing.T) {
@@ -13512,7 +13514,7 @@ func TestV2CoreAccountsPersonTokenPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountsPersonTokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonTokenPostClient(t *testing.T) {
@@ -13527,7 +13529,7 @@ func TestV2CoreAccountsPersonTokenPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreAccountsPersonTokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonTokenGetService(t *testing.T) {
@@ -13542,7 +13544,7 @@ func TestV2CoreAccountsPersonTokenGetService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountsPersonTokens.Get("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountsPersonTokenGetClient(t *testing.T) {
@@ -13558,7 +13560,7 @@ func TestV2CoreAccountsPersonTokenGetClient(t *testing.T) {
 	result, err := sc.V2CoreAccountsPersonTokens.Retrieve(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountLinkPostService(t *testing.T) {
@@ -13594,7 +13596,7 @@ func TestV2CoreAccountLinkPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountLinks.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountLinkPostClient(t *testing.T) {
@@ -13630,7 +13632,7 @@ func TestV2CoreAccountLinkPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreAccountLinks.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountTokenPostService(t *testing.T) {
@@ -13643,7 +13645,7 @@ func TestV2CoreAccountTokenPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountTokens.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountTokenPostClient(t *testing.T) {
@@ -13656,7 +13658,7 @@ func TestV2CoreAccountTokenPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreAccountTokens.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountTokenGetService(t *testing.T) {
@@ -13669,7 +13671,7 @@ func TestV2CoreAccountTokenGetService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreAccountTokens.Get("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreAccountTokenGetClient(t *testing.T) {
@@ -13683,7 +13685,7 @@ func TestV2CoreAccountTokenGetClient(t *testing.T) {
 	result, err := sc.V2CoreAccountTokens.Retrieve(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventGetService(t *testing.T) {
@@ -13720,7 +13722,7 @@ func TestV2CoreEventGet2Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEvents.Get("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventGet2Client(t *testing.T) {
@@ -13733,7 +13735,7 @@ func TestV2CoreEventGet2Client(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreEvents.Retrieve(context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationGetService(t *testing.T) {
@@ -13775,7 +13777,7 @@ func TestV2CoreEventDestinationPostService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEventDestinations.New(params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPostClient(t *testing.T) {
@@ -13793,7 +13795,7 @@ func TestV2CoreEventDestinationPostClient(t *testing.T) {
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 	result, err := sc.V2CoreEventDestinations.Create(context.TODO(), params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationDeleteService(t *testing.T) {
@@ -13806,7 +13808,7 @@ func TestV2CoreEventDestinationDeleteService(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEventDestinations.Del("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationDeleteClient(t *testing.T) {
@@ -13820,7 +13822,7 @@ func TestV2CoreEventDestinationDeleteClient(t *testing.T) {
 	result, err := sc.V2CoreEventDestinations.Delete(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationGet2Service(t *testing.T) {
@@ -13833,7 +13835,7 @@ func TestV2CoreEventDestinationGet2Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEventDestinations.Get("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationGet2Client(t *testing.T) {
@@ -13847,7 +13849,7 @@ func TestV2CoreEventDestinationGet2Client(t *testing.T) {
 	result, err := sc.V2CoreEventDestinations.Retrieve(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPost2Service(t *testing.T) {
@@ -13860,7 +13862,7 @@ func TestV2CoreEventDestinationPost2Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEventDestinations.Update("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPost2Client(t *testing.T) {
@@ -13874,7 +13876,7 @@ func TestV2CoreEventDestinationPost2Client(t *testing.T) {
 	result, err := sc.V2CoreEventDestinations.Update(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPost3Service(t *testing.T) {
@@ -13887,7 +13889,7 @@ func TestV2CoreEventDestinationPost3Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEventDestinations.Disable("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPost3Client(t *testing.T) {
@@ -13901,7 +13903,7 @@ func TestV2CoreEventDestinationPost3Client(t *testing.T) {
 	result, err := sc.V2CoreEventDestinations.Disable(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPost4Service(t *testing.T) {
@@ -13914,7 +13916,7 @@ func TestV2CoreEventDestinationPost4Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEventDestinations.Enable("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPost4Client(t *testing.T) {
@@ -13928,7 +13930,7 @@ func TestV2CoreEventDestinationPost4Client(t *testing.T) {
 	result, err := sc.V2CoreEventDestinations.Enable(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPost5Service(t *testing.T) {
@@ -13941,7 +13943,7 @@ func TestV2CoreEventDestinationPost5Service(t *testing.T) {
 	sc := client.New(TestAPIKey, backends)
 	result, err := sc.V2CoreEventDestinations.Ping("id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestV2CoreEventDestinationPost5Client(t *testing.T) {
@@ -13955,7 +13957,7 @@ func TestV2CoreEventDestinationPost5Client(t *testing.T) {
 	result, err := sc.V2CoreEventDestinations.Ping(
 		context.TODO(), "id_123", params)
 	assert.NotNil(t, result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRateLimitErrorService(t *testing.T) {
@@ -13997,7 +13999,8 @@ func TestTemporarySessionExpiredErrorService(t *testing.T) {
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
 	sc := client.New(TestAPIKey, backends)
-	sc.V2BillingMeterEventStreams.New(params)
+	err := sc.V2BillingMeterEventStreams.New(params)
+	assert.NoError(t, err)
 }
 
 func TestTemporarySessionExpiredErrorClient(t *testing.T) {
@@ -14015,5 +14018,6 @@ func TestTemporarySessionExpiredErrorClient(t *testing.T) {
 	backends := stripe.NewBackendsWithConfig(
 		&stripe.BackendConfig{URL: &testServer.URL})
 	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
-	sc.V2BillingMeterEventStreams.Create(context.TODO(), params)
+	err := sc.V2BillingMeterEventStreams.Create(context.TODO(), params)
+	assert.NoError(t, err)
 }

--- a/example/v2/event_notification_webhook_handler/event_notification_webhook_handler.go
+++ b/example/v2/event_notification_webhook_handler/event_notification_webhook_handler.go
@@ -56,7 +56,7 @@ func main() {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			fmt.Fprintf(os.Stdout, "Meter %s (%s) had a problem\n", meter.DisplayName, meter.ID)
+			_, _ = fmt.Fprintf(os.Stdout, "Meter %s (%s) had a problem\n", meter.DisplayName, meter.ID) // stdout write errors are not actionable in example code
 
 			// And you can always fetch the full event:
 			event, err := evt.FetchEvent(context.TODO())

--- a/example/v2/meter_event_stream/meter_event_stream.go
+++ b/example/v2/meter_event_stream/meter_event_stream.go
@@ -59,7 +59,7 @@ func sendMeterEvent(client rawrequest.Client, eventName string, stripeCustomerID
 	}
 
 	if sessionAuthToken == "" {
-		err = fmt.Errorf("Unable to refresh meter event session")
+		err = fmt.Errorf("unable to refresh meter event session")
 		return
 	}
 

--- a/example/v2/meter_event_stream/meter_event_stream.go
+++ b/example/v2/meter_event_stream/meter_event_stream.go
@@ -54,7 +54,9 @@ func refreshMeterEventSession(client rawrequest.Client) (err error) {
 
 func sendMeterEvent(client rawrequest.Client, eventName string, stripeCustomerID string, value string) (err error) {
 	// Refresh the meter event session if necessary
-	refreshMeterEventSession(client)
+	if err = refreshMeterEventSession(client); err != nil {
+		return
+	}
 
 	if sessionAuthToken == "" {
 		err = fmt.Errorf("Unable to refresh meter event session")

--- a/example_test.go
+++ b/example_test.go
@@ -17,7 +17,9 @@ func ExampleCharge_new() {
 		Amount:   stripe.Int64(1000),
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
 	}
-	params.SetSource("tok_visa")
+	if err := params.SetSource("tok_visa"); err != nil {
+		log.Fatal(err)
+	}
 	params.AddMetadata("key", "value")
 
 	ch, err := charge.New(params)

--- a/file/client_test.go
+++ b/file/client_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestFileGet(t *testing.T) {
 	file, err := Get("file_123", nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, file)
 }
 
@@ -60,7 +60,8 @@ func TestFileBackend(t *testing.T) {
 	b := &testBackend{calledMultipart: false}
 	stripe.SetBackend(stripe.UploadsBackend, b)
 	fileParams := &stripe.FileParams{}
-	New(fileParams)
+	_, err := New(fileParams)
+	assert.NoError(t, err)
 	assert.Equal(t, b.calledMultipart, true)
 	stripe.SetBackend(stripe.UploadsBackend, orig)
 }

--- a/form/form.go
+++ b/form/form.go
@@ -579,8 +579,8 @@ func (f *Values) Encode() string {
 			buf.WriteByte('&')
 		}
 		key := url.QueryEscape(v.Key)
-		key = strings.Replace(key, "%5B", "[", -1)
-		key = strings.Replace(key, "%5D", "]", -1)
+		key = strings.ReplaceAll(key, "%5B", "[")
+		key = strings.ReplaceAll(key, "%5D", "]")
 		buf.WriteString(key)
 		buf.WriteString("=")
 		buf.WriteString(url.QueryEscape(v.Value))

--- a/form/form.go
+++ b/form/form.go
@@ -1,3 +1,6 @@
+// Package form encodes Go structs into URL-encoded form values for Stripe API
+// requests. It uses struct field tags (e.g. `form:"name"`) to control encoding
+// behavior.
 package form
 
 import (

--- a/justfile
+++ b/justfile
@@ -38,8 +38,8 @@ build:
 # install dependencies (including those needed for development). Mostly called by other recipes
 install:
     go get -t
-    which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.11.4
-    which goimports || go install golang.org/x/tools/cmd/goimports@v0.39.0
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+    go install golang.org/x/tools/cmd/goimports@v0.39.0
 
 # run benchmarking to check for performance regressions
 bench:

--- a/log.go
+++ b/log.go
@@ -80,7 +80,9 @@ type LeveledLogger struct {
 // Debugf logs a debug message using Printf conventions.
 func (l *LeveledLogger) Debugf(format string, v ...interface{}) {
 	if l.Level >= LevelDebug {
-		fmt.Fprintf(l.stdout(), "[DEBUG] "+format+"\n", v...)
+		// Logger write failures are silently discarded — callers can't handle them,
+		// and adding error returns to these methods would be a breaking API change.
+		_, _ = fmt.Fprintf(l.stdout(), "[DEBUG] "+format+"\n", v...)
 	}
 }
 
@@ -88,21 +90,27 @@ func (l *LeveledLogger) Debugf(format string, v ...interface{}) {
 func (l *LeveledLogger) Errorf(format string, v ...interface{}) {
 	// Infof logs a debug message using Printf conventions.
 	if l.Level >= LevelError {
-		fmt.Fprintf(l.stderr(), "[ERROR] "+format+"\n", v...)
+		// Logger write failures are silently discarded — callers can't handle them,
+		// and adding error returns to these methods would be a breaking API change.
+		_, _ = fmt.Fprintf(l.stderr(), "[ERROR] "+format+"\n", v...)
 	}
 }
 
 // Infof logs an informational message using Printf conventions.
 func (l *LeveledLogger) Infof(format string, v ...interface{}) {
 	if l.Level >= LevelInfo {
-		fmt.Fprintf(l.stdout(), "[INFO] "+format+"\n", v...)
+		// Logger write failures are silently discarded — callers can't handle them,
+		// and adding error returns to these methods would be a breaking API change.
+		_, _ = fmt.Fprintf(l.stdout(), "[INFO] "+format+"\n", v...)
 	}
 }
 
 // Warnf logs a warning message using Printf conventions.
 func (l *LeveledLogger) Warnf(format string, v ...interface{}) {
 	if l.Level >= LevelWarn {
-		fmt.Fprintf(l.stderr(), "[WARN] "+format+"\n", v...)
+		// Logger write failures are silently discarded — callers can't handle them,
+		// and adding error returns to these methods would be a breaking API change.
+		_, _ = fmt.Fprintf(l.stderr(), "[WARN] "+format+"\n", v...)
 	}
 }
 

--- a/loginlink/client.go
+++ b/loginlink/client.go
@@ -39,7 +39,7 @@ func New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 // [migration guide]: https://github.com/stripe/stripe-go/wiki/Migration-guide-for-Stripe-Client
 func (c Client) New(params *stripe.LoginLinkParams) (*stripe.LoginLink, error) {
 	if params.Account == nil {
-		return nil, fmt.Errorf("Invalid login link params: Account must be set")
+		return nil, fmt.Errorf("invalid login link params: Account must be set")
 	}
 	path := stripe.FormatURLPath(
 		"/v1/accounts/%s/login_links", stripe.StringValue(params.Account))

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,3 +1,6 @@
+// Package mock provides a test helper for spinning up a local HTTP server that
+// simulates the Stripe API, for use in unit tests that don't require
+// stripe-mock.
 package mock
 
 import (

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -12,13 +12,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/stripe-go/v85"
-	"github.com/stripe/stripe-go/v85/client"
 	stripetest "github.com/stripe/stripe-go/v85/testing"
 )
 
 type Assertion func(*testing.T, *http.Request)
 
-func Server[T any](t *testing.T, method, path string, req T, resp func(T) []byte, asserts ...Assertion) (*httptest.Server, *client.API) {
+func Server[T any](t *testing.T, method, path string, req T, resp func(T) []byte, asserts ...Assertion) (*httptest.Server, *stripe.Client) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for _, assert := range asserts {
 			assert(t, r)
@@ -41,6 +40,6 @@ func Server[T any](t *testing.T, method, path string, req T, resp func(T) []byte
 			URL: stripe.String(server.URL),
 		},
 	)
-	sc := client.New(stripetest.TestAPIKey, backends)
+	sc := stripe.NewClient(stripetest.TestAPIKey, stripe.WithBackends(backends))
 	return server, sc
 }

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/stripe-go/v85"
 	"github.com/stripe/stripe-go/v85/client"
-	. "github.com/stripe/stripe-go/v85/testing"
+	stripetest "github.com/stripe/stripe-go/v85/testing"
 )
 
 type Assertion func(*testing.T, *http.Request)
@@ -25,7 +25,7 @@ func Server[T any](t *testing.T, method, path string, req T, resp func(T) []byte
 		}
 		assert.Equal(t, r.Method, method)
 		assert.Equal(t, r.URL.Path, path)
-		assert.Equal(t, r.Header.Get("Authorization"), "Bearer "+TestAPIKey)
+		assert.Equal(t, r.Header.Get("Authorization"), "Bearer "+stripetest.TestAPIKey)
 
 		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
@@ -41,6 +41,6 @@ func Server[T any](t *testing.T, method, path string, req T, resp func(T) []byte
 			URL: stripe.String(server.URL),
 		},
 	)
-	sc := client.New(TestAPIKey, backends)
+	sc := client.New(stripetest.TestAPIKey, backends)
 	return server, sc
 }

--- a/oauth/client_test.go
+++ b/oauth/client_test.go
@@ -134,7 +134,8 @@ func TestNewOAuthToken(t *testing.T) {
 	// stripe-mock doesn't support connect URLs so this stubs out the server.
 	httpClient := newTestClient(func(req *http.Request) *http.Response {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(req.Body)
+		_, err := buf.ReadFrom(req.Body)
+		assert.NoError(t, err)
 		reqBody := buf.String()
 
 		assert.Contains(t, req.URL.String(), "https://localhost:12113/oauth/token")
@@ -181,7 +182,8 @@ func TestNewOAuthTokenWithCustomKey(t *testing.T) {
 	// stripe-mock doesn't support connect URLs so this stubs out the server.
 	httpClient := newTestClient(func(req *http.Request) *http.Response {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(req.Body)
+		_, err := buf.ReadFrom(req.Body)
+		assert.NoError(t, err)
 		reqBody := buf.String()
 		assert.Contains(t, reqBody, "client_secret=sk_999")
 
@@ -207,7 +209,8 @@ func TestNewOAuthTokenWithError(t *testing.T) {
 	responseBody := `{"error":"invalid_grant","error_description": "Authorization code does not exist"}`
 	httpClient := newTestClient(func(req *http.Request) *http.Response {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(req.Body)
+		_, err := buf.ReadFrom(req.Body)
+		assert.NoError(t, err)
 		reqBody := buf.String()
 		assert.Contains(t, reqBody, "client_secret=sk_999")
 
@@ -238,7 +241,8 @@ func TestDeauthorize(t *testing.T) {
 	// stripe-mock doesn't support connect URLs so this stubs out the server.
 	httpClient := newTestClient(func(req *http.Request) *http.Response {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(req.Body)
+		_, err := buf.ReadFrom(req.Body)
+		assert.NoError(t, err)
 		reqBody := buf.String()
 		assert.Contains(t, req.URL.String(), "https://localhost:12113/oauth/deauthorize")
 		assert.Contains(t, reqBody, "client_id=sk_999")

--- a/oauth/client_test.go
+++ b/oauth/client_test.go
@@ -2,7 +2,7 @@ package oauth
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -155,7 +155,7 @@ func TestNewOAuthToken(t *testing.T) {
     }`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(responseBody)),
+			Body:       io.NopCloser(bytes.NewBufferString(responseBody)),
 			Header:     make(http.Header),
 		}
 	})
@@ -189,7 +189,7 @@ func TestNewOAuthTokenWithCustomKey(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`{}`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
 			Header:     make(http.Header),
 		}
 	})
@@ -216,7 +216,7 @@ func TestNewOAuthTokenWithError(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(responseBody)),
+			Body:       io.NopCloser(bytes.NewBufferString(responseBody)),
 			Header:     make(http.Header),
 		}
 	})
@@ -251,7 +251,7 @@ func TestDeauthorize(t *testing.T) {
 		resBody := `{"stripe_user_id": "acct_123"}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(resBody)),
+			Body:       io.NopCloser(bytes.NewBufferString(resBody)),
 			Header:     make(http.Header),
 		}
 	})

--- a/paymentsource.go
+++ b/paymentsource.go
@@ -70,7 +70,7 @@ func SourceParamsFor(obj interface{}) (*PaymentSourceSourceParams, error) {
 			Token: &p,
 		}
 	default:
-		err = fmt.Errorf("Unsupported source type %s", p)
+		err = fmt.Errorf("unsupported source type %s", p)
 	}
 	return sp, err
 }

--- a/paymentsource/client.go
+++ b/paymentsource/client.go
@@ -47,7 +47,7 @@ func (c Client) New(params *stripe.PaymentSourceParams) (*stripe.PaymentSource, 
 		return nil, fmt.Errorf("params should not be nil")
 	}
 	if params.Customer == nil {
-		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("invalid source params: customer needs to be set")
 	}
 	path := stripe.FormatURLPath(
 		"/v1/customers/%s/sources", stripe.StringValue(params.Customer))
@@ -71,7 +71,7 @@ func (c Client) Get(id string, params *stripe.PaymentSourceParams) (*stripe.Paym
 		return nil, fmt.Errorf("params should not be nil")
 	}
 	if params.Customer == nil {
-		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("invalid source params: customer needs to be set")
 	}
 	path := stripe.FormatURLPath(
 		"/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
@@ -95,7 +95,7 @@ func (c Client) Update(id string, params *stripe.PaymentSourceParams) (*stripe.P
 		return nil, fmt.Errorf("params should not be nil")
 	}
 	if params.Customer == nil {
-		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("invalid source params: customer needs to be set")
 	}
 	path := stripe.FormatURLPath(
 		"/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
@@ -119,7 +119,7 @@ func (c Client) Del(id string, params *stripe.PaymentSourceParams) (*stripe.Paym
 		return nil, fmt.Errorf("params should not be nil")
 	}
 	if params.Customer == nil {
-		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("invalid source params: customer needs to be set")
 	}
 	path := stripe.FormatURLPath(
 		"/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)
@@ -152,7 +152,7 @@ func (c Client) Verify(id string, params *stripe.PaymentSourceVerifyParams) (*st
 	} else if len(params.Values) > 0 {
 		path = stripe.FormatURLPath("/v1/sources/%s/verify", id)
 	} else {
-		return nil, fmt.Errorf("Only customer bank accounts or sources can be verified in this manner")
+		return nil, fmt.Errorf("only customer bank accounts or sources can be verified in this manner")
 	}
 
 	source := &stripe.PaymentSource{}
@@ -177,7 +177,7 @@ func (c Client) List(listParams *stripe.PaymentSourceListParams) *Iter {
 	if listParams == nil {
 		outerErr = fmt.Errorf("params should not be nil")
 	} else if listParams.Customer == nil {
-		outerErr = fmt.Errorf("Invalid source params: customer needs to be set")
+		outerErr = fmt.Errorf("invalid source params: customer needs to be set")
 	} else {
 		path = stripe.FormatURLPath("/v1/customers/%s/sources",
 			stripe.StringValue(listParams.Customer))

--- a/paymentsource_service.go
+++ b/paymentsource_service.go
@@ -56,7 +56,7 @@ func (c v1PaymentSourceService) Update(ctx context.Context, id string, params *P
 		return nil, fmt.Errorf("params should not be nil")
 	}
 	if params.Customer == nil {
-		return nil, fmt.Errorf("Invalid source params: customer needs to be set")
+		return nil, fmt.Errorf("invalid source params: customer needs to be set")
 	}
 	if params == nil {
 		params = &PaymentSourceUpdateParams{}

--- a/rawrequest/client_test.go
+++ b/rawrequest/client_test.go
@@ -35,13 +35,14 @@ func TestV2PostRequest(t *testing.T) {
 	var contentType string
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		body = string(req)
 		path = r.URL.RequestURI()
 		method = r.Method
 		contentType = r.Header.Get("Content-Type")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	client := createTestClient(testServer)
@@ -67,13 +68,14 @@ func TestRawV1PostRequest(t *testing.T) {
 	var contentType string
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		body = string(req)
 		path = r.URL.RequestURI()
 		method = r.Method
 		contentType = r.Header.Get("Content-Type")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	client := createTestClient(testServer)
@@ -101,7 +103,7 @@ func TestV2GetRequestWithAdditionalHeaders(t *testing.T) {
 	var stripeContext string
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		body = string(req)
 		path = r.URL.RequestURI()
 		method = r.Method
@@ -109,7 +111,8 @@ func TestV2GetRequestWithAdditionalHeaders(t *testing.T) {
 		fooHeader = r.Header.Get("foo")
 		stripeContext = r.Header.Get("Stripe-Context")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	client := createTestClient(testServer)

--- a/scripts/test_with_stripe_mock/main.go
+++ b/scripts/test_with_stripe_mock/main.go
@@ -176,7 +176,7 @@ func stopStripeMock(process *os.Process) {
 	}
 
 	fmt.Printf("Stopping stripe-mock...\n")
-	process.Signal(os.Interrupt)
-	process.Wait()
+	_ = process.Signal(os.Interrupt) // best-effort; process may have already exited
+	_, _ = process.Wait()            // wait for process cleanup; exit status is irrelevant
 	fmt.Printf("Stopped stripe-mock\n")
 }

--- a/scripts/test_with_stripe_mock/main.go
+++ b/scripts/test_with_stripe_mock/main.go
@@ -114,7 +114,7 @@ func runTests(port string) error {
 
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Error running tests: %v", err)
+		return fmt.Errorf("error running tests: %v", err)
 	}
 
 	return nil
@@ -134,12 +134,12 @@ func startStripeMock() (string, *os.Process, error) {
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return "", nil, fmt.Errorf("Error starting stripe-mock: %v", err)
+		return "", nil, fmt.Errorf("error starting stripe-mock: %v", err)
 	}
 
 	err = cmd.Start()
 	if err != nil {
-		return "", nil, fmt.Errorf("Error starting stripe-mock: %v", err)
+		return "", nil, fmt.Errorf("error starting stripe-mock: %v", err)
 	}
 
 	b := make([]byte, 1024)

--- a/search_iter_test.go
+++ b/search_iter_test.go
@@ -113,9 +113,11 @@ func TestSearchIterMultiplePages(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.RawQuery {
 		case "query=my+query":
-			w.Write([]byte(`{"data":[{"id": "1"}, {"id":"2"}], "has_more":true, "next_page":"page2", "total_count": 4 }`))
+			_, err := w.Write([]byte(`{"data":[{"id": "1"}, {"id":"2"}], "has_more":true, "next_page":"page2", "total_count": 4 }`))
+			assert.NoError(t, err)
 		case "query=my+query&page=page2":
-			w.Write([]byte(`{"data":[{"id": "3"}, {"id":"4"}], "has_more":false, "next_page":null }`))
+			_, err := w.Write([]byte(`{"data":[{"id": "3"}, {"id":"4"}], "has_more":false, "next_page":null }`))
+			assert.NoError(t, err)
 		default:
 			assert.Fail(t, "shouldn't be hit")
 		}
@@ -229,9 +231,11 @@ func TestV1SearchListMultiplePages(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.RawQuery {
 		case "query=my+query":
-			w.Write([]byte(`{"data":[{"id": "1"}, {"id":"2"}], "has_more":true, "next_page":"page2", "total_count": 4 }`))
+			_, err := w.Write([]byte(`{"data":[{"id": "1"}, {"id":"2"}], "has_more":true, "next_page":"page2", "total_count": 4 }`))
+			assert.NoError(t, err)
 		case "query=my+query&page=page2":
-			w.Write([]byte(`{"data":[{"id": "3"}, {"id":"4"}], "has_more":false, "next_page":null }`))
+			_, err := w.Write([]byte(`{"data":[{"id": "3"}, {"id":"4"}], "has_more":false, "next_page":null }`))
+			assert.NoError(t, err)
 		default:
 			assert.Fail(t, "shouldn't be hit")
 		}

--- a/search_iter_test.go
+++ b/search_iter_test.go
@@ -111,14 +111,14 @@ func TestSearchIterListAndMeta(t *testing.T) {
 func TestSearchIterMultiplePages(t *testing.T) {
 	// Create an ephemeral test server so that we can inspect request attributes.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.RawQuery == "query=my+query" {
+		switch r.URL.RawQuery {
+		case "query=my+query":
 			w.Write([]byte(`{"data":[{"id": "1"}, {"id":"2"}], "has_more":true, "next_page":"page2", "total_count": 4 }`))
-			return
-		} else if r.URL.RawQuery == "query=my+query&page=page2" {
+		case "query=my+query&page=page2":
 			w.Write([]byte(`{"data":[{"id": "3"}, {"id":"4"}], "has_more":false, "next_page":null }`))
-			return
+		default:
+			assert.Fail(t, "shouldn't be hit")
 		}
-		assert.Fail(t, "shouldn't be hit")
 	}))
 	defer ts.Close()
 
@@ -227,14 +227,14 @@ func TestV1SearchListTwoPagesErr(t *testing.T) {
 func TestV1SearchListMultiplePages(t *testing.T) {
 	// Create an ephemeral test server so that we can inspect request attributes.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.RawQuery == "query=my+query" {
+		switch r.URL.RawQuery {
+		case "query=my+query":
 			w.Write([]byte(`{"data":[{"id": "1"}, {"id":"2"}], "has_more":true, "next_page":"page2", "total_count": 4 }`))
-			return
-		} else if r.URL.RawQuery == "query=my+query&page=page2" {
+		case "query=my+query&page=page2":
 			w.Write([]byte(`{"data":[{"id": "3"}, {"id":"4"}], "has_more":false, "next_page":null }`))
-			return
+		default:
+			assert.Fail(t, "shouldn't be hit")
 		}
-		assert.Fail(t, "shouldn't be hit")
 	}))
 	defer ts.Close()
 

--- a/source/client.go
+++ b/source/client.go
@@ -90,7 +90,7 @@ func Detach(id string, params *stripe.SourceDetachParams) (*stripe.Source, error
 func (c Client) Detach(id string, params *stripe.SourceDetachParams) (*stripe.Source, error) {
 	if params.Customer == nil {
 		return nil, fmt.Errorf(
-			"Invalid source detach params: Customer needs to be set")
+			"invalid source detach params: Customer needs to be set")
 	}
 	path := stripe.FormatURLPath(
 		"/v1/customers/%s/sources/%s", stripe.StringValue(params.Customer), id)

--- a/source_service.go
+++ b/source_service.go
@@ -59,7 +59,7 @@ func (c v1SourceService) Update(ctx context.Context, id string, params *SourceUp
 func (c v1SourceService) Detach(ctx context.Context, id string, params *SourceDetachParams) (*Source, error) {
 	if params.Customer == nil {
 		return nil, fmt.Errorf(
-			"Invalid source detach params: Customer needs to be set")
+			"invalid source detach params: Customer needs to be set")
 	}
 	if params == nil {
 		params = &SourceDetachParams{}

--- a/sourcetransaction/client.go
+++ b/sourcetransaction/client.go
@@ -36,7 +36,7 @@ func (c Client) List(listParams *stripe.SourceTransactionListParams) *Iter {
 		return &Iter{
 			Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
 				list := &stripe.SourceTransactionList{}
-				return nil, list, fmt.Errorf("Invalid source transaction params: Source needs to be set")
+				return nil, list, fmt.Errorf("invalid source transaction params: Source needs to be set")
 			}),
 		}
 	}

--- a/stripe.go
+++ b/stripe.go
@@ -481,7 +481,7 @@ func setNestedNull(m map[string]json.RawMessage, path []string) {
 	if idx, err := strconv.Atoi(rest[0]); err == nil {
 		var arr []json.RawMessage
 		if existing, ok := m[key]; ok {
-			_ = json.Unmarshal(existing, &arr)
+			_ = json.Unmarshal(existing, &arr) // on failure arr stays nil; idx < len(arr) will be false and the null is silently not written
 		}
 		if idx < len(arr) {
 			if len(rest) == 1 {
@@ -1041,7 +1041,12 @@ func (s *BackendImplementation) handleResponseBufferingErrors(res *http.Response
 	// when logging the error
 	var resBody []byte
 	resBody, err = io.ReadAll(res.Body)
-	res.Body.Close()
+	if closeErr := res.Body.Close(); closeErr != nil {
+		// Body is already fully buffered; close error is a transport-layer issue that
+		// doesn't affect API semantics. Log but don't return it — the caller needs the
+		// API error (e.g. "card declined"), not a connection cleanup failure.
+		s.logWarnf(res.Request.Context(), "Error closing response body: %v", closeErr)
+	}
 	if err == nil {
 		err = s.ResponseToError(res, resBody)
 	} else {
@@ -1076,7 +1081,12 @@ func (s *BackendImplementation) Do(req *http.Request, body *bytes.Buffer, v Last
 		var resBody []byte
 		if err == nil {
 			resBody, err = io.ReadAll(res.Body)
-			res.Body.Close()
+			if closeErr := res.Body.Close(); closeErr != nil {
+				// Body is already fully buffered; close error is a transport-layer issue that
+				// doesn't affect API semantics. Log but don't return it — the caller needs the
+				// API result (success or structured error), not a connection cleanup failure.
+				s.logWarnf(req.Context(), "Error closing response body: %v", closeErr)
+			}
 		}
 
 		ver, pathErr := extractVersion(req.URL.Path)

--- a/stripe.go
+++ b/stripe.go
@@ -343,13 +343,13 @@ func extractParams(params ParamsContainer) (*form.Values, *Params, error) {
 
 			if !reflectValue.Elem().FieldByName("Metadata").IsZero() {
 				if commonParams.Metadata != nil {
-					return nil, nil, fmt.Errorf("You cannot specify both the (deprecated) .Params.Metadata and .Metadata in %s", reflectValue.Elem().Type().Name())
+					return nil, nil, fmt.Errorf("you cannot specify both the (deprecated) .Params.Metadata and .Metadata in %s", reflectValue.Elem().Type().Name())
 				}
 			}
 
 			if !reflectValue.Elem().FieldByName("Expand").IsZero() {
 				if commonParams.Expand != nil {
-					return nil, nil, fmt.Errorf("You cannot specify both the (deprecated) .Params.Expand and .Expand in %s", reflectValue.Elem().Type().Name())
+					return nil, nil, fmt.Errorf("you cannot specify both the (deprecated) .Params.Expand and .Expand in %s", reflectValue.Elem().Type().Name())
 				}
 			}
 
@@ -1275,7 +1275,7 @@ func (s *BackendImplementation) unmarshalJSONVerbose(ctx context.Context, status
 		// Make sure a multi-line response ends up all on one line
 		bodySample = strings.ReplaceAll(bodySample, "\n", "\\n")
 
-		newErr := fmt.Errorf("Couldn't deserialize JSON (response status: %v, body sample: '%s'): %v",
+		newErr := fmt.Errorf("couldn't deserialize JSON (response status: %v, body sample: '%s'): %v",
 			statusCode, bodySample, err)
 		s.logErrorf(ctx, "%s", newErr.Error())
 		return newErr
@@ -1678,7 +1678,7 @@ func ParseID(data []byte) (string, bool) {
 // SetAppInfo sets app information. See AppInfo.
 func SetAppInfo(info *AppInfo) {
 	if info != nil && info.Name == "" {
-		panic(fmt.Errorf("App info name cannot be empty"))
+		panic(fmt.Errorf("app info name cannot be empty"))
 	}
 	appInfo = info
 

--- a/stripe.go
+++ b/stripe.go
@@ -574,7 +574,7 @@ func (s *BackendImplementation) Call(method, path, key string, params ParamsCont
 			}
 		}
 		body = []byte(bodyParams.Encode())
-	} else if params != nil && !(reflect.ValueOf(params).Kind() == reflect.Ptr && reflect.ValueOf(params).IsNil()) {
+	} else if params != nil && (reflect.ValueOf(params).Kind() != reflect.Ptr || !reflect.ValueOf(params).IsNil()) {
 		body, err = marshalV2JSON(params)
 		if err != nil {
 			return err
@@ -1263,7 +1263,7 @@ func (s *BackendImplementation) unmarshalJSONVerbose(ctx context.Context, status
 		}
 
 		// Make sure a multi-line response ends up all on one line
-		bodySample = strings.Replace(bodySample, "\n", "\\n", -1)
+		bodySample = strings.ReplaceAll(bodySample, "\n", "\\n")
 
 		newErr := fmt.Errorf("Couldn't deserialize JSON (response status: %v, body sample: '%s'): %v",
 			statusCode, bodySample, err)

--- a/stripe_client_test.go
+++ b/stripe_client_test.go
@@ -226,7 +226,8 @@ func TestParseUnknownEventNotificationWithRelatedObject(t *testing.T) {
 		assert.Equal(t, "Bearer "+TestAPIKey, r.Header.Get("Authorization"))
 		assert.Equal(t, "ctx_123", r.Header.Get("Stripe-Context"))
 		assert.Equal(t, "event=evt_test_webhook", r.Header.Get("Stripe-Request-Trigger"))
-		w.Write([]byte(relatedObjectResp))
+		_, err := w.Write([]byte(relatedObjectResp))
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -297,7 +298,8 @@ func TestFetchEventHTTPCall(t *testing.T) {
 		assert.Equal(t, "Bearer "+TestAPIKey, r.Header.Get("Authorization"))
 		assert.Equal(t, "ctx_123", r.Header.Get("Stripe-Context"))
 		assert.Equal(t, "event=evt_123", r.Header.Get("Stripe-Request-Trigger"))
-		w.Write([]byte(mockEventResponse))
+		_, err := w.Write([]byte(mockEventResponse))
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -360,7 +362,8 @@ func TestFetchRelatedObject(t *testing.T) {
 		assert.Equal(t, "/v1/billing/meters/bm_123", r.URL.Path)
 		assert.Equal(t, "Bearer "+TestAPIKey, r.Header.Get("Authorization"))
 		assert.Equal(t, "event=evt_123", r.Header.Get("Stripe-Request-Trigger"))
-		w.Write([]byte(mockRelatedObjectResponse))
+		_, err := w.Write([]byte(mockRelatedObjectResponse))
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -433,7 +436,8 @@ func TestFetchRelatedObjectUnknownEvent(t *testing.T) {
 		assert.Equal(t, "Bearer "+TestAPIKey, r.Header.Get("Authorization"))
 		assert.Equal(t, "ctx_123", r.Header.Get("Stripe-Context"))
 		assert.Equal(t, "event=evt_123", r.Header.Get("Stripe-Request-Trigger"))
-		w.Write([]byte(mockRelatedObjectResponse))
+		_, err := w.Write([]byte(mockRelatedObjectResponse))
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -1620,7 +1620,7 @@ func TestDoStreaming_UnparsableError(t *testing.T) {
 	assert.NotNil(t, err)
 	_, ok := err.(*Error)
 	assert.False(t, ok)
-	assert.True(t, strings.Contains(err.Error(), "Couldn't deserialize JSON"))
+	assert.True(t, strings.Contains(err.Error(), "couldn't deserialize JSON"))
 }
 
 func TestFormatURLPath(t *testing.T) {
@@ -1859,7 +1859,7 @@ func TestUnmarshalJSONVerbose(t *testing.T) {
 		var sample testServerResponse
 		err := backend.unmarshalJSONVerbose(context.Background(), 200, []byte(body), &sample)
 		assert.Regexp(t,
-			fmt.Sprintf(`^Couldn't deserialize JSON \(response status: 200, body sample: '%s'\): invalid character`, body),
+			fmt.Sprintf(`^couldn't deserialize JSON \(response status: 200, body sample: '%s'\): invalid character`, body),
 			err)
 	}
 
@@ -1873,7 +1873,7 @@ func TestUnmarshalJSONVerbose(t *testing.T) {
 		var sample testServerResponse
 		err := backend.unmarshalJSONVerbose(context.Background(), 200, []byte(body), &sample)
 		assert.Regexp(t,
-			fmt.Sprintf(`^Couldn't deserialize JSON \(response status: 200, body sample: '%s ...'\): invalid character`, body[0:500]),
+			fmt.Sprintf(`^couldn't deserialize JSON \(response status: 200, body sample: '%s ...'\): invalid character`, body[0:500]),
 			err)
 	}
 }

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -99,7 +99,8 @@ func TestDo_Retry(t *testing.T) {
 		switch requestNum {
 		case 0:
 			w.WriteHeader(http.StatusConflict)
-			w.Write([]byte(`{"error":"Conflict (this should be retried)."}`))
+			_, err := w.Write([]byte(`{"error":"Conflict (this should be retried)."}`))
+			assert.NoError(t, err)
 
 		case 1:
 			response := testServerResponse{Message: message}
@@ -1202,8 +1203,10 @@ func TestCall_V1PathPostNestedUnsetFields(t *testing.T) {
 		// "details[feedback]" should have a value
 		assert.Equal(t, "too_slow", vals.Get("details[feedback]"))
 
-		data, _ := json.Marshal(testServerResponse{Message: "ok"})
-		w.Write(data)
+		data, err := json.Marshal(testServerResponse{Message: "ok"})
+		assert.NoError(t, err)
+		_, err = w.Write(data)
+		assert.NoError(t, err)
 	}))
 	defer testServer.Close()
 
@@ -1265,8 +1268,10 @@ func TestCall_V2PathPostNestedUnsetFields(t *testing.T) {
 		assert.Equal(t, "null", string(details["comment"]))
 		assert.Equal(t, `"too_slow"`, string(details["feedback"]))
 
-		data, _ := json.Marshal(testServerResponse{Message: "ok"})
-		w.Write(data)
+		data, err := json.Marshal(testServerResponse{Message: "ok"})
+		assert.NoError(t, err)
+		_, err = w.Write(data)
+		assert.NoError(t, err)
 	}))
 	defer testServer.Close()
 
@@ -1326,8 +1331,10 @@ func TestCall_V1PathPostSliceElementUnsetFields(t *testing.T) {
 		assert.Equal(t, "", vals.Get("line_items[1][tax_rates]"))
 		assert.Contains(t, bodyStr, "line_items[1][tax_rates]=")
 
-		data, _ := json.Marshal(testServerResponse{Message: "ok"})
-		w.Write(data)
+		data, err := json.Marshal(testServerResponse{Message: "ok"})
+		assert.NoError(t, err)
+		_, err = w.Write(data)
+		assert.NoError(t, err)
 	}))
 	defer testServer.Close()
 
@@ -1397,8 +1404,10 @@ func TestCall_V2PathPostSliceElementUnsetFields(t *testing.T) {
 		assert.Equal(t, `"price_456"`, string(item1["price"]))
 		assert.Equal(t, "null", string(item1["tax_rates"]))
 
-		data, _ := json.Marshal(testServerResponse{Message: "ok"})
-		w.Write(data)
+		data, err := json.Marshal(testServerResponse{Message: "ok"})
+		assert.NoError(t, err)
+		_, err = w.Write(data)
+		assert.NoError(t, err)
 	}))
 	defer testServer.Close()
 
@@ -2234,13 +2243,14 @@ func TestRawRequestPreviewPost(t *testing.T) {
 	var contentType string
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		body = string(req)
 		path = r.URL.RequestURI()
 		method = r.Method
 		contentType = r.Header.Get("Content-Type")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	backend := GetBackendWithConfig(
@@ -2284,14 +2294,15 @@ func TestRawRequestStandardGet(t *testing.T) {
 	var stripeVersion string
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		body = string(req)
 		path = r.URL.RequestURI()
 		method = r.Method
 		contentType = r.Header.Get("Content-Type")
 		stripeVersion = r.Header.Get("Stripe-Version")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	backend := GetBackendWithConfig(
@@ -2322,14 +2333,15 @@ func TestRawRequestStandardPost(t *testing.T) {
 	var stripeVersion string
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		body = string(req)
 		path = r.URL.RequestURI()
 		method = r.Method
 		contentType = r.Header.Get("Content-Type")
 		stripeVersion = r.Header.Get("Stripe-Version")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	backend := GetBackendWithConfig(
@@ -2359,13 +2371,14 @@ func TestRawRequestPreviewGet(t *testing.T) {
 	var contentType string
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		body = string(req)
 		path = r.URL.RequestURI()
 		method = r.Method
 		contentType = r.Header.Get("Content-Type")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	backend := GetBackendWithConfig(
@@ -2398,7 +2411,7 @@ func TestRawRequestWithAdditionalHeaders(t *testing.T) {
 	var stripeContext string
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := io.ReadAll(r.Body)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		body = string(req)
 		path = r.URL.RequestURI()
 		method = r.Method
@@ -2406,7 +2419,8 @@ func TestRawRequestWithAdditionalHeaders(t *testing.T) {
 		fooHeader = r.Header.Get("foo")
 		stripeContext = r.Header.Get("Stripe-Context")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	backend := GetBackendWithConfig(
@@ -2438,12 +2452,13 @@ func TestRawRequestTelemetry(t *testing.T) {
 	var telemetry []byte
 	i := 0
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 		telemetry = []byte(r.Header.Get("X-Stripe-Client-Telemetry"))
 		i += 1
 		w.Header().Add("Request-Id", fmt.Sprintf("req_%d", i))
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		_, err := w.Write([]byte(`{"object": "abc", "xyz": {"def": "jih"}}`))
+		assert.NoError(t, err)
 	}))
 
 	backend := GetBackendWithConfig(
@@ -2466,7 +2481,7 @@ func TestRawRequestTelemetry(t *testing.T) {
 	metrics := struct {
 		LastRequestMetrics requestMetrics `json:"last_request_metrics"`
 	}{}
-	json.Unmarshal(telemetry, &metrics)
+	assert.NoError(t, json.Unmarshal(telemetry, &metrics))
 	assert.Equal(t, []string{"raw_request"}, metrics.LastRequestMetrics.Usage)
 	defer testServer.Close()
 }

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,3 +1,6 @@
+// Package testing provides shared test fixtures and helpers used across all
+// packages in the Stripe Go SDK, including test API keys and connectivity
+// checks for stripe-mock.
 package testing
 
 import (

--- a/v2/core/event/client_test.go
+++ b/v2/core/event/client_test.go
@@ -1,6 +1,7 @@
 package event_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -15,7 +16,7 @@ import (
 
 func TestEventGet(t *testing.T) {
 	timeNow := time.Now()
-	params := stripe.V2CoreEventParams{}
+	params := stripe.V2CoreEventRetrieveParams{}
 	testServer, sc := mock.Server(t, string(http.MethodGet), "/v2/core/events/evt_123", nil, func(p *stripe.V2CoreEventParams) []byte {
 		data, err := json.Marshal(stripe.V1BillingMeterErrorReportTriggeredEvent{
 			V2BaseEvent: stripe.V2BaseEvent{
@@ -35,7 +36,7 @@ func TestEventGet(t *testing.T) {
 	})
 	defer testServer.Close()
 
-	event, err := sc.V2CoreEvents.Get("evt_123", &params)
+	event, err := sc.V2CoreEvents.Retrieve(context.TODO(), "evt_123", &params)
 	assert.Nil(t, err)
 	v1BillingEvent, ok := event.(*stripe.V1BillingMeterErrorReportTriggeredEvent)
 	assert.True(t, ok)
@@ -92,7 +93,7 @@ func TestEventAll(t *testing.T) {
 	})
 	defer testServer.Close()
 	cnt := 1
-	sc.V2CoreEvents.All(params)(func(event stripe.V2CoreEvent, err error) bool {
+	sc.V2CoreEvents.List(context.TODO(), params).All(context.TODO())(func(event stripe.V2CoreEvent, err error) bool {
 		assert.Nil(t, err)
 		assert.NotNil(t, event)
 		if cnt == 1 {

--- a/v2/core/eventdestination/client_test.go
+++ b/v2/core/eventdestination/client_test.go
@@ -1,6 +1,7 @@
 package eventdestination_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,25 +12,24 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go/v85"
-	"github.com/stripe/stripe-go/v85/client"
 	"github.com/stripe/stripe-go/v85/mock"
 	. "github.com/stripe/stripe-go/v85/testing"
 )
 
 func TestEventDestinationNew(t *testing.T) {
 	timeNow := time.Now()
-	params := &stripe.V2CoreEventDestinationParams{
+	params := &stripe.V2CoreEventDestinationCreateParams{
 		Name:          stripe.String("My Event Destination"),
 		Description:   stripe.String("This is my event destination, I like it a lot"),
 		EnabledEvents: stripe.StringSlice([]string{"v1.billing.meter.error_report_triggered"}),
 		Type:          stripe.String(string(stripe.V2CoreEventDestinationTypeWebhookEndpoint)),
-		WebhookEndpoint: &stripe.V2CoreEventDestinationWebhookEndpointParams{
+		WebhookEndpoint: &stripe.V2CoreEventDestinationCreateWebhookEndpointParams{
 			URL: stripe.String("https://example.com/my/webhook/endpoint"),
 		},
 		EventPayload: stripe.String(string(stripe.V2CoreEventDestinationEventPayloadThin)),
 		Include:      stripe.StringSlice([]string{"webhook_endpoint.url"}),
 	}
-	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations", params, func(p *stripe.V2CoreEventDestinationParams) []byte {
+	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations", params, func(p *stripe.V2CoreEventDestinationCreateParams) []byte {
 		var enabledEvents []string
 		for _, event := range params.EnabledEvents {
 			enabledEvents = append(enabledEvents, *event)
@@ -53,7 +53,7 @@ func TestEventDestinationNew(t *testing.T) {
 	})
 	defer testServer.Close()
 
-	dest, err := sc.V2CoreEventDestinations.New(params)
+	dest, err := sc.V2CoreEventDestinations.Create(context.Background(), params)
 	assert.Nil(t, err)
 	assert.Equal(t, dest.Name, *params.Name)
 	assert.Equal(t, dest.Description, *params.Description)
@@ -71,10 +71,10 @@ func TestEventDestinationNew(t *testing.T) {
 
 func TestEventDestinationGet(t *testing.T) {
 	timeNow := time.Now()
-	params := stripe.V2CoreEventDestinationParams{
+	params := stripe.V2CoreEventDestinationRetrieveParams{
 		Include: stripe.StringSlice([]string{"webhook_endpoint.url"}),
 	}
-	testServer, sc := mock.Server(t, string(http.MethodGet), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil, func(p *stripe.V2CoreEventDestinationParams) []byte {
+	testServer, sc := mock.Server(t, string(http.MethodGet), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil, func(p *stripe.V2CoreEventDestinationRetrieveParams) []byte {
 		data, err := json.Marshal(stripe.V2CoreEventDestination{
 			Created:       timeNow,
 			Description:   "This is my event destination, I like it a lot",
@@ -94,7 +94,7 @@ func TestEventDestinationGet(t *testing.T) {
 	})
 	defer testServer.Close()
 
-	dest, err := sc.V2CoreEventDestinations.Get("ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", &params)
+	dest, err := sc.V2CoreEventDestinations.Retrieve(context.Background(), "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", &params)
 	assert.Nil(t, err)
 	assert.Equal(t, dest.Name, "My Event Destination")
 	assert.Equal(t, dest.Description, "This is my event destination, I like it a lot")
@@ -110,10 +110,10 @@ func TestEventDestinationGet(t *testing.T) {
 
 func TestEventDestinationUpdate(t *testing.T) {
 	timeNow := time.Now()
-	params := stripe.V2CoreEventDestinationParams{
+	params := stripe.V2CoreEventDestinationUpdateParams{
 		Description: stripe.String("Better description"),
 	}
-	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", &params, func(p *stripe.V2CoreEventDestinationParams) []byte {
+	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", &params, func(p *stripe.V2CoreEventDestinationUpdateParams) []byte {
 		data, err := json.Marshal(stripe.V2CoreEventDestination{
 			Created:       timeNow,
 			Description:   "Better description",
@@ -131,7 +131,7 @@ func TestEventDestinationUpdate(t *testing.T) {
 	})
 	defer testServer.Close()
 
-	dest, err := sc.V2CoreEventDestinations.Update("ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", &params)
+	dest, err := sc.V2CoreEventDestinations.Update(context.Background(), "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", &params)
 	assert.Nil(t, err)
 	assert.Equal(t, dest.Name, "My Event Destination")
 	assert.Equal(t, dest.Description, *params.Description)
@@ -146,22 +146,22 @@ func TestEventDestinationUpdate(t *testing.T) {
 }
 
 func TestEventDestinationDel(t *testing.T) {
-	testServer, sc := mock.Server(t, string(http.MethodDelete), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil, func(p *stripe.V2CoreEventDestinationParams) []byte {
-		data, err := json.Marshal(stripe.V2CoreEventDestination{
+	testServer, sc := mock.Server(t, string(http.MethodDelete), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", &stripe.V2CoreEventDestinationDeleteParams{}, func(p *stripe.V2CoreEventDestinationDeleteParams) []byte {
+		data, err := json.Marshal(stripe.V2DeletedObject{
 			ID: "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6",
 		})
 		assert.NoError(t, err)
 		return data
 	})
 	defer testServer.Close()
-	dest, err := sc.V2CoreEventDestinations.Del("ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil)
+	dest, err := sc.V2CoreEventDestinations.Delete(context.Background(), "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, dest.ID, "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6")
 }
 
 func TestEventDestinationDisable(t *testing.T) {
 	timeNow := time.Now()
-	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6/disable", nil, func(p *stripe.V2CoreEventDestinationParams) []byte {
+	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6/disable", &stripe.V2CoreEventDestinationDisableParams{}, func(p *stripe.V2CoreEventDestinationDisableParams) []byte {
 		data, err := json.Marshal(stripe.V2CoreEventDestination{
 			Created:       timeNow,
 			Description:   "This is my event destination, I like it a lot",
@@ -178,7 +178,7 @@ func TestEventDestinationDisable(t *testing.T) {
 		return data
 	})
 	defer testServer.Close()
-	dest, err := sc.V2CoreEventDestinations.Disable("ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil)
+	dest, err := sc.V2CoreEventDestinations.Disable(context.Background(), "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, dest.ID, "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6")
 	assert.Equal(t, dest.Status, stripe.V2CoreEventDestinationStatusDisabled)
@@ -186,7 +186,7 @@ func TestEventDestinationDisable(t *testing.T) {
 
 func TestEventDestinationEnable(t *testing.T) {
 	timeNow := time.Now()
-	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6/enable", nil, func(p *stripe.V2CoreEventDestinationParams) []byte {
+	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6/enable", &stripe.V2CoreEventDestinationEnableParams{}, func(p *stripe.V2CoreEventDestinationEnableParams) []byte {
 		data, err := json.Marshal(stripe.V2CoreEventDestination{
 			Created:       timeNow,
 			Description:   "This is my event destination, I like it a lot",
@@ -203,7 +203,7 @@ func TestEventDestinationEnable(t *testing.T) {
 		return data
 	})
 	defer testServer.Close()
-	dest, err := sc.V2CoreEventDestinations.Enable("ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil)
+	dest, err := sc.V2CoreEventDestinations.Enable(context.Background(), "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, dest.ID, "ed_test_61RM8ltWcTW4mbsxf16RJyfa2xSQLHJJh1sxm7H0KVT6")
 	assert.Equal(t, dest.Status, stripe.V2CoreEventDestinationStatusEnabled)
@@ -211,7 +211,7 @@ func TestEventDestinationEnable(t *testing.T) {
 
 func TestEventDestinationPing(t *testing.T) {
 	timeNow := time.Now()
-	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92/ping", nil, func(p *stripe.V2CoreEventDestinationParams) []byte {
+	testServer, sc := mock.Server(t, string(http.MethodPost), "/v2/core/event_destinations/evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92/ping", &stripe.V2CoreEventDestinationPingParams{}, func(p *stripe.V2CoreEventDestinationPingParams) []byte {
 		data, err := json.Marshal(stripe.V2CoreRawEvent{
 			V2BaseEvent: stripe.V2BaseEvent{
 				ID:      "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92",
@@ -227,7 +227,7 @@ func TestEventDestinationPing(t *testing.T) {
 		return data
 	})
 	defer testServer.Close()
-	event, err := sc.V2CoreEventDestinations.Ping("evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92", nil)
+	event, err := sc.V2CoreEventDestinations.Ping(context.Background(), "evt_test_65RM8sQH2oXnebF5Rpc16RJyfa2xSQLHJJh1sxm7H0KI92", nil)
 	assert.Nil(t, err)
 	ping, ok := event.(*stripe.V2CoreEventDestinationPingEvent)
 	assert.True(t, ok)
@@ -268,7 +268,7 @@ func TestEventDestinationList_SinglePage(t *testing.T) {
 	})
 	defer testServer.Close()
 	cnt := 1
-	sc.V2CoreEventDestinations.All(params)(func(dest *stripe.V2CoreEventDestination, err error) bool {
+	sc.V2CoreEventDestinations.List(context.Background(), params).All(context.Background())(func(dest *stripe.V2CoreEventDestination, err error) bool {
 		assert.Nil(t, err)
 		assert.NotNil(t, dest)
 		assert.Equal(t, dest.Description, fmt.Sprintf("Event destination %d", cnt))
@@ -330,9 +330,9 @@ func TestEventDestinationList_MultiplePages(t *testing.T) {
 			URL: stripe.String(testServer.URL),
 		},
 	)
-	sc := client.New(TestAPIKey, backends)
+	sc := stripe.NewClient(TestAPIKey, stripe.WithBackends(backends))
 
-	sc.V2CoreEventDestinations.All(params)(func(dest *stripe.V2CoreEventDestination, err error) bool {
+	sc.V2CoreEventDestinations.List(context.Background(), params).All(context.Background())(func(dest *stripe.V2CoreEventDestination, err error) bool {
 		assert.Nil(t, err)
 		assert.NotNil(t, dest)
 		assert.Equal(t, dest.Description, fmt.Sprintf("Event destination %d", cnt))

--- a/v2_events.go
+++ b/v2_events.go
@@ -1632,7 +1632,7 @@ func EventNotificationFromJSON(payload []byte, client Client) (EventNotification
 	}
 
 	if result.Object == "event" {
-		return nil, fmt.Errorf("Did you use EventNotificationFromJSON to parse a webhook payload? If so, use ConstructEvent instead.")
+		return nil, fmt.Errorf("did you use EventNotificationFromJSON to parse a webhook payload? If so, use ConstructEvent instead")
 	}
 
 	// V2EventNotificationTypes: The beginning of the section generated from our OpenAPI spec

--- a/v2_events.go
+++ b/v2_events.go
@@ -179,7 +179,7 @@ type V1BillingMeterErrorReportTriggeredEventNotification struct {
 
 // FetchEvent retrieves the V1BillingMeterErrorReportTriggeredEvent that created this Notification
 func (n *V1BillingMeterErrorReportTriggeredEventNotification) FetchEvent(ctx context.Context) (*V1BillingMeterErrorReportTriggeredEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ type V1BillingMeterNoMeterFoundEventNotification struct {
 
 // FetchEvent retrieves the V1BillingMeterNoMeterFoundEvent that created this Notification
 func (n *V1BillingMeterNoMeterFoundEventNotification) FetchEvent(ctx context.Context) (*V1BillingMeterNoMeterFoundEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ type V2CommerceProductCatalogImportsFailedEventNotification struct {
 
 // FetchEvent retrieves the V2CommerceProductCatalogImportsFailedEvent that created this Notification
 func (n *V2CommerceProductCatalogImportsFailedEventNotification) FetchEvent(ctx context.Context) (*V2CommerceProductCatalogImportsFailedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +283,7 @@ type V2CommerceProductCatalogImportsProcessingEventNotification struct {
 
 // FetchEvent retrieves the V2CommerceProductCatalogImportsProcessingEvent that created this Notification
 func (n *V2CommerceProductCatalogImportsProcessingEventNotification) FetchEvent(ctx context.Context) (*V2CommerceProductCatalogImportsProcessingEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ type V2CommerceProductCatalogImportsSucceededEventNotification struct {
 
 // FetchEvent retrieves the V2CommerceProductCatalogImportsSucceededEvent that created this Notification
 func (n *V2CommerceProductCatalogImportsSucceededEventNotification) FetchEvent(ctx context.Context) (*V2CommerceProductCatalogImportsSucceededEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ type V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification struct 
 
 // FetchEvent retrieves the V2CommerceProductCatalogImportsSucceededWithErrorsEvent that created this Notification
 func (n *V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification) FetchEvent(ctx context.Context) (*V2CommerceProductCatalogImportsSucceededWithErrorsEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ type V2CoreAccountClosedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountClosedEvent that created this Notification
 func (n *V2CoreAccountClosedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountClosedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ type V2CoreAccountCreatedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountCreatedEvent that created this Notification
 func (n *V2CoreAccountCreatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountCreatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -488,7 +488,7 @@ type V2CoreAccountUpdatedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountUpdatedEvent that created this Notification
 func (n *V2CoreAccountUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +530,7 @@ type V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNoti
 
 // FetchEvent retrieves the V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -571,7 +571,7 @@ type V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification struct 
 
 // FetchEvent retrieves the V2CoreAccountIncludingConfigurationCustomerUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingConfigurationCustomerUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +613,7 @@ type V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNoti
 
 // FetchEvent retrieves the V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -654,7 +654,7 @@ type V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification struct 
 
 // FetchEvent retrieves the V2CoreAccountIncludingConfigurationMerchantUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingConfigurationMerchantUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +696,7 @@ type V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNot
 
 // FetchEvent retrieves the V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -737,7 +737,7 @@ type V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification struct
 
 // FetchEvent retrieves the V2CoreAccountIncludingConfigurationRecipientUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingConfigurationRecipientUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -778,7 +778,7 @@ type V2CoreAccountIncludingDefaultsUpdatedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountIncludingDefaultsUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingDefaultsUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingDefaultsUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -819,7 +819,7 @@ type V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountIncludingFutureRequirementsUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingFutureRequirementsUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -860,7 +860,7 @@ type V2CoreAccountIncludingIdentityUpdatedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountIncludingIdentityUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingIdentityUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingIdentityUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -901,7 +901,7 @@ type V2CoreAccountIncludingRequirementsUpdatedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountIncludingRequirementsUpdatedEvent that created this Notification
 func (n *V2CoreAccountIncludingRequirementsUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountIncludingRequirementsUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -935,7 +935,7 @@ type V2CoreAccountLinkReturnedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountLinkReturnedEvent that created this Notification
 func (n *V2CoreAccountLinkReturnedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountLinkReturnedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -965,7 +965,7 @@ type V2CoreAccountPersonCreatedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountPersonCreatedEvent that created this Notification
 func (n *V2CoreAccountPersonCreatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountPersonCreatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1007,7 +1007,7 @@ type V2CoreAccountPersonDeletedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountPersonDeletedEvent that created this Notification
 func (n *V2CoreAccountPersonDeletedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountPersonDeletedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1049,7 +1049,7 @@ type V2CoreAccountPersonUpdatedEventNotification struct {
 
 // FetchEvent retrieves the V2CoreAccountPersonUpdatedEvent that created this Notification
 func (n *V2CoreAccountPersonUpdatedEventNotification) FetchEvent(ctx context.Context) (*V2CoreAccountPersonUpdatedEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1090,7 +1090,7 @@ type V2CoreEventDestinationPingEventNotification struct {
 
 // FetchEvent retrieves the V2CoreEventDestinationPingEvent that created this Notification
 func (n *V2CoreEventDestinationPingEventNotification) FetchEvent(ctx context.Context) (*V2CoreEventDestinationPingEvent, error) {
-	evt, err := n.V2CoreEventNotification.fetchEvent(ctx)
+	evt, err := n.fetchEvent(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -190,22 +190,22 @@ type signedHeader struct {
 // Private functions
 //
 
-func isCompatibleAPIVersion(sdkApiVersion, eventApiVersion string) bool {
+func isCompatibleAPIVersion(sdkAPIVersion, eventAPIVersion string) bool {
 	// If the event api version is from before we started adding
 	// a release train, there's no way its compatible with this
 	// version
-	if !strings.Contains(eventApiVersion, ".") {
+	if !strings.Contains(eventAPIVersion, ".") {
 		return false
 	}
 
 	// if the SDK is pinned to a preview version, the event's API version must match exactly
-	var currentReleaseTrain = strings.Split(sdkApiVersion, ".")[1]
+	var currentReleaseTrain = strings.Split(sdkAPIVersion, ".")[1]
 	if currentReleaseTrain == "preview" {
-		return sdkApiVersion == eventApiVersion
+		return sdkAPIVersion == eventAPIVersion
 	}
 
 	// versions are yyyy-MM-dd.train
-	var eventReleaseTrain = strings.Split(eventApiVersion, ".")[1]
+	var eventReleaseTrain = strings.Split(eventAPIVersion, ".")[1]
 	return eventReleaseTrain == currentReleaseTrain
 }
 

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -227,11 +227,11 @@ func constructEvent(payload []byte, sigHeader string, secret string, options Con
 	}
 
 	if err := json.Unmarshal(payload, &e); err != nil {
-		return e, fmt.Errorf("Failed to parse webhook body json: %s", err.Error())
+		return e, fmt.Errorf("failed to parse webhook body json: %s", err.Error())
 	}
 
 	if !options.IgnoreAPIVersionMismatch && !isCompatibleAPIVersion(stripe.APIVersion, e.APIVersion) {
-		return e, fmt.Errorf("Received event with API version %s, but stripe-go %s expects API version %s. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this error by using `ConstructEventWithOptions(..., ConstructEventOptions{..., ignoreAPIVersionMismatch: true})`  but be wary that objects may be incorrectly deserialized.", e.APIVersion, stripe.ClientVersion, stripe.APIVersion)
+		return e, fmt.Errorf("received event with API version %s, but stripe-go %s expects API version %s. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this error by using `ConstructEventWithOptions(..., ConstructEventOptions{..., ignoreAPIVersionMismatch: true})`  but be wary that objects may be incorrectly deserialized", e.APIVersion, stripe.ClientVersion, stripe.APIVersion)
 	}
 
 	return e, nil
@@ -242,11 +242,11 @@ func checkEventNotification(payload []byte) error {
 		Object string `json:"object"`
 	}{}
 	if err := json.Unmarshal(payload, &e); err != nil {
-		return fmt.Errorf("Failed to parse webhook body json: %s", err.Error())
+		return fmt.Errorf("failed to parse webhook body json: %s", err.Error())
 	}
 
 	if e.Object != "event" {
-		return fmt.Errorf("Did you use ConstructEvent to parse a thin event notification? If so, use ParseEventNotification instead.")
+		return fmt.Errorf("did you use ConstructEvent to parse a thin event notification? If so, use ParseEventNotification instead")
 	}
 
 	return nil

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -50,7 +50,7 @@ var (
 // See https://stripe.com/docs/webhooks#signatures for more information.
 func ComputeSignature(t time.Time, payload []byte, secret string) []byte {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("%d", t.Unix())))
+	fmt.Fprintf(mac, "%d", t.Unix())
 	mac.Write([]byte("."))
 	mac.Write(payload)
 	return mac.Sum(nil)
@@ -335,7 +335,7 @@ type SignedPayload struct {
 func GenerateTestSignedPayload(options *UnsignedPayload) *SignedPayload {
 	signedPayload := &SignedPayload{UnsignedPayload: *options}
 
-	if signedPayload.Timestamp == (time.Time{}) {
+	if signedPayload.Timestamp.IsZero() {
 		signedPayload.Timestamp = time.Now()
 	}
 

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -1,3 +1,6 @@
+// Package webhook provides utilities for parsing and validating Stripe webhook
+// event payloads, including signature verification against the
+// Stripe-Signature header.
 package webhook
 
 import (

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -50,7 +50,8 @@ var (
 // See https://stripe.com/docs/webhooks#signatures for more information.
 func ComputeSignature(t time.Time, payload []byte, secret string) []byte {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "%d", t.Unix())
+	// hmac.Hash.Write never returns a non-nil error per the hash.Hash interface contract.
+	_, _ = fmt.Fprintf(mac, "%d", t.Unix())
 	mac.Write([]byte("."))
 	mac.Write(payload)
 	return mac.Sum(nil)

--- a/webhook/client_handler_test.go
+++ b/webhook/client_handler_test.go
@@ -27,11 +27,11 @@ func Example() {
 
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest) // Return a 400 error on a bad signature
-			fmt.Fprintf(w, "%v", err)
+			_, _ = fmt.Fprintf(w, "%v", err)
 			return
 		}
 
-		fmt.Fprintf(w, "Received signed event: %v", event)
+		_, _ = fmt.Fprintf(w, "Received signed event: %v", event)
 	})
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/webhook/client_test.go
+++ b/webhook/client_test.go
@@ -249,7 +249,7 @@ func TestConstructEvent_ErrorOnLegacyAPIVersionMismatch(t *testing.T) {
 		t.Errorf("Expected error due to API version mismatch.")
 	}
 
-	if !strings.Contains(err.Error(), "Received event with API version") {
+	if !strings.Contains(err.Error(), "received event with API version") {
 		t.Errorf("Expected API version mismatch error but received %v", err)
 	}
 }
@@ -265,7 +265,7 @@ func TestConstructEvent_ErrorOnReleaseTrainMismatch(t *testing.T) {
 		t.Errorf("Expected error due to API version mismatch.")
 	}
 
-	if !strings.Contains(err.Error(), "Received event with API version") {
+	if !strings.Contains(err.Error(), "received event with API version") {
 		t.Errorf("Expected API version mismatch error but received %v", err)
 	}
 }

--- a/webhook/client_test.go
+++ b/webhook/client_test.go
@@ -313,8 +313,8 @@ func TestConstructEventWithOptions_UsesDefaultToleranceWhenNoneProvided(t *testi
 
 func TestApiVersionCompatibility(t *testing.T) {
 	tests := []struct {
-		sdkApiVersion   string
-		eventApiVersion string
+		sdkAPIVersion   string
+		eventAPIVersion string
 		expected        bool
 	}{
 		{"2024-02-31.acacia", "1999-03-31", false},
@@ -326,9 +326,9 @@ func TestApiVersionCompatibility(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := isCompatibleAPIVersion(test.sdkApiVersion, test.eventApiVersion)
+		result := isCompatibleAPIVersion(test.sdkAPIVersion, test.eventAPIVersion)
 		if result != test.expected {
-			t.Errorf("Expected %v for API version %s <> %s, got %v", test.expected, test.sdkApiVersion, test.eventApiVersion, result)
+			t.Errorf("Expected %v for API version %s <> %s, got %v", test.expected, test.sdkAPIVersion, test.eventAPIVersion, result)
 		}
 	}
 }

--- a/webhooks.go
+++ b/webhooks.go
@@ -174,11 +174,11 @@ func constructEvent(payload []byte, sigHeader string, secret string, cfg webhook
 	}
 
 	if err := json.Unmarshal(payload, &e); err != nil {
-		return e, fmt.Errorf("Failed to parse webhook body json: %s", err.Error())
+		return e, fmt.Errorf("failed to parse webhook body json: %s", err.Error())
 	}
 
 	if !cfg.IgnoreAPIVersionMismatch && !isCompatibleAPIVersion(APIVersion, e.APIVersion) {
-		return e, fmt.Errorf("Received event with API version %s, but stripe-go %s expects API version %s. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this error by using `ConstructEventWithOptions(..., ConstructEventOptions{..., ignoreAPIVersionMismatch: true})`  but be wary that objects may be incorrectly deserialized.", e.APIVersion, ClientVersion, APIVersion)
+		return e, fmt.Errorf("received event with API version %s, but stripe-go %s expects API version %s. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this error by using `ConstructEventWithOptions(..., ConstructEventOptions{..., ignoreAPIVersionMismatch: true})`  but be wary that objects may be incorrectly deserialized", e.APIVersion, ClientVersion, APIVersion)
 	}
 
 	return e, nil
@@ -189,11 +189,11 @@ func checkEventNotification(payload []byte) error {
 		Object string `json:"object"`
 	}{}
 	if err := json.Unmarshal(payload, &e); err != nil {
-		return fmt.Errorf("Failed to parse webhook body json: %s", err.Error())
+		return fmt.Errorf("failed to parse webhook body json: %s", err.Error())
 	}
 
 	if e.Object != "event" {
-		return fmt.Errorf("Did you use ConstructEvent to parse a thin event notification? If so, use ParseEventNotification instead.")
+		return fmt.Errorf("did you use ConstructEvent to parse a thin event notification? If so, use ParseEventNotification instead")
 	}
 
 	return nil

--- a/webhooks.go
+++ b/webhooks.go
@@ -45,7 +45,8 @@ var (
 // See https://stripe.com/docs/webhooks#signatures for more information.
 func ComputeSignature(t time.Time, payload []byte, secret string) []byte {
 	mac := hmac.New(sha256.New, []byte(secret))
-	fmt.Fprintf(mac, "%d", t.Unix())
+	// hmac.Hash.Write never returns a non-nil error per the hash.Hash interface contract.
+	_, _ = fmt.Fprintf(mac, "%d", t.Unix())
 	mac.Write([]byte("."))
 	mac.Write(payload)
 	return mac.Sum(nil)

--- a/webhooks.go
+++ b/webhooks.go
@@ -45,7 +45,7 @@ var (
 // See https://stripe.com/docs/webhooks#signatures for more information.
 func ComputeSignature(t time.Time, payload []byte, secret string) []byte {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("%d", t.Unix())))
+	fmt.Fprintf(mac, "%d", t.Unix())
 	mac.Write([]byte("."))
 	mac.Write(payload)
 	return mac.Sum(nil)
@@ -282,7 +282,7 @@ type SignedPayload struct {
 func GenerateTestSignedPayload(options *UnsignedPayload) *SignedPayload {
 	signedPayload := &SignedPayload{UnsignedPayload: *options}
 
-	if signedPayload.Timestamp == (time.Time{}) {
+	if signedPayload.Timestamp.IsZero() {
 		signedPayload.Timestamp = time.Now()
 	}
 

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -248,7 +248,7 @@ func TestConstructEvent_ErrorOnLegacyAPIVersionMismatch(t *testing.T) {
 		t.Errorf("Expected error due to API version mismatch.")
 	}
 
-	if !strings.Contains(err.Error(), "Received event with API version") {
+	if !strings.Contains(err.Error(), "received event with API version") {
 		t.Errorf("Expected API version mismatch error but received %v", err)
 	}
 }
@@ -264,7 +264,7 @@ func TestConstructEvent_ErrorOnReleaseTrainMismatch(t *testing.T) {
 		t.Errorf("Expected error due to API version mismatch.")
 	}
 
-	if !strings.Contains(err.Error(), "Received event with API version") {
+	if !strings.Contains(err.Error(), "received event with API version") {
 		t.Errorf("Expected API version mismatch error but received %v", err)
 	}
 }


### PR DESCRIPTION
### Why?
Follow-up to #2360 (golangci-lint migration), which replaced staticcheck with golangci-lint. The latter has a superset of linters, some of which were failing so we suppressed them temporarily. This PR unsuppresses most of the new checks.

### What?
Unsuppresses and fixes almost all golangci-lint checks:
- **ST1000**: Add missing package comments to `form`, `mock`, `testing`, and `webhook` packages
- **ST1001**: Replace dot import in `mock/mock.go` with explicit `stripetest` alias
- **ST1003**: Rename `sdkApiVersion`/`eventApiVersion` → `sdkAPIVersion`/`eventAPIVersion` in `webhook/` to comply with Go initialisms convention
- **QF**: Apply staticcheck quickfix suggestions across 6 files:
  - `strings.ReplaceAll` instead of `strings.Replace(..., -1)`
  - De Morgan's law on double-negation in `stripe.go`
  - `fmt.Fprintf` instead of `Write([]byte(fmt.Sprintf(...)))`
  - `time.Time.IsZero()` instead of `== time.Time{}`
  - Tagged `switch` on `r.URL.RawQuery` in `search_iter_test.go`
  - Remove redundant embedded-field qualifier in `v2_events.go` (regenerated via codegen fix)
- `errcheck`: unchecked errors in `stripe.go`, `log.go`, and test files
- `SA1019`: deprecated `client.New` usage in some files
- `ST1005`: capitalized error strings

Remaining checks left suppressed
- `ST1020`/`ST1021`: Our type and function comments are derived from the OpenAPI spec (same as the descriptions found in https://docs.stripe.com/api). These comments do not adhere to the Go standard of starting comments with the name of the type/function
- `SA1019`: Some tests purposefully depend on the deprecated `client.API`. Once we remove that deprecated type, we can remove those deprecated call sites.

## Changelog
- Lint compliance for golangci-lint, which includes uncapitalizing some `Error` strings. If you are handling errors by matching on error strings, we recommend switching to use `error` types like `CardError` instead.