### PR TITLE
Add "source" field to user-agent header

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -4,7 +4,9 @@ package stripe
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -1810,6 +1813,7 @@ type stripeClientUserAgent struct {
 	Language        string   `json:"lang"`
 	LanguageVersion string   `json:"lang_version"`
 	Platform        string   `json:"platform,omitempty"`
+	Source          string   `json:"source,omitempty"`
 }
 
 // requestMetrics contains the id and duration of the last request sent
@@ -1888,6 +1892,16 @@ func initUserAgent() {
 	encodedStripeUserAgentReady = &sync.Once{}
 }
 
+func getMachineSigHash() string {
+	cmd := exec.Command("uname", "-a")
+	output, err := cmd.Output()
+	if err != nil {
+		output = []byte(runtime.GOOS + " " + runtime.GOARCH)
+	}
+	hash := md5.Sum(output)
+	return hex.EncodeToString(hash[:])
+}
+
 func getEncodedStripeUserAgent(enableTelemetry bool) string {
 	encodedStripeUserAgentReady.Do(func() {
 		stripeUserAgent := &stripeClientUserAgent{
@@ -1898,6 +1912,7 @@ func getEncodedStripeUserAgent(enableTelemetry bool) string {
 		}
 		if enableTelemetry {
 			stripeUserAgent.Platform = runtime.GOOS + " " + runtime.GOARCH
+			stripeUserAgent.Source = getMachineSigHash()
 		}
 		if agent, ok := detectAIAgent(os.LookupEnv); ok {
 			stripeUserAgent.AIAgent = agent

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -2091,6 +2091,47 @@ func TestStripeClientUserAgentOmitsPlatformWithoutTelemetry(t *testing.T) {
 	assert.Empty(t, userAgent["platform"])
 }
 
+func TestStripeClientUserAgentIncludesSourceWithTelemetry(t *testing.T) {
+	originalEncoded := encodedStripeUserAgent
+	originalReady := encodedStripeUserAgentReady
+	defer func() {
+		encodedStripeUserAgent = originalEncoded
+		encodedStripeUserAgentReady = originalReady
+	}()
+
+	encodedStripeUserAgentReady = &sync.Once{}
+
+	encoded := getEncodedStripeUserAgent(true)
+	var userAgent map[string]interface{}
+	err := json.Unmarshal([]byte(encoded), &userAgent)
+	assert.NoError(t, err)
+
+	source, ok := userAgent["source"].(string)
+	assert.True(t, ok, "source field should be a string")
+	assert.Equal(t, 32, len(source), "source should be a 32-character MD5 hex string")
+	for _, c := range source {
+		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'), "source should contain only hex characters")
+	}
+}
+
+func TestStripeClientUserAgentOmitsSourceWithoutTelemetry(t *testing.T) {
+	originalEncoded := encodedStripeUserAgent
+	originalReady := encodedStripeUserAgentReady
+	defer func() {
+		encodedStripeUserAgent = originalEncoded
+		encodedStripeUserAgentReady = originalReady
+	}()
+
+	encodedStripeUserAgentReady = &sync.Once{}
+
+	encoded := getEncodedStripeUserAgent(false)
+	var userAgent map[string]string
+	err := json.Unmarshal([]byte(encoded), &userAgent)
+	assert.NoError(t, err)
+
+	assert.Empty(t, userAgent["source"])
+}
+
 func TestResponseToError(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 


### PR DESCRIPTION
### Why?

The \`uname\` output was previously removed from the user-agent header for
privacy reasons. Stripe's support team has since asked for a way to
identify which machine produced an API call for complex debugging tasks.

Rather than reverting the original change, this takes a privacy-preserving
approach: send an MD5 hash of \`uname -a\` instead of the plaintext output.
Users can reproduce the hash locally to confirm the source of a call without
the SDK ever exposing raw machine information.

### What?

- Add \`source\` field to \`stripeClientUserAgent\`, containing an MD5 hash of \`uname -a\`
- Falls back to hashing \`runtime.GOOS + " " + runtime.GOARCH\` on platforms where \`uname\` is unavailable
- Gated on \`enableTelemetry\`, consistent with the existing \`platform\` field
- Add tests

### See Also

- #2370