### PR TITLE
Replace source hash with Telemetry UUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,20 +78,28 @@ jobs:
         run: govulncheck ./...
 
   test:
-    runs-on: "ubuntu-24.04"
+    name: "Test: go v${{ matrix.go }} (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
+        os:
+          - "ubuntu-24.04"
         go:
           # most recent 4 versions, once we're on schedule
           # https://docs.stripe.com/sdks/versioning?lang=go#stripe-sdk-language-version-support-policy
+          # https://endoflife.date/go
           - "1.26"
           - "1.25"
           - "1.24"
           - "1.23"
           - "1.22"
-    name: "Test: go v${{ matrix.go }}"
+        include:
+          - os: windows-latest
+            # use any modern-ish version
+            go: "1.26"
     steps:
       - uses: extractions/setup-just@v2
       - uses: actions/checkout@v6

--- a/stripe.go
+++ b/stripe.go
@@ -4,9 +4,7 @@ package stripe
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1812,7 +1810,7 @@ type stripeClientUserAgent struct {
 	Language        string   `json:"lang"`
 	LanguageVersion string   `json:"lang_version"`
 	Platform        string   `json:"platform,omitempty"`
-	Source          string   `json:"source,omitempty"`
+	TelemetryId     string   `json:"telemetry_id,omitempty"`
 }
 
 // requestMetrics contains the id and duration of the last request sent
@@ -1837,7 +1835,6 @@ var backends Backends
 var encodedStripeUserAgent string
 var encodedStripeUserAgentReady *sync.Once
 var encodedUserAgent string
-var stripeSourceHash string
 
 // The default HTTP client used for communication with any of Stripe's
 // backends.
@@ -1881,15 +1878,6 @@ func init() {
 	initUserAgent()
 }
 
-func init() {
-	parts := []string{runtime.GOOS, runtime.GOARCH, runtime.Version()}
-	if h, err := os.Hostname(); err == nil {
-		parts = append(parts, h)
-	}
-	hash := md5.Sum([]byte(strings.Join(parts, " ")))
-	stripeSourceHash = hex.EncodeToString(hash[:])
-}
-
 func initUserAgent() {
 	encodedUserAgent = "Stripe/v1 GoBindings/" + clientversion
 	if appInfo != nil {
@@ -1908,10 +1896,10 @@ func getEncodedStripeUserAgent(enableTelemetry bool) string {
 			BindingsVersion: clientversion,
 			Language:        "go",
 			LanguageVersion: runtime.Version(),
-			Source:          stripeSourceHash,
 		}
 		if enableTelemetry {
 			stripeUserAgent.Platform = runtime.GOOS + " " + runtime.GOARCH
+			stripeUserAgent.TelemetryId = getTelemetryId()
 		}
 		if agent, ok := detectAIAgent(os.LookupEnv); ok {
 			stripeUserAgent.AIAgent = agent

--- a/stripe.go
+++ b/stripe.go
@@ -1810,7 +1810,7 @@ type stripeClientUserAgent struct {
 	Language        string   `json:"lang"`
 	LanguageVersion string   `json:"lang_version"`
 	Platform        string   `json:"platform,omitempty"`
-	TelemetryId     string   `json:"telemetry_id,omitempty"`
+	TelemetryID     string   `json:"telemetry_id,omitempty"`
 }
 
 // requestMetrics contains the id and duration of the last request sent
@@ -1899,7 +1899,7 @@ func getEncodedStripeUserAgent(enableTelemetry bool) string {
 		}
 		if enableTelemetry {
 			stripeUserAgent.Platform = runtime.GOOS + " " + runtime.GOARCH
-			stripeUserAgent.TelemetryId = getTelemetryId()
+			stripeUserAgent.TelemetryID = getTelemetryID()
 		}
 		if agent, ok := detectAIAgent(os.LookupEnv); ok {
 			stripeUserAgent.AIAgent = agent

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -2091,16 +2091,17 @@ func TestStripeClientUserAgentOmitsPlatformWithoutTelemetry(t *testing.T) {
 	assert.Empty(t, userAgent["platform"])
 }
 
-func TestStripeClientUserAgentContainsTelemetryId(t *testing.T) {
+func TestStripeClientUserAgentContainsTelemetryID(t *testing.T) {
 	originalEncoded := encodedStripeUserAgent
 	originalReady := encodedStripeUserAgentReady
 	defer func() {
 		encodedStripeUserAgent = originalEncoded
 		encodedStripeUserAgentReady = originalReady
-		resetTelemetryId()
+		resetTelemetryID()
 	}()
 
-	resetTelemetryId()
+	resetTelemetryID()
+	configDirOverride = t.TempDir()
 	encodedStripeUserAgentReady = &sync.Once{}
 
 	encoded := getEncodedStripeUserAgent(true)
@@ -2111,23 +2112,23 @@ func TestStripeClientUserAgentContainsTelemetryId(t *testing.T) {
 	// telemetry_id should be present when telemetry is enabled. The value is a
 	// 32-character hex string (16 random bytes encoded as hex). We validate format
 	// rather than exact value because it is generated at runtime.
-	telemetryId, ok := userAgent["telemetry_id"]
+	telemetryID, ok := userAgent["telemetry_id"]
 	assert.True(t, ok, "expected 'telemetry_id' field to be present in X-Stripe-Client-User-Agent when telemetry is enabled")
-	telemetryIdStr, isString := telemetryId.(string)
+	telemetryIDStr, isString := telemetryID.(string)
 	assert.True(t, isString, "expected 'telemetry_id' field to be a string")
-	assert.Regexp(t, `^[0-9a-f]{32}$`, telemetryIdStr, "expected 'telemetry_id' to be a 32-char lowercase hex string")
+	assert.Regexp(t, `^[0-9a-f]{32}$`, telemetryIDStr, "expected 'telemetry_id' to be a 32-char lowercase hex string")
 }
 
-func TestStripeClientUserAgentOmitsTelemetryIdWhenDisabled(t *testing.T) {
+func TestStripeClientUserAgentOmitsTelemetryIDWhenDisabled(t *testing.T) {
 	originalEncoded := encodedStripeUserAgent
 	originalReady := encodedStripeUserAgentReady
 	defer func() {
 		encodedStripeUserAgent = originalEncoded
 		encodedStripeUserAgentReady = originalReady
-		resetTelemetryId()
+		resetTelemetryID()
 	}()
 
-	resetTelemetryId()
+	resetTelemetryID()
 	encodedStripeUserAgentReady = &sync.Once{}
 
 	encoded := getEncodedStripeUserAgent(false)

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -2091,14 +2091,16 @@ func TestStripeClientUserAgentOmitsPlatformWithoutTelemetry(t *testing.T) {
 	assert.Empty(t, userAgent["platform"])
 }
 
-func TestStripeClientUserAgentSourceHash(t *testing.T) {
+func TestStripeClientUserAgentContainsTelemetryId(t *testing.T) {
 	originalEncoded := encodedStripeUserAgent
 	originalReady := encodedStripeUserAgentReady
 	defer func() {
 		encodedStripeUserAgent = originalEncoded
 		encodedStripeUserAgentReady = originalReady
+		resetTelemetryId()
 	}()
 
+	resetTelemetryId()
 	encodedStripeUserAgentReady = &sync.Once{}
 
 	encoded := getEncodedStripeUserAgent(true)
@@ -2106,37 +2108,35 @@ func TestStripeClientUserAgentSourceHash(t *testing.T) {
 	err := json.Unmarshal([]byte(encoded), &userAgent)
 	assert.NoError(t, err)
 
-	// stripeSourceHash is computed from `uname -a` in init(). On systems where
-	// uname is available (all CI environments), the field should be a non-empty
-	// 32-character hex MD5 digest. We validate format rather than value because
-	// the hash is machine-specific.
-	source, ok := userAgent["source"]
-	assert.True(t, ok, "expected 'source' field to be present in X-Stripe-Client-User-Agent")
-	sourceStr, isString := source.(string)
-	assert.True(t, isString, "expected 'source' field to be a string")
-	assert.Regexp(t, `^[0-9a-f]{32}$`, sourceStr, "expected 'source' to be a 32-char lowercase hex MD5 digest")
+	// telemetry_id should be present when telemetry is enabled. The value is a
+	// 32-character hex string (16 random bytes encoded as hex). We validate format
+	// rather than exact value because it is generated at runtime.
+	telemetryId, ok := userAgent["telemetry_id"]
+	assert.True(t, ok, "expected 'telemetry_id' field to be present in X-Stripe-Client-User-Agent when telemetry is enabled")
+	telemetryIdStr, isString := telemetryId.(string)
+	assert.True(t, isString, "expected 'telemetry_id' field to be a string")
+	assert.Regexp(t, `^[0-9a-f]{32}$`, telemetryIdStr, "expected 'telemetry_id' to be a 32-char lowercase hex string")
 }
 
-func TestStripeClientUserAgentOmitsSourceWhenEmpty(t *testing.T) {
+func TestStripeClientUserAgentOmitsTelemetryIdWhenDisabled(t *testing.T) {
 	originalEncoded := encodedStripeUserAgent
 	originalReady := encodedStripeUserAgentReady
-	originalSourceHash := stripeSourceHash
 	defer func() {
 		encodedStripeUserAgent = originalEncoded
 		encodedStripeUserAgentReady = originalReady
-		stripeSourceHash = originalSourceHash
+		resetTelemetryId()
 	}()
 
-	stripeSourceHash = ""
+	resetTelemetryId()
 	encodedStripeUserAgentReady = &sync.Once{}
 
-	encoded := getEncodedStripeUserAgent(true)
+	encoded := getEncodedStripeUserAgent(false)
 	var userAgent map[string]interface{}
 	err := json.Unmarshal([]byte(encoded), &userAgent)
 	assert.NoError(t, err)
 
-	_, ok := userAgent["source"]
-	assert.False(t, ok, "expected 'source' field to be absent from X-Stripe-Client-User-Agent when stripeSourceHash is empty")
+	_, ok := userAgent["telemetry_id"]
+	assert.False(t, ok, "expected 'telemetry_id' field to be absent from X-Stripe-Client-User-Agent when telemetry is disabled")
 }
 
 func TestResponseToError(t *testing.T) {

--- a/telemetry_id.go
+++ b/telemetry_id.go
@@ -1,0 +1,77 @@
+package stripe
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var (
+	telemetryIdOnce  sync.Once
+	telemetryIdValue string
+)
+
+func getConfigDir() string {
+	if runtime.GOOS == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return ""
+		}
+		return filepath.Join(appData, "Stripe")
+	}
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+	if xdg != "" {
+		return filepath.Join(xdg, "stripe")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "stripe")
+}
+
+func getTelemetryId() string {
+	telemetryIdOnce.Do(func() {
+		configDir := getConfigDir()
+		if configDir == "" {
+			return
+		}
+
+		filePath := filepath.Join(configDir, "telemetry_id")
+
+		data, err := os.ReadFile(filePath)
+		if err == nil {
+			content := strings.TrimSpace(string(data))
+			if content != "" {
+				telemetryIdValue = content
+				return
+			}
+		}
+
+		b := make([]byte, 16)
+		if _, err := rand.Read(b); err != nil {
+			return
+		}
+		newId := hex.EncodeToString(b)
+
+		if err := os.MkdirAll(configDir, 0700); err != nil {
+			return
+		}
+		if err := os.WriteFile(filePath, []byte(newId), 0600); err != nil {
+			return
+		}
+
+		telemetryIdValue = newId
+	})
+	return telemetryIdValue
+}
+
+// resetTelemetryId resets the telemetry ID singleton for testing purposes.
+func resetTelemetryId() {
+	telemetryIdOnce = sync.Once{}
+	telemetryIdValue = ""
+}

--- a/telemetry_id.go
+++ b/telemetry_id.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	telemetryIdOnce  sync.Once
-	telemetryIdValue string
+	telemetryIDOnce  sync.Once
+	telemetryIDValue string
 )
 
 func getConfigDir() string {
@@ -34,9 +34,15 @@ func getConfigDir() string {
 	return filepath.Join(home, ".config", "stripe")
 }
 
-func getTelemetryId() string {
-	telemetryIdOnce.Do(func() {
-		configDir := getConfigDir()
+// configDirOverride is used by tests to redirect file I/O to a temp directory.
+var configDirOverride string
+
+func getTelemetryID() string {
+	telemetryIDOnce.Do(func() {
+		configDir := configDirOverride
+		if configDir == "" {
+			configDir = getConfigDir()
+		}
 		if configDir == "" {
 			return
 		}
@@ -47,7 +53,7 @@ func getTelemetryId() string {
 		if err == nil {
 			content := strings.TrimSpace(string(data))
 			if content != "" {
-				telemetryIdValue = content
+				telemetryIDValue = content
 				return
 			}
 		}
@@ -56,22 +62,23 @@ func getTelemetryId() string {
 		if _, err := rand.Read(b); err != nil {
 			return
 		}
-		newId := hex.EncodeToString(b)
+		newID := hex.EncodeToString(b)
 
-		if err := os.MkdirAll(configDir, 0700); err != nil {
+		if err := os.MkdirAll(configDir, 0755); err != nil {
 			return
 		}
-		if err := os.WriteFile(filePath, []byte(newId), 0600); err != nil {
+		if err := os.WriteFile(filePath, []byte(newID), 0644); err != nil {
 			return
 		}
 
-		telemetryIdValue = newId
+		telemetryIDValue = newID
 	})
-	return telemetryIdValue
+	return telemetryIDValue
 }
 
-// resetTelemetryId resets the telemetry ID singleton for testing purposes.
-func resetTelemetryId() {
-	telemetryIdOnce = sync.Once{}
-	telemetryIdValue = ""
+// resetTelemetryID resets the telemetry ID singleton for testing purposes.
+func resetTelemetryID() {
+	telemetryIDOnce = sync.Once{}
+	telemetryIDValue = ""
+	configDirOverride = ""
 }

--- a/telemetry_id_test.go
+++ b/telemetry_id_test.go
@@ -3,6 +3,7 @@ package stripe
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -60,6 +61,9 @@ func TestGetTelemetryIDGeneratesAndPersistsNewID(t *testing.T) {
 }
 
 func TestGetTelemetryIDReturnsEmptyWhenConfigDirEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod doesn't prevent writes on Windows")
+	}
 	resetTelemetryID()
 	t.Cleanup(resetTelemetryID)
 
@@ -75,6 +79,9 @@ func TestGetTelemetryIDReturnsEmptyWhenConfigDirEmpty(t *testing.T) {
 }
 
 func TestGetConfigDirRespectsXDGConfigHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG is not used on Windows")
+	}
 	t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
 
 	dir := getConfigDir()
@@ -82,6 +89,9 @@ func TestGetConfigDirRespectsXDGConfigHome(t *testing.T) {
 }
 
 func TestGetConfigDirFallsBackToHomeConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG is not used on Windows")
+	}
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", "/testhome")
 

--- a/telemetry_id_test.go
+++ b/telemetry_id_test.go
@@ -1,0 +1,111 @@
+package stripe
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetTelemetryIDReturns32CharHex(t *testing.T) {
+	resetTelemetryID()
+	t.Cleanup(resetTelemetryID)
+
+	configDirOverride = t.TempDir()
+
+	id := getTelemetryID()
+	assert.Regexp(t, `^[0-9a-f]{32}$`, id)
+}
+
+func TestGetTelemetryIDIsCached(t *testing.T) {
+	resetTelemetryID()
+	t.Cleanup(resetTelemetryID)
+
+	configDirOverride = t.TempDir()
+
+	first := getTelemetryID()
+	second := getTelemetryID()
+	assert.Equal(t, first, second)
+}
+
+func TestGetTelemetryIDReadsExistingFile(t *testing.T) {
+	resetTelemetryID()
+	t.Cleanup(resetTelemetryID)
+
+	dir := t.TempDir()
+	configDirOverride = dir
+
+	existingID := "aabbccddeeff00112233445566778899"
+	err := os.WriteFile(filepath.Join(dir, "telemetry_id"), []byte(existingID), 0644)
+	assert.NoError(t, err)
+
+	id := getTelemetryID()
+	assert.Equal(t, existingID, id)
+}
+
+func TestGetTelemetryIDGeneratesAndPersistsNewID(t *testing.T) {
+	resetTelemetryID()
+	t.Cleanup(resetTelemetryID)
+
+	dir := t.TempDir()
+	configDirOverride = dir
+
+	id := getTelemetryID()
+	assert.Regexp(t, `^[0-9a-f]{32}$`, id)
+
+	data, err := os.ReadFile(filepath.Join(dir, "telemetry_id"))
+	assert.NoError(t, err)
+	assert.Equal(t, id, string(data))
+}
+
+func TestGetTelemetryIDReturnsEmptyWhenConfigDirEmpty(t *testing.T) {
+	resetTelemetryID()
+	t.Cleanup(resetTelemetryID)
+
+	// Use a read-only parent directory so MkdirAll fails on the child path.
+	// getTelemetryID returns "" when it cannot persist the generated ID.
+	roDir := t.TempDir()
+	assert.NoError(t, os.Chmod(roDir, 0555))
+	t.Cleanup(func() { os.Chmod(roDir, 0755) })
+	configDirOverride = filepath.Join(roDir, "stripe")
+
+	id := getTelemetryID()
+	assert.Equal(t, "", id)
+}
+
+func TestGetConfigDirRespectsXDGConfigHome(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
+
+	dir := getConfigDir()
+	assert.Equal(t, "/custom/xdg/stripe", dir)
+}
+
+func TestGetConfigDirFallsBackToHomeConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "/testhome")
+
+	dir := getConfigDir()
+	assert.Equal(t, "/testhome/.config/stripe", dir)
+}
+
+func TestGetTelemetryIDCreatesParentDirectories(t *testing.T) {
+	resetTelemetryID()
+	t.Cleanup(resetTelemetryID)
+
+	// Point configDirOverride at a nested path that does not yet exist.
+	base := t.TempDir()
+	configDirOverride = filepath.Join(base, "nested", "stripe")
+
+	id := getTelemetryID()
+	assert.Regexp(t, `^[0-9a-f]{32}$`, id)
+
+	// The directory should have been created.
+	_, err := os.Stat(configDirOverride)
+	assert.NoError(t, err)
+
+	// And the file should exist inside it.
+	data, err := os.ReadFile(filepath.Join(configDirOverride, "telemetry_id"))
+	assert.NoError(t, err)
+	assert.Equal(t, id, string(data))
+}

--- a/telemetry_id_test.go
+++ b/telemetry_id_test.go
@@ -67,7 +67,7 @@ func TestGetTelemetryIDReturnsEmptyWhenConfigDirEmpty(t *testing.T) {
 	// getTelemetryID returns "" when it cannot persist the generated ID.
 	roDir := t.TempDir()
 	assert.NoError(t, os.Chmod(roDir, 0555))
-	t.Cleanup(func() { os.Chmod(roDir, 0755) })
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0755) })
 	configDirOverride = filepath.Join(roDir, "stripe")
 
 	id := getTelemetryID()


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Recently, we introduced the `source` hash in the user-agent header to help our support team track down exactly where incoming requests originated from.

They've reported back to us that this hasn't been as useful as we wanted, so we're going a different direction.

Instead, we're adopting an industry-standard method of persisting a small UUID on disk that we include with subsequent requests. It's easy for users to read this file and it contains no PII. It also honors our existing telemetry opt outs.

It's meant to be lightweight and failure tolerant.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove `source` key from user-agent header
- add `telemetry_id` to the user-agent header
- adjust tests accordingly

### See Also

<!-- Include any links or additional information that help explain this change. -->

- original request: [DEVSDK-3131](https://go/j/DEVSDK-3131)
- update request: [RUN_DEVSDK-2563](https://go/j/RUN_DEVSDK-2563)
