### PR TITLE
Use an origin-relative path in the beta-header tests

### DIFF
--- a/stripe_test.go
+++ b/stripe_test.go
@@ -52,7 +52,7 @@ func TestApiVersion(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	key := "apiKey"
 
-	req, err := c.NewRequest("", "", key, "", nil)
+	req, err := c.NewRequest("", "/v1/hello", key, "", nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, APIVersion, req.Header.Get("Stripe-Version"))
@@ -65,7 +65,7 @@ func TestCanSetBetaHeaders(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	key := "apiKey"
 
-	req, err := c.NewRequest("", "", key, "", nil)
+	req, err := c.NewRequest("", "/v1/hello", key, "", nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, APIVersion+"; feature_in_beta=v3", req.Header.Get("Stripe-Version"))
@@ -81,7 +81,7 @@ func TestSetBetaVersionTwiceAsc(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	key := "apiKey"
 
-	req, err := c.NewRequest("", "", key, "", nil)
+	req, err := c.NewRequest("", "/v1/hello", key, "", nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, APIVersion+"; feature_in_beta=v5", req.Header.Get("Stripe-Version"))
@@ -100,7 +100,7 @@ func TestSetBetaVersionTwiceDesc(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	key := "apiKey"
 
-	req, err := c.NewRequest("", "", key, "", nil)
+	req, err := c.NewRequest("", "/v1/hello", key, "", nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, APIVersion+"; feature_in_beta=v5", req.Header.Get("Stripe-Version"))
@@ -129,7 +129,7 @@ func TestCanSetSecondBetaHeaders(t *testing.T) {
 	c := GetBackend(APIBackend).(*BackendImplementation)
 	key := "apiKey"
 
-	req, err := c.NewRequest("", "", key, "", nil)
+	req, err := c.NewRequest("", "/v1/hello", key, "", nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, APIVersion+"; feature_in_beta=v3; second_feature_in_beta=v2", req.Header.Get("Stripe-Version"))


### PR DESCRIPTION
### Why?
`validatePath` (#2424) rejects a request path that isn't origin-relative. Four beta-header tests pass `""`, so both `latest-codegen` branches went red as soon as master merged in.

### What?
Passes `/v1/hello` instead of `""` as the request path in the five affected tests.

### See Also
- #2424 — added the path validation
- Failing run: https://github.com/stripe/stripe-go/actions/runs/33447456855
