### PR TITLE
Harden API requestor code against malicious URLs

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -653,16 +653,13 @@ func (s *BackendImplementation) CallMultipart(method, path, key, boundary string
 //
 // The absolute URL is built by concatenating a base URL onto this path, and no
 // base URL ends in a slash (normalizeURL actively strips a trailing one). A path
-// like "@evil.example/v1/x" or ".evil.example/v1/x" would therefore land inside
-// the authority component and send the request -- Authorization header included
-// -- to a host of the path's choosing. Some request paths originate in remote
-// data (a webhook body's related_object.url, a response's next_page_url), so the
-// path cannot be assumed to be well-formed.
+// like "@evil.example/v1/x" or ".evil.example/v1/x" would modify the resulting
+// host and direct the request (including the API key) to a non-Stripe host.
 //
-// A single leading slash is sufficient: it terminates the authority component,
-// after which nothing in the path can extend it. This check replaces an earlier
-// silent "prepend a slash if missing" normalization, which had the same
-// protective effect but did not say so and could be removed as dead tidying.
+// Because some relative urls arrive from potentially untrusted sources (like
+// webhook bodies), we have to be a little defensive.
+//
+// So, we require that a path starts with a leading slash.
 func validatePath(path string) error {
 	if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
 		return fmt.Errorf("path must begin with a single \"/\", got %q", path)

--- a/stripe.go
+++ b/stripe.go
@@ -648,6 +648,28 @@ func (s *BackendImplementation) CallMultipart(method, path, key, boundary string
 	return nil
 }
 
+// validatePath ensures a request path is origin-relative: that it
+// begins with a single "/".
+//
+// The absolute URL is built by concatenating a base URL onto this path, and no
+// base URL ends in a slash (normalizeURL actively strips a trailing one). A path
+// like "@evil.example/v1/x" or ".evil.example/v1/x" would therefore land inside
+// the authority component and send the request -- Authorization header included
+// -- to a host of the path's choosing. Some request paths originate in remote
+// data (a webhook body's related_object.url, a response's next_page_url), so the
+// path cannot be assumed to be well-formed.
+//
+// A single leading slash is sufficient: it terminates the authority component,
+// after which nothing in the path can extend it. This check replaces an earlier
+// silent "prepend a slash if missing" normalization, which had the same
+// protective effect but did not say so and could be removed as dead tidying.
+func validatePath(path string) error {
+	if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
+		return fmt.Errorf("path must begin with a single \"/\", got %q", path)
+	}
+	return nil
+}
+
 // extractVersion ensures the path starts with /v1, /v2, or contains /oauth
 // and returns the corresponding APIMode.
 func extractVersion(path string) (APIMode, error) {
@@ -752,8 +774,13 @@ func (s *BackendImplementation) CallRaw(method, path, key string, body []byte, p
 // NewRequest is used by Call to generate an http.Request. It handles encoding
 // parameters and attaching the appropriate headers.
 func (s *BackendImplementation) NewRequest(method, path, key, contentType string, params *Params) (*http.Request, error) {
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
+	if err := validatePath(path); err != nil {
+		ctx := context.Background()
+		if params != nil && params.Context != nil {
+			ctx = params.Context
+		}
+		s.logErrorf(ctx, "Cannot create Stripe request: %v", err)
+		return nil, err
 	}
 
 	// Body is set later by `Do`.

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -2773,12 +2773,6 @@ func BenchmarkCollectAllUnsetFields(b *testing.B) {
 	})
 }
 
-// The absolute URL is built by concatenating a base URL onto a relative path, and
-// no base URL ends in a slash. A path that does not begin with a single "/" can
-// therefore land inside the URL's authority component and redirect the request --
-// Authorization header included -- to a host of the path's choosing. This matters
-// because some request paths originate in remote data: a webhook body's
-// related_object.url, a response's next_page_url.
 func TestAssertOriginRelativePath(t *testing.T) {
 	originRelative := []string{
 		"/v1/customers/cus_123",

--- a/stripe_test.go
+++ b/stripe_test.go
@@ -52,7 +52,7 @@ func TestApiVersion(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	key := "apiKey"
 
-	req, err := c.NewRequest("", "", key, "", nil)
+	req, err := c.NewRequest("", "/v1/hello", key, "", nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, APIVersion, req.Header.Get("Stripe-Version"))
@@ -2771,4 +2771,64 @@ func BenchmarkCollectAllUnsetFields(b *testing.B) {
 			collectAllUnsetFields(reflect.ValueOf(params))
 		}
 	})
+}
+
+// The absolute URL is built by concatenating a base URL onto a relative path, and
+// no base URL ends in a slash. A path that does not begin with a single "/" can
+// therefore land inside the URL's authority component and redirect the request --
+// Authorization header included -- to a host of the path's choosing. This matters
+// because some request paths originate in remote data: a webhook body's
+// related_object.url, a response's next_page_url.
+func TestAssertOriginRelativePath(t *testing.T) {
+	originRelative := []string{
+		"/v1/customers/cus_123",
+		"/v1/customers",
+		"/v2/core/accounts?page=page_123&limit=2",
+		// "@" is legal inside a path or query string -- it only opens an
+		// authority when it precedes the first "/".
+		"/v1/customers?email=user%40example.com",
+		"/v1/invoices/in_123@456",
+		// A backslash does not open an authority: the "/" already closed it.
+		`/v1/\evil.example`,
+	}
+	for _, path := range originRelative {
+		assert.NoError(t, validatePath(path), "expected to accept %q", path)
+	}
+
+	hostile := []string{
+		// Each of these moves the request's authority off api.stripe.com.
+		"@evil.example/v1/leak",
+		":pw@evil.example/v1/leak",
+		":80@evil.example/v1/leak",
+		// Extends the host into an attacker-owned subdomain
+		// (api.stripe.com.evil.example), which has a valid certificate.
+		".evil.example/v1/leak",
+		"-evil.example/v1/leak",
+		"https://evil.example/v1/leak",
+		"//evil.example/v1/leak",
+		"",
+		"v1/customers",
+	}
+	for _, path := range hostile {
+		assert.Error(t, validatePath(path), "expected to reject %q", path)
+	}
+}
+
+func TestNewRequestRejectsHostilePath(t *testing.T) {
+	c := GetBackend(APIBackend).(*BackendImplementation)
+
+	req, err := c.NewRequest(http.MethodGet, "@evil.example/v1/leak", "sk_test_123", "", nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, req)
+	assert.Contains(t, err.Error(), `must begin with a single "/"`)
+}
+
+func TestRawRequestRejectsHostilePath(t *testing.T) {
+	backend := GetBackend(APIBackend).(*BackendImplementation)
+
+	// A hostile path must be refused before any connection is attempted.
+	_, err := backend.RawRequest(http.MethodGet, "@evil.example/v1/leak", "sk_test_123", "", nil)
+
+	assert.Error(t, err)
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

If an attacker got access to a user's webhook secret (or the user wasn't validating incoming webhook signatures) _and_ a user was calling the built-in `event_notification.fetch_related_object()` method, a malicious webhook payload could cause a user integration to make an authenticated request to an attacker-controlled domain (leaking the secret key)

To solve, we're being more careful during url construction to ensure user input can't be used to send requests to non-`stripe.com` domains (on a per-request basis).

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add path validation method and call it before the final URL is built
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2808](https://go/j/RUN_DEVSDK-2808)
