### PR TITLE
Fix Windows test hang in TestRawRequestTimeout_NilResponsePanic

### DIFF
--- a/rawrequest/client_test.go
+++ b/rawrequest/client_test.go
@@ -142,9 +142,11 @@ func TestV2GetRequestWithAdditionalHeaders(t *testing.T) {
 func TestRawRequestTimeout_NilResponsePanic(t *testing.T) {
 	// Create a test server that deliberately times out by never responding
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Simulate a slow endpoint that exceeds the timeout
-		// Don't write any response, causing the client to timeout
-		select {}
+		// Block until the client disconnects or the server is closed.
+		// Using r.Context().Done() instead of select{} ensures the handler
+		// exits when the connection is closed, allowing httptest.Server.Close()
+		// to drain cleanly.
+		<-r.Context().Done()
 	}))
 	defer testServer.Close()
 


### PR DESCRIPTION
### Why?
The handler used `select {}` to block forever, simulating a slow endpoint.  It's not entirely clear what's happening from the CI failure, but our hypothesis is that on Windows, the 1ns client timeout (possibly because the timer granularity is coarser, like 1ms) doesn't fire before the TCP handshake completes (coarser timer granularity), so the handler is invoked and blocks indefinitely. httptest.Server.Close() then hangs waiting for the active connection to drain.

When timing works (Linux, usually):

  1. Client calls Do() with a 1ns timeout (context deadline set)
  2. Client starts TCP dial to loopback
  3. The 1ns deadline fires → context cancelled → dial is aborted
  4. Do() returns nil response + deadline error
  5. The handler was never invoked because the connection never fully established
  6. testServer.Close() has no active connections → returns immediately

The test works because the timeout fires before the TCP handshake completes.

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

### What?
- Replace `select {}` with `<-r.Context().Done()` so the handler exits when the connection is closed, allowing the server to shut down cleanly.


### See Also
<!-- Include any links or additional information that help explain this change. -->
