### PR TITLE
maybe fix windows tests again

### DIFF
--- a/rawrequest/client_test.go
+++ b/rawrequest/client_test.go
@@ -140,15 +140,21 @@ func TestV2GetRequestWithAdditionalHeaders(t *testing.T) {
 // times out, causing http.Client.Do to return a nil response with an error,
 // which then leads to a nil pointer dereference in handleResponseBufferingErrors.
 func TestRawRequestTimeout_NilResponsePanic(t *testing.T) {
-	// Create a test server that deliberately times out by never responding
+	// Create a test server that deliberately times out by never responding.
+	// We use an explicit channel rather than r.Context().Done() because on
+	// Windows the server often fails to detect the client's TCP close, leaving
+	// the handler blocked and httptest.Server.Close() hanging indefinitely.
+	done := make(chan struct{})
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Block until the client disconnects or the server is closed.
-		// Using r.Context().Done() instead of select{} ensures the handler
-		// exits when the connection is closed, allowing httptest.Server.Close()
-		// to drain cleanly.
-		<-r.Context().Done()
+		select {
+		case <-r.Context().Done():
+		case <-done:
+		}
 	}))
-	defer testServer.Close()
+	defer func() {
+		close(done)
+		testServer.Close()
+	}()
 
 	// Create a backend with a very short timeout
 	backend := stripe.GetBackendWithConfig(

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -66,7 +66,7 @@ func init() {
 		Transport: transport,
 	}
 
-	resp, err := httpClient.Get("https://localhost:" + port)
+	resp, err := httpClient.Get("https://127.0.0.1:" + port)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't reach stripe-mock at `localhost:%s` (%v). Is "+
 			"it running? Please see README for setup instructions.\n", port, err)
@@ -95,7 +95,7 @@ func init() {
 	stripeMockBackend := stripe.GetBackendWithConfig(
 		stripe.APIBackend,
 		&stripe.BackendConfig{
-			URL:           stripe.String("https://localhost:" + port),
+			URL:           stripe.String("https://127.0.0.1:" + port),
 			HTTPClient:    httpClient,
 			LeveledLogger: stripe.DefaultLeveledLogger,
 		},


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've taken a couple of passes on fixing a single flaky windows test but it hasn't stuck yet. This is our latest attempt. If this doesn't work, we'll just skip this tests on windows (I believe the failure is on the test setup, not revealing an underlying problem in our SDK).

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- close the test server explicitly in a test
- use `127.0.0.1` instead of `localhost` to speed up windows tests (see https://github.com/stripe/stripe-python/pull/1849/changes) 

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://github.com/stripe/stripe-go/pull/2397