### PR TITLE
Add lint exclusions for pre-existing issues (DEVSDK-3134)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,3 +40,20 @@ linters:
         linters: [staticcheck]
         text: "SA1019"
 
+      # Deferred lint fixes: pre-existing issues surfaced by the golangci-lint
+      # migration (#2360/#2361). Tracked in DEVSDK-3134.
+      #
+      # errcheck: unchecked returns in tests and example code.
+      - path: "^stripe_test\\.go$"
+        linters: [errcheck]
+      - path: "^example/"
+        linters: [errcheck]
+      # ST1005: error string punctuation in generated file.
+      - path: "^stripe_event_notification_handler\\.go$"
+        linters: [staticcheck]
+        text: "ST1005"
+      # ST1003: trimApiVersion naming in webhook/client.go (private-preview code).
+      - path: "^webhook/client\\.go$"
+        linters: [staticcheck]
+        text: "ST1003"
+


### PR DESCRIPTION
## Summary

The golangci-lint migration (#2360/#2361) surfaced lint issues in private-preview code that were not caught by the previous linter setup. This adds exclusion rules to unblock the `latest-codegen-private-preview` branch (#2365) while tracking proper fixes in [DEVSDK-3134](http://jira.corp.stripe.com/browse/DEVSDK-3134).

Suppressed issues:
- `errcheck` in `stripe_test.go` (unchecked `AddBetaVersion` returns)
- `errcheck` in `example/v2/` (example code)
- `ST1005` in `stripe_event_notification_handler.go` (generated file — error string punctuation)
- `ST1003` in `webhook/client.go` (`trimApiVersion` naming — private-preview code)

## Test plan

- [x] `just lint` passes locally with 0 issues
- [ ] CI passes on this PR
- [ ] CI passes on #2365 after merging this

🤖 Generated with [Claude Code](https://claude.com/claude-code)