### PR TITLE
Add `.PreHandle` method to `EventNotificationHandler`

### DIFF
--- a/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
+++ b/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
@@ -7,6 +7,7 @@
 //   - write a fallback callback to handle unrecognized event notifications
 //   - create a stripe.Client called client
 //   - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+//   - register a PreHandle hook that deduplicates events by ID before any callback runs
 //   - register a specific handler for the "v1.billing.meter.error_report_triggered" event notification type
 //   - use handler.Handle() to process the received notification webhook body
 
@@ -18,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/stripe/stripe-go/v86"
 )
@@ -29,6 +31,32 @@ var handler = stripe.NewEventNotificationHandler(client, webhookSecret, func(con
 	fmt.Printf("Received unhandled event with type %s", notif.GetEventNotification().Type)
 	return nil
 })
+
+// seenEventIDs tracks event IDs we've already processed so that redelivered webhooks
+// (e.g. after a slow response causes Stripe to retry) don't get handled twice.
+var (
+	seenEventIDsMu sync.Mutex
+	seenEventIDs   = map[string]bool{}
+)
+
+func init() {
+	// PreHandle runs after Handle() parses the payload but before any callback (registered
+	// or fallback) fires. Returning false here skips every callback for this event, which is
+	// exactly what we want for a duplicate delivery.
+	handler.PreHandle(func(ctx context.Context, notif stripe.EventNotificationContainer, client *stripe.Client) (bool, error) {
+		eventID := notif.GetEventNotification().ID
+
+		seenEventIDsMu.Lock()
+		defer seenEventIDsMu.Unlock()
+
+		if seenEventIDs[eventID] {
+			fmt.Printf("Skipping duplicate delivery of event %s\n", eventID)
+			return false, nil
+		}
+		seenEventIDs[eventID] = true
+		return true, nil
+	})
+}
 
 // Handles events delivered through a channel that has already authenticated them, such as
 // AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so

--- a/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
+++ b/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
@@ -33,29 +33,37 @@ var handler = stripe.NewEventNotificationHandler(client, webhookSecret, func(con
 })
 
 // seenEventIDs tracks event IDs we've already processed so that redelivered webhooks
-// (e.g. after a slow response causes Stripe to retry) don't get handled twice.
+// (e.g. after a slow response causes Stripe to retry) don't get handled twice. A real
+// integration would keep this in a database or cache rather than in memory.
 var (
 	seenEventIDsMu sync.Mutex
 	seenEventIDs   = map[string]bool{}
 )
 
-func init() {
-	// PreHandle runs after Handle() parses the payload but before any callback (registered
-	// or fallback) fires. Returning false here skips every callback for this event, which is
-	// exactly what we want for a duplicate delivery.
-	handler.PreHandle(func(ctx context.Context, notif stripe.EventNotificationContainer, client *stripe.Client) (bool, error) {
-		eventID := notif.GetEventNotification().ID
+// skipDuplicateEvents is registered via PreHandle() on both handlers below. It runs after
+// Handle() parses the payload but before any callback fires, and returning false stops
+// handling entirely: neither the registered callback nor the fallback runs.
+func skipDuplicateEvents(ctx context.Context, notif stripe.EventNotificationContainer, client *stripe.Client) (bool, error) {
+	eventID := notif.GetEventNotification().ID
 
-		seenEventIDsMu.Lock()
-		defer seenEventIDsMu.Unlock()
+	seenEventIDsMu.Lock()
+	defer seenEventIDsMu.Unlock()
 
-		if seenEventIDs[eventID] {
-			fmt.Printf("Skipping duplicate delivery of event %s\n", eventID)
-			return false, nil
-		}
-		seenEventIDs[eventID] = true
-		return true, nil
-	})
+	if seenEventIDs[eventID] {
+		fmt.Printf("Skipping duplicate delivery of event %s\n", eventID)
+		return false, nil
+	}
+	seenEventIDs[eventID] = true
+
+	return true, nil
+}
+
+// registering a callback only fails on a programming error (registering twice, or after an
+// event has already been handled), so there's nothing to recover from at runtime.
+func mustRegister(err error) {
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Handles events delivered through a channel that has already authenticated them, such as
@@ -77,7 +85,8 @@ func handleMeterErrors(ctx context.Context, notif *stripe.V1BillingMeterErrorRep
 }
 
 func main() {
-	handler.OnV1BillingMeterErrorReportTriggered(handleMeterErrors)
+	mustRegister(handler.PreHandle(skipDuplicateEvents))
+	mustRegister(handler.OnV1BillingMeterErrorReportTriggered(handleMeterErrors))
 
 	http.HandleFunc("/webhook", func(w http.ResponseWriter, req *http.Request) {
 		const MaxBodyBytes = int64(65536)
@@ -99,7 +108,8 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	unverifiedHandler.OnV1BillingMeterErrorReportTriggered(handleMeterErrors)
+	mustRegister(unverifiedHandler.PreHandle(skipDuplicateEvents))
+	mustRegister(unverifiedHandler.OnV1BillingMeterErrorReportTriggered(handleMeterErrors))
 
 	http.HandleFunc("/webhook-from-cloud-provider", func(w http.ResponseWriter, req *http.Request) {
 		const MaxBodyBytes = int64(65536)

--- a/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
+++ b/example/v2/event_notification_handler_endpoint/event_notification_handler_endpoint.go
@@ -32,17 +32,17 @@ var handler = stripe.NewEventNotificationHandler(client, webhookSecret, func(con
 	return nil
 })
 
-// seenEventIDs tracks event IDs we've already processed so that redelivered webhooks
-// (e.g. after a slow response causes Stripe to retry) don't get handled twice. A real
-// integration would keep this in a database or cache rather than in memory.
+// Webhooks can be delivered more than once, so we track ids we've already
+// processed. In production, back this with something durable and shared
+// across processes (e.g. Redis or a database table) instead of an in-memory map.
 var (
 	seenEventIDsMu sync.Mutex
 	seenEventIDs   = map[string]bool{}
 )
 
-// skipDuplicateEvents is registered via PreHandle() on both handlers below. It runs after
-// Handle() parses the payload but before any callback fires, and returning false stops
-// handling entirely: neither the registered callback nor the fallback runs.
+// skipDuplicateEvents runs before any registered callback. Returning false
+// here skips handling entirely for this delivery, which is useful for
+// deduplicating webhooks.
 func skipDuplicateEvents(ctx context.Context, notif stripe.EventNotificationContainer, client *stripe.Client) (bool, error) {
 	eventID := notif.GetEventNotification().ID
 

--- a/stripe_event_notification_handler.go
+++ b/stripe_event_notification_handler.go
@@ -65,7 +65,7 @@ func NewEventNotificationHandler(client *Client, webhookSecret string, fallbackC
 // synchronously on startup, so it'll only be read after it's done being written.
 func (h *eventNotificationHandlerBase) assertCanRegister() error {
 	if h.hasHandledEvent {
-		return fmt.Errorf("cannot register new event handlers after handling an event. This is indicative of a bug.")
+		return fmt.Errorf("cannot register new callbacks after an event has been handled. This is indicative of a bug.")
 	}
 
 	return nil
@@ -77,7 +77,7 @@ func (h *eventNotificationHandlerBase) register(eventType string, callback Callb
 	}
 
 	if h.eventHandlers[eventType] != nil {
-		return fmt.Errorf("handler for event type %s is already registered", eventType)
+		return fmt.Errorf("callback for event type %q is already registered", eventType)
 	}
 
 	h.eventHandlers[eventType] = callback

--- a/stripe_event_notification_handler.go
+++ b/stripe_event_notification_handler.go
@@ -12,7 +12,7 @@ type CallbackFunc = func(context.Context, EventNotificationContainer, *Client) e
 // FallbackCallbackFunc is run when an event is received that does not match any registered type. It contains additional details about the unhandled event (as compared to a CallbackFunc).
 type FallbackCallbackFunc = func(context.Context, EventNotificationContainer, *Client, UnhandledNotificationDetails) error
 
-// PreHandleFunc runs after Handle() parses the payload but before any user callback fires. Returning false stops handling entirely: no callback runs. Returning a non-nil error aborts handling and is returned from Handle.
+// PreHandleFunc is the function type registered via PreHandle.
 type PreHandleFunc = func(context.Context, EventNotificationContainer, *Client) (bool, error)
 
 type UnhandledNotificationDetails struct {
@@ -84,7 +84,13 @@ func (h *eventNotificationHandlerBase) register(eventType string, callback Callb
 	return nil
 }
 
-// PreHandle registers a hook that runs after Handle() parses the payload but before any other callback fires. Returning `false` from the hook stops handling: no callback runs. Returning an error aborts handling and is returned from the original Handle() call.
+// PreHandle registers a function that will be run before any event-specific callbacks. A useful
+// place to store event-agnostic logic, such as logging or checking for duplicate event deliveries
+// (https://docs.stripe.com/webhooks#handle-duplicate-events).
+//
+// Returning true causes handling to continue as normal; returning false returns from Handle()
+// immediately, so neither the registered callback nor the fallback callback are called. A non-nil
+// error aborts handling and is returned from Handle().
 func (h *eventNotificationHandlerBase) PreHandle(callback PreHandleFunc) error {
 	if err := h.assertCanRegister(); err != nil {
 		return err

--- a/stripe_event_notification_handler.go
+++ b/stripe_event_notification_handler.go
@@ -12,6 +12,9 @@ type CallbackFunc = func(context.Context, EventNotificationContainer, *Client) e
 // FallbackCallbackFunc is run when an event is received that does not match any registered type. It contains additional details about the unhandled event (as compared to a CallbackFunc).
 type FallbackCallbackFunc = func(context.Context, EventNotificationContainer, *Client, UnhandledNotificationDetails) error
 
+// PreHandleFunc runs after Handle() parses the payload but before any user callback fires. Returning false stops handling entirely: no callback runs. Returning a non-nil error aborts handling and is returned from Handle.
+type PreHandleFunc = func(context.Context, EventNotificationContainer, *Client) (bool, error)
+
 type UnhandledNotificationDetails struct {
 	// IsKnownEventType indicates whether the unhandled event is of a known type (i.e., it has a defined struct in the SDK) or is completely unknown.
 	IsKnownEventType bool
@@ -24,6 +27,7 @@ type eventNotificationHandlerBase struct {
 	eventHandlers    map[string]CallbackFunc
 	hasHandledEvent  bool
 	fallbackCallback FallbackCallbackFunc
+	preHandleFunc    PreHandleFunc
 }
 
 // newEventNotificationHandlerBase builds the shared handler state used by both the
@@ -53,11 +57,23 @@ func NewEventNotificationHandler(client *Client, webhookSecret string, fallbackC
 	}
 }
 
-func (h *eventNotificationHandlerBase) register(eventType string, callback CallbackFunc) error {
-	// intentionally not worried about concurrency because we expect all registrations to happen
-	// synchronously on startup, so it'll only be read after it's done being written.
+// assertCanRegister reports an error if callbacks can no longer be registered. Callbacks are
+// expected to be registered once on startup, so registering anything after handling has begun
+// indicates a bug.
+//
+// intentionally not worried about concurrency because we expect all registrations to happen
+// synchronously on startup, so it'll only be read after it's done being written.
+func (h *eventNotificationHandlerBase) assertCanRegister() error {
 	if h.hasHandledEvent {
 		return fmt.Errorf("cannot register new event handlers after handling an event. This is indicative of a bug.")
+	}
+
+	return nil
+}
+
+func (h *eventNotificationHandlerBase) register(eventType string, callback CallbackFunc) error {
+	if err := h.assertCanRegister(); err != nil {
+		return err
 	}
 
 	if h.eventHandlers[eventType] != nil {
@@ -65,6 +81,20 @@ func (h *eventNotificationHandlerBase) register(eventType string, callback Callb
 	}
 
 	h.eventHandlers[eventType] = callback
+	return nil
+}
+
+// PreHandle registers a hook that runs after Handle() parses the payload but before any other callback fires. Returning `false` from the hook stops handling: no callback runs. Returning an error aborts handling and is returned from the original Handle() call.
+func (h *eventNotificationHandlerBase) PreHandle(callback PreHandleFunc) error {
+	if err := h.assertCanRegister(); err != nil {
+		return err
+	}
+
+	if h.preHandleFunc != nil {
+		return fmt.Errorf("a PreHandle callback is already registered")
+	}
+
+	h.preHandleFunc = callback
 	return nil
 }
 
@@ -268,6 +298,16 @@ func (h *eventNotificationHandlerBase) dispatch(ctx context.Context, notif Event
 	clientWithContext, err := h.createClientWithContext(n.Context.StringPtr())
 	if err != nil {
 		return err
+	}
+
+	if h.preHandleFunc != nil {
+		shouldContinue, err := h.preHandleFunc(ctx, notif, clientWithContext)
+		if err != nil {
+			return err
+		}
+		if !shouldContinue {
+			return nil
+		}
 	}
 
 	callback, ok := h.eventHandlers[eventType]

--- a/stripe_event_notification_test.go
+++ b/stripe_event_notification_test.go
@@ -865,3 +865,308 @@ func TestNewEventNotificationHandler_PanicsOnEmptySecret(t *testing.T) {
 		NewEventNotificationHandler(client, "", onUnhandled)
 	})
 }
+
+// Test: With no PreHandle hook registered, the callback still runs (regression)
+func TestPreHandle_NoHookRegistered_CallbackStillRuns(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var callbackCalled bool
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		callbackCalled = true
+		return nil
+	}
+
+	err := handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.True(t, callbackCalled, "Callback should have been called")
+}
+
+// Test: PreHandle hook returning (true, nil) allows the callback to run, and runs first
+func TestPreHandle_ReturnsTrue_CallbackRunsAfterHook(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var order []string
+
+	err := handler.PreHandle(func(ctx context.Context, notif EventNotificationContainer, client *Client) (bool, error) {
+		order = append(order, "preHandle")
+		return true, nil
+	})
+	assert.NoError(t, err)
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		order = append(order, "callback")
+		return nil
+	}
+
+	err = handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"preHandle", "callback"}, order, "PreHandle should run before the callback")
+}
+
+// Test: PreHandle hook returning (false, nil) prevents the registered callback from running
+func TestPreHandle_ReturnsFalse_RegisteredCallbackDoesNotRun(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	err := handler.PreHandle(func(ctx context.Context, notif EventNotificationContainer, client *Client) (bool, error) {
+		return false, nil
+	})
+	assert.NoError(t, err)
+
+	var callbackCalled bool
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		callbackCalled = true
+		return nil
+	}
+
+	err = handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.False(t, callbackCalled, "Registered callback should not have been called")
+}
+
+// Test: PreHandle hook returning (false, nil) for an unknown event type prevents the fallback from running
+func TestPreHandle_ReturnsFalse_FallbackDoesNotRunForUnknownEvent(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	err := handler.PreHandle(func(ctx context.Context, notif EventNotificationContainer, client *Client) (bool, error) {
+		return false, nil
+	})
+	assert.NoError(t, err)
+
+	payload := unknownEventPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.NoError(t, err)
+	assert.False(t, unhandledCalled, "Fallback should not have been called")
+}
+
+// Test: PreHandle hook receives the context-scoped client, and the handler's own client is unmutated
+func TestPreHandle_ReceivesContextScopedClient(t *testing.T) {
+	config := &BackendConfig{StripeContext: String("original_context_123")}
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(config)))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	var receivedContext *string
+	err := handler.PreHandle(func(ctx context.Context, notif EventNotificationContainer, hookClient *Client) (bool, error) {
+		receivedContext = hookClient.backends.config.StripeContext
+		return true, nil
+	})
+	assert.NoError(t, err)
+
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		return nil
+	}
+	err = handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	// Verify original context before handle
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, receivedContext)
+	assert.Equal(t, "event_context_456", *receivedContext, "PreHandle should receive event's stripe_context")
+
+	// Handler's own client should be unmutated
+	assert.Equal(t, "original_context_123", *client.backends.config.StripeContext)
+}
+
+// Test: PreHandle hook returning a non-nil error aborts handling; the error is returned from
+// Handle and no callback runs
+func TestPreHandle_ReturnsError_AbortsHandling(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	preHandleErr := fmt.Errorf("pre-handle failure")
+	err := handler.PreHandle(func(ctx context.Context, notif EventNotificationContainer, client *Client) (bool, error) {
+		return false, preHandleErr
+	})
+	assert.NoError(t, err)
+
+	var callbackCalled bool
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		callbackCalled = true
+		return nil
+	}
+	err = handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err = handler.Handle(context.TODO(), []byte(payload), sigHeader)
+
+	assert.Error(t, err)
+	assert.Equal(t, preHandleErr, err)
+	assert.False(t, callbackCalled, "Callback should not have been called")
+	assert.False(t, unhandledCalled, "Fallback should not have been called")
+}
+
+// Test: PreHandle cannot be registered after handling
+func TestPreHandle_CannotRegisterAfterHandling(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	payload := v1BillingMeterPayload()
+	sigHeader := generateTestSignature(payload)
+	err := handler.Handle(context.TODO(), []byte(payload), sigHeader)
+	assert.NoError(t, err)
+
+	err = handler.PreHandle(func(ctx context.Context, notif EventNotificationContainer, client *Client) (bool, error) {
+		return true, nil
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot register new event handlers after handling an event")
+}
+
+// Test: PreHandle cannot be registered twice
+func TestPreHandle_CannotRegisterTwice(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandler(client, testWebhookSecret, onUnhandled)
+
+	hook := func(ctx context.Context, notif EventNotificationContainer, client *Client) (bool, error) {
+		return true, nil
+	}
+
+	err := handler.PreHandle(hook)
+	assert.NoError(t, err)
+
+	err = handler.PreHandle(hook)
+	assert.Error(t, err)
+}
+
+// Test: PreHandle is promoted onto EventNotificationHandlerWithoutVerification and gates it too
+func TestWithoutVerification_PreHandleIsPromotedAndGatesHandling(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	var unhandledCalled bool
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		unhandledCalled = true
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	var preHandleCalled bool
+	err := handler.PreHandle(func(ctx context.Context, notif EventNotificationContainer, client *Client) (bool, error) {
+		preHandleCalled = true
+		return false, nil
+	})
+	assert.NoError(t, err)
+
+	var callbackCalled bool
+	callback := func(ctx context.Context, event *V1BillingMeterErrorReportTriggeredEventNotification, client *Client) error {
+		callbackCalled = true
+		return nil
+	}
+	err = handler.OnV1BillingMeterErrorReportTriggered(callback)
+	assert.NoError(t, err)
+
+	payload := v1BillingMeterPayload()
+	err = handler.Handle(context.TODO(), []byte(payload))
+
+	assert.NoError(t, err)
+	assert.True(t, preHandleCalled, "PreHandle hook should have been called")
+	assert.False(t, callbackCalled, "Registered callback should not have been called")
+	assert.False(t, unhandledCalled, "Fallback should not have been called")
+}
+
+// Test: PreHandle registration errors (already-registered, and post-handling) are surfaced
+// through the promoted method on EventNotificationHandlerWithoutVerification
+func TestWithoutVerification_PreHandleRegistrationErrorsArePromoted(t *testing.T) {
+	client := NewClient("sk_test_1234", WithBackends(NewBackendsWithConfig(&BackendConfig{})))
+
+	onUnhandled := func(ctx context.Context, notif EventNotificationContainer, client *Client, details UnhandledNotificationDetails) error {
+		return nil
+	}
+
+	handler := NewEventNotificationHandlerWithoutVerification(client, onUnhandled)
+
+	hook := func(ctx context.Context, notif EventNotificationContainer, client *Client) (bool, error) {
+		return true, nil
+	}
+
+	err := handler.PreHandle(hook)
+	assert.NoError(t, err)
+
+	// Duplicate registration fails via the promoted method
+	err = handler.PreHandle(hook)
+	assert.Error(t, err)
+
+	payload := v1BillingMeterPayload()
+	err = handler.Handle(context.TODO(), []byte(payload))
+	assert.NoError(t, err)
+
+	// Registration after handling fails via the promoted method
+	err = handler.PreHandle(hook)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot register new event handlers after handling an event")
+}

--- a/stripe_event_notification_test.go
+++ b/stripe_event_notification_test.go
@@ -239,7 +239,7 @@ func TestEventHandler_CannotRegisterHandlerAfterHandling(t *testing.T) {
 
 	err = handler.OnV1BillingMeterNoMeterFound(callback2)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot register new event handlers after handling an event")
+	assert.Contains(t, err.Error(), "cannot register new callbacks after an event has been handled")
 }
 
 // Test: Cannot register duplicate handler
@@ -265,7 +265,7 @@ func TestEventHandler_CannotRegisterDuplicateHandler(t *testing.T) {
 
 	err = handler.OnV1BillingMeterErrorReportTriggered(callback2)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "handler for event type v1.billing.meter.error_report_triggered is already registered")
+	assert.Contains(t, err.Error(), `callback for event type "v1.billing.meter.error_report_triggered" is already registered`)
 }
 
 // Test: Handler uses event stripe context
@@ -1079,7 +1079,7 @@ func TestPreHandle_CannotRegisterAfterHandling(t *testing.T) {
 		return true, nil
 	})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot register new event handlers after handling an event")
+	assert.Contains(t, err.Error(), "cannot register new callbacks after an event has been handled")
 }
 
 // Test: PreHandle cannot be registered twice
@@ -1168,5 +1168,5 @@ func TestWithoutVerification_PreHandleRegistrationErrorsArePromoted(t *testing.T
 	// Registration after handling fails via the promoted method
 	err = handler.PreHandle(hook)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot register new event handlers after handling an event")
+	assert.Contains(t, err.Error(), "cannot register new callbacks after an event has been handled")
 }


### PR DESCRIPTION
### Why?

In final testing, users have expressed interest in being able to centrally run code before any other handler executes. It can be used for centralized logging, event deduplication, and more. I don't want to go full middleware, but this felt like a reasonable way to dip our toe into the waters.

Because users are responsible for [deduplicating events](https://docs.stripe.com/webhooks#handle-duplicate-events), this pre-handle hook (if present) should return a `bool`, signifying whether handling should continue.

If the function returns `true` (or is missing entirely), the handler proceeds like normal (running at-most-one other callback). If it returns `false`, no further callback is run and the original `.handle()` call finishes cleanly.

### What?

- add the `.pre_handle` method
- & associated tests
- update some error messages with correct verbs & consistency
- refactored some internal error handling
- updated example

### See Also

- http://go/j/DEVSDK-3249
