### PR TITLE
⚠️ Make `tax_rate.tax_details` expandable

### DIFF
--- a/creditnote.go
+++ b/creditnote.go
@@ -813,7 +813,7 @@ type CreditNoteShippingCost struct {
 // Additional details about the tax rate. Only present when `type` is `tax_rate_details`.
 type CreditNoteTotalTaxTaxRateDetails struct {
 	// ID of the tax rate
-	TaxRate string `json:"tax_rate"`
+	TaxRate *TaxRate `json:"tax_rate"`
 }
 
 // The aggregate tax information for all line items.

--- a/creditnotelineitem.go
+++ b/creditnotelineitem.go
@@ -87,7 +87,7 @@ type CreditNoteLineItemPretaxCreditAmount struct {
 // Additional details about the tax rate. Only present when `type` is `tax_rate_details`.
 type CreditNoteLineItemTaxTaxRateDetails struct {
 	// ID of the tax rate
-	TaxRate string `json:"tax_rate"`
+	TaxRate *TaxRate `json:"tax_rate"`
 }
 
 // The tax information of the line item.

--- a/invoice.go
+++ b/invoice.go
@@ -3677,7 +3677,7 @@ type InvoiceTotalPretaxCreditAmount struct {
 // Additional details about the tax rate. Only present when `type` is `tax_rate_details`.
 type InvoiceTotalTaxTaxRateDetails struct {
 	// ID of the tax rate
-	TaxRate string `json:"tax_rate"`
+	TaxRate *TaxRate `json:"tax_rate"`
 }
 
 // The aggregate tax information of all line items.

--- a/invoicelineitem.go
+++ b/invoicelineitem.go
@@ -512,7 +512,7 @@ type InvoiceLineItemPricing struct {
 // Additional details about the tax rate. Only present when `type` is `tax_rate_details`.
 type InvoiceLineItemTaxTaxRateDetails struct {
 	// ID of the tax rate
-	TaxRate string `json:"tax_rate"`
+	TaxRate *TaxRate `json:"tax_rate"`
 }
 
 // The tax information of the line item.


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In the recent `2026-04-22.dahlia` API version, we made `tax_details` [expandable wherever they appear](https://docs.stripe.com/changelog/dahlia/2026-04-22/adds-expandable-tax-rate-property-to-tax-rate-details). Changing the type of a field is a breaking change in the SDKs, so the team made the decision to hold that field change out of the SDKs until our next major version in September (which is a fairly common pattern for us).

We figured that by keeping the field as as string, existing users wouldn't have to navigate a breaking change, but users who wanted to could expand and use as needed (after doing some manual type casting). This _is_ true for our interpreted SDKs, but isn't in the compiled ones. In compiled SDKs, expanding `tax_details` fails at runtime because we try to deserialize an object into a string.

The feature needs to work, so we're biting the bullet and doing an out-of-band major in our compiled languages.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- regenerate SDK, which converts 4 usages of `tax_rate.tax_details` into expandable fields

### See Also

<!-- Include any links or additional information that help explain this change. -->
