### PR TITLE
Remove `payment_method_types` from manual tests

### DIFF
--- a/paymentintent/client_test.go
+++ b/paymentintent/client_test.go
@@ -53,7 +53,7 @@ func TestPaymentIntentNew(t *testing.T) {
 	intent, err := New(&stripe.PaymentIntentParams{
 		Amount:   stripe.Int64(123),
 		Currency: stripe.String(string(stripe.CurrencyUSD)),
-		PaymentMethodTypes: stripe.StringSlice([]string{
+		AllowedPaymentMethodTypes: stripe.StringSlice([]string{
 			"card",
 		}),
 	})


### PR DESCRIPTION
### Why?

We have a few manual tests that send `payment_method_types` in a `payment_intent`-related test. That field has already been removed from beta, so preview tests are failing. It's also being removed from GA in the next release, so fixing it in master saves us hassle later.

### What?

- swap `payment_method_types` to `allowed_payment_method_types` in manual tests
