### PR TITLE
Remove `Limit`, `StartingAfter`, and `EndingBefore` fields for `List` methods that do not accept those fields

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -64,8 +64,8 @@ const (
 
 // Returns a list of capabilities associated with the account. The capabilities are returned sorted by creation date, with the most recent capability appearing first.
 type CapabilityListParams struct {
-	ListParams `form:"*"`
-	Account    *string `form:"-"` // Included in URL
+	Params  `form:"*"`
+	Account *string `form:"-"` // Included in URL
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand" json:"expand,omitempty"`
 }

--- a/capability/client.go
+++ b/capability/client.go
@@ -75,12 +75,18 @@ func List(params *stripe.CapabilityListParams) *Iter {
 //
 // [migration guide]: https://github.com/stripe/stripe-go/wiki/Migration-guide-for-Stripe-Client
 func (c Client) List(listParams *stripe.CapabilityListParams) *Iter {
+	if listParams == nil {
+		listParams = &stripe.CapabilityListParams{}
+	}
+	p := listParams.GetParams()
 	path := stripe.FormatURLPath(
 		"/v1/accounts/%s/capabilities", stripe.StringValue(listParams.Account))
+	queryParams := &form.Values{}
+	form.AppendTo(queryParams, listParams)
 	return &Iter{
-		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+		Iter: stripe.GetIter(nil, func(_ *stripe.Params, _ *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.CapabilityList{}
-			err := c.B.CallRaw(http.MethodGet, path, c.Key, []byte(b.Encode()), p, list)
+			err := c.B.CallRaw(http.MethodGet, path, c.Key, []byte(queryParams.Encode()), p, list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/capability_service.go
+++ b/capability_service.go
@@ -50,16 +50,15 @@ func (c v1CapabilityService) List(ctx context.Context, listParams *CapabilityLis
 	if listParams == nil {
 		listParams = &CapabilityListParams{}
 	}
-	listParams.Context = ctx
+	p := listParams.GetParams()
+	p.Context = ctx
 	path := FormatURLPath(
 		"/v1/accounts/%s/capabilities", StringValue(listParams.Account))
-	return newV1List(ctx, listParams, func(ctx context.Context, p *Params, b *form.Values) (*v1Page[*Capability], error) {
+	queryParams := &form.Values{}
+	form.AppendTo(queryParams, listParams)
+	return newV1List(ctx, nil, func(ctx context.Context, _ *Params, _ *form.Values) (*v1Page[*Capability], error) {
 		list := &v1Page[*Capability]{}
-		if p == nil {
-			p = &Params{}
-		}
-		p.Context = ctx
-		err := c.B.CallRaw(http.MethodGet, path, c.Key, []byte(b.Encode()), p, list)
+		err := c.B.CallRaw(http.MethodGet, path, c.Key, []byte(queryParams.Encode()), p, list)
 		return list, err
 	})
 }

--- a/paymentlocationcapability.go
+++ b/paymentlocationcapability.go
@@ -49,7 +49,7 @@ const (
 
 // Returns a list of PaymentLocationCapability objects associated with the location.
 type PaymentLocationCapabilityListParams struct {
-	ListParams `form:"*"`
+	Params `form:"*"`
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand" json:"expand,omitempty"`
 	// The location for which the capabilities enable functionality.

--- a/paymentlocationcapability/client.go
+++ b/paymentlocationcapability/client.go
@@ -70,10 +70,16 @@ func List(params *stripe.PaymentLocationCapabilityListParams) *Iter {
 //
 // [migration guide]: https://github.com/stripe/stripe-go/wiki/Migration-guide-for-Stripe-Client
 func (c Client) List(listParams *stripe.PaymentLocationCapabilityListParams) *Iter {
+	if listParams == nil {
+		listParams = &stripe.PaymentLocationCapabilityListParams{}
+	}
+	p := listParams.GetParams()
+	queryParams := &form.Values{}
+	form.AppendTo(queryParams, listParams)
 	return &Iter{
-		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+		Iter: stripe.GetIter(nil, func(_ *stripe.Params, _ *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.PaymentLocationCapabilityList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/payment_location_capabilities", c.Key, []byte(b.Encode()), p, list)
+			err := c.B.CallRaw(http.MethodGet, "/v1/payment_location_capabilities", c.Key, []byte(queryParams.Encode()), p, list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/paymentlocationcapability_service.go
+++ b/paymentlocationcapability_service.go
@@ -50,14 +50,13 @@ func (c v1PaymentLocationCapabilityService) List(ctx context.Context, listParams
 	if listParams == nil {
 		listParams = &PaymentLocationCapabilityListParams{}
 	}
-	listParams.Context = ctx
-	return newV1List(ctx, listParams, func(ctx context.Context, p *Params, b *form.Values) (*v1Page[*PaymentLocationCapability], error) {
+	p := listParams.GetParams()
+	p.Context = ctx
+	queryParams := &form.Values{}
+	form.AppendTo(queryParams, listParams)
+	return newV1List(ctx, nil, func(ctx context.Context, _ *Params, _ *form.Values) (*v1Page[*PaymentLocationCapability], error) {
 		list := &v1Page[*PaymentLocationCapability]{}
-		if p == nil {
-			p = &Params{}
-		}
-		p.Context = ctx
-		err := c.B.CallRaw(http.MethodGet, "/v1/payment_location_capabilities", c.Key, []byte(b.Encode()), p, list)
+		err := c.B.CallRaw(http.MethodGet, "/v1/payment_location_capabilities", c.Key, []byte(queryParams.Encode()), p, list)
 		return list, err
 	})
 }

--- a/reporting/reporttype/client.go
+++ b/reporting/reporttype/client.go
@@ -51,10 +51,16 @@ func List(params *stripe.ReportingReportTypeListParams) *Iter {
 //
 // [migration guide]: https://github.com/stripe/stripe-go/wiki/Migration-guide-for-Stripe-Client
 func (c Client) List(listParams *stripe.ReportingReportTypeListParams) *Iter {
+	if listParams == nil {
+		listParams = &stripe.ReportingReportTypeListParams{}
+	}
+	p := listParams.GetParams()
+	queryParams := &form.Values{}
+	form.AppendTo(queryParams, listParams)
 	return &Iter{
-		Iter: stripe.GetIter(listParams, func(p *stripe.Params, b *form.Values) ([]interface{}, stripe.ListContainer, error) {
+		Iter: stripe.GetIter(nil, func(_ *stripe.Params, _ *form.Values) ([]interface{}, stripe.ListContainer, error) {
 			list := &stripe.ReportingReportTypeList{}
-			err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_types", c.Key, []byte(b.Encode()), p, list)
+			err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_types", c.Key, []byte(queryParams.Encode()), p, list)
 
 			ret := make([]interface{}, len(list.Data))
 			for i, v := range list.Data {

--- a/reporting_reporttype.go
+++ b/reporting_reporttype.go
@@ -8,7 +8,7 @@ package stripe
 
 // Returns a full list of Report Types.
 type ReportingReportTypeListParams struct {
-	ListParams `form:"*"`
+	Params `form:"*"`
 	// Specifies which fields in the response should be expanded.
 	Expand []*string `form:"expand" json:"expand,omitempty"`
 }

--- a/reporting_reporttype_service.go
+++ b/reporting_reporttype_service.go
@@ -36,14 +36,13 @@ func (c v1ReportingReportTypeService) List(ctx context.Context, listParams *Repo
 	if listParams == nil {
 		listParams = &ReportingReportTypeListParams{}
 	}
-	listParams.Context = ctx
-	return newV1List(ctx, listParams, func(ctx context.Context, p *Params, b *form.Values) (*v1Page[*ReportingReportType], error) {
+	p := listParams.GetParams()
+	p.Context = ctx
+	queryParams := &form.Values{}
+	form.AppendTo(queryParams, listParams)
+	return newV1List(ctx, nil, func(ctx context.Context, _ *Params, _ *form.Values) (*v1Page[*ReportingReportType], error) {
 		list := &v1Page[*ReportingReportType]{}
-		if p == nil {
-			p = &Params{}
-		}
-		p.Context = ctx
-		err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_types", c.Key, []byte(b.Encode()), p, list)
+		err := c.B.CallRaw(http.MethodGet, "/v1/reporting/report_types", c.Key, []byte(queryParams.Encode()), p, list)
 		return list, err
 	})
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Some Stripe V1 APIs return a list object but don't accept `limit`, `starting_after`, or `ending_before` as parameters. The Go SDK includes `ListParams` in every list method params struct, which makes those fields appear accessible. If a user sets them, the API returns a 400 \"param not recognized\" error.

Affected endpoints:
- `GET /v1/accounts/{account}/capabilities`
- `GET /v1/reporting/report_types`
- `GET /v1/reporting/payment_location_capabilities` (private preview only)

After this change, the params structs for these endpoints embed `Params` instead of `ListParams`, so those pagination fields simply don't exist on the type. 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Replaces the embedded `ListParams` with `Params` in `CapabilityListParams`, `PaymentLocationCapabilityListParams`, and `ReportingReportTypeListParams`. This removes the `Limit`, `StartingAfter`, and `EndingBefore` fields from those latter types.
- The corresponding service methods pass in an empty `ListParams` to the iteration infrastructure.

## Changelog
<!-- Include any links or additional information that help explain this change. -->
- Fixes a bug where `Limit`, `StartingAfter`, and `EndingBefore` were embedded in `CapabilityListParams`, `PaymentLocationCapabilityListParams`, and `ReportingReportTypeListParams` even though they are not valid parameters and would have always resulted in a 400 from the Stripe API if set. If you were including them before in any of those 3 structs, you can safely remove them.