### PR TITLE
Simplify internal `backends` implementation.

### DIFF
--- a/event_notification.go
+++ b/event_notification.go
@@ -80,6 +80,6 @@ func (n *UnknownEventNotification) FetchRelatedObject(ctx context.Context) (*API
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 
-	err := n.client.backend.Call(http.MethodGet, n.RelatedObject.URL, n.client.key, params, obj)
+	err := n.client.backends.API.Call(http.MethodGet, n.RelatedObject.URL, n.client.key, params, obj)
 	return obj, err
 }

--- a/stripe.go
+++ b/stripe.go
@@ -1408,6 +1408,7 @@ func (s *BackendImplementation) sleepTime(numRetries int) time.Duration {
 // Backends are the currently supported endpoints.
 type Backends struct {
 	API, Connect, Uploads, MeterEvents Backend
+	config                             *BackendConfig
 	mu                                 sync.RWMutex
 }
 
@@ -1626,16 +1627,8 @@ func Int64Slice(v []int64) []*int64 {
 
 // NewBackends creates a new set of backends with the given HTTP client.
 func NewBackends(httpClient *http.Client) *Backends {
-	apiConfig := &BackendConfig{HTTPClient: httpClient}
-	connectConfig := &BackendConfig{HTTPClient: httpClient}
-	uploadConfig := &BackendConfig{HTTPClient: httpClient}
-	meterConfig := &BackendConfig{HTTPClient: httpClient}
-	return &Backends{
-		API:         GetBackendWithConfig(APIBackend, apiConfig),
-		Connect:     GetBackendWithConfig(ConnectBackend, connectConfig),
-		Uploads:     GetBackendWithConfig(UploadsBackend, uploadConfig),
-		MeterEvents: GetBackendWithConfig(MeterEventsBackend, meterConfig),
-	}
+	config := &BackendConfig{HTTPClient: httpClient}
+	return NewBackendsWithConfig(config)
 }
 
 // NewBackendsWithConfig creates a new set of backends with the given config for all backends.
@@ -1646,6 +1639,7 @@ func NewBackendsWithConfig(config *BackendConfig) *Backends {
 		Connect:     GetBackendWithConfig(ConnectBackend, config),
 		Uploads:     GetBackendWithConfig(UploadsBackend, config),
 		MeterEvents: GetBackendWithConfig(MeterEventsBackend, config),
+		config:      config,
 	}
 }
 

--- a/stripe_client.go
+++ b/stripe_client.go
@@ -314,8 +314,8 @@ type Client struct {
 	V2CoreEvents *v2CoreEventService
 	// stripeClientStruct: The end of the section generated from our OpenAPI spec
 
-	backend Backend
-	key     string
+	backends *Backends
+	key      string
 }
 
 // NewClient creates a new Stripe [Client] with the given API key.
@@ -340,12 +340,12 @@ func initClient(client *Client, cfg clientConfig) {
 			Connect:     &UsageBackend{B: GetBackend(ConnectBackend), Usage: cfg.usage},
 			Uploads:     &UsageBackend{B: GetBackend(UploadsBackend), Usage: cfg.usage},
 			MeterEvents: &UsageBackend{B: GetBackend(MeterEventsBackend), Usage: cfg.usage},
+			config:      &BackendConfig{},
 		}
 	}
 	backends := cfg.backends
 	key := cfg.key
-	// enough information on the Client to make API calls
-	client.backend = backends.API
+	client.backends = backends
 	client.key = key
 
 	// stripeClientInit: The beginning of the section generated from our OpenAPI spec

--- a/v2_events.go
+++ b/v2_events.go
@@ -194,7 +194,7 @@ func (n *V1BillingMeterErrorReportTriggeredEventNotification) FetchRelatedObject
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &BillingMeter{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -257,7 +257,7 @@ func (n *V2CommerceProductCatalogImportsFailedEventNotification) FetchRelatedObj
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CommerceProductCatalogImport{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -298,7 +298,7 @@ func (n *V2CommerceProductCatalogImportsProcessingEventNotification) FetchRelate
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CommerceProductCatalogImport{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -339,7 +339,7 @@ func (n *V2CommerceProductCatalogImportsSucceededEventNotification) FetchRelated
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CommerceProductCatalogImport{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -380,7 +380,7 @@ func (n *V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification) Fe
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CommerceProductCatalogImport{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -421,7 +421,7 @@ func (n *V2CoreAccountClosedEventNotification) FetchRelatedObject(ctx context.Co
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -462,7 +462,7 @@ func (n *V2CoreAccountCreatedEventNotification) FetchRelatedObject(ctx context.C
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -503,7 +503,7 @@ func (n *V2CoreAccountUpdatedEventNotification) FetchRelatedObject(ctx context.C
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -545,7 +545,7 @@ func (n *V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEvent
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -586,7 +586,7 @@ func (n *V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification) Fe
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -628,7 +628,7 @@ func (n *V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEvent
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -669,7 +669,7 @@ func (n *V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification) Fe
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -711,7 +711,7 @@ func (n *V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEven
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -752,7 +752,7 @@ func (n *V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification) F
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -793,7 +793,7 @@ func (n *V2CoreAccountIncludingDefaultsUpdatedEventNotification) FetchRelatedObj
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -834,7 +834,7 @@ func (n *V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification) Fetch
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -875,7 +875,7 @@ func (n *V2CoreAccountIncludingIdentityUpdatedEventNotification) FetchRelatedObj
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -916,7 +916,7 @@ func (n *V2CoreAccountIncludingRequirementsUpdatedEventNotification) FetchRelate
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccount{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -980,7 +980,7 @@ func (n *V2CoreAccountPersonCreatedEventNotification) FetchRelatedObject(ctx con
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccountPerson{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -1022,7 +1022,7 @@ func (n *V2CoreAccountPersonDeletedEventNotification) FetchRelatedObject(ctx con
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccountPerson{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -1064,7 +1064,7 @@ func (n *V2CoreAccountPersonUpdatedEventNotification) FetchRelatedObject(ctx con
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreAccountPerson{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }
@@ -1105,7 +1105,7 @@ func (n *V2CoreEventDestinationPingEventNotification) FetchRelatedObject(ctx con
 	params.Headers = make(http.Header)
 	params.Headers.Set("Stripe-Request-Trigger", fmt.Sprintf("event=%s", n.ID))
 	relatedObj := &V2CoreEventDestination{}
-	err := n.client.backend.Call(
+	err := n.client.backends.API.Call(
 		http.MethodGet, n.RelatedObject.URL, n.client.key, params, relatedObj)
 	return relatedObj, err
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

This is a recreation of https://github.com/stripe/stripe-go/pull/2234, which was merged into https://github.com/stripe/stripe-go/pull/2209 and therefore hasn't hit the `master` branch yet. But, because our static `event_notification.go` is now getting properly synced, the way we call APIs needs to be standardized across the branches- we can't have it both ways. Given that, I'm brining this refactor `master` ahead of the rest of the managed event stuff.

It refactors the way we handle our API calling hardware, greatly simplifying making API calls with a `StripeClient` (because we reference the `API` host explicitly instead of having to guess what type we got). It's not super relevant here, but as you can see in Michael's original PR, it let us pull a ton of error handling out.

There are no user-facing changes.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- store `backends` on client instead of a single `backend`
- codegen

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://github.com/stripe/stripe-go/pull/2234
- https://github.com/stripe/stripe-go/pull/2209