### PR TITLE
Merge to private-preview

### DIFF
--- a/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
+++ b/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
@@ -1,0 +1,102 @@
+// event_notification_handler_endpoint.go - receive and process event notifications like the
+// "v1.billing.meter.error_report_triggered" event.
+//
+// This example uses the rawrequests module to make calls to /v2 APIs.
+//
+// In this example, we:
+//   - write a fallback callback to handle unrecognized event notifications
+//   - create a stripe.Client called client
+//   - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+//   - register a specific handler for the "v1.billing.meter.error_report_triggered" event notification type
+//   - use handler.Handle() to process the received notification webhook body
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/stripe/stripe-go/v86"
+)
+
+var apiKey = "{{API_KEY}}"
+var webhookSecret = "{{WEBHOOK_SECRET}}"
+var client = stripe.NewClient(apiKey)
+var handler = stripe.NewEventNotificationHandler(client, webhookSecret, func(context context.Context, notif stripe.EventNotificationContainer, client *stripe.Client, details stripe.UnhandledNotificationDetails) error {
+	fmt.Printf("Received unhandled event with type %s", notif.GetEventNotification().Type)
+	return nil
+})
+
+// Handles events delivered through a channel that has already authenticated them, such as
+// AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
+// this handler skips verification. Callbacks are registered separately from the one above.
+var unverifiedHandler = stripe.NewEventNotificationHandlerWithoutVerification(client, func(context context.Context, notif stripe.EventNotificationContainer, client *stripe.Client, details stripe.UnhandledNotificationDetails) error {
+	fmt.Printf("Received unhandled event with type %s", notif.GetEventNotification().Type)
+	return nil
+})
+
+func handleMeterErrors(ctx context.Context, notif *stripe.V1BillingMeterErrorReportTriggeredEventNotification, client *stripe.Client) error {
+	meter, err := notif.FetchRelatedObject(ctx)
+	if err != nil {
+		return fmt.Errorf("error fetching related object: %v", err)
+	}
+	fmt.Printf("Meter %s (%s) had a problem\n", meter.DisplayName, meter.ID)
+
+	return nil
+}
+
+func main() {
+	handler.OnV1BillingMeterErrorReportTriggered(handleMeterErrors)
+
+	http.HandleFunc("/webhook", func(w http.ResponseWriter, req *http.Request) {
+		const MaxBodyBytes = int64(65536)
+		req.Body = http.MaxBytesReader(w, req.Body, MaxBodyBytes)
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading request body: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		err = handler.Handle(req.Context(), payload, req.Header.Get("Stripe-Signature"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error handling event notification: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	unverifiedHandler.OnV1BillingMeterErrorReportTriggered(handleMeterErrors)
+
+	http.HandleFunc("/webhook-from-cloud-provider", func(w http.ResponseWriter, req *http.Request) {
+		const MaxBodyBytes = int64(65536)
+		req.Body = http.MaxBytesReader(w, req.Body, MaxBodyBytes)
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading request body: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Handle takes only the body here; there's no signature to check
+		err = unverifiedHandler.Handle(req.Context(), payload)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error handling event notification: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := http.ListenAndServe(":4242", nil)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/stripe_context.go
+++ b/stripe_context.go
@@ -65,9 +65,13 @@ func (c *Context) Pop() (*Context, error) {
 	return NewStripeContext(c.Segments[:len(c.Segments)-1]), nil
 }
 
-// StringPtr returns the string representation of the stripe.Context.
-// Segments are joined with "/" as the separator.
+// StringPtr returns the string representation of the stripe.Context. Returns nil if the context is nil.
+//
+// Otherwise, segments are joined with "/" as the separator.
 func (c *Context) StringPtr() *string {
+	if c == nil {
+		return nil
+	}
 	result := strings.Join(c.Segments, "/")
 	return &result
 }

--- a/stripe_event_notification_handler.go
+++ b/stripe_event_notification_handler.go
@@ -1,0 +1,314 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// CallbackFunc is run when an event of a registered type is received.
+type CallbackFunc = func(context.Context, EventNotificationContainer, *Client) error
+
+// FallbackCallbackFunc is run when an event is received that does not match any registered type. It contains additional details about the unhandled event (as compared to a CallbackFunc).
+type FallbackCallbackFunc = func(context.Context, EventNotificationContainer, *Client, UnhandledNotificationDetails) error
+
+type UnhandledNotificationDetails struct {
+	// IsKnownEventType indicates whether the unhandled event is of a known type (i.e., it has a defined struct in the SDK) or is completely unknown.
+	IsKnownEventType bool
+}
+
+// eventNotificationHandlerBase holds the shared registration and dispatch machinery
+// shared by the two user-facing event handlers.
+type eventNotificationHandlerBase struct {
+	client           *Client
+	eventHandlers    map[string]CallbackFunc
+	hasHandledEvent  bool
+	fallbackCallback FallbackCallbackFunc
+}
+
+// newEventNotificationHandlerBase builds the shared handler state used by both the
+// verifying and non-verifying constructors.
+func newEventNotificationHandlerBase(client *Client, fallbackCallback FallbackCallbackFunc) *eventNotificationHandlerBase {
+	return &eventNotificationHandlerBase{
+		client:           client,
+		eventHandlers:    make(map[string]CallbackFunc),
+		hasHandledEvent:  false,
+		fallbackCallback: fallbackCallback,
+	}
+}
+
+// EventNotificationHandler routes incoming Stripe event notifications to registered handlers based on event type.
+type EventNotificationHandler struct {
+	*eventNotificationHandlerBase
+	webhookSecret string
+}
+
+func NewEventNotificationHandler(client *Client, webhookSecret string, fallbackCallback FallbackCallbackFunc) *EventNotificationHandler {
+	if webhookSecret == "" {
+		panic("webhookSecret must be a non-empty string")
+	}
+	return &EventNotificationHandler{
+		eventNotificationHandlerBase: newEventNotificationHandlerBase(client, fallbackCallback),
+		webhookSecret:                webhookSecret,
+	}
+}
+
+func (h *eventNotificationHandlerBase) register(eventType string, callback CallbackFunc) error {
+	// intentionally not worried about concurrency because we expect all registrations to happen
+	// synchronously on startup, so it'll only be read after it's done being written.
+	if h.hasHandledEvent {
+		return fmt.Errorf("cannot register new event handlers after handling an event. This is indicative of a bug.")
+	}
+
+	if h.eventHandlers[eventType] != nil {
+		return fmt.Errorf("handler for event type %s is already registered", eventType)
+	}
+
+	h.eventHandlers[eventType] = callback
+	return nil
+}
+
+// RegisteredEventTypes returns a sorted list of all event types with registered handlers
+func (h *eventNotificationHandlerBase) RegisteredEventTypes() []string {
+	types := make([]string, 0, len(h.eventHandlers))
+	for eventType := range h.eventHandlers {
+		types = append(types, eventType)
+	}
+	sort.Strings(types)
+	return types
+}
+
+func registerTypedHandler[T EventNotificationContainer](
+	r *eventNotificationHandlerBase,
+	eventType string,
+	handler func(context.Context, T, *Client) error,
+) error {
+	wrapper := func(ctx context.Context, notif EventNotificationContainer, client *Client) error {
+		typedNotif, ok := notif.(T)
+		if !ok {
+			// Use a zero value to get the type name for the error message
+			var zero T
+			return fmt.Errorf("failed to cast notification to %T", zero)
+		}
+		return handler(ctx, typedNotif, client)
+	}
+	return r.register(eventType, wrapper)
+}
+
+// event-handler-methods: The beginning of the section generated from our OpenAPI spec
+
+// OnV1BillingMeterErrorReportTriggered registers a callback to handle notifications about the "v1.billing.meter.error_report_triggered" event.
+func (h *eventNotificationHandlerBase) OnV1BillingMeterErrorReportTriggered(callback func(ctx context.Context, notif *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v1.billing.meter.error_report_triggered", callback)
+}
+
+// OnV1BillingMeterNoMeterFound registers a callback to handle notifications about the "v1.billing.meter.no_meter_found" event.
+func (h *eventNotificationHandlerBase) OnV1BillingMeterNoMeterFound(callback func(ctx context.Context, notif *V1BillingMeterNoMeterFoundEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v1.billing.meter.no_meter_found", callback)
+}
+
+// OnV2CommerceProductCatalogImportsFailed registers a callback to handle notifications about the "v2.commerce.product_catalog.imports.failed" event.
+func (h *eventNotificationHandlerBase) OnV2CommerceProductCatalogImportsFailed(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsFailedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.commerce.product_catalog.imports.failed", callback)
+}
+
+// OnV2CommerceProductCatalogImportsProcessing registers a callback to handle notifications about the "v2.commerce.product_catalog.imports.processing" event.
+func (h *eventNotificationHandlerBase) OnV2CommerceProductCatalogImportsProcessing(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsProcessingEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.commerce.product_catalog.imports.processing", callback)
+}
+
+// OnV2CommerceProductCatalogImportsSucceeded registers a callback to handle notifications about the "v2.commerce.product_catalog.imports.succeeded" event.
+func (h *eventNotificationHandlerBase) OnV2CommerceProductCatalogImportsSucceeded(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsSucceededEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.commerce.product_catalog.imports.succeeded", callback)
+}
+
+// OnV2CommerceProductCatalogImportsSucceededWithErrors registers a callback to handle notifications about the "v2.commerce.product_catalog.imports.succeeded_with_errors" event.
+func (h *eventNotificationHandlerBase) OnV2CommerceProductCatalogImportsSucceededWithErrors(callback func(ctx context.Context, notif *V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.commerce.product_catalog.imports.succeeded_with_errors", callback)
+}
+
+// OnV2CoreAccountClosed registers a callback to handle notifications about the "v2.core.account.closed" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountClosed(callback func(ctx context.Context, notif *V2CoreAccountClosedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account.closed", callback)
+}
+
+// OnV2CoreAccountCreated registers a callback to handle notifications about the "v2.core.account.created" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountCreated(callback func(ctx context.Context, notif *V2CoreAccountCreatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account.created", callback)
+}
+
+// OnV2CoreAccountUpdated registers a callback to handle notifications about the "v2.core.account.updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountUpdated(callback func(ctx context.Context, notif *V2CoreAccountUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account.updated", callback)
+}
+
+// OnV2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated registers a callback to handle notifications about the "v2.core.account[configuration.customer].capability_status_updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.core.account[configuration.customer].capability_status_updated", callback)
+}
+
+// OnV2CoreAccountIncludingConfigurationCustomerUpdated registers a callback to handle notifications about the "v2.core.account[configuration.customer].updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationCustomerUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.core.account[configuration.customer].updated", callback)
+}
+
+// OnV2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated registers a callback to handle notifications about the "v2.core.account[configuration.merchant].capability_status_updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.core.account[configuration.merchant].capability_status_updated", callback)
+}
+
+// OnV2CoreAccountIncludingConfigurationMerchantUpdated registers a callback to handle notifications about the "v2.core.account[configuration.merchant].updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationMerchantUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.core.account[configuration.merchant].updated", callback)
+}
+
+// OnV2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated registers a callback to handle notifications about the "v2.core.account[configuration.recipient].capability_status_updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.core.account[configuration.recipient].capability_status_updated", callback)
+}
+
+// OnV2CoreAccountIncludingConfigurationRecipientUpdated registers a callback to handle notifications about the "v2.core.account[configuration.recipient].updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingConfigurationRecipientUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.core.account[configuration.recipient].updated", callback)
+}
+
+// OnV2CoreAccountIncludingDefaultsUpdated registers a callback to handle notifications about the "v2.core.account[defaults].updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingDefaultsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingDefaultsUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account[defaults].updated", callback)
+}
+
+// OnV2CoreAccountIncludingFutureRequirementsUpdated registers a callback to handle notifications about the "v2.core.account[future_requirements].updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingFutureRequirementsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.core.account[future_requirements].updated", callback)
+}
+
+// OnV2CoreAccountIncludingIdentityUpdated registers a callback to handle notifications about the "v2.core.account[identity].updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingIdentityUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingIdentityUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account[identity].updated", callback)
+}
+
+// OnV2CoreAccountIncludingRequirementsUpdated registers a callback to handle notifications about the "v2.core.account[requirements].updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountIncludingRequirementsUpdated(callback func(ctx context.Context, notif *V2CoreAccountIncludingRequirementsUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(
+		h, "v2.core.account[requirements].updated", callback)
+}
+
+// OnV2CoreAccountLinkReturned registers a callback to handle notifications about the "v2.core.account_link.returned" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountLinkReturned(callback func(ctx context.Context, notif *V2CoreAccountLinkReturnedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account_link.returned", callback)
+}
+
+// OnV2CoreAccountPersonCreated registers a callback to handle notifications about the "v2.core.account_person.created" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountPersonCreated(callback func(ctx context.Context, notif *V2CoreAccountPersonCreatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account_person.created", callback)
+}
+
+// OnV2CoreAccountPersonDeleted registers a callback to handle notifications about the "v2.core.account_person.deleted" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountPersonDeleted(callback func(ctx context.Context, notif *V2CoreAccountPersonDeletedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account_person.deleted", callback)
+}
+
+// OnV2CoreAccountPersonUpdated registers a callback to handle notifications about the "v2.core.account_person.updated" event.
+func (h *eventNotificationHandlerBase) OnV2CoreAccountPersonUpdated(callback func(ctx context.Context, notif *V2CoreAccountPersonUpdatedEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.account_person.updated", callback)
+}
+
+// OnV2CoreEventDestinationPing registers a callback to handle notifications about the "v2.core.event_destination.ping" event.
+func (h *eventNotificationHandlerBase) OnV2CoreEventDestinationPing(callback func(ctx context.Context, notif *V2CoreEventDestinationPingEventNotification, client *Client) error) error {
+	return registerTypedHandler(h, "v2.core.event_destination.ping", callback)
+}
+
+// event-handler-methods: The end of the section generated from our OpenAPI spec
+
+// createClientWithContext creates a new Client with a custom stripe_context.
+// It reuses the HTTPClient and other expensive resources from the base backend
+// to avoid re-establishing TLS connections (Flyweight pattern).
+func (h *eventNotificationHandlerBase) createClientWithContext(stripeContext *string) (*Client, error) {
+	baseConfig := h.client.backends.config
+	if baseConfig == nil {
+		return nil, fmt.Errorf("EventNotificationHandler requires a Backend created with NewBackendsWithConfig. If you're seeing this error, please file an issue at https://github.com/stripe/stripe-go/issues")
+	}
+	newConfig := *baseConfig
+	newConfig.StripeContext = stripeContext
+	return NewClient(h.client.key, WithBackends(NewBackendsWithConfig(&newConfig))), nil
+}
+
+// Handle processes an incoming webhook payload by routing it to the appropriate CallbackFunc (or the FallbackCallbackFunc if none is available).
+func (h *EventNotificationHandler) Handle(ctx context.Context, webhookBody []byte, sigHeader string) error {
+	// intentionally not worried about concurrency because we expect all registrations to happen
+	// synchronously on startup, so it'll only be read after it's done being written.
+	h.hasHandledEvent = true
+
+	notif, err := h.client.ParseEventNotification(webhookBody, sigHeader, h.webhookSecret)
+	if err != nil {
+		return err
+	}
+
+	return h.dispatch(ctx, notif)
+}
+
+func (h *eventNotificationHandlerBase) dispatch(ctx context.Context, notif EventNotificationContainer) error {
+	n := notif.GetEventNotification()
+	eventType := n.Type
+
+	// Create a new client with the event's context instead of modifying the shared backend
+	// This makes the code thread-safe for parallel webhook processing
+	clientWithContext, err := h.createClientWithContext(n.Context.StringPtr())
+	if err != nil {
+		return err
+	}
+
+	callback, ok := h.eventHandlers[eventType]
+	if !ok {
+		_, isUnknownEventType := notif.(*UnknownEventNotification)
+		details := UnhandledNotificationDetails{
+			IsKnownEventType: !isUnknownEventType,
+		}
+		return h.fallbackCallback(ctx, notif, clientWithContext, details)
+	}
+
+	return callback(ctx, notif, clientWithContext)
+}
+
+// EventNotificationHandlerWithoutVerification routes incoming Stripe event
+// notifications to registered handlers without verifying webhook signatures.
+// Intended for pre-authenticated channels like AWS EventBridge, Azure Event Grid,
+// or your own pre-authenticated event queue.
+//
+// Use NewEventNotificationHandlerWithoutVerification to create an instance.
+type EventNotificationHandlerWithoutVerification struct {
+	*eventNotificationHandlerBase
+}
+
+// NewEventNotificationHandlerWithoutVerification creates a handler that processes
+// events without webhook signature verification.
+func NewEventNotificationHandlerWithoutVerification(client *Client, fallbackCallback FallbackCallbackFunc) *EventNotificationHandlerWithoutVerification {
+	return &EventNotificationHandlerWithoutVerification{
+		eventNotificationHandlerBase: newEventNotificationHandlerBase(client, fallbackCallback),
+	}
+}
+
+// Handle processes an incoming webhook payload without signature verification,
+// routing it to the appropriate CallbackFunc (or the FallbackCallbackFunc if none is available).
+func (h *EventNotificationHandlerWithoutVerification) Handle(ctx context.Context, webhookBody []byte) error {
+	h.hasHandledEvent = true
+
+	notif, err := h.client.ParseEventNotificationWithoutVerification(webhookBody)
+	if err != nil {
+		return err
+	}
+
+	return h.dispatch(ctx, notif)
+}

--- a/stripe_event_notification_test.go
+++ b/stripe_event_notification_test.go
@@ -1,0 +1,867 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+const testWebhookSecret = "whsec_test_secret"
+
+// Test helper to generate a valid webhook signature
+func generateTestSignature(payload string) string {
+	signedPayload := GenerateTestSignedPayload(&UnsignedPayload{
+		Payload: []byte(payload),
+		Secret:  testWebhookSecret,
+	})
+	return signedPayload.Header
+}
+
+// Test payloads
+func v1BillingMeterPayload() string {
+	return `{
+		"id": "evt_123",
+		"object": "v2.core.event",
+		"type": "v1.billing.meter.error_report_triggered",
+		"livemode": false,
+		"created": "2022-02-15T00:27:45.330Z",
+		"context": "event_context_456",
+		"related_object": {
+			"id": "mtr_123",
+			"type": "billing.meter",
+			"url": "/v1/billing/meters/mtr_123"
+		}
+	}`
+}
+
+func v1BillingMeterNoMeterFoundPayload() string {
+	return `{
+		"id": "evt_456",
+		"object": "v2.core.event",
+		"type": "v1.billing.meter.no_meter_found",
+		"livemode": false,
+		"created": "2022-02-15T00:27:45.330Z",
+		"context": "event_context_789"
+	}`
+}
+
+func v1BillingMeterPayloadWithNilContext() string {
+	return `{
+		"id": "evt_789",
+		"object": "v2.core.event",
+		"type": "v1.billing.meter.error_report_triggered",
+		"livemode": false,
+		"created": "2022-02-15T00:27:45.330Z",
+		"context": null,
+		"related_object": {
+			"id": "mtr_456",
+			"type": "billing.meter",
+			"url": "/v1/billing/meters/mtr_456"
+		}
+	}`
+}
+
+func unknownEventPayload() string {
+	return `{
+		"id": "evt_unknown",
+		"object": "v2.core.event",
+		"type": "llama.created",
+		"livemode": false,
+		"created": "2022-02-15T00:27:45.330Z",
+		"context": "event_context_unknown",
+		"related_object": {
+			"id": "llama_123",
+			"type": "llama",
+			"url": "/v1/llamas/llama_123"
+		}
+	}`
+}
+
+// Test: Event is routed to registered handler
+func TestEventHandler_RoutesEventToRegisteredHandler(t *testing.T) {
+	// Setup
+	config := &BackendConfig{StripeContext: String("original_context_123")}
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(config)))
+
+	var unhandledCalled bool
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var handlerCalled bool
+	var receivedEvent *V1BillingMeterErrorReportTriggeredEventNotification
+	var receivedClient *Client
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		handlerCalled = true
+		receivedEvent = event
+		receivedClient = client
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Execute
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled, "Handler should have been called")
+	assert.NotNil(t, receivedEvent, "Handler should have received event")
+	assert.Equal(t, "v1.billing.meter.error_report_triggered", receivedEvent.Type)
+	assert.Equal(t, "evt_123", receivedEvent.ID)
+	assert.Equal(t, "mtr_123", receivedEvent.RelatedObject.ID)
+	assert.NotNil(t, receivedClient, "Handler should have received client")
+	assert.False(t, unhandledCalled, "Unhandled handler should not be called")
+}
+
+// Test: Different events route to correct handlers
+func TestEventHandler_RoutesDifferentEventsToCorrectHandlers(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var billingCallbackCalled, noMeterCallbackCalled bool
+	var billingEvent *V1BillingMeterErrorReportTriggeredEventNotification
+	var noMeterEvent *V1BillingMeterNoMeterFoundEventNotification
+
+	billingCallback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		billingCallbackCalled = true
+		billingEvent = event
+		return nil
+	}
+
+	noMeterCallback := func(ctx context.Context, event *V1BillingMeterNoMeterFoundEventNotification, client *Client) error {
+		noMeterCallbackCalled = true
+		noMeterEvent = event
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(billingCallback)
+	assert.NoError(t, err)
+	err = handler.OnV1BillingMeterNoMeterFound(noMeterCallback)
+	assert.NoError(t, err)
+
+	// Execute first event
+	payload1 := v1BillingMeterPayload()
+	sigHeader1 := generateTestSignature(payload1)
+	err = handler.Handle(context.TODO(), []byte(payload1), sigHeader1)
+	assert.NoError(t, err)
+
+	// Execute second event
+	payload2 := v1BillingMeterNoMeterFoundPayload()
+	sigHeader2 := generateTestSignature(payload2)
+	err = handler.Handle(context.TODO(), []byte(payload2), sigHeader2)
+	assert.NoError(t, err)
+
+	// Assert
+	assert.True(t, billingCallbackCalled, "Billing handler should have been called")
+	assert.True(t, noMeterCallbackCalled, "NoMeter handler should have been called")
+	assert.Equal(t, "v1.billing.meter.error_report_triggered", billingEvent.Type)
+	assert.Equal(t, "v1.billing.meter.no_meter_found", noMeterEvent.Type)
+	assert.False(t, unhandledCalled, "Unhandled handler should not be called")
+}
+
+// Test: Handler receives correct runtime type
+func TestEventHandler_HandlerReceivesCorrectRuntimeType(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var receivedEvent *V1BillingMeterErrorReportTriggeredEventNotification
+	var receivedClient *Client
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		receivedEvent = event
+		receivedClient = client
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, receivedEvent)
+	assert.Equal(t, "v1.billing.meter.error_report_triggered", receivedEvent.Type)
+	assert.Equal(t, "evt_123", receivedEvent.ID)
+	assert.Equal(t, "mtr_123", receivedEvent.RelatedObject.ID)
+	assert.NotNil(t, receivedClient)
+}
+
+// Test: Cannot register handler after handling
+func TestEventHandler_CannotRegisterHandlerAfterHandling(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+	assert.NoError(t, err)
+
+	// Try to register another handler after handling
+	callback2 := func(ctx context.Context, event *V1BillingMeterNoMeterFoundEventNotification, client *Client) error {
+		return nil
+	}
+
+	err = handler.OnV1BillingMeterNoMeterFound(callback2)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot register new event handlers after handling an event")
+}
+
+// Test: Cannot register duplicate handler
+func TestEventHandler_CannotRegisterDuplicateHandler(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	callback1 := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		return nil
+	}
+
+	callback2 := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback1)
+	assert.NoError(t, err)
+
+	err = handler.OnV1BillingMeterErrorReportTriggered(callback2)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "handler for event type v1.billing.meter.error_report_triggered is already registered")
+}
+
+// Test: Handler uses event stripe context
+func TestEventHandler_HandlerUsesEventStripeContext(t *testing.T) {
+	config := &BackendConfig{StripeContext: String("original_context_123")}
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(config)))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var receivedContext *string
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		receivedContext = client.backends.config.StripeContext
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Verify original context
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+	assert.NoError(t, err)
+
+	// Assert handler received event context
+	assert.NotNil(t, receivedContext)
+	assert.Equal(t, "event_context_456", *receivedContext)
+}
+
+// Test: Stripe context restored after handler success
+func TestEventHandler_StripeContextRestoredAfterHandlerSuccess(t *testing.T) {
+	config := &BackendConfig{StripeContext: String("original_context_123")}
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(config)))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		// Verify context is event context during handler
+		assert.Equal(t, "event_context_456", *client.backends.config.StripeContext)
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Verify original context before handle
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+	assert.NoError(t, err)
+
+	// Verify original client context is unchanged after handle
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+}
+
+// Test: Stripe context restored after handler error
+func TestEventHandler_StripeContextRestoredAfterHandlerError(t *testing.T) {
+	config := &BackendConfig{StripeContext: String("original_context_123")}
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(config)))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		// Verify context is event context during handler
+		assert.Equal(t, "event_context_456", *client.backends.config.StripeContext)
+		// Return an error
+		return fmt.Errorf("handler error")
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Verify original context before handle
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+	assert.Error(t, err) // Handler returned an error
+
+	// Verify original client context is unchanged after handler error
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+}
+
+// Test: Stripe context set to nil when event has no context
+func TestEventHandler_StripeContextSetToNilWhenEventHasNoContext(t *testing.T) {
+	config := &BackendConfig{StripeContext: String("original_context_123")}
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(config)))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var receivedContext *string
+	var receivedContextWasChecked bool
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		receivedContext = client.backends.config.StripeContext
+		receivedContextWasChecked = true
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Verify original context
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+
+	payload := v1BillingMeterPayloadWithNilContext()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+	assert.NoError(t, err)
+
+	// Assert handler received nil context
+	assert.True(t, receivedContextWasChecked)
+	assert.Nil(t, receivedContext)
+
+	// Verify original client context is unchanged
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+}
+
+// Test: Unknown event Oout
+func TestEventHandler_UnknownEventRoutesToOnUnhandled(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	var unhandledEvent EventNotificationContainer
+	var unhandledClient *Client
+	var unhandledDetails UnhandledNotificationDetails
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		unhandledEvent = notif
+		unhandledClient = client
+		unhandledDetails = details
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	payload := unknownEventPayload()
+	sigHeader := generateTestSignature(payload)
+	err := handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.True(t, unhandledCalled, "Unhandled handler should have been called")
+	assert.NotNil(t, unhandledEvent)
+
+	// Check if it's an UnknownEventNotification
+	_, isUnknown := unhandledEvent.(*UnknownEventNotification)
+	assert.True(t, isUnknown, "Event should be UnknownEventNotification")
+
+	assert.Equal(t, "llama.created", unhandledEvent.GetEventNotification().Type)
+	assert.NotNil(t, unhandledClient)
+	assert.False(t, unhandledDetails.IsKnownEventType, "Unknown event should have IsKnownEventType=false")
+}
+
+// Test: Known unregistered event Oout
+func TestEventHandler_KnownUnregisteredEventRoutesToOnUnhandled(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	var unhandledEvent EventNotificationContainer
+	var unhandledClient *Client
+	var unhandledDetails UnhandledNotificationDetails
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		unhandledEvent = notif
+		unhandledClient = client
+		unhandledDetails = details
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	// Don't register a handler for this known event type
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err := handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.True(t, unhandledCalled, "Unhandled handler should have been called")
+	assert.NotNil(t, unhandledEvent)
+
+	// Check if it's a known event type
+	_, isKnown := unhandledEvent.(*V1BillingMeterErrorReportTriggeredEventNotification)
+	assert.True(t, isKnown, "Event should be V1BillingMeterErrorReportTriggeredEventNotification")
+
+	assert.Equal(t, "v1.billing.meter.error_report_triggered", unhandledEvent.GetEventNotification().Type)
+	assert.NotNil(t, unhandledClient)
+	assert.True(t, unhandledDetails.IsKnownEventType, "Known event should have IsKnownEventType=true")
+}
+
+// Test: Registered event does Oot
+func TestEventHandler_RegisteredEventDoesNotCallOnUnhandled(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var callbackCalled bool
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		callbackCalled = true
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.True(t, callbackCalled, "Handler should have been called")
+	assert.False(t, unhandledCalled, "Unhandled handler should not be called")
+}
+
+// Test: Handler client retains configuration
+func TestEventHandler_HandlerClientRetainsConfiguration(t *testing.T) {
+	apiKey := "sk_test_custom_key"
+	config := &BackendConfig{StripeContext: String("original_context_xyz")}
+	client := NewClient(apiKey, WithBackends(NewBackendsWithConfig(config)))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var receivedAPIKey string
+	var receivedContext *string
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		receivedAPIKey = client.key
+		receivedContext = client.backends.config.StripeContext
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiKey, receivedAPIKey, "Handler should receive client with original API key")
+	assert.Equal(t, "event_context_456", *receivedContext, "Handler should receive event context")
+	assert.Equal(t, "original_context_xyz", *client.backends.config.StripeContext, "Original client context should be unchanged")
+}
+
+// Test: on_unhandled receives correct info for unknown
+func TestEventHandler_OnUnhandledReceivesCorrectInfoForUnknown(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var details UnhandledNotificationDetails
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, d UnhandledNotificationDetails) error {
+		details = d
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	payload := unknownEventPayload()
+	sigHeader := generateTestSignature(payload)
+	err := handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.False(t, details.IsKnownEventType)
+}
+
+// Test: on_unhandled receives correct info for known unregistered
+func TestEventHandler_OnUnhandledReceivesCorrectInfoForKnownUnregistered(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var details UnhandledNotificationDetails
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, d UnhandledNotificationDetails) error {
+		details = d
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err := handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.True(t, details.IsKnownEventType)
+}
+
+// Test: Validates webhook signature
+func TestEventHandler_ValidatesWebhookSignature(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	payload := v1BillingMeterPayload()
+	err := handler.Handle(context.TODO(), []byte(payload), "invalid_signature")
+
+	assert.Error(t, err)
+	// Check if error is related to signature verification
+	assert.Contains(t, err.Error(), "Stripe-Signature")
+}
+
+// Test: RegisteredEventTypes returns empty list
+func TestEventHandler_RegisteredEventTypesEmpty(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	types := handler.RegisteredEventTypes()
+	assert.Empty(t, types)
+}
+
+// Test: RegisteredEventTypes returns single event type
+func TestEventHandler_RegisteredEventTypesSingle(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	types := handler.RegisteredEventTypes()
+	assert.Equal(t, []string{"v1.billing.meter.error_report_triggered"}, types)
+}
+
+// Test: RegisteredEventTypes returns multiple event types in alphabetical order
+func TestEventHandler_RegisteredEventTypesMultipleAlphabetized(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	callback := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	callback1 := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		return nil
+	}
+	callback2 := func(ctx context.Context, event *V1BillingMeterNoMeterFoundEventNotification, client *Client) error {
+		return nil
+	}
+	callback3 := func(ctx context.Context, event *V2CoreAccountCreatedEventNotification, client *Client) error {
+		return nil
+	}
+
+	// Register in non-alphabetical order
+	err := callback.OnV2CoreAccountCreated(callback3)
+	assert.NoError(t, err)
+	err = callback.OnV1BillingMeterErrorReportTriggered(callback1)
+	assert.NoError(t, err)
+	err = callback.OnV1BillingMeterNoMeterFound(callback2)
+	assert.NoError(t, err)
+
+	types := callback.RegisteredEventTypes()
+	expected := []string{
+		"v1.billing.meter.error_report_triggered",
+		"v1.billing.meter.no_meter_found",
+		"v2.core.account.created",
+	}
+
+	assert.Equal(t, expected, types)
+}
+
+// Test: WithoutVerification routes event to registered handler
+func TestWithoutVerification_RoutesEventToHandler(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	var handlerCalled bool
+	var receivedEvent *V1BillingMeterErrorReportTriggeredEventNotification
+	var receivedClient *Client
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		handlerCalled = true
+		receivedEvent = event
+		receivedClient = client
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Execute — no signature header required
+	payload := v1BillingMeterPayload()
+	err = handler.Handle(context.TODO(), []byte(payload))
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled, "Handler should have been called")
+	assert.NotNil(t, receivedEvent, "Handler should have received event")
+	assert.Equal(t, "v1.billing.meter.error_report_triggered", receivedEvent.Type)
+	assert.Equal(t, "evt_123", receivedEvent.ID)
+	assert.Equal(t, "mtr_123", receivedEvent.RelatedObject.ID)
+	assert.NotNil(t, receivedClient, "Handler should have received client")
+	assert.False(t, unhandledCalled, "Unhandled handler should not be called")
+}
+
+// Test: WithoutVerification routes known unregistered event to fallback
+func TestWithoutVerification_FallbackForUnregisteredEvent(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	var unhandledEvent EventNotificationContainer
+	var unhandledDetails UnhandledNotificationDetails
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		unhandledEvent = notif
+		unhandledDetails = details
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	// Don't register a handler for this known event type
+	payload := v1BillingMeterPayload()
+	err := handler.Handle(context.TODO(), []byte(payload))
+
+	assert.NoError(t, err)
+	assert.True(t, unhandledCalled, "Fallback should have been called")
+	assert.NotNil(t, unhandledEvent)
+
+	_, isKnown := unhandledEvent.(*V1BillingMeterErrorReportTriggeredEventNotification)
+	assert.True(t, isKnown, "Event should be V1BillingMeterErrorReportTriggeredEventNotification")
+	assert.True(t, unhandledDetails.IsKnownEventType, "Known event should have IsKnownEventType=true")
+}
+
+// Test: WithoutVerification routes unknown event type to fallback with IsKnownEventType=false
+func TestWithoutVerification_UnknownEventType(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	var unhandledEvent EventNotificationContainer
+	var unhandledDetails UnhandledNotificationDetails
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		unhandledEvent = notif
+		unhandledDetails = details
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	payload := unknownEventPayload()
+	err := handler.Handle(context.TODO(), []byte(payload))
+
+	assert.NoError(t, err)
+	assert.True(t, unhandledCalled, "Fallback should have been called")
+	assert.NotNil(t, unhandledEvent)
+
+	_, isUnknown := unhandledEvent.(*UnknownEventNotification)
+	assert.True(t, isUnknown, "Event should be UnknownEventNotification")
+	assert.Equal(t, "llama.created", unhandledEvent.GetEventNotification().Type)
+	assert.False(t, unhandledDetails.IsKnownEventType, "Unknown event should have IsKnownEventType=false")
+}
+
+// Test: WithoutVerification propagates event stripe_context to the client in callbacks
+func TestWithoutVerification_ContextPropagation(t *testing.T) {
+	config := &BackendConfig{StripeContext: String("original_context_123")}
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(config)))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	var receivedContext *string
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		receivedContext = client.backends.config.StripeContext
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Verify original context before handle
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+
+	payload := v1BillingMeterPayload()
+	err = handler.Handle(context.TODO(), []byte(payload))
+
+	assert.NoError(t, err)
+	assert.NotNil(t, receivedContext)
+	assert.Equal(t, "event_context_456", *receivedContext, "Handler should receive event's stripe_context")
+	// Original client context should be unchanged
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+}
+
+// Test: WithoutVerification On* methods inherited from embedded handler work correctly
+func TestWithoutVerification_InheritedOnMethods(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	var billingCalled bool
+	var noMeterCalled bool
+
+	billingCallback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		billingCalled = true
+		return nil
+	}
+	noMeterCallback := func(ctx context.Context, event *V1BillingMeterNoMeterFoundEventNotification, client *Client) error {
+		noMeterCalled = true
+		return nil
+	}
+
+	// Register both handlers via the promoted On* methods
+	err := handler.OnV1BillingMeterErrorReportTriggered(billingCallback)
+	assert.NoError(t, err)
+	err = handler.OnV1BillingMeterNoMeterFound(noMeterCallback)
+	assert.NoError(t, err)
+
+	// RegisteredEventTypes is also promoted and should reflect both registrations
+	types := handler.RegisteredEventTypes()
+	assert.Equal(t, []string{"v1.billing.meter.error_report_triggered", "v1.billing.meter.no_meter_found"}, types)
+
+	// Route billing event — only billing handler should fire
+	err = handler.Handle(context.TODO(), []byte(v1BillingMeterPayload()))
+	assert.NoError(t, err)
+	assert.True(t, billingCalled, "Billing handler should have been called")
+	assert.False(t, noMeterCalled, "NoMeter handler should not have been called yet")
+
+	// Route no-meter event — only no-meter handler should fire
+	err = handler.Handle(context.TODO(), []byte(v1BillingMeterNoMeterFoundPayload()))
+	assert.NoError(t, err)
+	assert.True(t, noMeterCalled, "NoMeter handler should have been called")
+}
+
+// Test: NewEventNotificationHandler panics when webhookSecret is empty
+func TestNewEventNotificationHandler_PanicsOnEmptySecret(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	assert.Panics(t, func() {
+		NewEventNotificationHandler(client, "", onUnhandled)
+	})
+}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
<!-- Heads up! This section should include entries for any user-facing changes.
Either fill it out or remove it if there are no entries to report.

List changes that affect end users, e.g.
- Fixes crash when calling `foo.bar()` with null argument
- Adds support for new `baz` parameter on `PaymentIntent` creation

List breaking changes first with a ⚠️ prefix, e.g.
- ⚠️ Removes deprecated `legacy_method` function
-->
