### PR TITLE
Add non-verified methods to managed handlers

### DIFF
--- a/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
+++ b/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
@@ -36,6 +36,14 @@ var handler = stripe.NewEventNotificationHandler(client, webhookSecret, func(con
 	return nil
 })
 
+// Handles events delivered through a channel that has already authenticated them, such as
+// AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
+// this handler skips verification. Callbacks are registered separately from the one above.
+var unverifiedHandler = stripe.NewEventNotificationHandlerWithoutVerification(client, func(context context.Context, notif stripe.EventNotificationContainer, client *stripe.Client, details stripe.UnhandledNotificationDetails) error {
+	fmt.Printf("Received unhandled event with type %s", notif.GetEventNotification().Type)
+	return nil
+})
+
 func handleMeterErrors(ctx context.Context, notif *stripe.V1BillingMeterErrorReportTriggeredEventNotification, client *stripe.Client) error {
 	meter, err := notif.FetchRelatedObject(ctx)
 	if err != nil {
@@ -60,6 +68,29 @@ func main() {
 		}
 
 		err = handler.Handle(req.Context(), payload, req.Header.Get("Stripe-Signature"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error handling event notification: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	unverifiedHandler.OnV1BillingMeterErrorReportTriggered(handleMeterErrors)
+
+	http.HandleFunc("/webhook-from-cloud-provider", func(w http.ResponseWriter, req *http.Request) {
+		const MaxBodyBytes = int64(65536)
+		req.Body = http.MaxBytesReader(w, req.Body, MaxBodyBytes)
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading request body: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Handle takes only the body here; there's no signature to check
+		err = unverifiedHandler.Handle(req.Context(), payload)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error handling event notification: %v\n", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/stripe_event_notification_handler.go
+++ b/stripe_event_notification_handler.go
@@ -32,14 +32,24 @@ type EventNotificationHandler struct {
 	fallbackCallback FallbackCallbackFunc
 }
 
-func NewEventNotificationHandler(client *Client, webhookSecret string, fallbackCallback FallbackCallbackFunc) *EventNotificationHandler {
+// newEventNotificationHandler builds the shared handler state used by both the
+// verifying and non-verifying constructors.
+func newEventNotificationHandler(client *Client, fallbackCallback FallbackCallbackFunc) *EventNotificationHandler {
 	return &EventNotificationHandler{
 		client:           client,
-		webhookSecret:    webhookSecret,
 		eventHandlers:    make(map[string]CallbackFunc),
 		hasHandledEvent:  false,
 		fallbackCallback: fallbackCallback,
 	}
+}
+
+func NewEventNotificationHandler(client *Client, webhookSecret string, fallbackCallback FallbackCallbackFunc) *EventNotificationHandler {
+	if webhookSecret == "" {
+		panic("webhookSecret must be a non-empty string")
+	}
+	h := newEventNotificationHandler(client, fallbackCallback)
+	h.webhookSecret = webhookSecret
+	return h
 }
 
 func (h *EventNotificationHandler) register(eventType string, callback CallbackFunc) error {
@@ -604,6 +614,10 @@ func (h *EventNotificationHandler) Handle(ctx context.Context, webhookBody []byt
 		return err
 	}
 
+	return h.dispatch(ctx, notif)
+}
+
+func (h *EventNotificationHandler) dispatch(ctx context.Context, notif EventNotificationContainer) error {
 	n := notif.GetEventNotification()
 	eventType := n.Type
 
@@ -624,4 +638,34 @@ func (h *EventNotificationHandler) Handle(ctx context.Context, webhookBody []byt
 	}
 
 	return callback(ctx, notif, clientWithContext)
+}
+
+// EventNotificationHandlerWithoutVerification routes incoming Stripe event
+// notifications to registered handlers without verifying webhook signatures.
+// Intended for pre-authenticated channels like AWS EventBridge or Azure Event Grid.
+//
+// Use NewEventNotificationHandlerWithoutVerification to create an instance.
+type EventNotificationHandlerWithoutVerification struct {
+	*EventNotificationHandler
+}
+
+// NewEventNotificationHandlerWithoutVerification creates a handler that processes
+// events without webhook signature verification.
+func NewEventNotificationHandlerWithoutVerification(client *Client, fallbackCallback FallbackCallbackFunc) *EventNotificationHandlerWithoutVerification {
+	return &EventNotificationHandlerWithoutVerification{
+		EventNotificationHandler: newEventNotificationHandler(client, fallbackCallback),
+	}
+}
+
+// Handle processes an incoming webhook payload without signature verification,
+// routing it to the appropriate CallbackFunc (or the FallbackCallbackFunc if none is available).
+func (h *EventNotificationHandlerWithoutVerification) Handle(ctx context.Context, webhookBody []byte) error {
+	h.hasHandledEvent = true
+
+	notif, err := h.client.ParseEventNotificationWithoutVerification(webhookBody)
+	if err != nil {
+		return err
+	}
+
+	return h.dispatch(ctx, notif)
 }

--- a/stripe_event_notification_handler.go
+++ b/stripe_event_notification_handler.go
@@ -23,19 +23,19 @@ type UnhandledNotificationDetails struct {
 	IsKnownEventType bool
 }
 
-// EventNotificationHandler routes incoming Stripe event notifications to registered handlers based on event type.
-type EventNotificationHandler struct {
+// eventNotificationHandlerBase holds the shared registration and dispatch machinery
+// shared by the two user-facing event handlers.
+type eventNotificationHandlerBase struct {
 	client           *Client
-	webhookSecret    string
 	eventHandlers    map[string]CallbackFunc
 	hasHandledEvent  bool
 	fallbackCallback FallbackCallbackFunc
 }
 
-// newEventNotificationHandler builds the shared handler state used by both the
+// newEventNotificationHandlerBase builds the shared handler state used by both the
 // verifying and non-verifying constructors.
-func newEventNotificationHandler(client *Client, fallbackCallback FallbackCallbackFunc) *EventNotificationHandler {
-	return &EventNotificationHandler{
+func newEventNotificationHandlerBase(client *Client, fallbackCallback FallbackCallbackFunc) *eventNotificationHandlerBase {
+	return &eventNotificationHandlerBase{
 		client:           client,
 		eventHandlers:    make(map[string]CallbackFunc),
 		hasHandledEvent:  false,
@@ -43,16 +43,23 @@ func newEventNotificationHandler(client *Client, fallbackCallback FallbackCallba
 	}
 }
 
+// EventNotificationHandler routes incoming Stripe event notifications to registered handlers based on event type.
+type EventNotificationHandler struct {
+	*eventNotificationHandlerBase
+	webhookSecret string
+}
+
 func NewEventNotificationHandler(client *Client, webhookSecret string, fallbackCallback FallbackCallbackFunc) *EventNotificationHandler {
 	if webhookSecret == "" {
 		panic("webhookSecret must be a non-empty string")
 	}
-	h := newEventNotificationHandler(client, fallbackCallback)
-	h.webhookSecret = webhookSecret
-	return h
+	return &EventNotificationHandler{
+		eventNotificationHandlerBase: newEventNotificationHandlerBase(client, fallbackCallback),
+		webhookSecret:                webhookSecret,
+	}
 }
 
-func (h *EventNotificationHandler) register(eventType string, callback CallbackFunc) error {
+func (h *eventNotificationHandlerBase) register(eventType string, callback CallbackFunc) error {
 	// intentionally not worried about concurrency because we expect all registrations to happen
 	// synchronously on startup, so it'll only be read after it's done being written.
 	if h.hasHandledEvent {
@@ -68,7 +75,7 @@ func (h *EventNotificationHandler) register(eventType string, callback CallbackF
 }
 
 // RegisteredEventTypes returns a sorted list of all event types with registered handlers
-func (h *EventNotificationHandler) RegisteredEventTypes() []string {
+func (h *eventNotificationHandlerBase) RegisteredEventTypes() []string {
 	types := make([]string, 0, len(h.eventHandlers))
 	for eventType := range h.eventHandlers {
 		types = append(types, eventType)
@@ -78,7 +85,7 @@ func (h *EventNotificationHandler) RegisteredEventTypes() []string {
 }
 
 func registerTypedHandler[T EventNotificationContainer](
-	r *EventNotificationHandler,
+	r *eventNotificationHandlerBase,
 	eventType string,
 	handler func(context.Context, T, *Client) error,
 ) error {
@@ -97,493 +104,493 @@ func registerTypedHandler[T EventNotificationContainer](
 // event-handler-methods: The beginning of the section generated from our OpenAPI spec
 
 // OnV1BillingMeterErrorReportTriggered registers a callback to handle notifications about the "v1.billing.meter.error_report_triggered" event.
-func (h *EventNotificationHandler) OnV1BillingMeterErrorReportTriggered(callback func(ctx context.Context, notif *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV1BillingMeterErrorReportTriggered(callback func(ctx context.Context, notif *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v1.billing.meter.error_report_triggered", callback)
 }
 
 // OnV1BillingMeterNoMeterFound registers a callback to handle notifications about the "v1.billing.meter.no_meter_found" event.
-func (h *EventNotificationHandler) OnV1BillingMeterNoMeterFound(callback func(ctx context.Context, notif *V1BillingMeterNoMeterFoundEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV1BillingMeterNoMeterFound(callback func(ctx context.Context, notif *V1BillingMeterNoMeterFoundEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v1.billing.meter.no_meter_found", callback)
 }
 
 // OnV2CommerceProductCatalogImportsFailed registers a callback to handle notifications about the "v2.commerce.product_catalog.imports.failed" event.
-func (h *EventNotificationHandler) OnV2CommerceProductCatalogImportsFailed(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CommerceProductCatalogImportsFailed(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.commerce.product_catalog.imports.failed", callback)
 }
 
 // OnV2CommerceProductCatalogImportsProcessing registers a callback to handle notifications about the "v2.commerce.product_catalog.imports.processing" event.
-func (h *EventNotificationHandler) OnV2CommerceProductCatalogImportsProcessing(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsProcessingEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CommerceProductCatalogImportsProcessing(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsProcessingEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.commerce.product_catalog.imports.processing", callback)
 }
 
 // OnV2CommerceProductCatalogImportsSucceeded registers a callback to handle notifications about the "v2.commerce.product_catalog.imports.succeeded" event.
-func (h *EventNotificationHandler) OnV2CommerceProductCatalogImportsSucceeded(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsSucceededEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CommerceProductCatalogImportsSucceeded(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsSucceededEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.commerce.product_catalog.imports.succeeded", callback)
 }
 
 // OnV2CommerceProductCatalogImportsSucceededWithErrors registers a callback to handle notifications about the "v2.commerce.product_catalog.imports.succeeded_with_errors" event.
-func (h *EventNotificationHandler) OnV2CommerceProductCatalogImportsSucceededWithErrors(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CommerceProductCatalogImportsSucceededWithErrors(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.commerce.product_catalog.imports.succeeded_with_errors", callback)
 }
 
 // OnV2CoreAccountClosed registers a callback to handle notifications about the "v2.core.account.closed" event.
-func (h *EventNotificationHandler) OnV2CoreAccountClosed(callback func(ctx context.Context, notif *V2CoreAccountClosedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountClosed(callback func(ctx context.Context, notif *V2CoreAccountClosedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account.closed", callback)
 }
 
 // OnV2CoreAccountCreated registers a callback to handle notifications about the "v2.core.account.created" event.
-func (h *EventNotificationHandler) OnV2CoreAccountCreated(callback func(ctx context.Context, notif *V2CoreAccountCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountCreated(callback func(ctx context.Context, notif *V2CoreAccountCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account.created", callback)
 }
 
 // OnV2CoreAccountUpdated registers a callback to handle notifications about the "v2.core.account.updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountUpdated(callback func(ctx context.Context, notif *V2CoreAccountUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountUpdated(callback func(ctx context.Context, notif *V2CoreAccountUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account.updated", callback)
 }
 
 // OnV2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated registers a callback to handle notifications about the "v2.core.account[configuration.customer].capability_status_updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[configuration.customer].capability_status_updated", callback)
 }
 
 // OnV2CoreAccountIncludingConfigurationCustomerUpdated registers a callback to handle notifications about the "v2.core.account[configuration.customer].updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingConfigurationCustomerUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationCustomerUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[configuration.customer].updated", callback)
 }
 
 // OnV2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated registers a callback to handle notifications about the "v2.core.account[configuration.merchant].capability_status_updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[configuration.merchant].capability_status_updated", callback)
 }
 
 // OnV2CoreAccountIncludingConfigurationMerchantUpdated registers a callback to handle notifications about the "v2.core.account[configuration.merchant].updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingConfigurationMerchantUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationMerchantUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[configuration.merchant].updated", callback)
 }
 
 // OnV2CoreAccountIncludingConfigurationMoneyManagerCapabilityStatusUpdated registers a callback to handle notifications about the "v2.core.account[configuration.money_manager].capability_status_updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingConfigurationMoneyManagerCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMoneyManagerCapabilityStatusUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationMoneyManagerCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMoneyManagerCapabilityStatusUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[configuration.money_manager].capability_status_updated", callback)
 }
 
 // OnV2CoreAccountIncludingConfigurationMoneyManagerUpdated registers a callback to handle notifications about the "v2.core.account[configuration.money_manager].updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingConfigurationMoneyManagerUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMoneyManagerUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationMoneyManagerUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMoneyManagerUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[configuration.money_manager].updated", callback)
 }
 
 // OnV2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated registers a callback to handle notifications about the "v2.core.account[configuration.recipient].capability_status_updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[configuration.recipient].capability_status_updated", callback)
 }
 
 // OnV2CoreAccountIncludingConfigurationRecipientUpdated registers a callback to handle notifications about the "v2.core.account[configuration.recipient].updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingConfigurationRecipientUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationRecipientUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[configuration.recipient].updated", callback)
 }
 
 // OnV2CoreAccountIncludingDefaultsUpdated registers a callback to handle notifications about the "v2.core.account[defaults].updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingDefaultsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingDefaultsUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingDefaultsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingDefaultsUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account[defaults].updated", callback)
 }
 
 // OnV2CoreAccountIncludingFutureRequirementsUpdated registers a callback to handle notifications about the "v2.core.account[future_requirements].updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingFutureRequirementsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingFutureRequirementsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[future_requirements].updated", callback)
 }
 
 // OnV2CoreAccountIncludingIdentityUpdated registers a callback to handle notifications about the "v2.core.account[identity].updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingIdentityUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingIdentityUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingIdentityUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingIdentityUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account[identity].updated", callback)
 }
 
 // OnV2CoreAccountIncludingRequirementsUpdated registers a callback to handle notifications about the "v2.core.account[requirements].updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountIncludingRequirementsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingRequirementsUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingRequirementsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingRequirementsUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.account[requirements].updated", callback)
 }
 
 // OnV2CoreAccountLinkReturned registers a callback to handle notifications about the "v2.core.account_link.returned" event.
-func (h *EventNotificationHandler) OnV2CoreAccountLinkReturned(callback func(ctx context.Context, notif *V2CoreAccountLinkReturnedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountLinkReturned(callback func(ctx context.Context, notif *V2CoreAccountLinkReturnedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account_link.returned", callback)
 }
 
 // OnV2CoreAccountPersonCreated registers a callback to handle notifications about the "v2.core.account_person.created" event.
-func (h *EventNotificationHandler) OnV2CoreAccountPersonCreated(callback func(ctx context.Context, notif *V2CoreAccountPersonCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountPersonCreated(callback func(ctx context.Context, notif *V2CoreAccountPersonCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account_person.created", callback)
 }
 
 // OnV2CoreAccountPersonDeleted registers a callback to handle notifications about the "v2.core.account_person.deleted" event.
-func (h *EventNotificationHandler) OnV2CoreAccountPersonDeleted(callback func(ctx context.Context, notif *V2CoreAccountPersonDeletedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountPersonDeleted(callback func(ctx context.Context, notif *V2CoreAccountPersonDeletedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account_person.deleted", callback)
 }
 
 // OnV2CoreAccountPersonUpdated registers a callback to handle notifications about the "v2.core.account_person.updated" event.
-func (h *EventNotificationHandler) OnV2CoreAccountPersonUpdated(callback func(ctx context.Context, notif *V2CoreAccountPersonUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreAccountPersonUpdated(callback func(ctx context.Context, notif *V2CoreAccountPersonUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.account_person.updated", callback)
 }
 
 // OnV2CoreBatchJobBatchFailed registers a callback to handle notifications about the "v2.core.batch_job.batch_failed" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobBatchFailed(callback func(ctx context.Context, notif *V2CoreBatchJobBatchFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobBatchFailed(callback func(ctx context.Context, notif *V2CoreBatchJobBatchFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.batch_failed", callback)
 }
 
 // OnV2CoreBatchJobCanceled registers a callback to handle notifications about the "v2.core.batch_job.canceled" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobCanceled(callback func(ctx context.Context, notif *V2CoreBatchJobCanceledEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobCanceled(callback func(ctx context.Context, notif *V2CoreBatchJobCanceledEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.canceled", callback)
 }
 
 // OnV2CoreBatchJobCompleted registers a callback to handle notifications about the "v2.core.batch_job.completed" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobCompleted(callback func(ctx context.Context, notif *V2CoreBatchJobCompletedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobCompleted(callback func(ctx context.Context, notif *V2CoreBatchJobCompletedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.completed", callback)
 }
 
 // OnV2CoreBatchJobCreated registers a callback to handle notifications about the "v2.core.batch_job.created" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobCreated(callback func(ctx context.Context, notif *V2CoreBatchJobCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobCreated(callback func(ctx context.Context, notif *V2CoreBatchJobCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.created", callback)
 }
 
 // OnV2CoreBatchJobReadyForUpload registers a callback to handle notifications about the "v2.core.batch_job.ready_for_upload" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobReadyForUpload(callback func(ctx context.Context, notif *V2CoreBatchJobReadyForUploadEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobReadyForUpload(callback func(ctx context.Context, notif *V2CoreBatchJobReadyForUploadEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.ready_for_upload", callback)
 }
 
 // OnV2CoreBatchJobTimeout registers a callback to handle notifications about the "v2.core.batch_job.timeout" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobTimeout(callback func(ctx context.Context, notif *V2CoreBatchJobTimeoutEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobTimeout(callback func(ctx context.Context, notif *V2CoreBatchJobTimeoutEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.timeout", callback)
 }
 
 // OnV2CoreBatchJobUpdated registers a callback to handle notifications about the "v2.core.batch_job.updated" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobUpdated(callback func(ctx context.Context, notif *V2CoreBatchJobUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobUpdated(callback func(ctx context.Context, notif *V2CoreBatchJobUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.updated", callback)
 }
 
 // OnV2CoreBatchJobUploadTimeout registers a callback to handle notifications about the "v2.core.batch_job.upload_timeout" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobUploadTimeout(callback func(ctx context.Context, notif *V2CoreBatchJobUploadTimeoutEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobUploadTimeout(callback func(ctx context.Context, notif *V2CoreBatchJobUploadTimeoutEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.upload_timeout", callback)
 }
 
 // OnV2CoreBatchJobValidating registers a callback to handle notifications about the "v2.core.batch_job.validating" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobValidating(callback func(ctx context.Context, notif *V2CoreBatchJobValidatingEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobValidating(callback func(ctx context.Context, notif *V2CoreBatchJobValidatingEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.batch_job.validating", callback)
 }
 
 // OnV2CoreBatchJobValidationFailed registers a callback to handle notifications about the "v2.core.batch_job.validation_failed" event.
-func (h *EventNotificationHandler) OnV2CoreBatchJobValidationFailed(callback func(ctx context.Context, notif *V2CoreBatchJobValidationFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreBatchJobValidationFailed(callback func(ctx context.Context, notif *V2CoreBatchJobValidationFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.batch_job.validation_failed", callback)
 }
 
 // OnV2CoreEventDestinationPing registers a callback to handle notifications about the "v2.core.event_destination.ping" event.
-func (h *EventNotificationHandler) OnV2CoreEventDestinationPing(callback func(ctx context.Context, notif *V2CoreEventDestinationPingEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreEventDestinationPing(callback func(ctx context.Context, notif *V2CoreEventDestinationPingEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.core.event_destination.ping", callback)
 }
 
 // OnV2CoreHealthEventGenerationFailureResolved registers a callback to handle notifications about the "v2.core.health.event_generation_failure.resolved" event.
-func (h *EventNotificationHandler) OnV2CoreHealthEventGenerationFailureResolved(callback func(ctx context.Context, notif *V2CoreHealthEventGenerationFailureResolvedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2CoreHealthEventGenerationFailureResolved(callback func(ctx context.Context, notif *V2CoreHealthEventGenerationFailureResolvedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.core.health.event_generation_failure.resolved", callback)
 }
 
 // OnV2DataReportingQueryRunCreated registers a callback to handle notifications about the "v2.data.reporting.query_run.created" event.
-func (h *EventNotificationHandler) OnV2DataReportingQueryRunCreated(callback func(ctx context.Context, notif *V2DataReportingQueryRunCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2DataReportingQueryRunCreated(callback func(ctx context.Context, notif *V2DataReportingQueryRunCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.data.reporting.query_run.created", callback)
 }
 
 // OnV2DataReportingQueryRunFailed registers a callback to handle notifications about the "v2.data.reporting.query_run.failed" event.
-func (h *EventNotificationHandler) OnV2DataReportingQueryRunFailed(callback func(ctx context.Context, notif *V2DataReportingQueryRunFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2DataReportingQueryRunFailed(callback func(ctx context.Context, notif *V2DataReportingQueryRunFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.data.reporting.query_run.failed", callback)
 }
 
 // OnV2DataReportingQueryRunSucceeded registers a callback to handle notifications about the "v2.data.reporting.query_run.succeeded" event.
-func (h *EventNotificationHandler) OnV2DataReportingQueryRunSucceeded(callback func(ctx context.Context, notif *V2DataReportingQueryRunSucceededEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2DataReportingQueryRunSucceeded(callback func(ctx context.Context, notif *V2DataReportingQueryRunSucceededEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.data.reporting.query_run.succeeded", callback)
 }
 
 // OnV2DataReportingQueryRunUpdated registers a callback to handle notifications about the "v2.data.reporting.query_run.updated" event.
-func (h *EventNotificationHandler) OnV2DataReportingQueryRunUpdated(callback func(ctx context.Context, notif *V2DataReportingQueryRunUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2DataReportingQueryRunUpdated(callback func(ctx context.Context, notif *V2DataReportingQueryRunUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.data.reporting.query_run.updated", callback)
 }
 
 // OnV2ExtendWorkflowRunFailed registers a callback to handle notifications about the "v2.extend.workflow_run.failed" event.
-func (h *EventNotificationHandler) OnV2ExtendWorkflowRunFailed(callback func(ctx context.Context, notif *V2ExtendWorkflowRunFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2ExtendWorkflowRunFailed(callback func(ctx context.Context, notif *V2ExtendWorkflowRunFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.extend.workflow_run.failed", callback)
 }
 
 // OnV2ExtendWorkflowRunStarted registers a callback to handle notifications about the "v2.extend.workflow_run.started" event.
-func (h *EventNotificationHandler) OnV2ExtendWorkflowRunStarted(callback func(ctx context.Context, notif *V2ExtendWorkflowRunStartedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2ExtendWorkflowRunStarted(callback func(ctx context.Context, notif *V2ExtendWorkflowRunStartedEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.extend.workflow_run.started", callback)
 }
 
 // OnV2ExtendWorkflowRunSucceeded registers a callback to handle notifications about the "v2.extend.workflow_run.succeeded" event.
-func (h *EventNotificationHandler) OnV2ExtendWorkflowRunSucceeded(callback func(ctx context.Context, notif *V2ExtendWorkflowRunSucceededEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2ExtendWorkflowRunSucceeded(callback func(ctx context.Context, notif *V2ExtendWorkflowRunSucceededEventNotification, client *Client) error) error {
 	return registerTypedHandler(h, "v2.extend.workflow_run.succeeded", callback)
 }
 
 // OnV2MoneyManagementAdjustmentCreated registers a callback to handle notifications about the "v2.money_management.adjustment.created" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementAdjustmentCreated(callback func(ctx context.Context, notif *V2MoneyManagementAdjustmentCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementAdjustmentCreated(callback func(ctx context.Context, notif *V2MoneyManagementAdjustmentCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.adjustment.created", callback)
 }
 
 // OnV2MoneyManagementFinancialAccountCreated registers a callback to handle notifications about the "v2.money_management.financial_account.created" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementFinancialAccountCreated(callback func(ctx context.Context, notif *V2MoneyManagementFinancialAccountCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementFinancialAccountCreated(callback func(ctx context.Context, notif *V2MoneyManagementFinancialAccountCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.financial_account.created", callback)
 }
 
 // OnV2MoneyManagementFinancialAccountUpdated registers a callback to handle notifications about the "v2.money_management.financial_account.updated" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementFinancialAccountUpdated(callback func(ctx context.Context, notif *V2MoneyManagementFinancialAccountUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementFinancialAccountUpdated(callback func(ctx context.Context, notif *V2MoneyManagementFinancialAccountUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.financial_account.updated", callback)
 }
 
 // OnV2MoneyManagementFinancialAddressActivated registers a callback to handle notifications about the "v2.money_management.financial_address.activated" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementFinancialAddressActivated(callback func(ctx context.Context, notif *V2MoneyManagementFinancialAddressActivatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementFinancialAddressActivated(callback func(ctx context.Context, notif *V2MoneyManagementFinancialAddressActivatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.financial_address.activated", callback)
 }
 
 // OnV2MoneyManagementFinancialAddressFailed registers a callback to handle notifications about the "v2.money_management.financial_address.failed" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementFinancialAddressFailed(callback func(ctx context.Context, notif *V2MoneyManagementFinancialAddressFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementFinancialAddressFailed(callback func(ctx context.Context, notif *V2MoneyManagementFinancialAddressFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.financial_address.failed", callback)
 }
 
 // OnV2MoneyManagementInboundTransferAvailable registers a callback to handle notifications about the "v2.money_management.inbound_transfer.available" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementInboundTransferAvailable(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferAvailableEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementInboundTransferAvailable(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferAvailableEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.inbound_transfer.available", callback)
 }
 
 // OnV2MoneyManagementInboundTransferBankDebitFailed registers a callback to handle notifications about the "v2.money_management.inbound_transfer.bank_debit_failed" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementInboundTransferBankDebitFailed(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementInboundTransferBankDebitFailed(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.inbound_transfer.bank_debit_failed", callback)
 }
 
 // OnV2MoneyManagementInboundTransferBankDebitProcessing registers a callback to handle notifications about the "v2.money_management.inbound_transfer.bank_debit_processing" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementInboundTransferBankDebitProcessing(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitProcessingEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementInboundTransferBankDebitProcessing(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitProcessingEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.inbound_transfer.bank_debit_processing", callback)
 }
 
 // OnV2MoneyManagementInboundTransferBankDebitQueued registers a callback to handle notifications about the "v2.money_management.inbound_transfer.bank_debit_queued" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementInboundTransferBankDebitQueued(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitQueuedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementInboundTransferBankDebitQueued(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitQueuedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.inbound_transfer.bank_debit_queued", callback)
 }
 
 // OnV2MoneyManagementInboundTransferBankDebitReturned registers a callback to handle notifications about the "v2.money_management.inbound_transfer.bank_debit_returned" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementInboundTransferBankDebitReturned(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitReturnedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementInboundTransferBankDebitReturned(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitReturnedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.inbound_transfer.bank_debit_returned", callback)
 }
 
 // OnV2MoneyManagementInboundTransferBankDebitSucceeded registers a callback to handle notifications about the "v2.money_management.inbound_transfer.bank_debit_succeeded" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementInboundTransferBankDebitSucceeded(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitSucceededEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementInboundTransferBankDebitSucceeded(callback func(ctx context.Context, notif *V2MoneyManagementInboundTransferBankDebitSucceededEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.inbound_transfer.bank_debit_succeeded", callback)
 }
 
 // OnV2MoneyManagementOutboundPaymentCanceled registers a callback to handle notifications about the "v2.money_management.outbound_payment.canceled" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundPaymentCanceled(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentCanceledEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundPaymentCanceled(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentCanceledEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_payment.canceled", callback)
 }
 
 // OnV2MoneyManagementOutboundPaymentCreated registers a callback to handle notifications about the "v2.money_management.outbound_payment.created" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundPaymentCreated(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundPaymentCreated(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_payment.created", callback)
 }
 
 // OnV2MoneyManagementOutboundPaymentFailed registers a callback to handle notifications about the "v2.money_management.outbound_payment.failed" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundPaymentFailed(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundPaymentFailed(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_payment.failed", callback)
 }
 
 // OnV2MoneyManagementOutboundPaymentPosted registers a callback to handle notifications about the "v2.money_management.outbound_payment.posted" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundPaymentPosted(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentPostedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundPaymentPosted(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentPostedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_payment.posted", callback)
 }
 
 // OnV2MoneyManagementOutboundPaymentReturned registers a callback to handle notifications about the "v2.money_management.outbound_payment.returned" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundPaymentReturned(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentReturnedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundPaymentReturned(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentReturnedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_payment.returned", callback)
 }
 
 // OnV2MoneyManagementOutboundPaymentUnderReview registers a callback to handle notifications about the "v2.money_management.outbound_payment.under_review" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundPaymentUnderReview(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentUnderReviewEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundPaymentUnderReview(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentUnderReviewEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_payment.under_review", callback)
 }
 
 // OnV2MoneyManagementOutboundPaymentUpdated registers a callback to handle notifications about the "v2.money_management.outbound_payment.updated" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundPaymentUpdated(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundPaymentUpdated(callback func(ctx context.Context, notif *V2MoneyManagementOutboundPaymentUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_payment.updated", callback)
 }
 
 // OnV2MoneyManagementOutboundTransferCanceled registers a callback to handle notifications about the "v2.money_management.outbound_transfer.canceled" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundTransferCanceled(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferCanceledEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundTransferCanceled(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferCanceledEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_transfer.canceled", callback)
 }
 
 // OnV2MoneyManagementOutboundTransferCreated registers a callback to handle notifications about the "v2.money_management.outbound_transfer.created" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundTransferCreated(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundTransferCreated(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_transfer.created", callback)
 }
 
 // OnV2MoneyManagementOutboundTransferFailed registers a callback to handle notifications about the "v2.money_management.outbound_transfer.failed" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundTransferFailed(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundTransferFailed(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_transfer.failed", callback)
 }
 
 // OnV2MoneyManagementOutboundTransferPosted registers a callback to handle notifications about the "v2.money_management.outbound_transfer.posted" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundTransferPosted(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferPostedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundTransferPosted(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferPostedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_transfer.posted", callback)
 }
 
 // OnV2MoneyManagementOutboundTransferReturned registers a callback to handle notifications about the "v2.money_management.outbound_transfer.returned" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundTransferReturned(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferReturnedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundTransferReturned(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferReturnedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_transfer.returned", callback)
 }
 
 // OnV2MoneyManagementOutboundTransferUnderReview registers a callback to handle notifications about the "v2.money_management.outbound_transfer.under_review" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundTransferUnderReview(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferUnderReviewEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundTransferUnderReview(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferUnderReviewEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_transfer.under_review", callback)
 }
 
 // OnV2MoneyManagementOutboundTransferUpdated registers a callback to handle notifications about the "v2.money_management.outbound_transfer.updated" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementOutboundTransferUpdated(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementOutboundTransferUpdated(callback func(ctx context.Context, notif *V2MoneyManagementOutboundTransferUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.outbound_transfer.updated", callback)
 }
 
 // OnV2MoneyManagementPayoutMethodCreated registers a callback to handle notifications about the "v2.money_management.payout_method.created" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementPayoutMethodCreated(callback func(ctx context.Context, notif *V2MoneyManagementPayoutMethodCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementPayoutMethodCreated(callback func(ctx context.Context, notif *V2MoneyManagementPayoutMethodCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.payout_method.created", callback)
 }
 
 // OnV2MoneyManagementPayoutMethodUpdated registers a callback to handle notifications about the "v2.money_management.payout_method.updated" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementPayoutMethodUpdated(callback func(ctx context.Context, notif *V2MoneyManagementPayoutMethodUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementPayoutMethodUpdated(callback func(ctx context.Context, notif *V2MoneyManagementPayoutMethodUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.payout_method.updated", callback)
 }
 
 // OnV2MoneyManagementReceivedCreditAvailable registers a callback to handle notifications about the "v2.money_management.received_credit.available" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedCreditAvailable(callback func(ctx context.Context, notif *V2MoneyManagementReceivedCreditAvailableEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedCreditAvailable(callback func(ctx context.Context, notif *V2MoneyManagementReceivedCreditAvailableEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_credit.available", callback)
 }
 
 // OnV2MoneyManagementReceivedCreditFailed registers a callback to handle notifications about the "v2.money_management.received_credit.failed" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedCreditFailed(callback func(ctx context.Context, notif *V2MoneyManagementReceivedCreditFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedCreditFailed(callback func(ctx context.Context, notif *V2MoneyManagementReceivedCreditFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_credit.failed", callback)
 }
 
 // OnV2MoneyManagementReceivedCreditReturned registers a callback to handle notifications about the "v2.money_management.received_credit.returned" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedCreditReturned(callback func(ctx context.Context, notif *V2MoneyManagementReceivedCreditReturnedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedCreditReturned(callback func(ctx context.Context, notif *V2MoneyManagementReceivedCreditReturnedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_credit.returned", callback)
 }
 
 // OnV2MoneyManagementReceivedCreditSucceeded registers a callback to handle notifications about the "v2.money_management.received_credit.succeeded" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedCreditSucceeded(callback func(ctx context.Context, notif *V2MoneyManagementReceivedCreditSucceededEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedCreditSucceeded(callback func(ctx context.Context, notif *V2MoneyManagementReceivedCreditSucceededEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_credit.succeeded", callback)
 }
 
 // OnV2MoneyManagementReceivedDebitCanceled registers a callback to handle notifications about the "v2.money_management.received_debit.canceled" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedDebitCanceled(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitCanceledEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedDebitCanceled(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitCanceledEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_debit.canceled", callback)
 }
 
 // OnV2MoneyManagementReceivedDebitFailed registers a callback to handle notifications about the "v2.money_management.received_debit.failed" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedDebitFailed(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitFailedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedDebitFailed(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitFailedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_debit.failed", callback)
 }
 
 // OnV2MoneyManagementReceivedDebitPending registers a callback to handle notifications about the "v2.money_management.received_debit.pending" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedDebitPending(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitPendingEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedDebitPending(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitPendingEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_debit.pending", callback)
 }
 
 // OnV2MoneyManagementReceivedDebitSucceeded registers a callback to handle notifications about the "v2.money_management.received_debit.succeeded" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedDebitSucceeded(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitSucceededEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedDebitSucceeded(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitSucceededEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_debit.succeeded", callback)
 }
 
 // OnV2MoneyManagementReceivedDebitUpdated registers a callback to handle notifications about the "v2.money_management.received_debit.updated" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementReceivedDebitUpdated(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementReceivedDebitUpdated(callback func(ctx context.Context, notif *V2MoneyManagementReceivedDebitUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.received_debit.updated", callback)
 }
 
 // OnV2MoneyManagementTransactionCreated registers a callback to handle notifications about the "v2.money_management.transaction.created" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementTransactionCreated(callback func(ctx context.Context, notif *V2MoneyManagementTransactionCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementTransactionCreated(callback func(ctx context.Context, notif *V2MoneyManagementTransactionCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.transaction.created", callback)
 }
 
 // OnV2MoneyManagementTransactionUpdated registers a callback to handle notifications about the "v2.money_management.transaction.updated" event.
-func (h *EventNotificationHandler) OnV2MoneyManagementTransactionUpdated(callback func(ctx context.Context, notif *V2MoneyManagementTransactionUpdatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2MoneyManagementTransactionUpdated(callback func(ctx context.Context, notif *V2MoneyManagementTransactionUpdatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.money_management.transaction.updated", callback)
 }
 
 // OnV2OrchestratedCommerceAgreementConfirmed registers a callback to handle notifications about the "v2.orchestrated_commerce.agreement.confirmed" event.
-func (h *EventNotificationHandler) OnV2OrchestratedCommerceAgreementConfirmed(callback func(ctx context.Context, notif *V2OrchestratedCommerceAgreementConfirmedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2OrchestratedCommerceAgreementConfirmed(callback func(ctx context.Context, notif *V2OrchestratedCommerceAgreementConfirmedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.orchestrated_commerce.agreement.confirmed", callback)
 }
 
 // OnV2OrchestratedCommerceAgreementCreated registers a callback to handle notifications about the "v2.orchestrated_commerce.agreement.created" event.
-func (h *EventNotificationHandler) OnV2OrchestratedCommerceAgreementCreated(callback func(ctx context.Context, notif *V2OrchestratedCommerceAgreementCreatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2OrchestratedCommerceAgreementCreated(callback func(ctx context.Context, notif *V2OrchestratedCommerceAgreementCreatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.orchestrated_commerce.agreement.created", callback)
 }
 
 // OnV2OrchestratedCommerceAgreementPartiallyConfirmed registers a callback to handle notifications about the "v2.orchestrated_commerce.agreement.partially_confirmed" event.
-func (h *EventNotificationHandler) OnV2OrchestratedCommerceAgreementPartiallyConfirmed(callback func(ctx context.Context, notif *V2OrchestratedCommerceAgreementPartiallyConfirmedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2OrchestratedCommerceAgreementPartiallyConfirmed(callback func(ctx context.Context, notif *V2OrchestratedCommerceAgreementPartiallyConfirmedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.orchestrated_commerce.agreement.partially_confirmed", callback)
 }
 
 // OnV2OrchestratedCommerceAgreementTerminated registers a callback to handle notifications about the "v2.orchestrated_commerce.agreement.terminated" event.
-func (h *EventNotificationHandler) OnV2OrchestratedCommerceAgreementTerminated(callback func(ctx context.Context, notif *V2OrchestratedCommerceAgreementTerminatedEventNotification, client *Client) error) error {
+func (h *eventNotificationHandlerBase) OnV2OrchestratedCommerceAgreementTerminated(callback func(ctx context.Context, notif *V2OrchestratedCommerceAgreementTerminatedEventNotification, client *Client) error) error {
 	return registerTypedHandler(
 		h, "v2.orchestrated_commerce.agreement.terminated", callback)
 }
@@ -593,7 +600,7 @@ func (h *EventNotificationHandler) OnV2OrchestratedCommerceAgreementTerminated(c
 // createClientWithContext creates a new Client with a custom stripe_context.
 // It reuses the HTTPClient and other expensive resources from the base backend
 // to avoid re-establishing TLS connections (Flyweight pattern).
-func (h *EventNotificationHandler) createClientWithContext(stripeContext *string) (*Client, error) {
+func (h *eventNotificationHandlerBase) createClientWithContext(stripeContext *string) (*Client, error) {
 	baseConfig := h.client.backends.config
 	if baseConfig == nil {
 		return nil, fmt.Errorf("EventNotificationHandler requires a Backend created with NewBackendsWithConfig. If you're seeing this error, please file an issue at https://github.com/stripe/stripe-go/issues")
@@ -617,7 +624,7 @@ func (h *EventNotificationHandler) Handle(ctx context.Context, webhookBody []byt
 	return h.dispatch(ctx, notif)
 }
 
-func (h *EventNotificationHandler) dispatch(ctx context.Context, notif EventNotificationContainer) error {
+func (h *eventNotificationHandlerBase) dispatch(ctx context.Context, notif EventNotificationContainer) error {
 	n := notif.GetEventNotification()
 	eventType := n.Type
 
@@ -642,18 +649,19 @@ func (h *EventNotificationHandler) dispatch(ctx context.Context, notif EventNoti
 
 // EventNotificationHandlerWithoutVerification routes incoming Stripe event
 // notifications to registered handlers without verifying webhook signatures.
-// Intended for pre-authenticated channels like AWS EventBridge or Azure Event Grid.
+// Intended for pre-authenticated channels like AWS EventBridge, Azure Event Grid,
+// or your own pre-authenticated event queue.
 //
 // Use NewEventNotificationHandlerWithoutVerification to create an instance.
 type EventNotificationHandlerWithoutVerification struct {
-	*EventNotificationHandler
+	*eventNotificationHandlerBase
 }
 
 // NewEventNotificationHandlerWithoutVerification creates a handler that processes
 // events without webhook signature verification.
 func NewEventNotificationHandlerWithoutVerification(client *Client, fallbackCallback FallbackCallbackFunc) *EventNotificationHandlerWithoutVerification {
 	return &EventNotificationHandlerWithoutVerification{
-		EventNotificationHandler: newEventNotificationHandler(client, fallbackCallback),
+		eventNotificationHandlerBase: newEventNotificationHandlerBase(client, fallbackCallback),
 	}
 }
 

--- a/stripe_event_notification_test.go
+++ b/stripe_event_notification_test.go
@@ -679,3 +679,195 @@ func TestEventHandler_RegisteredEventTypesMultipleAlphabetized(t *testing.T) {
 
 	assert.Equal(t, expected, types)
 }
+
+// Test: WithoutVerification routes event to registered handler
+func TestWithoutVerification_RoutesEventToHandler(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	var handlerCalled bool
+	var receivedEvent *V1BillingMeterErrorReportTriggeredEventNotification
+	var receivedClient *Client
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		handlerCalled = true
+		receivedEvent = event
+		receivedClient = client
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Execute — no signature header required
+	payload := v1BillingMeterPayload()
+	err = handler.Handle(context.TODO(), []byte(payload))
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled, "Handler should have been called")
+	assert.NotNil(t, receivedEvent, "Handler should have received event")
+	assert.Equal(t, "v1.billing.meter.error_report_triggered", receivedEvent.Type)
+	assert.Equal(t, "evt_123", receivedEvent.ID)
+	assert.Equal(t, "mtr_123", receivedEvent.RelatedObject.ID)
+	assert.NotNil(t, receivedClient, "Handler should have received client")
+	assert.False(t, unhandledCalled, "Unhandled handler should not be called")
+}
+
+// Test: WithoutVerification routes known unregistered event to fallback
+func TestWithoutVerification_FallbackForUnregisteredEvent(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	var unhandledEvent EventNotificationContainer
+	var unhandledDetails UnhandledNotificationDetails
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		unhandledEvent = notif
+		unhandledDetails = details
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	// Don't register a handler for this known event type
+	payload := v1BillingMeterPayload()
+	err := handler.Handle(context.TODO(), []byte(payload))
+
+	assert.NoError(t, err)
+	assert.True(t, unhandledCalled, "Fallback should have been called")
+	assert.NotNil(t, unhandledEvent)
+
+	_, isKnown := unhandledEvent.(*V1BillingMeterErrorReportTriggeredEventNotification)
+	assert.True(t, isKnown, "Event should be V1BillingMeterErrorReportTriggeredEventNotification")
+	assert.True(t, unhandledDetails.IsKnownEventType, "Known event should have IsKnownEventType=true")
+}
+
+// Test: WithoutVerification routes unknown event type to fallback with IsKnownEventType=false
+func TestWithoutVerification_UnknownEventType(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	var unhandledEvent EventNotificationContainer
+	var unhandledDetails UnhandledNotificationDetails
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		unhandledEvent = notif
+		unhandledDetails = details
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	payload := unknownEventPayload()
+	err := handler.Handle(context.TODO(), []byte(payload))
+
+	assert.NoError(t, err)
+	assert.True(t, unhandledCalled, "Fallback should have been called")
+	assert.NotNil(t, unhandledEvent)
+
+	_, isUnknown := unhandledEvent.(*UnknownEventNotification)
+	assert.True(t, isUnknown, "Event should be UnknownEventNotification")
+	assert.Equal(t, "llama.created", unhandledEvent.GetEventNotification().Type)
+	assert.False(t, unhandledDetails.IsKnownEventType, "Unknown event should have IsKnownEventType=false")
+}
+
+// Test: WithoutVerification propagates event stripe_context to the client in callbacks
+func TestWithoutVerification_ContextPropagation(t *testing.T) {
+	config := &BackendConfig{StripeContext: String("original_context_123")}
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(config)))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	var receivedContext *string
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		receivedContext = client.backends.config.StripeContext
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Verify original context before handle
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+
+	payload := v1BillingMeterPayload()
+	err = handler.Handle(context.TODO(), []byte(payload))
+
+	assert.NoError(t, err)
+	assert.NotNil(t, receivedContext)
+	assert.Equal(t, "event_context_456", *receivedContext, "Handler should receive event's stripe_context")
+	// Original client context should be unchanged
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+}
+
+// Test: WithoutVerification On* methods inherited from embedded handler work correctly
+func TestWithoutVerification_InheritedOnMethods(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	var billingCalled bool
+	var noMeterCalled bool
+
+	billingCallback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		billingCalled = true
+		return nil
+	}
+	noMeterCallback := func(ctx context.Context, event *V1BillingMeterNoMeterFoundEventNotification, client *Client) error {
+		noMeterCalled = true
+		return nil
+	}
+
+	// Register both handlers via the promoted On* methods
+	err := handler.OnV1BillingMeterErrorReportTriggered(billingCallback)
+	assert.NoError(t, err)
+	err = handler.OnV1BillingMeterNoMeterFound(noMeterCallback)
+	assert.NoError(t, err)
+
+	// RegisteredEventTypes is also promoted and should reflect both registrations
+	types := handler.RegisteredEventTypes()
+	assert.Equal(t, []string{"v1.billing.meter.error_report_triggered", "v1.billing.meter.no_meter_found"}, types)
+
+	// Route billing event — only billing handler should fire
+	err = handler.Handle(context.TODO(), []byte(v1BillingMeterPayload()))
+	assert.NoError(t, err)
+	assert.True(t, billingCalled, "Billing handler should have been called")
+	assert.False(t, noMeterCalled, "NoMeter handler should not have been called yet")
+
+	// Route no-meter event — only no-meter handler should fire
+	err = handler.Handle(context.TODO(), []byte(v1BillingMeterNoMeterFoundPayload()))
+	assert.NoError(t, err)
+	assert.True(t, noMeterCalled, "NoMeter handler should have been called")
+}
+
+// Test: NewEventNotificationHandler panics when webhookSecret is empty
+func TestNewEventNotificationHandler_PanicsOnEmptySecret(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	assert.Panics(t, func() {
+		NewEventNotificationHandler(client, "", onUnhandled)
+	})
+}


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

On the back of my work in [DEVSDK-3085](https://go/j/DEVSDK-3085), we're adding support for non-verified webhook handing to the managed handlers. There were two key design stipulations:

1. It should be impossible to handle a webhook on the with-verification handler without supplying a signature header. As a result, we have to be very careful about overwriting/mixing our `handle` methods and if/when we call the signature verification methods.
2. The without-verification handler should feel like an implementation detail (where possible). Users should feel like they're interacting with "The" event notification handler

To that end, the main entrypoint for the non-verified handler is a new method on the client and a static method on the with-verification handler. The non-verified handlers are public in each language so users can interact with them normally, but the intention is that they're not something the user thinks much about on their own.

Design wise, the exact implementation varied between languages, but the general idea was the same. I moved all the generated `on_*` methods onto a private base class, then added sibling handlers for the "with" and "without" verification paths. That way they each have distinct `handle` methods and it's impossible for a caller to see the "wrong" one. If we had used inheritance, then the child would have the parent's `handle` signature exposed, which is confusing (even if we overrode it to always error). 

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Add `StripeEventNotificationHandlerWithoutVerification` class and associated constructors, docstrings, and client methods
- add tests
- update examples

### See Also

<!-- Include any links or additional information that help explain this change. -->

- Original handler PR: https://github.com/stripe/stripe-go/pull/2209
- Non-verified event parsing: https://github.com/stripe/stripe-go/pull/2399
