### PR TITLE
Add "source" field to user-agent header

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -4,7 +4,9 @@ package stripe
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1810,6 +1812,7 @@ type stripeClientUserAgent struct {
 	Language        string   `json:"lang"`
 	LanguageVersion string   `json:"lang_version"`
 	Platform        string   `json:"platform,omitempty"`
+	Source          string   `json:"source,omitempty"`
 }
 
 // requestMetrics contains the id and duration of the last request sent
@@ -1834,6 +1837,7 @@ var backends Backends
 var encodedStripeUserAgent string
 var encodedStripeUserAgentReady *sync.Once
 var encodedUserAgent string
+var stripeSourceHash string
 
 // The default HTTP client used for communication with any of Stripe's
 // backends.
@@ -1877,6 +1881,15 @@ func init() {
 	initUserAgent()
 }
 
+func init() {
+	parts := []string{runtime.GOOS, runtime.GOARCH, runtime.Version()}
+	if h, err := os.Hostname(); err == nil {
+		parts = append(parts, h)
+	}
+	hash := md5.Sum([]byte(strings.Join(parts, " ")))
+	stripeSourceHash = hex.EncodeToString(hash[:])
+}
+
 func initUserAgent() {
 	encodedUserAgent = "Stripe/v1 GoBindings/" + clientversion
 	if appInfo != nil {
@@ -1895,6 +1908,7 @@ func getEncodedStripeUserAgent(enableTelemetry bool) string {
 			BindingsVersion: clientversion,
 			Language:        "go",
 			LanguageVersion: runtime.Version(),
+			Source:          stripeSourceHash,
 		}
 		if enableTelemetry {
 			stripeUserAgent.Platform = runtime.GOOS + " " + runtime.GOARCH

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -2091,6 +2091,54 @@ func TestStripeClientUserAgentOmitsPlatformWithoutTelemetry(t *testing.T) {
 	assert.Empty(t, userAgent["platform"])
 }
 
+func TestStripeClientUserAgentSourceHash(t *testing.T) {
+	originalEncoded := encodedStripeUserAgent
+	originalReady := encodedStripeUserAgentReady
+	defer func() {
+		encodedStripeUserAgent = originalEncoded
+		encodedStripeUserAgentReady = originalReady
+	}()
+
+	encodedStripeUserAgentReady = &sync.Once{}
+
+	encoded := getEncodedStripeUserAgent(true)
+	var userAgent map[string]interface{}
+	err := json.Unmarshal([]byte(encoded), &userAgent)
+	assert.NoError(t, err)
+
+	// stripeSourceHash is computed from `uname -a` in init(). On systems where
+	// uname is available (all CI environments), the field should be a non-empty
+	// 32-character hex MD5 digest. We validate format rather than value because
+	// the hash is machine-specific.
+	source, ok := userAgent["source"]
+	assert.True(t, ok, "expected 'source' field to be present in X-Stripe-Client-User-Agent")
+	sourceStr, isString := source.(string)
+	assert.True(t, isString, "expected 'source' field to be a string")
+	assert.Regexp(t, `^[0-9a-f]{32}$`, sourceStr, "expected 'source' to be a 32-char lowercase hex MD5 digest")
+}
+
+func TestStripeClientUserAgentOmitsSourceWhenEmpty(t *testing.T) {
+	originalEncoded := encodedStripeUserAgent
+	originalReady := encodedStripeUserAgentReady
+	originalSourceHash := stripeSourceHash
+	defer func() {
+		encodedStripeUserAgent = originalEncoded
+		encodedStripeUserAgentReady = originalReady
+		stripeSourceHash = originalSourceHash
+	}()
+
+	stripeSourceHash = ""
+	encodedStripeUserAgentReady = &sync.Once{}
+
+	encoded := getEncodedStripeUserAgent(true)
+	var userAgent map[string]interface{}
+	err := json.Unmarshal([]byte(encoded), &userAgent)
+	assert.NoError(t, err)
+
+	_, ok := userAgent["source"]
+	assert.False(t, ok, "expected 'source' field to be absent from X-Stripe-Client-User-Agent when stripeSourceHash is empty")
+}
+
 func TestResponseToError(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Earlier this year, we removed the output of `uname` from the user-agent header for privacy reasons. It over-collected data we usually didn't need.

Since then, our tech support team has reached out asking us to re-add some of the information to help with complex debugging tasks: sometimes they need to help users identify exactly which machine produced an API call.

Rather than just revert the previous change and reintroduce the same privacy issues that caused its removal in the first place, we're taking a more privacy-focused approach. Rather than send all the PII in plaintext, we hash it first. This way it can still be used to confirm the source of an API call if a user generates the hashes themselves, but isn't sensitive in and of itself.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `source` key to user-agent hash. It's contents are an md5 hash of `uname -a`
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3131](https://go/j/DEVSDK-3131)
